### PR TITLE
Update documentation for `<a>` tag

### DIFF
--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -100,8 +100,7 @@ should you choose?
 
 - If clicking on the element will perform an _action_ on the page, use
   `<button>`.
-- If clicking on the element will _navigate_ the user to a new page (or load new
-  content in a single-page web app) then use `<a>`.
+- If clicking on the element will _navigate_ the user to a new page then use `<a>`.
 
 The reason for this is that buttons and links are announced differently by
 screen readers. Using the correct element helps screen reader users know which


### PR DESCRIPTION
If clicking on an element adds new content in the web page, we should still use `<button>` instead. As native `<a>` has properties like opening the link in new window or tab , this feature won't be helpful for loading the new content unless we change the url of the page.

Fixes # .

Changes proposed in this pull request:

- 
- 
- 
