### PR TITLE
Remove strong stags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ local-devsite.js
 
 # DS_Store
 .DS_Store
+
+# IDEs
+.idea

--- a/src/site/content/en/fast/codelab-text-compression/index.md
+++ b/src/site/content/en/fast/codelab-text-compression/index.md
@@ -96,7 +96,7 @@ module bundler. The specific version can be seen in `package.json`.
 ```json/2
 "devDependencies": {
   //...
-  <strong>"webpack": "^4.16.4",</strong>
+  "webpack": "^4.16.4",
   //...
 }
 ```
@@ -335,7 +335,7 @@ module.exports = {
   //...
   plugins: [
     //...
-    <strong>new CompressionPlugin()</strong>
+    new CompressionPlugin()
   ]
 }
 ```


### PR DESCRIPTION
### Summary
Remove unnecessary `strong` tags in articles.

Changes proposed in this pull request:

- Removes strong tags
- Updates `.gitignore`

### Preview
live url: https://web.dev/codelab-text-compression
#### Current

![Screenshot from 2019-06-23 17-25-44](https://user-images.githubusercontent.com/13482373/59978411-4ab17b80-95dc-11e9-9a8f-75510653f734.png)

![Screenshot from 2019-06-23 17-26-05](https://user-images.githubusercontent.com/13482373/59978414-4edd9900-95dc-11e9-92f3-72c97b254d76.png)


#### Proposed

![Screenshot from 2019-06-23 17-26-50](https://user-images.githubusercontent.com/13482373/59978420-5735d400-95dc-11e9-8274-c48e0e84461b.png)

![Screenshot from 2019-06-23 17-26-30](https://user-images.githubusercontent.com/13482373/59978419-54d37a00-95dc-11e9-9c3f-721b5f275a07.png)