### PR TITLE
Remove audit IDs from guides. These live with lh docs now.

### DIFF
--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -8,9 +8,6 @@ description: |
   Native HTML elements such as <button> or <input> have keyboard accessibility
   built-in for free. If you're building custom interactive components, use
   tabindex to ensure that they're keyboard accessible.
-web_lighthouse:
-  - tabindex
-  - focusable-controls
 ---
 
 Native HTML elements such as `<button>` or `<input>` have keyboard accessibility

--- a/src/site/content/en/accessible/headings-and-landmarks/index.md
+++ b/src/site/content/en/accessible/headings-and-landmarks/index.md
@@ -7,10 +7,6 @@ date: 2018-11-18
 description: |
   By using the correct elements for headings and landmarks, you can dramatically
   improve the navigation experience for users of assitive technology.
-web_lighthouse:
-  - heading-levels
-  - use-landmarks
-  - bypass
 ---
 
 Screen readers have commands to quickly jump between headings or to specific

--- a/src/site/content/en/accessible/keyboard-access/index.md
+++ b/src/site/content/en/accessible/keyboard-access/index.md
@@ -10,9 +10,6 @@ description: |
   shortcuts to be more efficient and productive. Having a good keyboard
   navigation strategy for your application creates a better experience for
   everyone.
-web_lighthouse:
-  - visual-order-follows-dom
-  - offscreen-content-hidden
 ---
 
 Many different users rely on the keyboard to navigate applications — from users

--- a/src/site/content/en/accessible/labels-and-text-alternatives/index.md
+++ b/src/site/content/en/accessible/labels-and-text-alternatives/index.md
@@ -9,15 +9,6 @@ description: |
   elements must have proper labels or text alternatives. A label or text
   alternative gives an element its accessible name, one of the key properties
   for expressing element semantics in the accessibility tree.
-web_lighthouse: 
-  - label
-  - image-alt
-  - input-image-alt
-  - frame-title
-  - object-alt
-  - document-title
-  - button-name
-  - link-name
 ---
 
 In order for a screen reader to present a spoken UI to the user, meaningful

--- a/src/site/content/en/accessible/semantics-and-screen-readers/index.md
+++ b/src/site/content/en/accessible/semantics-and-screen-readers/index.md
@@ -9,7 +9,6 @@ description: |
   reader, knows what to announce to users? The answer is that these technologies
   rely on developers marking up their pages with semantic HTML. But what are
   semantics, and how do screen readers use them?
-web_lighthouse: N/A
 ---
 
 Have you ever stopped to wonder _how_ assistive technology, such as a screen

--- a/src/site/content/en/accessible/style-focus/index.md
+++ b/src/site/content/en/accessible/style-focus/index.md
@@ -8,7 +8,6 @@ description: |
   The focus indicator (often signified by a "focus ring") identifies the currently
   focused element. For users who are unable to use a mouse, this indicator is
   extremely important, as it acts as a stand-in for their mouse-pointer.
-web_lighthouse: N/A
 ---
 
 The focus indicator (often signified by a "focus ring") identifies the currently

--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -8,7 +8,6 @@ description: |
   By using the correct semantic HTML elements you may be able to meet most or
   all of your keyboard access needs. That means less time fiddling with
   tabindex, and more happy users!
-web_lighthouse: N/A
 ---
 
 By using the correct semantic HTML elements you may be able to meet most or all

--- a/src/site/content/en/accessible/what-is-accessibility/index.md
+++ b/src/site/content/en/accessible/what-is-accessibility/index.md
@@ -8,7 +8,6 @@ description: |
   An accessible site is one whose content can be accessed regardless of any
   user's impairments, and whose functionality can also be operated by the most
   diverse range of users possible.
-web_lighthouse: N/A
 ---
 
 An accessible site is one whose content can be accessed regardless of any user's

