### PR TITLE
Remove Sam from default codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # Read more @ https://help.github.com/articles/about-code-owners/
 
 # Default owners for everything
-* @robdodson @samthor
+* @robdodson
 
 # Guide collections
 /content/ @robdodson @Meggin


### PR DESCRIPTION
- Cut down on spam by only having Rob as a default codeowner