### PR TITLE
Add licenses to templates.

### DIFF
--- a/templates/devsite.html
+++ b/templates/devsite.html
@@ -1,3 +1,5 @@
+{{!-- Copyright 2018 Google LLC. --}}
+{{!-- SPDX-License-Identifier: Apache-2.0 --}}
 <html devsite>
   <head>
 {{#if title}}

--- a/templates/glitch.html
+++ b/templates/glitch.html
@@ -1,3 +1,5 @@
+{{!-- Copyright 2018 Google LLC. --}}
+{{!-- SPDX-License-Identifier: Apache-2.0 --}}
 <style>
   /* Temporary hack while we're in code freeze :\ */
   .web-codelab-instructions__heading h1:first-of-type {

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -1,3 +1,5 @@
+{{!-- Copyright 2018 Google LLC. --}}
+{{!-- SPDX-License-Identifier: Apache-2.0 --}}
 <main class="guide-landing-page">
   <div class="container">
 

--- a/templates/path.html
+++ b/templates/path.html
@@ -1,3 +1,5 @@
+{{!-- Copyright 2018 Google LLC. --}}
+{{!-- SPDX-License-Identifier: Apache-2.0 --}}
 <header class="feature">
   <div class="container">
     <div class="row">

--- a/templates/root-cards.html
+++ b/templates/root-cards.html
@@ -1,3 +1,5 @@
+{{!-- Copyright 2018 Google LLC. --}}
+{{!-- SPDX-License-Identifier: Apache-2.0 --}}
 {{#each paths}}
 <div class="card card--{{id}}">
   <div class="card__header card__header--colored card__header--{{id}}">


### PR DESCRIPTION
I went with the same abbreviated license we're using in our glitches here cuz I was a little concerned about a super long license possibly breaking the template parser or something.