--- a/src/site/content/en/discoverable/fix-http-status-codes/index.md
+++ b/src/site/content/en/discoverable/fix-http-status-codes/index.md
@@ -8,8 +8,6 @@ description: |
   HTTP status codes indicate the response given by a server for a request to a
   URL. 4XX status codes signal to search engines that a page does not provide
   any content.
-web_lighthouse:
-  - http-status-code
 codelabs:
   - codelab-fix-sneaky-404
 ---

--- a/src/site/content/en/discoverable/fix-robot-errors/index.md
+++ b/src/site/content/en/discoverable/fix-robot-errors/index.md
@@ -7,8 +7,6 @@ date: 2018-11-05
 description: |
   The robots.txt file tells search engines which URLs of your site they can
   crawl. An invalid robots.txt file can cause problems with indexing.
-web_lighthouse:
-  - robots-txt
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/discoverable/fix-small-fonts/index.md
+++ b/src/site/content/en/discoverable/fix-small-fonts/index.md
@@ -10,8 +10,6 @@ description: |
   comfortable reading size. Mobile-friendly pages is a ranking factor for many
   search engines because users should be able to navigate your site on their
   mobile devices.
-web_lighthouse:
-  - font-size
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/discoverable/remove-browser-plugins/index.md
+++ b/src/site/content/en/discoverable/remove-browser-plugins/index.md
@@ -8,8 +8,6 @@ description: |
   Search engines often can't index content that requires browser plugins such as
   Java applets or Flash animations. Also, most mobile devices don't support
   plugins, and this can create frustrating experiences for mobile users.
-web_lighthouse:
-  - plugins
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/discoverable/tell-search-engine-canonical-url/index.md
+++ b/src/site/content/en/discoverable/tell-search-engine-canonical-url/index.md
@@ -9,8 +9,6 @@ description: |
   engines consider them duplicate versions of the same page. Providing
   search engines information about your preferred canonical URL helps search
   engines display the correct URL to users.
-web_lighthouse:
-  - canonical
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/discoverable/tell-search-translated-pages-equal/index.md
+++ b/src/site/content/en/discoverable/tell-search-translated-pages-equal/index.md
@@ -8,8 +8,6 @@ description: |
   If you have a page that's translated into multiple languages, add link
   elements with  hreflang attributes. This lets search engines know your page is
   translated, allowing them to display the correct language to users.
-web_lighthouse:
-  - hreflang
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/discoverable/write-descriptive-text/index.md
+++ b/src/site/content/en/discoverable/write-descriptive-text/index.md
@@ -11,8 +11,6 @@ description: |
   which in turn can increase your search traffic.
 web_lighthouse:
   - document-title
-  - meta-description
-  - link-text
 ---
 
 ## Why does this matter?

--- a/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
+++ b/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
@@ -8,7 +8,6 @@ description: |
   become interactive, faster. In this guide, learn how each of these techniques
   fit together but still can be used independently to achieve performance
   results.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/avoid-invisible-text/index.md
+++ b/src/site/content/en/fast/avoid-invisible-text/index.md
@@ -8,8 +8,6 @@ description: |
   browsers hide text until the font loads (the "flash of invisible text"). If
   you're optimizing for performance, you'll want to avoid the "flash of
   invisible text" and show content to users immediately using a system font.
-web_lighthouse:
-  - font-display
 date: 2018-11-05
 codelabs:
   - codelab-avoid-invisible-text

--- a/src/site/content/en/fast/chrome-ux-report-bigquery/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-bigquery/index.md
@@ -7,7 +7,6 @@ description: |
   In this guide, learn how to use BigQuery to write queries against the CrUX 
   dataset to extract insightful results about the state of user experiences on 
   the web.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
@@ -8,7 +8,6 @@ description: |
   dashboards on top of big data sources, like the Chrome UX Report In this
   guide, learn how to create your own custom CrUX Dashboard to track an origin's
   user experience.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/chrome-ux-report-pagespeed-insights/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-pagespeed-insights/index.md
@@ -7,7 +7,6 @@ description: |
   PageSpeed Insights (PSI) is a tool for web developers to understand what a
   page's performance is and how to improve it. In this guide, learn how to use
   PSI to extract insights from CrUX and better understand the user experience.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/chrome-ux-report/index.md
