### PR TITLE
Remove in-page anchor for now.

### DIFF
--- a/content/secure/same-origin-policy/index.md
+++ b/content/secure/same-origin-policy/index.md
@@ -19,7 +19,7 @@ expose everything on a user's browser.
 
 The same-origin policy prevents this from happening by blocking read access to
 resources loaded from a different origin. "But wait", you say. "I load images
-and scripts from other origins _all the time_." Browsers allow a few tags to embed resources from different origin. This is mostly historical artifacts and could expose your site to vulnerabilities such as [clickjacking using iframe](#clickjacking). You can restrict the origins for these
+and scripts from other origins _all the time_." Browsers allow a few tags to embed resources from different origin. This is mostly historical artifacts and could expose your site to vulnerabilities such as clickjacking using iframe. You can restrict the origins for these
 tags using a [Content Security Policy](https://developers.google.com/web/fundamentals/security/csp/).
 
 ## What is considered "same-origin"?  
@@ -75,7 +75,7 @@ cross-origin resource is blocked.
     </tbody>
 </table>
 
-### How to prevent Clickjacking {: #clickjacking }
+### How to prevent Clickjacking
 
 <figure class="attempt-right">
   <img src="./clickjacking.png" alt="clickjacking">


### PR DESCRIPTION
how we parse markdown file seems to not include in-page anchor tag. Removing it for now. (see screenshot below, `{: #clickjacking }` should not be visible to readers)

CC: @robdodson  this is how I put anchor in `developer.google.com/web` to do "jump to __" link. (I don't know how it's called) Would be great if we can do the same for web.dev

https://web.dev/secure/same-origin-policy
<img width="451" alt="same_origin_policy_ _ _web_dev" src="https://user-images.githubusercontent.com/4581495/48757208-56a02c80-ecdf-11e8-99f0-04d2a7d74baa.png">
