### PR TITLE
simple generated learning page

### DIFF
--- a/content/path/discover/guides.yaml
+++ b/content/path/discover/guides.yaml
@@ -2,9 +2,9 @@ title: Discover
 blurb: Learn how to make your site awesomely discoverable.
 overview: |
 
+order: 2
 
 topics:
-
 # Topic containing several guides
 - title: Optimize content for search engines
   guides:

--- a/content/path/fast/guides.yaml
+++ b/content/path/fast/guides.yaml
@@ -6,6 +6,8 @@ overview: |
     _"53% of mobile site visits are abandoned if pages take longer than 3 seconds to load."_
     - The Need for Mobile Speed.
 
+order: 1
+
 topics:
 # Topic containing several guides
 - title: Measure your site’s performance

--- a/lib/config/generators.js
+++ b/lib/config/generators.js
@@ -297,9 +297,36 @@ async function ContentPageBuilder(cf) {
 }
 
 
+/**
+ * @param {!content.ContentFile} cf 
+ * @return {string}
+ */
+async function LearningPageBuilder(cf) {
+  const loader = cf.loader;
+
+  // Grab all known Paths under `path/*/guides.yaml`.
+  const paths = [];
+  const allPathGuides = await loader.contents(cf.rel('path/*/guides.yaml'));
+  for (const pathGuideFile of allPathGuides) {
+    const id = path.basename(pathGuideFile.dir);  // parent of guides.yaml
+    paths.push({
+      id,
+      config: await pathGuideFile.config,
+      href: `path/${id}`,
+    });
+  }
+  paths.sort((a, b) => a.config.order - b.config.order);
+
+  const body = await templates('learning.html', {paths});
+  const meta = devsiteMeta(cf);
+  return templates('devsite.html', {body, title: 'Learning', meta});
+}
+
+
 module.exports = {
   AllGuidesJSON,
   PathPageBuilder,
   MarkdownBuilder,
   ContentPageBuilder,
+  LearningPageBuilder,
 };

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -38,8 +38,9 @@ module.exports = (callback) => {
   });
   loader.register('path/*.html', generators.PathPageBuilder);
 
-  // Generate top-level HTML dependencies files.
+  // Generate top-level HTML files.
   loader.register('guides-json.html', generators.AllGuidesJSON);
+  loader.register('learning.html', generators.LearningPageBuilder);
 
   // filter files which aren't relevant to DevSite
   loader.register('./*.yaml', filters.FilterYaml);

--- a/templates/learning.html
+++ b/templates/learning.html
@@ -1,0 +1,30 @@
+<main class="learning-landin-page">
+  <div class="container">
+    <div class="hero-area hero-area-row row">
+      <h1 class="hero-title">Learn</h1>
+      <p>Explore our structured learning paths to discover everything you need to know about building for the modern web.</p>
+    </div>
+    <div class="heading-row row">
+      <h2>Discover how to make your site better</h2>
+    </div>
+    <div class="row">
+      <div class="card-row">
+{{#each paths}}
+<div class="card">
+  <div class="card__header card__header--colored">
+    <a href="#" class="card__new">1 New</a>
+    <a href="#" class="card__progress">In Progress</a>
+  </div>
+  <div class="card__content">
+    <p class="card__title">{{config.title}}</p>
+    <p class="card__desc">{{config.blurb}}</p>
+    <div class="card__actions">
+      <a href="{{href}}" class="button button-flat button-justify-left">Explore</a>
+    </div>
+  </div>
+</div>
+{{/each}}
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
Uses the top template design from the dev repo. Generates path cards based on `path/*/guides.yaml` config files.