### PR TITLE
Install the Mozjpeg plugin

### DIFF
--- a/content/fast/use-imagemin-to-compress-images/codelab-imagemin-webpack.md
+++ b/content/fast/use-imagemin-to-compress-images/codelab-imagemin-webpack.md
@@ -158,7 +158,13 @@ Instead of using `imagemin-webpack-plugin`'s default plugin for JPG compression
 (`imagemin-jpegtran`), use the `imagemin-mozjpeg` plugin. Unlike Jpegtran,
 Mozjpeg let's you specify a compression quality for your JPG compression.
 
-- Initialize the `imagemin-mozjpeg` plugin by adding the following line at the
+- First, let's install the Mozjpeg plugin:
+
+<pre class="devsite-terminal devsite-click-to-copy">
+npm install --save-dev imagemin-mozjpeg
+</pre>
+
+- Now, initialize the `imagemin-mozjpeg` plugin by adding the following line at the
   top of your `webpack.config.js` file:
 
 ```javascript

--- a/content/fast/use-imagemin-to-compress-images/codelab-imagemin-webpack.md
+++ b/content/fast/use-imagemin-to-compress-images/codelab-imagemin-webpack.md
@@ -158,13 +158,13 @@ Instead of using `imagemin-webpack-plugin`'s default plugin for JPG compression
 (`imagemin-jpegtran`), use the `imagemin-mozjpeg` plugin. Unlike Jpegtran,
 Mozjpeg let's you specify a compression quality for your JPG compression.
 
-- First, let's install the Mozjpeg plugin:
+- Install the Mozjpeg plugin:
 
 <pre class="devsite-terminal devsite-click-to-copy">
 npm install --save-dev imagemin-mozjpeg
 </pre>
 
-- Now, initialize the `imagemin-mozjpeg` plugin by adding the following line at the
+- Next, initialize the `imagemin-mozjpeg` plugin by adding the following line at the
   top of your `webpack.config.js` file:
 
 ```javascript


### PR DESCRIPTION
Fix: $ webpack --config webpack.config.js --mode production
/app/node_modules/webpack-cli/bin/cli.js:244
                                throw err;
                                ^
Error: Cannot find module 'imagemin-mozjpeg'