### PR TITLE
Remove unused features till we are ready to implement.

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -36,43 +36,6 @@ The Chrome team has spent over a decade learning about user needs and what works
     </div>
   </div>
 
-  <article class="measure container container--lp">
-    <div class="row">
-      <div class="measure__subgrid col-sm-12 col-xl-10">
-        <div class="measure__copy">
-          <h2 class="overline measure__copy-overline">Measure</h2>
-          <h3 class="measure__copy-title">See how your site stacks up</h3>
-          <p class="measure__copy-body">Run Lighthouse against your web page to analyze its code, then get detailed guidance on how to improve it.</p>
-          <ul class="measure__copy-list">
-            <li class="measure__copy-list-item">
-              <div class="arrow-right" aria-hidden="true">keyboard_arrow_right</div>
-              Run a diagnostic audit of your code
-            </li>
-            <li class="measure__copy-list-item">
-              <div class="arrow-right" aria-hidden="true">keyboard_arrow_right</div>
-              Analyze your page for improvements
-            </li>
-            <li class="measure__copy-list-item">
-              <div class="arrow-right" aria-hidden="true">keyboard_arrow_right</div>
-              Get tips to improve your scores
-            </li>
-          </ul>
-        </div>
-
-        <div class="measure__get-started">
-            <button class="button button-primary">
-              Get Started
-            </button>
-            <input id="url" type="url" class="lh-input"
-            placeholder="Enter any url"
-            list="savedurls" autocomplete="off">
-        </div>
-
-        <figure class="measure__illustration"></figure>
-      </div>
-    </div>
-  </article>
-
   <div class="learning container container--lp">
     <div class="row">
       <div class="learning__header col-sm-12 col-l-10 col-xl-8">
@@ -130,10 +93,13 @@ The Chrome team has spent over a decade learning about user needs and what works
     <div class="row">
       <div class="join-us__header col-sm-12 col-l-6">
         <h2 class="overline join-us__header-overline">Join Us</h2>
-        <h3 class="join-us__header-title">Sign in to manage your real-time audits and track your learning progress.</h3>
-        <button class="button button-primary">
-          Sign in with Google
-        </button>
+        <h3 class="join-us__header-title">
+          Create a profile to manage your real-time audits and track your
+          learning progress.
+        </h3>
+        <a class="button button-primary" href="/profile">
+          Create Profile
+        </a>
       </div>
     </div>
   </div>

--- a/templates/path.html
+++ b/templates/path.html
@@ -9,7 +9,6 @@
   <div>
     <h1>{{title}}</h1>
     <p>{{blurb}}</p>
-    <button class="button button-primary">Resume</button>
   </div>
 </div>
 
@@ -49,9 +48,6 @@
   <div class="topic">
     <div class="title">
       <h2 id="topic-{{id}}">{{title}}</h2>
-      <a href="#" class="button button-flat button-justify-right">
-        Start
-      </a>
     </div>
 
     <!-- GUIDES FOR TOPIC  -->
@@ -62,20 +58,6 @@
     <a href="{{href}}">
       {{title}}
     </a>
-    {{#if codelabs.length}}
-    <input type="radio" name="artifacts-open" id="guides__{{id}}" class="artifacts-control" value="{{id}}" />
-    <label for="guides__{{id}}">Toggle</label>
-
-    <!-- ARTIFACTS FOR TOPIC -->
-    <div class="artifacts">
-      <h3>Codelabs</h3>
-      <ul>
-  {{#each codelabs}}
-  <li><a href="{{href}}">{{title}}</a></li>
-  {{/each}}
-      </ul>
-    </div>
-    {{/if}}
   </li>
   {{/each}}
     </ul>


### PR DESCRIPTION
Trying to descope things a bit for launch.

- Removed the measure module entirely from the home page. We have a big Test My Site button that serves the same purpose.
- Made the CTA at the bottom of the home page just link to /profile
- Removed the Resume and Start buttons from the path page. These aren't implemented yet, they're not p0 for launch, and folks are filing bugs against them.
- Removed the codelabs dropdown. Folks were filing bugs against it being broken/confusing and in our usability studies folks found it a bit confusing as well. Just going to disable for now until we have a chance to rethink this feature.

The reason I didn't just comment these out is because I figure there's a high likelihood that some or all of these things won't make it for launch and I didn't want to leave a bunch of commented out HTML in the source. But if folks prefer commenting out cuz they're worried we might lose the markup I'm happy to do that instead.