+++ b/src/site/content/en/fast/chrome-ux-report/index.md
@@ -7,7 +7,6 @@ description: |
   The Chrome UX Report (informally known as CrUX) is a public dataset of real
   user experience data on millions of websites. Unlike lab data, CrUX data
   actually comes from opted-in users in the field.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/codelab-preload-critical-assets/index.md
+++ b/src/site/content/en/fast/codelab-preload-critical-assets/index.md
@@ -6,8 +6,6 @@ authors:
 description: |
   In this codelab, learn how to improve the performance of a page by preloading
   and prefetching resources.
-web_lighthouse:
-  - uses-rel-preload
 date: 2018-04-24
 glitch: preload-critical-assets
 ---

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -6,9 +6,6 @@ authors:
 description: |
   Learn how to defer non-critical CSS with the goal of optimizing the Critical
   Rendering Path, and improve FCP (First Contentful Paint).
-web_lighthouse:
-  - unused-css-rules
-  - render-blocking-resources
 date: 2019-02-17
 ---
 

--- a/src/site/content/en/fast/discover-performance-opportunities-with-lighthouse/index.md
+++ b/src/site/content/en/fast/discover-performance-opportunities-with-lighthouse/index.md
@@ -9,7 +9,6 @@ description: |
   performance. Lighthouse gives you a report on how the page did. The report
   provides a score for each metric and a list of opportunities which, if you
   implement them, should make the page load faster.
-web_lighthouse: N/A
 ---
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) is a tool that

--- a/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
+++ b/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
@@ -6,7 +6,6 @@ author:
 description: |
   The best way to keep an eye on your performance budget is to automate it. Find
   out how to choose a tool that best fits your needs and current setup.
-web_lighthouse: N/A
 date: 2019-02-01
 codelabs:
   - codelab-setting-performance-budgets-with-webpack

--- a/src/site/content/en/fast/performance-budgets-101/index.md
+++ b/src/site/content/en/fast/performance-budgets-101/index.md
@@ -6,7 +6,6 @@ authors:
 description: |
   Good performance is rarely a side effect. Learn about performance budgets and
   how they can set you on track for success.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/fast/preload-critical-assets/index.md
+++ b/src/site/content/en/fast/preload-critical-assets/index.md
@@ -8,8 +8,6 @@ description: |
   server, parses the contents of the HTML file, and submits separate requests
   for any other external references. The critical request chain represents the
   order of resources that are prioritized and fetched by the browser.
-web_lighthouse:
-  - uses-rel-preload
 date: 2018-11-05
 codelabs:
   - codelab-preload-critical-assets

--- a/src/site/content/en/fast/reduce-javascript-payloads-with-code-splitting/index.md
+++ b/src/site/content/en/fast/reduce-javascript-payloads-with-code-splitting/index.md
@@ -8,8 +8,6 @@ description: |
   significantly. Instead of shipping all the JavaScript to your user as soon as
   the first page of your application is loaded, code-split your bundle into
   multiple "pieces" and only send what's necessary at the very beginning.
-web_lighthouse:
-  - bootup-time
 date: 2018-11-05
 codelabs:
   - codelab-code-splitting

--- a/src/site/content/en/fast/reduce-network-payloads-using-text-compression/index.md
+++ b/src/site/content/en/fast/reduce-network-payloads-using-text-compression/index.md
@@ -8,10 +8,6 @@ description: |
   There are two useful techniques that can be used to improve the performance of
   your web page, minification and data compression. Incorporating both of these
   techniques reduces payload sizes and in turn improves page load times.
-web_lighthouse:
-  - uses-text-compression
-  - unminified-css
-  - unminified-javascript
 codelabs:
   - codelab-text-compression
   - codelab-text-compression-brotli

