### PR TITLE
Codelab linking to wrong glitch!

### DIFF
--- a/content/fast/use-imagemin-to-compress-images/codelab-imagemin-gulp.md
+++ b/content/fast/use-imagemin-to-compress-images/codelab-imagemin-gulp.md
@@ -2,7 +2,7 @@
 title: Using Imagemin with Gulp
 author: khempenius
 page_type: glitch
-glitch: imagemin-grunt
+glitch: imagemin-gulp
 ---
 
 ## Install the Imagemin Gulp plugin


### PR DESCRIPTION
Codelab was linking to grunt glitch, and it should be gulp glitch.