### PR TITLE
Add the ability to mark a guide as "draft"

### DIFF
--- a/lib/config/generators.js
+++ b/lib/config/generators.js
@@ -25,6 +25,8 @@ const templates = require('../templates.js');
 const markdown = require('../deps/markdown.js');
 const flags = require('../flags.js');
 const {loadContributorFromConfiguration} = require('./contributors.js');
+const log = require('fancy-log');
+const colors = require('ansi-colors');
 
 /**
  * Returns default DevSite 2 meta content for this path.
@@ -198,6 +200,13 @@ async function AllGuidesJSON(cf) {
       // for each topic in the path
       guides.forEach(({id, title, config: guideConfig}) => {
         // for each guide in that topic
+
+        if (guideConfig.web_status === 'draft') {
+          log.info(
+            colors.yellow(`- Ignoring "${sitePath}/${id}" with status "draft"`)
+          );
+          return;
+        }
 
         const lighthouse = [];
         if (guideConfig.web_lighthouse instanceof Array) {


### PR DESCRIPTION
If a guide has `web_status: draft`, do not generate a guide file.

![image](https://user-images.githubusercontent.com/5948271/51121628-c8908000-180f-11e9-85c1-100c7828949f.png)


Fixes #419