### PR TITLE
Use noindex instead of robots.txt to block search pages.

### DIFF
--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
-Disallow: /s/results*
 Sitemap: https://web.dev/sitemap.xml


### PR DESCRIPTION
This is a recommendation from search console. I'll update the devsite template to use the `noindex` meta tag.