--- a/src/site/content/en/fast/remove-unused-code/index.md
+++ b/src/site/content/en/fast/remove-unused-code/index.md
@@ -12,7 +12,6 @@ description: |
   allowing anyone to easily download and use over half a million public
   packages. But we often include libraries we're not fully utilizing. To fix
   this issue, analyze your bundle to detect unused code.
-web_lighthouse: N/A
 codelabs:
   - codelab-remove-unused-code
 ---

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -8,8 +8,6 @@ description: |
   inspected it in your dev tools, only to find out that GIF was really a video?
   There's a good reason for that. Animated GIFs can be downright huge! By
   converting large GIFs to videos, you can save big on users' bandwidth.
-web_lighthouse:
-  - efficient-animated-content
 date: 2018-11-05
 codelabs:
   - codelab-replace-gifs-with-video

--- a/src/site/content/en/fast/serve-images-webp/index.md
+++ b/src/site/content/en/fast/serve-images-webp/index.md
@@ -7,8 +7,6 @@ description: |
   WebP images are smaller than their JPEG and PNG counterparts - usually on the
   magnitude of a 25-35% reduction in filesize. This decreases page sizes and
   improves performance.
-web_lighthouse:
-  - uses-webp-images
 date: 2018-11-05
 codelabs:
   - codelab-serve-images-webp

--- a/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
+++ b/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
@@ -7,8 +7,6 @@ description: |
   We've all been there—you forgot to scale down an image before adding it to the
   page. The image looks fine, but it is wasting users' data and hurting page
   performance.
-web_lighthouse:
-  - uses-responsive-images
 date: 2018-11-05
 wf_blink_components: N/A
 codelabs:

--- a/src/site/content/en/fast/serve-responsive-images/index.md
+++ b/src/site/content/en/fast/serve-responsive-images/index.md
@@ -7,8 +7,6 @@ description: |
   Serving desktop-sized images to mobile devices can use 2–4x more data than
   needed. Instead of a "one-size-fits-all" approach to images, serve different
   image sizes to different devices.
-web_lighthouse:
-  - uses-responsive-images
 date: 2018-11-05
 codelabs:
   - codelab-specifying-multiple-slot-widths

--- a/src/site/content/en/fast/use-imagemin-to-compress-images/index.md
+++ b/src/site/content/en/fast/use-imagemin-to-compress-images/index.md
@@ -7,8 +7,6 @@ date: 2018-11-05
 description: |
   Uncompressed images bloat your pages with unnecessary bytes. Run Lighthouse to
   check for opportunities to improve page load by compressing images.
-web_lighthouse:
-  - uses-optimized-images
 codelabs:
   - codelab-imagemin-webpack
   - codelab-imagemin-gulp

--- a/src/site/content/en/fast/use-lazysizes-to-lazyload-images/index.md
+++ b/src/site/content/en/fast/use-lazysizes-to-lazyload-images/index.md
@@ -7,8 +7,6 @@ description: |
   Lazy loading is the strategy of loading resources as they are needed, rather
   than in advance. This approach frees up resources during the initial page load
   and avoids loading assets that are never used.
-web_lighthouse:
-  - offscreen-images
 date: 2018-11-05
 codelabs:
   - codelab-use-lazysizes-to-lazyload-images

--- a/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
+++ b/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
@@ -5,7 +5,6 @@ authors:
   - mihajlija
 description: |
   Define performance budgets with minimal setup and enforce them as part of your development workflow using bundlesize with Travis CI.
-web_lighthouse: N/A
 date: 2019-02-01
 ---
 

--- a/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
+++ b/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
@@ -6,7 +6,6 @@ authors:
 description: |
   You’ve done hard work to get fast, now make sure you stay fast by automating
   performance testing in Travis CI with Lighthouse Bot.
-web_lighthouse: N/A
 date: 2019-01-28
 ---
 

--- a/src/site/content/en/fast/your-first-performance-budget/index.md
+++ b/src/site/content/en/fast/your-first-performance-budget/index.md
@@ -6,7 +6,6 @@ authors:
 description: |
   Ensure your site loads fast with a step-by-step guide to defining thresholds
   for performance metrics that are meaningful for your site.
