### PR TITLE
Fix build on Windows.

### DIFF
--- a/lib/deps/yaml-prefix.js
+++ b/lib/deps/yaml-prefix.js
@@ -18,8 +18,12 @@
 
 'use strict';
 
-const START_DIVIDER = `---\n`;
-const TAIL_DIVIDER = `\n---\n`;
+// TODO(robdodson): I think someday we should scrap all this yaml parsing
+// and just use the yaml-front-matter module on npm.
+// github.com/dworthen/js-yaml-front-matter
+const isWin = process.platform === 'win32';
+const START_DIVIDER = isWin ? `---\r\n` : `---\n`;
+const TAIL_DIVIDER = isWin ? `\r\n---\r\n` : `\n---\n`;
 
 /**
  * Splits files that have a YAML prefix delineated by ---'s on whole lines.
@@ -38,6 +42,8 @@ module.exports = function(s) {
   }
 
   if (!s.startsWith(START_DIVIDER)) {
+    // eslint-disable-next-line no-console
+    console.error('Could not find YAML front matter.');
     return {config: null, rest: s};
   }
 


### PR DESCRIPTION
This should make `npm run build` work again on Windows.
I think the way the build is currently implemented is it's manually stripping the yaml out of the markdown and then parsing the files separately. There's a nicer module that does this, [js-yaml-front-matter](https://github.com/dworthen/js-yaml-front-matter), that I've used before. But adding it would be a bigger refactor of these scripts. Putting that off for another day 🌅