### PR TITLE
switch to absolute links

### DIFF
--- a/lib/config/generators.js
+++ b/lib/config/generators.js
@@ -192,7 +192,7 @@ async function PathPageBuilder(cf) {
       builtGuides.push({
         id,
         title: guideConfig.title,
-        href: cf.devsiteRelative(guideIndexPage),
+        href: guideIndexPage.devsiteAbsolute(),
         codelabs: null,  // TODO(samthor): Read artifacts about guide
       });
     }
@@ -244,7 +244,7 @@ async function ContentPageBuilder(cf) {
           continue;
         }
         codelabs.push({
-          href: cf.devsiteRelative(artifact),
+          href: artifact.devsiteAbsolute(),
           title: config.title,
         });
       }
@@ -275,7 +275,7 @@ async function ContentPageBuilder(cf) {
         title: config.title,
         glitch: config.glitch,
         relatedGuide: await relatedGuide.config,
-        relatedGuideHref: cf.devsiteRelative(relatedGuide),
+        relatedGuideHref: relatedGuide.devsiteAbsolute(),
       };
       body = await templates('glitch.html', context);
       break;

--- a/lib/deps/content.js
+++ b/lib/deps/content.js
@@ -176,7 +176,7 @@ class ContentFile {
       return this.path;
     }
     if (this.name !== 'index') {
-      // non-index pages are served at their actual path
+      // non-index pages are served at their actual path without ext
       return path.join(this.dir, this.name);
     }
     // otherwise, it's served from the directory name without a slash ¯\_(ツ)_/¯
@@ -184,13 +184,10 @@ class ContentFile {
   }
 
   /**
-   * @param {!ContentFile} toOther
-   * @return {string} relative path to the other content file
+   * @return {string} the absolute path DevSite will serve this file under
    */
-  devsiteRelative(toOther) {
-    const ourDir = path.dirname(this.devsitePath);
-    const out = path.relative(ourDir, toOther.devsitePath);
-    return out ? out : './';
+  devsiteAbsolute() {
+    return path.join('/', this.devsitePath);
   }
 
   /**

--- a/templates/glitch.html
+++ b/templates/glitch.html
@@ -3,7 +3,7 @@
     <div class="web-codelab-instructions">
       <div class="web-codelab-instructions__heading">
         <div class="web-codelab-instructions__heading-breadcrumb">
-          <a class="go-back" href="{{relatedGuideHref}}" aria-label="Return to all guides">
+          <a class="go-back" href="{{relatedGuideHref}}" aria-label="Return to guides">
             {{relatedGuide.title}}
           </a>
         </div>


### PR DESCRIPTION
Use absolute links instead of relative ones, because DevSite has ambiguous URLs.

e.g. it serves from both /foo and /foo/ for the same content.