### PR TITLE
Update guide title

### DIFF
--- a/content/fast/your-first-performance-budget/index.md
+++ b/content/fast/your-first-performance-budget/index.md
@@ -1,12 +1,12 @@
 ---
 page_type: guide
-title: Incorporate performance budgets into your build process
+title: Your first performance budget
 author: mihajlija
 web_lighthouse: N/A
 wf_blink_components: N/A
 ---
 
-# Incorporate performance budgets into your build process
+# Your first performance budget
 
 When you set a personal, business or family budget, you are setting a limit to your spending and making sure you stay within it. [Performance budgets](/fast/performance-budgets-101) work in the same way, but for metrics that affect website performance. 
 


### PR DESCRIPTION
The previous title was duplicate of fast/incorporate-performance-budgets-into-your-build-tools It was probably a copy-paste issue.