### PR TITLE
Remove mark as complete button.

### DIFF
--- a/templates/guide.html
+++ b/templates/guide.html
@@ -12,21 +12,6 @@
             {{/if}}
           </ul>
         </div>
-        {{#if topic}}
-        <div class="progress">
-          <div>Progress</div>
-          <div class="progress__markers">
-            <div>
-              <!-- <span class="progress__marker--complete progress__marker--active"></span>
-              <span class="progress__marker--complete progress__marker--active"></span>
-              <span class="progress__marker--incomplete progress__marker--active"></span> -->
-              {{#each topic.guides}}
-              <span class="progress__marker--incomplete" id="topic-progress__{{id}}"></span>
-              {{/each}}
-            </div>
-          </div>
-        </div>
-        {{/if}}
       </div>
     </div>
 


### PR DESCRIPTION
Related to #94.

Let's remove this button entirely. If you click 'Next Guide' at the bottom, we'll assume you've read the thing and will mark it as complete for you.