### PR TITLE
Link "Defer unused CSS" guide to "Extract critical CSS" guide.

### DIFF
--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -173,7 +173,4 @@ In this guide, you used vanilla code to implement this optimization. In a real
 production scenario, it’s a good practice to use functions like
 [loadCSS](https://github.com/filamentgroup/loadCSS/blob/master/README.md), that
 can encapsulate this behavior and work well across browsers. As a complement to
-this, you can use tools like
-[Critical](https://github.com/addyosmani/critical/blob/master/README.md), which
-helps extracting and inlining the “Above the Fold” CSS you did manually in the
-**Optimize** step.
+this, the [extract critical CSS guide](https://web.dev/extract-critical-css/) covers some of the most popular tools to extract critical CSS and includes [a codelab](https://web.dev/codelab-extract-and-inline-critical-css/), to see how they work in practice.

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -173,7 +173,7 @@ In this guide, you used vanilla code to implement this optimization. In a real
 production scenario, it’s a good practice to use functions like
 [loadCSS](https://github.com/filamentgroup/loadCSS/blob/master/README.md), that
 can encapsulate this behavior and work well across browsers. As a complement to
-this, the [extract critical CSS guide](https://web.dev/extract-critical-css/) 
+this, the [extract critical CSS guide](/extract-critical-css/) 
 covers some of the most popular tools to extract critical CSS and includes 
 [a codelab](https://web.dev/codelab-extract-and-inline-critical-css/) to see how 
 they work in practice.

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -175,5 +175,5 @@ production scenario, it’s a good practice to use functions like
 can encapsulate this behavior and work well across browsers. As a complement to
 this, the [extract critical CSS guide](https://web.dev/extract-critical-css/) 
 covers some of the most popular tools to extract critical CSS and includes 
-[a codelab](https://web.dev/codelab-extract-and-inline-critical-css/), to see how 
+[a codelab](https://web.dev/codelab-extract-and-inline-critical-css/) to see how 
 they work in practice.

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -173,4 +173,7 @@ In this guide, you used vanilla code to implement this optimization. In a real
 production scenario, it’s a good practice to use functions like
 [loadCSS](https://github.com/filamentgroup/loadCSS/blob/master/README.md), that
 can encapsulate this behavior and work well across browsers. As a complement to
-this, the [extract critical CSS guide](https://web.dev/extract-critical-css/) covers some of the most popular tools to extract critical CSS and includes [a codelab](https://web.dev/codelab-extract-and-inline-critical-css/), to see how they work in practice.
+this, the [extract critical CSS guide](https://web.dev/extract-critical-css/) 
+covers some of the most popular tools to extract critical CSS and includes 
+[a codelab](https://web.dev/codelab-extract-and-inline-critical-css/), to see how 
+they work in practice.

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -175,5 +175,5 @@ production scenario, it’s a good practice to use functions like
 can encapsulate this behavior and work well across browsers. As a complement to
 this, the [extract critical CSS guide](/extract-critical-css/) 
 covers some of the most popular tools to extract critical CSS and includes 
-[a codelab](https://web.dev/codelab-extract-and-inline-critical-css/) to see how 
+[a codelab](/codelab-extract-and-inline-critical-css/) to see how 
 they work in practice.


### PR DESCRIPTION
Adding reference to the [Extract critical CSS guide](https://web.dev/extract-critical-css/), so developers can continue navigating to that article, after reading the [Defer Unused CSS](https://web.dev/defer-non-critical-css) one.