### PR TITLE
Correct .mjs, .js typo

### DIFF
--- a/content/fast/serve-modern-code-to-modern-browsers/codelab-serve-modern-code.md
+++ b/content/fast/serve-modern-code-to-modern-browsers/codelab-serve-modern-code.md
@@ -511,8 +511,8 @@ const plugins = [
 ];
 </pre>
 
-These plugin settings add a `type="module"` attribute for all `.js` script
-elements as well as a `nomodule` attribute for all `.mjs` script modules.
+These plugin settings add a `type="module"` attribute for all `.mjs` script
+elements as well as a `nomodule` attribute for all `.js` script modules.
 
 <div class="aside note">
   If you're having trouble understanding how to add all of these configurations to <code>webpack.config.js</code>, take a look at the <a href="https://glitch.com/edit/#!/serve-modern-code-complete?path=webpack.config.js:1:0">complete version of the file</a>.


### PR DESCRIPTION
`type="module"` are added to all `.mjs`, and `nomodule` attributes are added to `.js`