### PR TITLE
Redirect to HTTPS by default

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,3 +12,9 @@
 # limitations under the License.
 
 runtime: nodejs10
+
+handlers:
+- url: /.*
+  script: auto
+  secure: always
+  redirect_http_response_code: 301


### PR DESCRIPTION
This should redirect incoming HTTP responses to HTTPS

Changes proposed in this pull request:
- Updated default handler in `app.yaml`

I gave this a quick test and it looks like it works, but please sanity check!