-web_lighthouse: N/A
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/installable/add-manifest/index.md
+++ b/src/site/content/en/installable/add-manifest/index.md
@@ -8,7 +8,6 @@ description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when 'installed' on the user's mobile
   device or desktop.
-web_lighthouse: N/A
 ---
 
 The web app manifest is a simple JSON file that tells the browser about your web

--- a/src/site/content/en/installable/discover-installable/index.md
+++ b/src/site/content/en/installable/discover-installable/index.md
@@ -9,7 +9,6 @@ description: |
   users device and run like other installed apps. Once installed, it's launched
   from the Start menu or app launcher, and run in an app window, without an
   address bar or tabs.
-web_lighthouse: N/A
 codelabs:
   - codelab-make-installable
 ---

--- a/src/site/content/en/lighthouse-accessibility/frame-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/frame-title/index.md
@@ -2,9 +2,9 @@
 layout: post
 title: Ensure IFrame and frame elements contain a non-empty title attribute
 description: |
-  Learn about document-title audit.
+  Learn about frame-title audit.
 web_lighthouse:
-  - document-title
+  - frame-title
 ---
 
 Screen reader users rely on frame titles to describe the contents of frames.

--- a/src/site/content/en/lighthouse-accessibility/offscreen-content-hidden/index.md
+++ b/src/site/content/en/lighthouse-accessibility/offscreen-content-hidden/index.md
@@ -29,31 +29,22 @@ the screen reader shouldn't announce hidden content.
 ## How to fix
 
 To hide offscreen content,
-remove the element containing that content from the tab order
-using `tabindex="-1"`.
+remove the element containing that content from the
+tab order by setting it to `display: none` or `visiblity: hidden`.
 
-<!--
-***Todo*** Ask Rob if `aria-hidden="true"` is also necessary to truly remove something.
--->
 For example:
 
-```html
-<button tabindex="-1">Can't reach me with the TAB key!</button>
+```css
+.remove-me {
+  visibility: hidden;
+}
 ```
 
-This removes an element from the natural tab order,
-but the element can still be
-focused by calling its `focus()` method.
+```html
+<button class="remove-me">Can't reach me with the TAB key!</button>
+```
 
-<div class="glitch-embed-wrap" style="height: 346px; width: 100%;">
-  <iframe
-    src="https://glitch.com/embed/#!/embed/tabindex-negative-one?path=index.html&previewSize=100&attributionHidden=true"
-    alt="tabindex-negative-one on Glitch"
-    style="height: 100%; width: 100%; border: 0;">
-  </iframe>
-</div>
-
-See also [Control focus with tabindex](/control-focus-with-tabindex).
+See also [Correctly set the visibility of offscreen content](/keyboard-access/#correctly-set-the-visibility-of-offscreen-content).
 
 ## More information
 

--- a/src/site/content/en/lighthouse-accessibility/use-landmarks/index.md
+++ b/src/site/content/en/lighthouse-accessibility/use-landmarks/index.md
@@ -4,6 +4,7 @@ title: Manually check landmark elements improve navigation
 description: |
   Learn about managed-focus audit.
 web_lighthouse:
+  - use-landmarks
   - managed-focus
 ---
 
@@ -23,18 +24,18 @@ For example:
 
 ```html
 <header role="banner">
-   <p>Put product name and logo here</p>
+  <p>Put product name and logo here</p>
 </header>
 <nav role="navigation">
-   <ul>
-      <li>Put navigation here</li>
-   </ul>
+  <ul>
+    <li>Put navigation here</li>
+  </ul>
 </nav>
 <main role="main">
-   <p>Put main content here</p>
+  <p>Put main content here</p>
 </main>
 <footer role="contentinfo">
