### PR TITLE
Fixes merge conflict markers

### DIFF
--- a/content/fast/use-lazysizes-to-lazyload-images/codelab-use-lazysizes-to-lazyload-images.md
+++ b/content/fast/use-lazysizes-to-lazyload-images/codelab-use-lazysizes-to-lazyload-images.md
@@ -24,7 +24,6 @@ makes this a very simple strategy to implement.
 `lazysizes.min.js` has already been downloaded and added to this Glitch. To
 include it in the page:
 
-<<<<<<< HEAD
 - Add the following `<script>` tag to `index.html`:
 
 <pre class="prettyprint devsite-disable-click-to-copy">
@@ -32,25 +31,11 @@ include it in the page:
   &lt;!-- Images End --&gt;
 &lt;/body&gt;
 </pre>
-=======
-(Note: The
-[lazysizes.min.js](https://raw.githubusercontent.com/aFarkas/lazysizes/gh-pages/lazysizes.min.js)
-file has already been added to this project, so there is no need to add it
-separately.)
-
-lazysizes will intelligently load images as the user scrolls through the page
-and prioritize the images that the user is going to encounter soon.
->>>>>>> wip
 
 lazysizes will intelligently load images as the user scrolls through the page
 and prioritize the images that the user is going to encounter soon.
 
-<<<<<<< HEAD
 ## Indicate the images to lazy load
-=======
-- Add the class `lazyload` to images that should be lazy loaded. In addition,
-  change the `src` attribute to `data-src`.
->>>>>>> wip
 
 - Add the class `lazyload` to images that should be lazy loaded. In addition,
   change the `src` attribute to `data-src`.
@@ -62,11 +47,7 @@ For example, the changes for `flower3.png` would look like this:
 <strong>&lt;img data-src=&quot;images/flower3.png&quot; class=&quot;lazyload&quot;&gt;</strong>
 </pre>
 
-<<<<<<< HEAD
 For this example, try lazy loading `flower3.png`, `flower4.jpg`, and
-=======
-For this example, we recommend lazy loading `flower3.png`, `flower4.jpg`, and
->>>>>>> wip
 `flower5.jpg`.
 
 <div class="aside note">
@@ -87,11 +68,8 @@ That's it! To see these changes in action, follow these steps:
 
 - Click on the **Show Live** button to view the live version of the the Glitch.
 
-<<<<<<< HEAD
 <web-screenshot type="show-live"></web-screenshot>
 
-=======
->>>>>>> wip
 - Open the console and find the images that were just added. Their classes
   should change from `lazyload` to `lazyloaded` as you scroll down the page.
 
@@ -108,13 +86,7 @@ Lastly, it's a good idea to use Lighthouse to verify these changes. Lighthouse's
 "Defer offscreen images" performance audit will indicate if you've forgotten to
 add lazy loading to any offscreen images.
 
-<<<<<<< HEAD
 - Click on the **Show Live** button to view the live version of the your Glitch.
-=======
-Lastly, it's a good idea to use Lighthouse to verify these changes. Lighthouse's
-"Defer offscreen images" performance audit will indicate if you've forgotten to
-add lazy loading to any offscreen images.
->>>>>>> wip
 
 <web-screenshot type="show-live"></web-screenshot>
 


### PR DESCRIPTION
@robdodson Looks like some HEAD/commit markers were accidentally [merged in](https://github.com/GoogleChrome/web.dev/pull/420/commits/8173b1207febbf253ad59e644c840cbdcc856dd3)

I'm assuming everything was supposed to be HEAD but please take a quick look unless I chose the wrong marker