### PR TITLE
Fix missing glitch

### DIFF
--- a/content/discoverable/fix-http-status-codes/codelab-fix-sneaky-404.md
+++ b/content/discoverable/fix-http-status-codes/codelab-fix-sneaky-404.md
@@ -7,7 +7,7 @@ description: |
   page from being properly indexed.
 web_updated_on: 2018-12-06
 web_published_on: 2018-11-05
-glitch: sneaky-404
+glitch: fix-sneaky-404
 ---
 
 Single Page Apps can show different content without loading a new page.


### PR DESCRIPTION
Not sure what happened but I noticed this glitch started 404ing. Looks like the name was updated maybe? This PR should fix it.

Glitch is here:
https://glitch.com/~fix-sneaky-404