### PR TITLE
Hide codelab attribution

### DIFF
--- a/templates/glitch.html
+++ b/templates/glitch.html
@@ -1,5 +1,5 @@
 <main class="codelab-landing-page">
-  <web-codelab glitch="{{glitch}}">
+  <web-codelab glitch="{{glitch}}" attribution-hidden>
     <div class="web-codelab-instructions">
       <div class="web-codelab-instructions__heading">
         <div class="web-codelab-instructions__heading-breadcrumb">


### PR DESCRIPTION
This hides the author's profile photo and makes room for the 'show live' button.