### PR TITLE
Don't increment numbered lists when there are nested lists.

### DIFF
--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -17,14 +17,14 @@ ol:not([class]) {
   position: relative;
 }
 
-ol:not([class]) li {
+ol:not([class]) > li {
   counter-increment: ol-step-counter;
   font-size: 1.125rem;
   line-height: 1.778rem;
   margin-bottom: 8px;
 }
 
-ol:not([class]) li::before {
+ol:not([class]) > li::before {
   -ms-flex-align: center;
   -ms-flex-negative: 0;
   -ms-flex-pack: center;
@@ -55,13 +55,13 @@ ul:not([class]) {
   position: relative;
 }
 
-ul:not([class]) li {
+ul:not([class]) > li {
   font-size: 1.125rem;
   line-height: 1.778rem;
   margin-bottom: 8px;
 }
 
-ul:not([class]) li::before {
+ul:not([class]) > li::before {
   background: $GREY_700;
   border-radius: $GLOBAL_ROUNDED;
   color: $WHITE;


### PR DESCRIPTION
Fixes an issue where nested ordered lists were forcing the outer list to increment.
See example on: https://web.dev/value-of-speed/

Changes proposed in this pull request:

- Only increment lists when the immediate child is an li, ignoring nested sublists. 
