### PR TITLE
Fix deploy

### DIFF
--- a/lib/.devsite.js
+++ b/lib/.devsite.js
@@ -1,0 +1,1 @@
+/google/src/head/depot/google3/devrel/web/dev/devsite.js


### PR DESCRIPTION
One of the doc merges add a `\n` to the end of the symlink and broke it This should fix it.