-   <p>Put copyright, etc. here</p>
+  <p>Put copyright, etc. here</p>
 </footer>
 ```
 

--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -21,7 +21,8 @@ to lower [Time to Interactive](/interactive):
   </figcaption>
 </figure>
 
+See also [Lazy load offscreen images with lazysizes codelab](/codelab-use-lazysizes-to-lazyload-images).
+
 ## More information
 
 - [Defer offscreen images audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/offscreen-images.js)
-- [Lazy load offscreen images with lazysizes codelab](/codelab-use-lazysizes-to-lazyload-images)

--- a/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
+++ b/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
@@ -4,7 +4,7 @@ title: Avoid enormous network payloads
 description: |
   Learn about the total-byte-weight audit.
 web_lighthouse:
-  - font display
+  - total-byte-weight
 ---
 
 Large network payloads cost users real money and are highly correlated with long load times.

--- a/src/site/content/en/lighthouse-performance/unminified-css/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-css/index.md
@@ -80,3 +80,4 @@ Learn how to minify your CSS code in [Minify CSS](/minify-css).
 
 - [Unminified CSS audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/unminified-css.js)
 - [Minify CSS](/minify-css)
+- [Minify and compress network payloads](/reduce-network-payloads-using-text-compression)

--- a/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
@@ -84,6 +84,8 @@ as soon as possible.
 See [Can I Use link-rel-preload?](http://caniuse.com/#feat=link-rel-preload)
 to see browser support for preload links.
 
+See also [Preload critical assets to improve loading speed](/preload-critical-assets)
+
 ## More information
 
 - [Preload key requests audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/uses-rel-preload.js)

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -53,4 +53,4 @@ either when you upload an image, or request it from your page.
 ## More information
 
 - [Properly size images audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js)
-- [Serve images with correct dimensions codelab](/codelab-serve-images-correct-dimensions)
+- [Serve images with correct dimensions](/serve-images-with-correct-dimensions)

--- a/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
@@ -4,7 +4,7 @@ title: Enable text compression
 description: |
   Learn about the uses-text-compression audit.
 web_lighthouse:
-  - uses-text-conmpression
+  - uses-text-compression
 ---
 
 Text-based resources should be served with compression
@@ -85,6 +85,8 @@ See [Use large request rows](https://developers.google.com/web/tools/chrome-devt
 1. Look at the **Size** column for the response you're interested in. The
    top value is the compressed size. The bottom value is the de-compressed
    size.
+
+See also [Minify and compress network payloads](/reduce-network-payloads-using-text-compression).
 
 
 ## More information

--- a/src/site/content/en/reliable/http-cache/index.md
+++ b/src/site/content/en/reliable/http-cache/index.md
@@ -10,7 +10,6 @@ description: |
   lifetime of cached responses. But there are several rules of thumb that give
   you a sensible caching implementation without much work, so you should always
   try to follow them.
-web_lighthouse: N/A
 codelabs:
   - codelab-http-cache
 ---

--- a/src/site/content/en/reliable/identify-resources-via-network-panel/index.md
+++ b/src/site/content/en/reliable/identify-resources-via-network-panel/index.md
@@ -10,7 +10,6 @@ description: |
   application, the network can be subject to all kinds of dark forces. You need
   to understand the network's vulnerabilities if you hope to cope with them in
   your app.
-web_lighthouse: N/A
 codelabs:
   - codelab-explore-network-panel
 ---

--- a/src/site/content/en/reliable/network-connections-unreliable/index.md
+++ b/src/site/content/en/reliable/network-connections-unreliable/index.md
@@ -10,8 +10,6 @@ description: |
   users all across the world, but delivering a reliable experience on the web
   for all of your users can be challenging. It can be a challenge just to
   understand what reliability means.
-web_lighthouse: 
-  - works-offline
 ---
 
 The modern web is enjoyed by a wide swath of people, using a range of different

--- a/src/site/content/en/reliable/precache-with-workbox/index.md
+++ b/src/site/content/en/reliable/precache-with-workbox/index.md
@@ -9,7 +9,6 @@ description: |
   the service worker is installing. Precaching makes it possible to serve cached
   files to the browser without going to the network. Use precaching with Workbox
   for critical assets that your site needs even when offline.
-web_lighthouse: N/A
 ---
 
 One feature of service workers is the ability to save files to the cache when

--- a/src/site/content/en/reliable/runtime-caching-with-workbox/index.md
+++ b/src/site/content/en/reliable/runtime-caching-with-workbox/index.md
@@ -9,7 +9,6 @@ description: |
   While runtime caching doesn't help with the reliability of the current
   request, runtime caching with Workbox can help make future requests for the
   same URL more reliable.
-web_lighthouse: N/A
 ---
 
 Runtime caching refers to gradually adding responses to a cache "as you go".

--- a/src/site/content/en/reliable/service-workers-cache-storage/index.md
+++ b/src/site/content/en/reliable/service-workers-cache-storage/index.md
@@ -10,7 +10,6 @@ description: |
   lifetime of cached responses. But there are several rules of thumb that give
   you a sensible caching implementation without much work, so you should always
   try to follow them.
-web_lighthouse: N/A
 ---
 
 You're locked in a struggle for network reliability. The browser's HTTP cache is

--- a/src/site/content/en/reliable/workbox/index.md
+++ b/src/site/content/en/reliable/workbox/index.md
@@ -8,7 +8,6 @@ description: |
   Workbox is a high-level service worker toolkit built on top of the Service
   Worker and Cache Storage APIs. It provides a production-ready set of libraries
   for adding offline support to web apps.
-web_lighthouse: N/A
 ---
 
 Two APIs play a crucial role in building reliable web apps:

--- a/src/site/content/en/secure/browser-sandbox/index.md
+++ b/src/site/content/en/secure/browser-sandbox/index.md
@@ -8,7 +8,6 @@ description: |
   To defend against attacks, a developer needs to mitigate vulnerabilities and
   add security features to an application. Luckily, on the web, the browser
   provides many security features, including the idea of a "sandbox".
-web_lighthouse: N/A
 ---
 
 To defend against attacks, a developer needs to mitigate vulnerabilities and add

--- a/src/site/content/en/secure/cross-origin-resource-sharing/index.md
+++ b/src/site/content/en/secure/cross-origin-resource-sharing/index.md
@@ -10,7 +10,6 @@ description: |
   data, but it also prevents legitimate uses. What if you wanted to get weather
   data from another country? Enabling CORS lets the server tell the browser it's
   permitted to use an additional origin.
-web_lighthouse: N/A
 ---
 
 The browser's same-origin policy blocks reading a resource from a different

--- a/src/site/content/en/secure/same-origin-policy/index.md
+++ b/src/site/content/en/secure/same-origin-policy/index.md
@@ -9,7 +9,6 @@ description: |
   restriction on interactions between those resources, and if a script is
   compromised by an attacker, the script could expose everything on a user's
   browser.
-web_lighthouse: N/A
 codelabs:
   - codelab-same-origin-fetch
   - codelab-same-origin-iframe

--- a/src/site/content/en/secure/security-attacks/index.md
+++ b/src/site/content/en/secure/security-attacks/index.md
@@ -10,7 +10,6 @@ description: |
   features to their advantage to cause damage, it is called an attack. We'll
   take a look at different types of attacks in this guide so you know what to
   look for when securing your application.
-web_lighthouse: N/A
 ---
 
 An insecure application could expose users and systems to various types of

--- a/src/site/content/en/secure/security-not-scary/index.md
+++ b/src/site/content/en/secure/security-not-scary/index.md
@@ -8,7 +8,6 @@ description: |
   When the word "security" comes to mind, it's usually in the context of bad
   news. But security is something to be taken as a positive and necessary part
   of web development just like "user experience" or "accessibility".
-web_lighthouse: N/A
 ---
 
 What do you imagine when someone says "security"?


### PR DESCRIPTION
Since we have docs for all of the LH audits now, we can remove the audit IDs from learning path guides. Instead, the LH audit docs will refer out to the learning path guides. This way we have a consistent way for users to find an answer to why they failed a LH audit.