### PR TITLE
contributors.js: use correct filename for missing author image

### DIFF
--- a/lib/config/contributors.js
+++ b/lib/config/contributors.js
@@ -64,7 +64,7 @@ async function loadContributorFromConfiguration(author) {
     path.resolve(CONTRIBUTORS_PICTURES_LOCATION, author + '.jpg'),
   );
 
-  authorInformation.picture = hasPictureFile ? author : 'no-picture';
+  authorInformation.picture = hasPictureFile ? author : 'no-photo';
 
   return authorInformation;
 }


### PR DESCRIPTION
The file name is: https://github.com/GoogleChrome/web.dev/blob/master/content/images/contributors/no-photo.jpg