### PR TITLE
Add code owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,24 @@
+# Auto-assign owners for different areas of the site.
+# These folks will automatically get tagged to review PRs in their area.
+# Read more @ https://help.github.com/articles/about-code-owners/
+
+# Default owners for everything
+* @robdodson
+
+# Guide collections
+/content/ @Meggin
+/content/accessible/ @robdodson
+/content/discoverable/ @ekharvey @AVGP
+/content/fast/ @addyosmani @housseindjirdeh @khempenius
+/content/installable/ @petele
+/content/reliable/ @jeffposnick
+/content/secure/ @kosamari
+
+# Build scripts
+/lib/ @TimvdLippe
+
+# Measure page
+/content/measure.html @ebidel @TimvdLippe
+
+# Preview server
+/server/ @ebidel


### PR DESCRIPTION
Adds a CODEOWNERS file to go along with branch protection settings.
Read more here:
https://help.github.com/articles/about-code-owners/