### PR TITLE
Fix path links in codelabs.

### DIFF
--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -43,7 +43,7 @@ this inline style tag.
       {{ content | safe }}
       {% if related_post %}
         {% ArticleNavigation {
-          back: '/' + path.slug + '/' + related_post,
+          back: '/' + related_post,
           backLabel: 'Return to article'
         } %}
       {% else %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Codelabs were including the learning path in the URL but all URLs should be flat now.