### PR TITLE
use local-devsite.js if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ For more information on the build system (such as how to write build steps), [se
 
 ### Internal Users
 
-While on your desktop, a Googler may run the `stage` command (rather than `build`) to deploy changed files to the internal staging environment.
+Googlers may use the `deploy` command to deploy changed files to the internal staging environment.
+Contact the web.dev team for more information.
 
 ## Staging
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,2 @@
 devsite.js
+local-devsite.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,7 +165,12 @@ async function write(fullPath, data) {
 }
 
 
-async function report({stats, paths}) {
+/**
+ * Log total stats and optionally deploy changes.
+ * 
+ * @param {{stats: !Object<string, number>, paths: !Array<string>}}
+ */
+async function reportAndDeploy({stats, paths}) {
   log.info(`${stats['total']} files done`);
   if (stats['warning']) {
     log.warn(colors.red(`${stats['warning']} files with warnings`));
@@ -174,6 +179,29 @@ async function report({stats, paths}) {
   }
   if (!opts.deploy) {
     return;
+  }
+
+  // pretend all content is inside 'en' for now
+  const buildDir = path.join(moduleDir, 'build');
+  const pathsWithLang = paths.map((c) => path.join('en', c));
+
+  const devsite = await requireInternalDeployScript();
+  await devsite(buildDir, buildAll ? null : pathsWithLang);
+}
+
+
+/**
+ * Finds the internal deploy script, or a local dev version.
+ *
+ * @return {!function(string, ?Array<string>): !Promise<void>}
+ */
+async function requireInternalDeployScript() {
+  // If there's a local file `local-devsite.js`, then use it. This helps us
+  // for testing.
+  try {
+    return require('./local-devsite.js');
+  } catch (e) {
+    // whatever
   }
 
   // This copies the internal `devsite.js` file to this folder. This is needed
@@ -191,20 +219,14 @@ async function report({stats, paths}) {
   try {
     await fsp.copyFile(path.join(__dirname, '.devsite.js'), devsiteJsTarget);
   } catch (e) {
-    log.warn(`couldn't copy '.devsite.js' to local ver, failing deploy`);
-    return process.exit(3);
+    throw new Error(`couldn't copy '.devsite.js' to local ver, failing deploy`);
   }
 
-  // pretend all content is inside 'en' for now
-  const buildDir = path.join(moduleDir, 'build');
-  const pathsWithLang = paths.map((c) => path.join('en', c));
-
-  const devsite = require('./devsite.js');
-  await devsite(buildDir, buildAll ? null : pathsWithLang);
+  return require('./devsite.js');
 }
 
 
-run().then(report).catch((err) => {
+run().then(reportAndDeploy).catch((err) => {
   console.warn(err);
   return process.exit(1);
 });


### PR DESCRIPTION
This helps me test new deployment scripts rather than just assuming we always pull it from google3. :)