### PR TITLE
Don't add redirects meta tag to html

### DIFF
--- a/lib/config/generators.js
+++ b/lib/config/generators.js
@@ -37,7 +37,6 @@ function devsiteMeta(cf) {
   return {
     project_path: `/${closest(cf.path, '_project.yaml')}`,
     book_path: `/${closest(cf.path, '_book.yaml')}`,
-    redirects_path: `/${closest(cf.path, '_redirects.yaml')}`,
   };
 }
 
@@ -249,7 +248,6 @@ async function MarkdownBuilder(cf, cb) {
   const preamble = {
     project_path: '/' + closest(cf.path, '_project.yaml'),
     book_path: '/' + closest(cf.path, '_book.yaml'),
-    redirects_path: '/' + closest(cf.path, '_redirects.yaml'),
   };
   const generated = Object.keys(preamble)
     .map((key) => `${key}: ${preamble[key]}`)


### PR DESCRIPTION
It turns out we just need to copy the _redirects.yaml over, we don't need to also add meta tags to the page.