### PR TITLE
enables customizing previewSize from front matter

### DIFF
--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -61,7 +61,7 @@ this inline style tag.
         <div class="glitch-embed-wrap" style="height: 100%; width: 100%;">
           <iframe
             allow="geolocation; microphone; camera; midi; encrypted-media"
-            src="https://glitch.com/embed/#!/embed/{{ glitch }}?path={{ path }}&amp;previewSize=0"
+            src="https://glitch.com/embed/#!/embed/{{ glitch }}?path={{ path }}&amp;previewSize={{ previewSize }}"
             alt="{{ glitch }} on Glitch"
             style="height: 100%; width: 100%; border: 0;"
           >

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -23,7 +23,7 @@ this inline style tag.
 {% endif %}
 
 <main class="codelab-landing-page">
-  <web-codelab glitch="{{ glitch }}" attribution-hidden>
+  <web-codelab glitch="{{ glitch }}" preview-size="{{ previewSize }}" attribution-hidden>
     <div class="web-codelab-instructions">
       <h1 class="w-headline w-headline--two w-mb--sm">{{ title }}</h1>
       <time class="w-author__published">{{date | prettyDate}}</time>


### PR DESCRIPTION
Adds the ability pass a previewsize to a codelab, giving the author the ability to control whether or not a preview is shown 👍 

Changes proposed in this pull request:
- accept a previewSize param from frontmatter