### PR TITLE
Add Instruction shortcode.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,6 +35,7 @@ const Breadcrumbs = require(`./${componentsDir}/Breadcrumbs`);
 const CodelabsCallout = require(`./${componentsDir}/CodelabsCallout`);
 const Compare = require(`./${componentsDir}/Compare`);
 const Hero = require(`./${componentsDir}/Hero`);
+const Instruction = require(`./${componentsDir}/Instruction`);
 const PathCard = require(`./${componentsDir}/PathCard`);
 const PostCard = require(`./${componentsDir}/PostCard`);
 
@@ -121,6 +122,7 @@ module.exports = function(config) {
   config.addShortcode('CodelabsCallout', CodelabsCallout);
   config.addPairedShortcode('Compare', Compare);
   config.addShortcode('Hero', Hero);
+  config.addShortcode('Instruction', Instruction);
   config.addShortcode('PathCard', PathCard);
   config.addShortcode('PostCard', PostCard);
   config.addShortcode('ShareAction', ShareAction);

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -159,7 +159,7 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`
         ${shared.devtools}
         ${shared.audits}
-        ${bullet}Check the **SEO** checkbox.
+        ${bullet}Select the **SEO** checkbox.
         ${shared.runAudit}
       `;
       break;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -49,7 +49,7 @@ module.exports = (type, listStyle = 'ul') => {
 
   // These are common phrases shared across multiple instructions.
   const shared = {
-    devtools: `${bullet}Press \`CTRL + SHIFT + J\` or \`CMD + OPTION + J\` (Mac), to open DevTools.`,
+    devtools: `${bullet}Press \`Control+Shift+J\` (or \`Command+Option+J\` on Mac) to open DevTools.`,
     audits: `${bullet}Click the **Audits** tab.`,
     runAudit: `${bullet}Click **Run audits**.`,
   };

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -61,7 +61,7 @@ module.exports = (type, listStyle = 'ul') => {
 
     case 'console':
       instruction = html`
-        ${bullet}Click the **Tools** button.
+        ${bullet}Click **Tools**.
         ${bullet}Click the **Logs** button.
         ${bullet}Click the **Console** button.
       `;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -56,7 +56,7 @@ module.exports = (type, listStyle = 'ul') => {
 
   switch (type) {
     case 'remix':
-      instruction = `${bullet}Click the **Remix to Edit** button to make the project editable.`;
+      instruction = `${bullet}Click **Remix to Edit** to make the project editable.`;
       break;
 
     case 'console':

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -62,8 +62,8 @@ module.exports = (type, listStyle = 'ul') => {
     case 'console':
       instruction = html`
         ${bullet}Click **Tools**.
-        ${bullet}Click the **Logs** button.
-        ${bullet}Click the **Console** button.
+        ${bullet}Click **Logs**.
+        ${bullet}Click **Console**.
       `;
       break;
 
@@ -186,7 +186,7 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`
         ${shared.devtools}
         ${shared.audits}
-        ${bullet}Check the **Best practices** checkbox.
+        ${bullet}Select the **Best practices** checkbox.
         ${shared.runAudit}
       `;
       break;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -150,7 +150,7 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`
         ${shared.devtools}
         ${shared.audits}
-        ${bullet}Check the **Performance** checkbox.
+        ${bullet}Select the **Performance** checkbox.
         ${shared.runAudit}
       `;
       break;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -168,7 +168,7 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`
         ${shared.devtools}
         ${shared.audits}
-        ${bullet}Check the **Accessibility** checkbox.
+        ${bullet}Select the **Accessibility** checkbox.
         ${shared.runAudit}
       `;
       break;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+
+const {html} = require('common-tags');
+
+/**
+ * A component to help DRY up common lists of instructions.
+ * This helps ensure consistency in our docs and makes it easy
+ * to respond when Glitch changes their UI.
+ * @param {string} type The type of instruction to print.
+ * @param {string} listStyle The list style to use. Defaults to 'ul'.
+ * @return {string} A list of instructions.
+ */
+module.exports = (type, listStyle = 'ul') => {
+  let instruction;
+  let bullet;
+
+  switch (listStyle) {
+    case 'ol':
+      bullet = '1. ';
+      break;
+
+    case 'ul':
+      bullet = '- ';
+      break;
+
+    case 'none':
+      bullet = '';
+      break;
+
+    default:
+      throw new Error(`Could not create Instruction with listStyle: ${listStyle}`);
+  }
+
+  // These are common phrases shared across multiple instructions.
+  const shared = {
+    devtools: `${bullet}Press \`CTRL + SHIFT + J\` or \`CMD + OPTION + J\` (Mac), to open DevTools.`,
+    audits: `${bullet}Click the **Audits** tab.`,
+    runAudit: `${bullet}Click **Run audits**.`,
+  };
+
+  switch (type) {
+    case 'remix':
+      instruction = `${bullet}Click the **Remix to Edit** button to make the project editable.`;
+      break;
+
+    case 'console':
+      instruction = html`
+        ${bullet}Click the **Tools** button.
+        ${bullet}Click the **Logs** button.
+        ${bullet}Click the **Console** button.
+      `;
+      break;
+
+    case 'preview':
+      // Note: This uses an inline style on the image button instead of pulling
+      // from one of our CSS files. This is mainly because this style is only
+      // used by this component so it's a bit easier to keep everything
+      // contained in this one file.
+      instruction = html`
+        ${bullet}To preview the site, press the **View App** button, then press the <img src="/images/glitch/fullscreen.svg"
+          alt="fullscreen" style="padding: 4px 8px; opacity: .5; border: 1px solid #c3c3c3; border-radius: 5px;"> button.
+      `;
+      break;
+
+    case 'devtools':
+      instruction = html`${shared.devtools}`;
+      break;
+
+    case 'devtools-elements':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Elements** tab.
+      `;
+      break;
+
+    case 'devtools-console':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Console** tab.
+      `;
+      break;
+
+
+    case 'devtools-sources':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Sources** tab.
+      `;
+      break;
+
+    case 'devtools-network':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Network** tab.
+      `;
+      break;
+
+    case 'devtools-performance':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Performance** tab.
+      `;
+      break;
+
+    case 'devtools-memory':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Memory** tab.
+      `;
+      break;
+
+    case 'devtools-application':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Application** tab.
+      `;
+      break;
+
+    case 'devtools-security':
+      instruction = html`
+        ${shared.devtools}
+        ${bullet}Click the **Security** tab.
+      `;
+      break;
+
+    case 'devtools-audits':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+      `;
+      break;
+
+    case 'performance-audit':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+        ${bullet}Check the **Performance** checkbox.
+        ${shared.runAudit}
+      `;
+      break;
+
+    case 'seo-audit':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+        ${bullet}Check the **SEO** checkbox.
+        ${shared.runAudit}
+      `;
+      break;
+
+    case 'accessibility-audit':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+        ${bullet}Check the **Accessibility** checkbox.
+        ${shared.runAudit}
+      `;
+      break;
+
+    case 'pwa-audit':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+        ${bullet}Check the **Progressive Web App** checkbox.
+        ${shared.runAudit}
+      `;
+      break;
+
+    case 'best-practices-audit':
+      instruction = html`
+        ${shared.devtools}
+        ${shared.audits}
+        ${bullet}Check the **Best practices** checkbox.
+        ${shared.runAudit}
+      `;
+      break;
+
+    default:
+      throw new Error(`Could not find Instruction with type: ${type}`);
+  }
+  return instruction;
+};

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -177,7 +177,7 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`
         ${shared.devtools}
         ${shared.audits}
-        ${bullet}Check the **Progressive Web App** checkbox.
+        ${bullet}Select the **Progressive Web App** checkbox.
         ${shared.runAudit}
       `;
       break;

--- a/src/site/content/en/discoverable/codelab-fix-sneaky-404/index.md
+++ b/src/site/content/en/discoverable/codelab-fix-sneaky-404/index.md
@@ -27,7 +27,7 @@ fine!
 Unfortunately there is a subtle bug in the app. Let's take a look!
 
 {% Instruction 'preview' %}
-- Click on the link that says **Doggos**. Notice how the URL changed.
+- Click the **Doggos** link. Notice how the URL changed.
 - Refresh the page.
 
 You get a page with "`Cannot GET /doggos`" on it - a sneaky 404. It is "sneaky",
@@ -51,7 +51,7 @@ JavaScript. Let's fix the server, so it responds with index.html and the single
 page app will take care of the rest.
 
 {% Instruction 'remix' %}
-- Select the **server.js** file
+- Select the `server.js` file.
 
 This file contains the server code. It sets up an express.js server and sends
 the content of index.html. The route setup in line 15 only serves the web app

--- a/src/site/content/en/discoverable/codelab-fix-sneaky-404/index.md
+++ b/src/site/content/en/discoverable/codelab-fix-sneaky-404/index.md
@@ -26,8 +26,7 @@ fine!
 
 Unfortunately there is a subtle bug in the app. Let's take a look!
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Click on the link that says **Doggos**. Notice how the URL changed.
 - Refresh the page.
 
@@ -51,7 +50,7 @@ This project uses an [express.js](https://expressjs.com/) server written in
 JavaScript. Let's fix the server, so it responds with index.html and the single
 page app will take care of the rest.
 
-- Click the **Remix To Edit** button to make the project editable.
+{% Instruction 'remix' %}
 - Select the **server.js** file
 
 This file contains the server code. It sets up an express.js server and sends
@@ -71,8 +70,7 @@ app.get('/*', function(request, response) {
 The `/*` matches any URL and the server now responds with the web app in
 `index.html` for any given URL.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 Refreshing and opening the links in a new incognito window should now work as
 expected.

--- a/src/site/content/en/discoverable/pass-lighthouse-seo-audit/index.md
+++ b/src/site/content/en/discoverable/pass-lighthouse-seo-audit/index.md
@@ -8,7 +8,7 @@ description: |
   The Lighthouse SEO audit scans your page, tests for things that matter to
   search engines, and gives you a score so you can see specific areas for
   improvement. SEO matters because it's how you get more relevant users viewing
-  your content.  
+  your content.
 web_lighthouse: N/A
 ---
 
@@ -18,16 +18,14 @@ The Lighthouse SEO audit scans your page, tests for things that matter to search
 engines, and gives you a score so you can see specific areas for improvement.
 SEO matters because it's how you get more relevant users viewing your content.
 If a search engine has trouble seeing your page, you're possibly missing out on
-traffic sources. 
+traffic sources.
 
 ## Audit your page with Lighthouse
 
 Run Lighthouse on a page that's representative of content that you want a search
 engine to see:
 
-1. Navigate to the **Audits** panel in DevTools.
-1. Select the **SEO** checkbox.
-1. Click **Run Audits** to generate a report. 
+{% Instruction 'seo-audit', 'ol' %}
 
 Lighthouse generates a report for your page so you can see areas where you could
 improve SEO for your site. For more information, see [Discover performance
@@ -41,7 +39,7 @@ individual search engines, because they may have different requirements (for
 example,
 [Bing](https://www.bing.com/webmaster/help/webmaster-guidelines-30fba23a),
 [Google Search](https://support.google.com/webmasters/answer/35769),
-[Yandex](https://webmaster.yandex.com/). 
+[Yandex](https://webmaster.yandex.com/).
 
 There are also non-technical aspects that can improve visibility of your content
 in search engines, such as writing in the style of your target audience. Bottom

--- a/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
+++ b/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
@@ -27,9 +27,10 @@ used independently to achieve performance results.
 Run Lighthouse to identify opportunities for improvement aligned with the PRPL
 techniques:
 
-1. Navigate to the **Audits** panel in DevTools.
-2. Select the **Performance** and **Progressive Web App** checkboxes.
-3. Click **Run Audits** to generate a report.
+{% Instruction 'devtools', 'ol' %}
+1. Click on the **Audits** tab.
+1. Select the **Performance** and **Progressive Web App** checkboxes.
+1. Click **Run Audits** to generate a report.
 
 For more information, see [Discover performance opportunities with Lighthouse](/discover-performance-opportunities-with-lighthouse).
 

--- a/src/site/content/en/fast/avoid-invisible-text/index.md
+++ b/src/site/content/en/fast/avoid-invisible-text/index.md
@@ -133,9 +133,7 @@ Here are the changes you can expect to make in order to implement this:
 Run Lighthouse to verify the site is using `font-display: swap` to display
 text:
 
-1. Navigate to the **Audits** panel in DevTools.
-1. Select the **Performance** checkbox.
-1. Click **Run Audits** to generate a report.
+{% Instruction 'performance-audit', 'ol' %}
 
 Confirm this audit is passing: **Ensure text remains visible during webfont
 load**.

--- a/src/site/content/en/fast/avoid-invisible-text/index.md
+++ b/src/site/content/en/fast/avoid-invisible-text/index.md
@@ -135,5 +135,4 @@ text:
 
 {% Instruction 'performance-audit', 'ol' %}
 
-Confirm this audit is passing: **Ensure text remains visible during webfont
-load**.
+Confirm the **Ensure text remains visible during webfont load** audit is passing.

--- a/src/site/content/en/fast/codelab-adapt-video-to-image-serving-based-on-network-quality/index.md
+++ b/src/site/content/en/fast/codelab-adapt-video-to-image-serving-based-on-network-quality/index.md
@@ -143,10 +143,9 @@ if (navigator.connection.effectiveType === '4g') {
 
 To test it yourself:
 
-1. Mouse over the editor, click **App** button, then click **Show** to preview the app.
-2. Press `CTRL + SHIFT + J` or `CMD + OPTION + J` (Mac), to open DevTools.
-3. Click the **Network** tab.
-4. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
+{% Instruction 'preview', 'ol' %}
+{% Instruction 'devtools-network', 'ol' %}
+1. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
 
 <img class="w-screenshot" src="./devtools_network_throttling.png" alt='DevTools Network tab with Fast 3G throttling option highlighted'>
 
@@ -186,11 +185,10 @@ Here’s the final state of the [app on Glitch](https://glitch.com/~adaptive-ser
 
 To test it again:
 
-1. Mouse over the editor, click **App** button, then click **Show** to preview the app.
-2. Press `CTRL + SHIFT + J` or `CMD + OPTION + J` (Mac), to open DevTools.
-3. Click the **Network** tab.
-4. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
-5. Reload the page.
+{% Instruction 'preview', 'ol' %}
+{% Instruction 'devtools-network', 'ol' %}
+1. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
+1. Reload the page.
 
 The app will update the network information to **3g**:
 

--- a/src/site/content/en/fast/codelab-adapt-video-to-image-serving-based-on-network-quality/index.md
+++ b/src/site/content/en/fast/codelab-adapt-video-to-image-serving-based-on-network-quality/index.md
@@ -145,7 +145,7 @@ To test it yourself:
 
 {% Instruction 'preview', 'ol' %}
 {% Instruction 'devtools-network', 'ol' %}
-1. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
+1. Click the **Throttling** drop-down, which is set to **No throttling** by default. Select **Fast 3G**.
 
 <img class="w-screenshot" src="./devtools_network_throttling.png" alt='DevTools Network tab with Fast 3G throttling option highlighted'>
 
@@ -187,7 +187,7 @@ To test it again:
 
 {% Instruction 'preview', 'ol' %}
 {% Instruction 'devtools-network', 'ol' %}
-1. Click the **Throttling** dropdown, which is set to **No throttling** by default. Select **Fast 3G**.
+1. Click the **Throttling** drop-down, which is set to **No throttling** by default. Select **Fast 3G**.
 1. Reload the page.
 
 The app will update the network information to **3g**:

--- a/src/site/content/en/fast/codelab-art-direction/index.md
+++ b/src/site/content/en/fast/codelab-art-direction/index.md
@@ -13,8 +13,7 @@ related_post: serve-responsive-images
 
 ## Try out this demo
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Reload the app using different browser sizes. Notice how different the images
   are - they are not just different sizes but also different croppings and
   aspect ratios.

--- a/src/site/content/en/fast/codelab-art-direction/index.md
+++ b/src/site/content/en/fast/codelab-art-direction/index.md
@@ -15,7 +15,7 @@ related_post: serve-responsive-images
 
 {% Instruction 'preview' %}
 - Reload the app using different browser sizes. Notice how different the images
-  are - they are not just different sizes but also different croppings and
+  are: they're not only different sizes but also different croppings and
   aspect ratios.
 
 ## What's going on here?

--- a/src/site/content/en/fast/codelab-avoid-invisible-text/index.md
+++ b/src/site/content/en/fast/codelab-avoid-invisible-text/index.md
@@ -22,7 +22,7 @@ that detects when a font loads. The
 file has already been saved to the project directory, so you don't need to add it
 separately. However, you do need to add a script tag for it.
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 - Add a script tag for `fontfaceobserver.js` to `index.html`:
 
 ```html/1
@@ -158,8 +158,7 @@ html.fonts-loaded .text {
 
 ## Verify
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 If the page looks like this, then you've successfully implemented Font Face
 Observer and gotten rid of the "Flash of Invisible Text."

--- a/src/site/content/en/fast/codelab-code-splitting/index.md
+++ b/src/site/content/en/fast/codelab-code-splitting/index.md
@@ -30,10 +30,8 @@ Since webpack is used in this application, any changes made to the code will tri
 Like always, it's important to first measure how well a website performs before
 attempting to add any optimizations.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
--  Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
--  Click on the **Network** panel.
+{% Instruction 'preview' %}
+{% Instruction 'devtools-network' %}
 -  Make sure `Disable Cache` is checked and reload the app.
 
 <img class="w-screenshot" src="./codelab-code-splitting-3.png" alt="Network panel showing 71.2 KB JavaScript bundle.">

--- a/src/site/content/en/fast/codelab-code-splitting/index.md
+++ b/src/site/content/en/fast/codelab-code-splitting/index.md
@@ -30,8 +30,8 @@ Since webpack is used in this application, any changes made to the code will tri
 Like always, it's important to first measure how well a website performs before
 attempting to add any optimizations.
 
-{% Instruction 'preview' %}
-{% Instruction 'devtools-network' %}
+{% Instruction 'preview', 'ol' %}
+{% Instruction 'devtools-network', 'ol' %}
 -  Make sure `Disable Cache` is checked and reload the app.
 
 <img class="w-screenshot" src="./codelab-code-splitting-3.png" alt="Network panel showing 71.2 KB JavaScript bundle.">

--- a/src/site/content/en/fast/codelab-density-descriptors/index.md
+++ b/src/site/content/en/fast/codelab-density-descriptors/index.md
@@ -13,8 +13,7 @@ related_post: serve-responsive-images
 
 ## Explore This Demo
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Reload the page using different devices to see the browser load different
   images.
 

--- a/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
+++ b/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
@@ -24,10 +24,11 @@ To run a Lighthouse audit on this page:
 
 {% Instruction 'devtools', 'ol' %}
 1. Click the **Audits** tab. 
-1. Make sure the **Mobile** radio button is selected. 
-1. Make sure the **Performance** checkbox is enabled. You can disable the rest of the checkboxes in the Audits section.
-1. Make sure the **Simulated Fast 3G, 4x CPU Slowdown** radio button is selected. 
-1. Make sure that the **Clear Storage** checkbox is enabled. With this option selected, Lighthouse will not load resources from the cache, which simulates how first-time visitors would experience the page.
+1. Click **Mobile**.
+{% Instruction 'performance-audit', 'ol' %}
+1. Clear the rest of the checkboxes in the Audits section.
+1. Click **Simulated Fast 3G, 4x CPU Slowdown**. 
+1. Select the **Clear Storage** checkbox. With this option selected, Lighthouse will not load resources from the cache, which simulates how first-time visitors would experience the page.
 1. Click **Run Audits**. 
 
 ![Audits panel of Chrome DevTools, powered by Lighthouse](lighthouse-audits.png)

--- a/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
+++ b/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
@@ -18,24 +18,17 @@ This responsive ice cream gallery is built with [Bootstrap](https://getbootstrap
 
 ## Measure
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 To run a Lighthouse audit on this page:
 
-1. Press **Control+Shift+J** or **Command+Option+J** (Mac) to open DevTools.
-
-2. Click the **Audits** tab. 
-
-3. Make sure the **Mobile** radio button is selected. 
-
-4. Make sure the **Performance** checkbox is enabled. You can disable the rest of the checkboxes in the Audits section.
-
-5. Make sure the **Simulated Fast 3G, 4x CPU Slowdown** radio button is selected. 
-
-6. Make sure that the **Clear Storage** checkbox is enabled. With this option selected, Lighthouse will not load resources from the cache, which simulates how first-time visitors would experience the page.
-
-7. Click **Run Audits**. 
+{% Instruction 'devtools', 'ol' %}
+1. Click the **Audits** tab. 
+1. Make sure the **Mobile** radio button is selected. 
+1. Make sure the **Performance** checkbox is enabled. You can disable the rest of the checkboxes in the Audits section.
+1. Make sure the **Simulated Fast 3G, 4x CPU Slowdown** radio button is selected. 
+1. Make sure that the **Clear Storage** checkbox is enabled. With this option selected, Lighthouse will not load resources from the cache, which simulates how first-time visitors would experience the page.
+1. Click **Run Audits**. 
 
 ![Audits panel of Chrome DevTools, powered by Lighthouse](lighthouse-audits.png)
 
@@ -50,7 +43,7 @@ Lighthouse is here to help you fix performance issues, so look for solutions in 
 
 ## Optimize
 
-Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 
 To speed things up, Critical is already installed and an empty configuration file is included in the codelab.
 

--- a/src/site/content/en/fast/codelab-imagemin-grunt/index.md
+++ b/src/site/content/en/fast/codelab-imagemin-grunt/index.md
@@ -17,7 +17,7 @@ This Glitch already contains `grunt`, `grunt-cli`, and the `grunt-contrib-imagem
 plugin. To add the configuration for Imagemin, you'll need to edit your 
 `gruntfile.js` file.
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 - In `gruntfile.js`, replace the `//Add configuration here` comment  
 with this code block:
 
@@ -229,8 +229,7 @@ Lastly, it's a good idea to use Lighthouse to verify the changes that you just
 made. Lighthouse's "Efficiently encode images" performance audit will let you
 know if the JPEG images on your page are optimally compressed.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Run the Lighthouse performance audit (Lighthouse > Options > Performance) on
   the live version of your Glitch and verify that the "Efficiently encode
   images" audit was passed.

--- a/src/site/content/en/fast/codelab-imagemin-gulp/index.md
+++ b/src/site/content/en/fast/codelab-imagemin-gulp/index.md
@@ -16,7 +16,7 @@ related_post: use-imagemin-to-compress-images
 This Glitch already contains `gulp`, `gulp-cli`, and the `gulp-imagemin` plugin.
 To add the configuration for Imagemin, you'll need to edit your `gulpfile.js` file.
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 - First, initialize the `gulp-imagemin` plugin by adding this code at the top of 
 `gulpfile.js`:
 
@@ -184,8 +184,7 @@ made.
 Lighthouse's "Efficiently encode images" performance audit can let you know if
 the JPEG images on your page are optimally compressed.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Run the Lighthouse performance audit (Lighthouse > Options > Performance) on
   the live version of your Glitch and verify that the "Efficiently encode
   images" audit was passed.

--- a/src/site/content/en/fast/codelab-imagemin-webpack/index.md
+++ b/src/site/content/en/fast/codelab-imagemin-webpack/index.md
@@ -1,6 +1,6 @@
 ---
 layout: codelab
-title: Using Imagemin with Webpack
+title: Using Imagemin with webpack
 authors:
   - katiehempenius
 date: 2018-11-05
@@ -11,7 +11,7 @@ glitch: imagemin-webpack
 related_post: use-imagemin-to-compress-images
 ---
 
-## Setup the Imagemin Webpack plugin
+## Setup the Imagemin webpack plugin
 
 This Glitch already contains `webpack`, `webpack-cli`, and 
 `imagemin-webpack-plugin`. To add the configuration for Imagemin, you'll need
@@ -21,7 +21,7 @@ The existing `webpack.config.js` for this project has been copying images from
 the `images/` directory to the `dist/` directory but it hasn't been
 compressing them.
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 
 {% Aside %}
 Why would you copy images to a new `dist/` folder? `dist/` is short for
@@ -38,7 +38,7 @@ const ImageminPlugin = require('imagemin-webpack-plugin').default;
 ```
 
 - Next, add the following code as the last item in the `plugins[]` array. This
-adds Imagemin to the list of plugins that Webpack uses:
+adds Imagemin to the list of plugins that webpack uses:
 
 ```javascript
 new ImageminPlugin()
@@ -74,31 +74,30 @@ module.exports = {
 }
 ```
 
-You now have a Webpack config that compresses images using Imagemin.
+You now have a webpack config that compresses images using Imagemin.
 
-## Run Webpack
+## Run webpack
 
-1. Click the **Tools** button.
-1. Then click the **Console** button.
-1. To compress your images, run Webpack by typing the following command into the 
+{% Instruction 'console' %}
+1. To compress your images, run webpack by typing the following command into the 
 console:
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```
 webpack --config webpack.config.js --mode development
-</pre>
+```
 
-But what happens if you run Webpack in production mode?
+But what happens if you run webpack in production mode?
 
-- Re-run Webpack, but this time in production mode:
+- Re-run webpack, but this time in production mode:
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```
 webpack --config webpack.config.js --mode production
-</pre>
+```
 
-This time around, Webpack displays a warning letting you know that your PNG
+This time around, webpack displays a warning letting you know that your PNG
 files, in spite of some compression, still exceed the recommended size limit.
-(Webpack's `development` & `production` modes prioritize different things, which
-is why you only see this warning while running Webpack in production mode.)
+(webpack's `development` & `production` modes prioritize different things, which
+is why you only see this warning while running webpack in production mode.)
 
 Customize our Imagemin configuration to fix this warning.
 
@@ -170,7 +169,7 @@ new ImageminPlugin({
 })
 ```
 
-This code tells Webpack to compress JPGs to a quality of 50 (0 is the worst;
+This code tells webpack to compress JPGs to a quality of 50 (0 is the worst;
 100 is the best) using the Mozjpeg plugin.
 
 {% Aside %}
@@ -216,25 +215,24 @@ module.exports = {
 }
 ```
 
-## Re-run Webpack & verify results with Lighthouse
+## Re-run webpack & verify results with Lighthouse
 
-- In the console, re-run Webpack:
+- In the console, re-run webpack:
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```
 webpack --config webpack.config.js --mode production
-</pre>
+```
 
-Hooray! Your changes should have fixed the Webpack warnings.
+Hooray! Your changes should have fixed the webpack warnings.
 
-Webpack warns you about large images, but it can't tell you if images are
+webpack warns you about large images, but it can't tell you if images are
 uncompressed or undercompressed. This is why it's always a good idea to use
 Lighthouse to verify your changes.
 
 Lighthouse's "Efficiently encode images" performance audit can let you know if
 the JPEG images on your page are optimally compressed.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 - Run the Lighthouse performance audit (**Lighthouse > Options > Performance**)
   on the live version of your Glitch and verify that the **Efficiently encode
   images** audit was passed.

--- a/src/site/content/en/fast/codelab-imagemin-webpack/index.md
+++ b/src/site/content/en/fast/codelab-imagemin-webpack/index.md
@@ -11,7 +11,7 @@ glitch: imagemin-webpack
 related_post: use-imagemin-to-compress-images
 ---
 
-## Setup the Imagemin webpack plugin
+## Set up the Imagemin webpack plugin
 
 This Glitch already contains `webpack`, `webpack-cli`, and 
 `imagemin-webpack-plugin`. To add the configuration for Imagemin, you'll need
@@ -215,7 +215,7 @@ module.exports = {
 }
 ```
 
-## Re-run webpack & verify results with Lighthouse
+## Re-run webpack and verify results with Lighthouse
 
 - In the console, re-run webpack:
 

--- a/src/site/content/en/fast/codelab-preload-critical-assets/index.md
+++ b/src/site/content/en/fast/codelab-preload-critical-assets/index.md
@@ -19,8 +19,7 @@ by preloading and prefetching a few resources:
 
 First measure how the website performs before adding any optimizations.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 Run the Lighthouse performance audit (**Lighthouse > Options > Performance**) on
 the live version of your Glitch (see also
@@ -31,8 +30,7 @@ late:
 
 <img class="w-screenshot" src="./preload-requests-codelab.png" alt="Lighthouse: Preload key requests audit">
 
-Open the **Network** panel in DevTools and take a look at all the resources that
-are fetched.
+{% Instruction 'devtools-network' %}
 
 <img class="w-screenshot" src="./network-panel-one.png" alt="Network panel with late-discovered resource">
 

--- a/src/site/content/en/fast/codelab-preload-web-fonts/index.md
+++ b/src/site/content/en/fast/codelab-preload-web-fonts/index.md
@@ -16,12 +16,8 @@ any flash of unstyled text (FOUT).
 ## Measure
 
 First measure how the website performs before adding any optimizations.
-1. To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
-2. Open DevTools by pressing `CMD + OPTION + i `/ `CTRL + SHIFT + i`.
-3. Click on the **Audits** panel.
-4. Select the **Performance** checkbox.
-5. Click **Run Audits** to generate a report.
+{% Instruction 'preview', 'ol' %}
+{% Instruction 'performance-audit', 'ol' %}
 
 The Lighthouse report that is generated will show you the fetching sequence of resources under **Maximum critical path latency**.
 

--- a/src/site/content/en/fast/codelab-remove-unused-code/index.md
+++ b/src/site/content/en/fast/codelab-remove-unused-code/index.md
@@ -27,16 +27,14 @@ should see your changes reflected in the application.
 It's always a good idea to first measure how well a website performs before
 adding optimizations.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 Go ahead and click on your favorite kitten! Firebase's
 [Realtime Database](https://firebase.google.com/products/realtime-database/) is
 used in this application which is why the score updates in real-time and is
 synchronized with every other person using the application. 🐈
 
-- Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
-- Click on the **Network** tab.
+{% Instruction 'devtools-network' %}
 
 <img class="w-screenshot" src="./network.png" alt="Network tab">
 

--- a/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
+++ b/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
@@ -35,7 +35,7 @@ as well.
 
 ## Open the console
 
-Double-check that FFmpeg is installed and working.
+Double-check that FFmpeg is installed and working:
 
 {% Instruction 'remix', 'ol' %}
 {% Instruction 'console', 'ol' %}

--- a/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
+++ b/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
@@ -18,12 +18,8 @@ video.
 
 First measure how the website performs:
 
-1. To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
-1. Open Chrome DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`
-1. Click on the **Audits** panel.
-1. Select the **Performance** checkbox.
-1. Click **Run Audits** to generate a report.
+{% Instruction 'preview', 'ol' %}
+{% Instruction 'performance-audit', 'ol' %}
 
 When you're finished, you should see that Lighthouse has flagged the GIF as an
 issue in its "Use video formats for animated content" audit.
@@ -41,9 +37,8 @@ as well.
 
 Double-check that FFmpeg is installed and working.
 
-1. Click the **Remix to Edit** button to make the project editable.
-1. Click the **Tools** button.
-1. Click the **Console** button.
+{% Instruction 'remix', 'ol' %}
+{% Instruction 'console', 'ol' %}
 1. In the console, run:
 
 ```bash
@@ -161,17 +156,14 @@ instead. If you prefer a WebM `<source>` be used first, specify it first!
 
 ## Preview
 
--  Preview the site using the **Show** button.
+{% Instruction 'preview' %}
 
 The experience should look the same. So far so good.  
 
 ## Verify with Lighthouse
 
 With the live site open:
-1. Open Chrome DevTools.
-1. Click on the **Audits** tab.
-1. Check the **Performance** checkbox.
-1. Click **Run audits**.
+{% Instruction 'performance-audit', 'ol' %}
 
 You should see that the "Use video formats for animated content" audit is now
 passing! Woohoo! 💪

--- a/src/site/content/en/fast/codelab-serve-images-correct-dimensions/index.md
+++ b/src/site/content/en/fast/codelab-serve-images-correct-dimensions/index.md
@@ -16,8 +16,7 @@ related_post: serve-images-with-correct-dimensions
 This Glitch is small enough that its images could be inspected by hand. However
 for most websites, using a tool like Lighthouse to automate this is essential.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 - Run the Lighthouse performance audit (**Lighthouse > Options > Performance**)
   and look for the results of the **Properly Size Images** audit.
@@ -50,10 +49,9 @@ to match. You can use [ImageMagick](https://www.imagemagick.org) to resize the
 image to fit. ImageMagick is a CLI tool for image editing that comes
 pre-installed in the codelab environment.
 
-- Click the **Remix to Edit** button to make the project editable.
-- Click the **Tools** button.
-- Click the **Console** button.
-- In the console, type:
+{% Instruction 'remix', 'ol' %}
+{% Instruction 'console', 'ol' %}
+1. In the console, type:
 
 ```
 convert flower_logo.png -resize 50x50 flower_logo.png

--- a/src/site/content/en/fast/codelab-serve-images-webp/index.md
+++ b/src/site/content/en/fast/codelab-serve-images-webp/index.md
@@ -17,10 +17,9 @@ converts JPG, PNG, and TIFF images to WebP.
 
 ## Convert images to WebP
 
-- Click the **Remix to Edit** button to make the project editable.
-- Click the **Tools** button.
-- Click the **Console** button.
-- Type the following command:
+{% Instruction 'remix', 'ol' %}
+{% Instruction 'console', 'ol' %}
+1. Type the following command:
 
 ```bash
 cwebp -q 50 images/flower1.jpg -o images/flower1.webp
@@ -135,8 +134,7 @@ site.
 Lighthouse's **Serve images in next-gen formats** performance audit can let you
 know if all the images on your site are using next-gen formats like WebP.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 - Run the Lighthouse performance audit (**Lighthouse > Options > Performance**)
   on the live version of your app and verify that the **Serve images in next-gen

--- a/src/site/content/en/fast/codelab-serve-modern-code/index.md
+++ b/src/site/content/en/fast/codelab-serve-modern-code/index.md
@@ -30,10 +30,8 @@ image.
 It's always a good idea to begin by inspecting a website before adding any
 optimizations.
 
-+ To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
-+ Open DevTools by pressing `CTRL + SHIFT + i` / `CMD + OPTION + i`.
-+ Click on the **Network** panel.
+{% Instruction 'preview' %}
+{% Instruction 'devtools-network' %}
 
 <img class="w-screenshot" src="./network-panel.png" alt="Network panel">
 

--- a/src/site/content/en/fast/codelab-setting-performance-budgets-with-webpack/index.md
+++ b/src/site/content/en/fast/codelab-setting-performance-budgets-with-webpack/index.md
@@ -31,8 +31,7 @@ This codelab already contains the app bundled with webpack.
 
 {% Instruction 'remix', 'ol' %}
 {% Instruction 'console', 'ol' %}
-1. To get a color-coded list of assets and their sizes, in the console
-   type:
+1. To get a color-coded list of assets and their sizes, type `webpack` in the console.
 
 ```bash
 webpack

--- a/src/site/content/en/fast/codelab-setting-performance-budgets-with-webpack/index.md
+++ b/src/site/content/en/fast/codelab-setting-performance-budgets-with-webpack/index.md
@@ -29,10 +29,9 @@ It’s built with [React](https://reactjs.org/) and [moment.js](https://momentjs
 
 This codelab already contains the app bundled with webpack.
 
-1. To start, click the **Remix to Edit** button to make the project editable.
-2. Click the **Tools** button.
-3. Then click the **Console** button. It will open the Console in another tab.
-4. To get a color-coded list of assets and their sizes, in the console
+{% Instruction 'remix', 'ol' %}
+{% Instruction 'console', 'ol' %}
+1. To get a color-coded list of assets and their sizes, in the console
    type:
 
 ```bash

--- a/src/site/content/en/fast/codelab-specifying-multiple-slot-widths/index.md
+++ b/src/site/content/en/fast/codelab-specifying-multiple-slot-widths/index.md
@@ -13,8 +13,7 @@ related_post: serve-responsive-images
 
 ## Try out this demo
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 - Reload the app in different sized browser windows to see the browser load
 different images and use different layouts at different browser sizes.

--- a/src/site/content/en/fast/codelab-specifying-multiple-slot-widths/index.md
+++ b/src/site/content/en/fast/codelab-specifying-multiple-slot-widths/index.md
@@ -15,7 +15,7 @@ related_post: serve-responsive-images
 
 {% Instruction 'preview' %}
 
-- Reload the app in different sized browser windows to see the browser load
+- Reload the app in differently sized browser windows to see the browser load
 different images and use different layouts at different browser sizes.
 
 ## View the code

--- a/src/site/content/en/fast/codelab-text-compression-brotli/index.md
+++ b/src/site/content/en/fast/codelab-text-compression-brotli/index.md
@@ -32,9 +32,8 @@ application.
 Before diving in to add optimizations, it's always a good idea to first analyze
 the current state of the application.
 
-1. Click the **Remix to Edit** button to make the project editable.
-1. To preview the site, mouse over the editor, press the **App** button, then
-   the **Show** button.
+{% Instruction 'remix', 'ol' %}
+{% Instruction 'preview', 'ol' %}
 
 In the previous [Minify and compress network payloads
 codelab](/codelab-text-compression),

--- a/src/site/content/en/fast/codelab-text-compression/index.md
+++ b/src/site/content/en/fast/codelab-text-compression/index.md
@@ -29,8 +29,7 @@ the app's request size.
 Before diving in to add optimizations, it's always a good idea to first analyze
 the current state of the application.
 
-+ To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 This app, which was also covered in the ["Remove unused
 code"](/remove-unused-code) codelab, lets you vote for your favorite
@@ -38,8 +37,7 @@ kitten. 🐈
 
 Now take a look at how large this application is:
 
-+  Open the DevTools by pressing `Command+Option+i / Ctrl+Shift+i`.
-+  Click on the **Network** panel.
+{% Instruction 'devtools-network' %}
 
 <img class="w-screenshot" src="./network-tab.png" alt="Network panel">
 

--- a/src/site/content/en/fast/codelab-use-lazysizes-to-lazyload-images/index.md
+++ b/src/site/content/en/fast/codelab-use-lazysizes-to-lazyload-images/index.md
@@ -21,7 +21,7 @@ makes this a very simple strategy to implement.
 
 ## Add the lazysizes script to the page
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 
 `lazysizes.min.js` has already been downloaded and added to this Glitch. To
 include it in the page:
@@ -72,8 +72,7 @@ than the browser.
 
 That's it! To see these changes in action, follow these steps:
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 - Open the console and find the images that were just added. Their classes
   should change from `lazyload` to `lazyloaded` as you scroll down the page.
@@ -91,7 +90,7 @@ Lastly, it's a good idea to use Lighthouse to verify these changes. Lighthouse's
 "Defer offscreen images" performance audit will indicate if you've forgotten to
 add lazy loading to any offscreen images.
 
-- Preview the site with the **Show** button.
+{% Instruction 'preview' %}
 
 - Run the Lighthouse performance audit (Lighthouse > Options > Performance) on
   the live version of your Glitch and verify that the "Defer offscreen images"

--- a/src/site/content/en/fast/discover-performance-opportunities-with-lighthouse/index.md
+++ b/src/site/content/en/fast/discover-performance-opportunities-with-lighthouse/index.md
@@ -44,7 +44,7 @@ the Google Chrome browser. You don't have to download anything to get DevTools.
 If you have Chrome, then you have DevTools.
 
 1. In Chrome, go to the page that you want to audit.
-1. Press `Control+Shift+J` or `Command+Option+J` (Mac) to open DevTools.
+{% Instruction 'devtools', 'ol' %}
 
 <img class="w-screenshot w-screenshot--filled" src="./discover-performance-opportunities-with-lighthouse-1.png" alt="DevTools opened and docked to the right hand side of the screen.">
 

--- a/src/site/content/en/fast/minify-css/index.md
+++ b/src/site/content/en/fast/minify-css/index.md
@@ -160,7 +160,8 @@ To inspect the size and content of the files:
 
 {% Instruction 'devtools-network', 'ol' %}
 1. Click the **CSS** filter.
-1. Make sure **Disable Cache** is checked and reload the page.
+1. Select the **Disable cache** checkbox if it isn't already.
+1. Reload the page.
 
 <img class="w-screenshot" width="700px" height="120px" src="./cdt-css-optimized.png" alt="DevTools CSS unoptimized response">
 

--- a/src/site/content/en/fast/minify-css/index.md
+++ b/src/site/content/en/fast/minify-css/index.md
@@ -67,8 +67,8 @@ The resulting report shows that up to **16KB** can be saved from the **animate.c
 Now you'll inspect the content of the CSS:
 
 1. Open the [Fav Kitties site](https://fav-kitties-animated.glitch.me/) in Chrome (it might take a while for Glitch servers to respond the first time).
-1. Press `Control+Shift+J` or `Cmd+Option+J` (Mac), to open DevTools.
-1. Click on the **Network** panel and filter for **CSS**.
+{% Instruction 'devtools-network', 'ol' %}
+1. Click the **CSS** filter.
 1. Make sure **Disable Cache** is checked and reload the page.
 
 <img class="w-screenshot" width="700px" height="120px" src="./cdt-css-unoptimized.png" alt="DevTools CSS unoptimized trace">
@@ -150,13 +150,17 @@ Next, you'll check the result of this optimization with performance tools.
 
 ## Verify
 
-Click **Show live** and then, **In New Window**, to open your optimized app in a new window. If you got lost in any previous step, you can click [here](https://fav-kitties-animated-min.glitch.me/), to open an optimized version of the site.
+{% Instruction 'preview' %}
+
+If you got lost in any previous step, you can click
+[here](https://fav-kitties-animated-min.glitch.me/), to open an optimized
+version of the site.
 
 To inspect the size and content of the files:
 
-1. Open DevTools.
-1. Click in the **Network** panel and filter for “CSS”.
-1. Make sure "Disable Cache" is checked and reload the page.
+{% Instruction 'devtools-network', 'ol' %}
+1. Click the **CSS** filter.
+1. Make sure **Disable Cache** is checked and reload the page.
 
 <img class="w-screenshot" width="700px" height="120px" src="./cdt-css-optimized.png" alt="DevTools CSS unoptimized response">
 

--- a/src/site/content/en/fast/minify-css/index.md
+++ b/src/site/content/en/fast/minify-css/index.md
@@ -64,12 +64,13 @@ The resulting report shows that up to **16KB** can be saved from the **animate.c
 
 <img class="screenshot" width="700px" height="150px" src="./lighthouse-unoptimized.png" alt="Lighthouse - Minify CSS opportunity.">
 
-Now you'll inspect the content of the CSS:
+Now inspect the content of the CSS:
 
-1. Open the [Fav Kitties site](https://fav-kitties-animated.glitch.me/) in Chrome (it might take a while for Glitch servers to respond the first time).
+1. Open the [Fav Kitties site](https://fav-kitties-animated.glitch.me/) in Chrome. (It might take a while for Glitch servers to respond the first time.)
 {% Instruction 'devtools-network', 'ol' %}
 1. Click the **CSS** filter.
-1. Make sure **Disable Cache** is checked and reload the page.
+1. Select the **Disable cache** checkbox.
+1. Reload the page.
 
 <img class="w-screenshot" width="700px" height="120px" src="./cdt-css-unoptimized.png" alt="DevTools CSS unoptimized trace">
 

--- a/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
+++ b/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
@@ -38,8 +38,9 @@ kitty](https://glitch.com/edit/#!/scarce-pixie).
 ## Set the performance budget
 
 [This Glitch](https://glitch.com/edit/#!/scarce-pixie) already contains
-bundlesize. To start, click the **Remix to Edit** button to make the project
-editable.
+bundlesize.
+
+{% Instruction 'remix' %}
 
 The main bundle of this app is in the public folder. To test its size, add the
 following section to the `package.json` file:

--- a/src/site/content/en/images/glitch/fullscreen.svg
+++ b/src/site/content/en/images/glitch/fullscreen.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="15" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.08 13.957H1V11M11 1h3.08v2.957M1.467 13.515l3.13-3.106m5.87-5.894l3.13-3.106M10.92 13.957H14V11M4 1H.92v2.957m12.613 9.558l-3.13-3.106m-5.87-5.894L1.403 1.41" stroke="#000" stroke-width="1.5" fill="none" stroke-linecap="square" stroke-linejoin="round"/>
+</svg>

--- a/src/site/content/en/installable/codelab-make-installable/index.md
+++ b/src/site/content/en/installable/codelab-make-installable/index.md
@@ -31,7 +31,7 @@ that the Progressive Web App can be installed and an install button can be shown
 to the user. The `beforeinstallprompt` event is fired when the PWA meets the
 criteria for installability.
 
-1. Click the **Remix To Edit** button to make the project editable.
+{% Instruction 'remix', 'ol' %}
 1. Add a `beforeinstallprompt` event handler to the `window` object.
 1. Save the `event` as a global variable, we'll need it later to show the
     prompt.

--- a/src/site/content/en/installable/codelab-make-installable/index.md
+++ b/src/site/content/en/installable/codelab-make-installable/index.md
@@ -33,7 +33,7 @@ criteria for installability.
 
 {% Instruction 'remix', 'ol' %}
 1. Add a `beforeinstallprompt` event handler to the `window` object.
-1. Save the `event` as a global variable, we'll need it later to show the
+1. Save the `event` as a global variable; we'll need it later to show the
     prompt.
 1. Unhide the install button.
 

--- a/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
@@ -65,7 +65,7 @@ for examples.
 
 To check if a server compressed a response:
 
-1. Go to the **Network** panel in DevTools.
+{% Instruction 'devtools-network', 'ol' %}
 1. Click the request that caused the response you're interested in.
 1. Click the **Headers** tab.
 1. Check the `content-heading` header in the **Response Headers** section.
@@ -79,7 +79,7 @@ To check if a server compressed a response:
 
 To compare the compressed and de-compressed sizes of a response:
 
-1. Go to the **Network** panel.
+{% Instruction 'devtools-network', 'ol' %}
 1. Enable large request rows.
 See [Use large request rows](https://developers.google.com/web/tools/chrome-devtools/network/reference#request-rows).
 1. Look at the **Size** column for the response you're interested in. The

--- a/src/site/content/en/react/add-manifest-react/index.md
+++ b/src/site/content/en/react/add-manifest-react/index.md
@@ -87,7 +87,7 @@ To find out if all the properties are working correctly in this example:
 {% Instruction 'preview' %}
 {% Instruction 'devtools' %}
 -  Click on the **Application** panel.
--  Switch to the **Manifest** tab.
+-  Click the **Manifest** tab.
 
 <img class="w-screenshot w-screenshot--filled" src="./devtools.png" alt="DevTool's Manifest tab shows the properties from the app manifest file.">
 

--- a/src/site/content/en/react/add-manifest-react/index.md
+++ b/src/site/content/en/react/add-manifest-react/index.md
@@ -84,11 +84,10 @@ file:
 
 To find out if all the properties are working correctly in this example:
 
-+  Mouse over the editor, press the **App** button, then press the **Show**
-   button to preview the app.
-+  Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
-+  Click on the **Application** panel.
-+  Switch to the **Manifest** tab.
+{% Instruction 'preview' %}
+{% Instruction 'devtools' %}
+-  Click on the **Application** panel.
+-  Switch to the **Manifest** tab.
 
 <img class="w-screenshot w-screenshot--filled" src="./devtools.png" alt="DevTool's Manifest tab shows the properties from the app manifest file.">
 

--- a/src/site/content/en/react/code-splitting-suspense/index.md
+++ b/src/site/content/en/react/code-splitting-suspense/index.md
@@ -95,11 +95,10 @@ weak network connections.
 
 To better demonstrate how this works:
 
-+  Mouse over the editor and press the **Show** button to preview the app.
-+  Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
-+  Click on the **Network** tab.
-+  Click the [**Throttling**](https://developers.google.com/web/tools/chrome-devtools/network/#throttle) dropdown and select `Slow 3G`.
-+  Click the button on the application.
+{% Instruction 'preview' %}
+{% Instruction 'devtools-network' %}
+-  Click the [**Throttling**](https://developers.google.com/web/tools/chrome-devtools/network/#throttle) dropdown and select `Slow 3G`.
+-  Click the button on the application.
 
 The loading indicator will show for longer now. Notice how all the code that
 makes up the `AvatarComponent` is fetched as a separate chunk.

--- a/src/site/content/en/react/code-splitting-suspense/index.md
+++ b/src/site/content/en/react/code-splitting-suspense/index.md
@@ -98,7 +98,7 @@ To better demonstrate how this works:
 {% Instruction 'preview' %}
 {% Instruction 'devtools-network' %}
 -  Click the [**Throttling**](https://developers.google.com/web/tools/chrome-devtools/network/#throttle) dropdown and select `Slow 3G`.
--  Click the button on the application.
+-  Click the **Click Me** button in the application.
 
 The loading indicator will show for longer now. Notice how all the code that
 makes up the `AvatarComponent` is fetched as a separate chunk.

--- a/src/site/content/en/react/precache-with-workbox-react/index.md
+++ b/src/site/content/en/react/precache-with-workbox-react/index.md
@@ -65,7 +65,7 @@ Here is an example of a React app built with CRA that has a service worker enabl
   </iframe>
 </div>
 
-In order to see which assets are being cached:
+To see which assets are being cached:
 
 {% Instruction 'preview' %}
 {% Instruction 'devtools-network' %}

--- a/src/site/content/en/react/precache-with-workbox-react/index.md
+++ b/src/site/content/en/react/precache-with-workbox-react/index.md
@@ -67,10 +67,9 @@ Here is an example of a React app built with CRA that has a service worker enabl
 
 In order to see which assets are being cached:
 
-+  Mouse over the editor and press the **Show** button to preview the app.
-+  Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
-+  Click on the **Network** tab.
-+  Reload the application.
+{% Instruction 'preview' %}
+{% Instruction 'devtools-network' %}
+-  Reload the application.
 
 You'll notice that instead of showing the payload size, the `Size` column shows
 a `(from ServiceWorker)` message to indicate that these resources were retrieved

--- a/src/site/content/en/reliable/codelab-explore-network-panel/index.md
+++ b/src/site/content/en/reliable/codelab-explore-network-panel/index.md
@@ -27,7 +27,7 @@ you see in this codelab.
 Navigate to the Network panel to see the network traffic for the demo
 application.
 
-{% Instruction 'preview' %}
+{% Instruction 'preview', 'ol' %}
 
 {% Instruction 'devtools-network', 'ol' %}
 1. Reload the page to see the network traffic.

--- a/src/site/content/en/reliable/codelab-explore-network-panel/index.md
+++ b/src/site/content/en/reliable/codelab-explore-network-panel/index.md
@@ -27,11 +27,9 @@ you see in this codelab.
 Navigate to the Network panel to see the network traffic for the demo
 application.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
-1. Open DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
-1. Select the **Network** tab.
+{% Instruction 'devtools-network', 'ol' %}
 1. Reload the page to see the network traffic.
 
 You should see the DevTools interface open up, in either a new window or as a

--- a/src/site/content/en/reliable/codelab-http-cache/codelab-http-cache.md
+++ b/src/site/content/en/reliable/codelab-http-cache/codelab-http-cache.md
@@ -71,7 +71,7 @@ conditionally set this header is to write a custom
 [`setHeaders function`](https://expressjs.com/en/resources/middleware/serve-static.html#setheaders),
 and within that, check to see if the incoming request is for an HTML document.
 
-- Click the **Remix to Edit** button to make the project editable.
+{% Instruction 'remix' %}
 
 The static serving configuration in `server.js` starts out as this:
 
@@ -159,8 +159,7 @@ working through [this codelab](/codelab-explore-network-panel).
 With the modifications to the static file server in place, you can check to make
 sure that the right headers are being set by previewing the live app with the DevTools Network panel open.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
+{% Instruction 'preview' %}
 
 - Customize the columns that are
 displayed in the Network panel to include the information that is most relevant, by right-clicking in

--- a/src/site/content/en/reliable/codelab-service-workers/index.md
+++ b/src/site/content/en/reliable/codelab-service-workers/index.md
@@ -124,7 +124,7 @@ the service worker in action.
 
 {% Instruction 'preview' %}
 {% Instruction 'devtools' %}
--  Click on the **Console** tab.
+{% Instruction 'devtools-console', 'ul' %}
 
 You should see something like the following log messages,
 showing that the service worker has been installed and activated:

--- a/src/site/content/en/reliable/codelab-service-workers/index.md
+++ b/src/site/content/en/reliable/codelab-service-workers/index.md
@@ -122,9 +122,8 @@ Now that you've got the code added to `register-sw.js` and `service-worker.js`
 files, it's time to visit the Live version of your sample project, and observe
 the service worker in action.
 
-- To preview the site, mouse over the editor, press the **App** button, then the
-  **Show** button.
--  Open the DevTools by pressing `CMD + OPTION + i` / `CTRL + SHIFT + i`.
+{% Instruction 'preview' %}
+{% Instruction 'devtools' %}
 -  Click on the **Console** tab.
 
 You should see something like the following log messages,

--- a/src/site/content/en/sandbox/index.md
+++ b/src/site/content/en/sandbox/index.md
@@ -18,6 +18,7 @@ To see how to use each component, [view this page's source on GitHub](https://gi
 1. [Details](#details)
 1. [Glitch](#glitch)
 1. [Images](#images)
+1. [Instruction](#instruction)
 1. [Lists](#lists)
 1. [Stats](#stats)
 1. [Tables](#tables)
@@ -368,6 +369,47 @@ at.
     Fig. 5 — Regular screenshot.
   </figcaption>
 </figure>
+
+## Instruction
+
+{% Instruction 'remix' %}
+{% Instruction 'preview' %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'console', 'ol' %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'devtools', 'none' %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'devtools-performance' %}
+
+{% Aside %}
+All DevTools panels are supported. View [the element source](https://github.com/GoogleChrome/web.dev/blob/master/src/site/_includes/components/Instructions.js) for details.
+{% endAside %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'performance-audit', 'ol' %}
+
+{% Aside %}
+All Lighthouse audits are supported. View [the element source](https://github.com/GoogleChrome/web.dev/blob/master/src/site/_includes/components/Instructions.js) for details.
+{% endAside %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
 
 ## Lists
 

--- a/src/site/content/en/sandbox/instruction/index.md
+++ b/src/site/content/en/sandbox/instruction/index.md
@@ -1,0 +1,20 @@
+---
+permalink: false
+layout: sandbox/article
+title: instruction
+---
+
+{% Instruction 'remix' %}
+{% Instruction 'preview' %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'console', 'ol' %}
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum alias esse
+accusantium quibusdam perspiciatis, sunt vero at accusamus temporibus molestias
+iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
+
+{% Instruction 'devtools', 'none' %}

--- a/src/site/content/en/secure/cross-origin-resource-sharing/index.md
+++ b/src/site/content/en/secure/cross-origin-resource-sharing/index.md
@@ -140,7 +140,7 @@ The first endpoint (line 5) does not have any response header set, it just sends
 a file in response.
 
 {% Instruction 'devtools' %}
-- Click on the **Console** tab.
+{% Instruction 'devtools-console', 'ul' %}
 - Try the following command:
 
 ```js

--- a/src/site/content/en/secure/cross-origin-resource-sharing/index.md
+++ b/src/site/content/en/secure/cross-origin-resource-sharing/index.md
@@ -139,7 +139,9 @@ const listener = app.listen(process.env.PORT, function() {
 The first endpoint (line 5) does not have any response header set, it just sends
 a file in response.
 
-Open the devtools javascript console and try:
+{% Instruction 'devtools' %}
+- Click on the **Console** tab.
+- Try the following command:
 
 ```js
 fetch('https://cors-demo.glitch.me/', {mode:'cors'})


### PR DESCRIPTION
Adds a new `{% Instruction %}` shortcode which can be used
to DRY up common lists of instructions.

Fixes #964

Changes proposed in this pull request:

- Add a new Instruction component.
- Update articles to use Instruction component.
- Add examples to sandbox page.
