### PR TITLE
Fix the usage of react-window-infinite-loader

### DIFF
--- a/src/site/content/en/react/virtualize-long-lists-react-window/index.md
+++ b/src/site/content/en/react/virtualize-long-lists-react-window/index.md
@@ -235,7 +235,8 @@ class App extends Component {
     super(props);
     this.state = {
       items: [], // instantiate initial list here
-      moreItemsLoading: false
+      moreItemsLoading: false,
+      hasNextPage: true
     };
 
     this.loadMore = this.loadMore.bind(this);
@@ -246,10 +247,15 @@ class App extends Component {
   }
 
   render() {
-    const { items, moreItemsLoading } = this.state;
+    const { items, moreItemsLoading, hasNextPage } = this.state;
 
     return (
-      <ListComponent items={items} moreItemsLoading={moreItemsLoading} loadMore={this.loadMore}/>
+      <ListComponent
+        items={items}
+        moreItemsLoading={moreItemsLoading}
+        loadMore={this.loadMore}
+        hasNextPage={hasNextPage}
+      />
     );
   }
 }
@@ -269,22 +275,24 @@ import React from 'react';
 import { FixedSizeList } from 'react-window';
 import InfiniteLoader from "react-window-infinite-loader";
 
-const ListComponent = ({ items, moreItemsLoading, loadMore }) => {
+const ListComponent = ({ items, moreItemsLoading, loadMore, hasNextPage }) => {
   const Row = ({ index, style }) => (
      {/* define the row component using items[index] */}
   );
 
+  const itemCount = hasNextPage ? items.length + 1 : items.length;
+
   return (
     <InfiniteLoader
-      isItemLoaded={index => index < items.length - 1}
-      itemCount={items.length}
+      isItemLoaded={index => index < items.length}
+      itemCount={itemCount}
       loadMoreItems={loadMore}
     >
       {({ onItemsRendered, ref }) => (
         <FixedSizeList
           height={500}
           width={500}
-          itemCount={items.length}
+          itemCount={itemCount}
           itemSize={120}
           onItemsRendered={onItemsRendered}
           ref={ref}


### PR DESCRIPTION
Fixes # . (Not mentioned in Issues)

Changes proposed in this pull request:

In https://web.dev/virtualize-long-lists-react-window/

- Fix the usage of InfiniteLoader

---

Thanks for the wonderful article which is useful in real use cases!
My proposal is about the usage of the library mentioned in the article which title is `Virtualize large lists with react-window`.

---

I think the usage of `react-window-infinite-loader` is wrong.

`itemCount` should be the size of the remote data. If it's unknown, it should be a larger value than the current value. The codes in the article didn't work well.

It is mentioned in the official readme.
https://github.com/bvaughn/react-window-infinite-loader#example-usage
https://github.com/bvaughn/react-window-infinite-loader#creating-an-infinite-loading-list
