### PR TITLE
Add links to GitHub source content

### DIFF
--- a/lib/config/generators.js
+++ b/lib/config/generators.js
@@ -434,6 +434,7 @@ async function ContentPageBuilder(cf) {
       const context = {
         flags,
         main,
+        path: sitePathConfig,
         title: config.title,
         glitch: config.glitch,
         relatedGuide: await relatedGuide.config,

--- a/templates/glitch.html
+++ b/templates/glitch.html
@@ -49,6 +49,8 @@
       </div>
       <div class="web-codelab-instructions__body">
 {{{main}}}
+        <hr>
+        <a href="https://github.com/GoogleChrome/web.dev/tree/master/content{{relatedGuideHref}}/codelab-{{glitch}}.md" target="_blank" rel="noopener" class="web-breadcrumbs__edit-link">Edit this page on GitHub</a>
       </div>
     </div>
   </web-codelab>

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -6,7 +6,7 @@
     <!-- BREADRUMBS AND PROGRESS -->
     <div class="row">
       <div class="breadcrumbs-and-progress">
-        <div class="web-breadcrumbs">
+        <div class="breadcrumbs">
           <ul>
             <li>
               <a href="{{path.href}}"
@@ -26,7 +26,6 @@
             {{/if}}
           </ul>
         </div>
-        <a href="https://github.com/GoogleChrome/web.dev/tree/master/content{{path.href}}/{{id}}/index.md" target="_blank" rel="noopener" class="web-breadcrumbs__edit-link">Edit this page on GitHub</a>
       </div>
     </div>
 
@@ -55,6 +54,10 @@
         {{/if}}
 {{{main}}}
 
+  <h2>Help us improve!</h2>
+  <a class="button button-secondary" href="https://github.com/GoogleChrome/web.dev/tree/master/content{{path.href}}/{{id}}/index.md" rel="noopener">
+    Edit this page on GitHub
+  </a>
   <hr />
 
   {{#if codelabs.length}}

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -6,7 +6,7 @@
     <!-- BREADRUMBS AND PROGRESS -->
     <div class="row">
       <div class="breadcrumbs-and-progress">
-        <div class="breadcrumbs">
+        <div class="web-breadcrumbs">
           <ul>
             <li>
               <a href="{{path.href}}"
@@ -26,6 +26,7 @@
             {{/if}}
           </ul>
         </div>
+        <a href="https://github.com/GoogleChrome/web.dev/tree/master/content{{path.href}}/{{id}}/index.md" target="_blank" rel="noopener" class="web-breadcrumbs__edit-link">Edit this page on GitHub</a>
       </div>
     </div>
 


### PR DESCRIPTION
This is currently based on the author information blocks, which already
have the necessary basic styling. However, we should wait for the CSS to
be deployed before we can iterate on the design.

Fixes #294