### PR TITLE
Add `alt` attribute to each image tag

### DIFF
--- a/src/site/content/en/fast/use-lazysizes-to-lazyload-images/index.md
+++ b/src/site/content/en/fast/use-lazysizes-to-lazyload-images/index.md
@@ -54,12 +54,12 @@ your pages:
 
 **Before:**
 ```html
-<img src="flower.jpg">
+<img src="flower.jpg" alt="">
 ```
 
 **After:**
 ```html
-<img data-src="flower.jpg" class="lazyload">
+<img data-src="flower.jpg" class="lazyload" alt="">
 ```
 
 When you update the `<img>` tag you make two changes:
@@ -77,7 +77,7 @@ When you update the `<img>` tag you make two changes:
 <picture>
   <source type="image/webp" srcset="flower.webp">
   <source type="image/jpeg" srcset="flower.jpg">
-  <img src="flower.jpg">
+  <img src="flower.jpg" alt="">
 </picture>
 ```
 
@@ -86,7 +86,7 @@ When you update the `<img>` tag you make two changes:
 <picture>
   <source type="image/webp" data-srcset="flower.webp">
   <source type="image/jpeg" data-srcset="flower.jpg">
-  <img data-src="flower.jpg" class="lazyload">
+  <img data-src="flower.jpg" class="lazyload" alt="">
 </picture>
 ```
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adding an `alt` attribute to each `img` tag within the article

More information:

Following a discussion we had on Twitter. I would like to propose the addition of a `alt` attribute to each instance of an image tag.
I know that this attribute is not related to the lazy-loading system described in this article but it could be a good practice to always display the alt attribute in tutorial.
This attribute is mandatory on an accessibility point-of-view to either provide a textual alternative or to declare the image as decorative with an empty alt.
Also, if the presence would trigger questions, we can always make a link to the article about this from the same platform:
https://web.dev/labels-and-text-alternatives/#include-text-alternatives-for-images-and-objects

For more information:
 - [the twitter thread](https://twitter.com/iamhiwelo/status/1125893686519324672)
 - [HTML5 Specification – 4.7.1.1. Requirements for providing text to act as an alternative for images](https://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#alt)
