### PR TITLE
Secure Guide - Doc fix for double-quotes merged into links 

### DIFF
--- a/content/secure/same-origin-policy/index.md
+++ b/content/secure/same-origin-policy/index.md
@@ -33,7 +33,7 @@ tags using a [Content Security Policy](https://developers.google.com/web/fundame
 An origin is defined by the scheme (also known as the  protocol, for example
 HTTP or HTTPS), port (if it is specified), and host. When all three are the same
 for two URLs, it is considered same-origin. For example.
-"[http://www.example.com/foo](http://www.example.com/foo)" is same-origin as "[http://www.example.com/bar](http://www.example.com/bar)" but
+`http://www.example.com/foo` is the same-origin as `http://www.example.com/bar` but
 not "[**https**://www.example.com/baz](https://www.example.com/baz)" (the scheme is different).
 
 ## What is permitted and what is blocked?

--- a/content/secure/same-origin-policy/index.md
+++ b/content/secure/same-origin-policy/index.md
@@ -33,8 +33,8 @@ tags using a [Content Security Policy](https://developers.google.com/web/fundame
 An origin is defined by the scheme (also known as the  protocol, for example
 HTTP or HTTPS), port (if it is specified), and host. When all three are the same
 for two URLs, it is considered same-origin. For example.
-"http://www.example.com/foo" is same-origin as "http://www.example.com/bar" but
-not "**https**://www.example.com/baz" (the scheme is different).
+"[http://www.example.com/foo](http://www.example.com/foo)" is same-origin as "[http://www.example.com/bar](http://www.example.com/bar)" but
+not "[**https**://www.example.com/baz](https://www.example.com/baz)" (the scheme is different).
 
 ## What is permitted and what is blocked?
 

--- a/content/secure/same-origin-policy/index.md
+++ b/content/secure/same-origin-policy/index.md
@@ -34,7 +34,7 @@ An origin is defined by the scheme (also known as the  protocol, for example
 HTTP or HTTPS), port (if it is specified), and host. When all three are the same
 for two URLs, it is considered same-origin. For example.
 `http://www.example.com/foo` is the same-origin as `http://www.example.com/bar` but
-not "[**https**://www.example.com/baz](https://www.example.com/baz)" (the scheme is different).
+not <code><strong>https</strong>://www.example.com/baz</code> (the scheme is different).
 
 ## What is permitted and what is blocked?
 


### PR DESCRIPTION
Fixes double-quotes merged into links at https://web.dev/secure/same-origin-policy as displayed below:

![links-webdev](https://user-images.githubusercontent.com/26493779/54078513-9fe5ad80-42c9-11e9-9981-0202d8bfbf6f.png)
