### PR TITLE
Update codeowners so it's a much smaller list.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,18 +6,4 @@
 * @robdodson @samthor
 
 # Guide collections
-/content/accessible/ @robdodson
-/content/discoverable/ @ekharvey @AVGP
-/content/fast/ @addyosmani @housseindjirdeh @khempenius
-/content/installable/ @petele
-/content/reliable/ @jeffposnick
-/content/secure/ @kosamari
-
-# Build scripts
-/lib/ @TimvdLippe
-
-# Measure page
-/content/measure.html @ebidel @TimvdLippe
-
-# Preview server
-/server/ @ebidel
+/content/ @robdodson @Meggin


### PR DESCRIPTION
Changes proposed in this pull request:

- Scopes down the list of code owners to just rob, sam, and meggin.
