### PR TITLE
Density descriptor fixes

### DIFF
--- a/content/path/fast/serve-responsive-images/codelab-density-descriptors.md
+++ b/content/path/fast/serve-responsive-images/codelab-density-descriptors.md
@@ -20,7 +20,7 @@ simple, but "pixel" can actually have many meanings:
 <thead>
 <th>Type</th>
 <th>Defintion</th>
-</head>
+</thead>
 <tbody>
 <tr>
 <td>Device pixel <br>


### PR DESCRIPTION
The "&lt;img&gt;" in line 94 isn't a typo - the code snippet otherwise wouldn't play nicely with table.

Fixes https://github.com/GoogleChrome/web.dev/issues/122