### PR TITLE
Added missing proxx github repo link

### DIFF
--- a/src/site/content/en/blog/proxx-announce/index.md
+++ b/src/site/content/en/blog/proxx-announce/index.md
@@ -126,6 +126,6 @@ Until then, please check the talk Mariko gave at I/O on this project.
   <iframe style="width:100%; height: 100%;position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);" src="https://www.youtube.com/embed/w8P5HLxcIO4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-You can browse the code at [proxx github repo](https://github.com/GoogleChromeLabs/proxx).
+You can browse the code at [the proxx github repo](https://github.com/GoogleChromeLabs/proxx).
 
 Cheers! Surma, Jake, Mariko

--- a/src/site/content/en/blog/proxx-announce/index.md
+++ b/src/site/content/en/blog/proxx-announce/index.md
@@ -126,4 +126,6 @@ Until then, please check the talk Mariko gave at I/O on this project.
   <iframe style="width:100%; height: 100%;position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);" src="https://www.youtube.com/embed/w8P5HLxcIO4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
+You can browse the code at [proxx github repo](https://github.com/GoogleChromeLabs/proxx).
+
 Cheers! Surma, Jake, Mariko


### PR DESCRIPTION
Changes proposed in this pull request:

- The [proxx anouncement blog](https://web.dev/proxx-announce/) didn't have the link of the github repo. I have added that to the blog.

---

👋 Thanks for submitting this PR! Please take a moment to let us know what's been added.

