### PR TITLE
change mention of uglifyjs to terser

### DIFF
--- a/content/fast/reduce-network-payloads-using-text-compression/codelab-text-compression.md
+++ b/content/fast/reduce-network-payloads-using-text-compression/codelab-text-compression.md
@@ -100,8 +100,8 @@ module bundler. The specific version can be seen in `package.json`.
 </pre>
 
 Version 4 already minifies the bundle by default during production mode. It uses 
-`UglifyjsWebpackPlugin,` a plugin for [UglifyJS v3](https://github.com/mishoo/UglifyJS2/tree/harmony). 
-UglifyJS is a popular tool used to minify (or 'uglify') JavaScript code.
+`TerserWebpackPlugin` a plugin for [Terser](https://github.com/terser-js/terser). 
+Terser is a popular tool used to compress JavaScript code.
 
 To get an idea of what the minified code looks like, go ahead and click
 `main.bundle.js` while still in the DevTools **Network** panel. Now click the
@@ -141,13 +141,13 @@ that you use:
 
 + If webpack v4 or greater is used, no additional work needs to be done 
 since code is minified by default in production mode. 👍
-+ If an older version of webpack is used, install and include the `UglifyjsWebpackPlugin` 
-into the webpack build process. The [documentation](https://webpack.js.org/plugins/uglifyjs-webpack-plugin/) 
++ If an older version of webpack is used, install and include `TerserWebpackPlugin` 
+into the webpack build process. The [documentation](https://webpack.js.org/plugins/terser-webpack-plugin/) 
 explains this in detail.
 + Other minification plugins also exist and can be used instead, 
 such as [BabelMinifyWebpackPlugin](https://github.com/webpack-contrib/babel-minify-webpack-plugin) 
 and [ClosureCompilerPlugin](https://github.com/roman01la/webpack-closure-compiler).
-+ If a module bundler is not being used at all, use [UglifyJS](https://github.com/mishoo/UglifyJS2) 
++ If a module bundler is not being used at all, use [Terser](https://github.com/terser-js/terser) 
 as a CLI tool or include it directly as a dependency.
 
 ## Compression

--- a/content/fast/reduce-network-payloads-using-text-compression/index.md
+++ b/content/fast/reduce-network-payloads-using-text-compression/index.md
@@ -45,19 +45,19 @@ It also audits for any uncompressed assets.
 
 **Minification** is the process of removing whitespace and any code that is not
 necessary to create a smaller but perfectly valid code file.
-[UglifyJS](https://github.com/mishoo/UglifyJS2) is a popular JavaScript
-minification tool and [webpack](https://webpack.js.org/) v4 includes a plugin
+[Terser](https://github.com/terser-js/terser) is a popular JavaScript
+compression tool and [webpack](https://webpack.js.org/) v4 includes a plugin
 for this library by default to create minified build files.
 
 * If you're using webpack v4 or greater, you should be good to go
     without doing any additional work. 👍
 * If you are using an older version of webpack, install and include
-`UglifyjsWebpackPlugin` into your webpack configuration settings. Follow
-the [documentation](https://webpack.js.org/plugins/uglifyjs-webpack-plugin/) to
+`TerserWebpackPlugin` into your webpack configuration settings. Follow
+the [documentation](https://webpack.js.org/plugins/terser-webpack-plugin/) to
 learn how. 
-* If you are not using a module bundler, use `UglifyJS` as a CLI tool or
+* If you are not using a module bundler, use `Terser` as a CLI tool or
 include it directly as a dependency to your application. The project 
-[documentation](https://github.com/mishoo/UglifyJS2) provides instructions.
+[documentation](https://github.com/terser-js/terser) provides instructions.
 
 ## Data compression
 


### PR DESCRIPTION
Webpac v4 now uses Terser as a default minification tool, not UglifyJS.

This updates a codelab to change mentions of UglifyJS to Terser.