### PR TITLE
Move perf budgets to start of /fast

### DIFF
--- a/src/site/content/en/blog/speed-at-scale/index.md
+++ b/src/site/content/en/blog/speed-at-scale/index.md
@@ -32,7 +32,7 @@ allowfullscreen></iframe>
 
 [LightWallet](https://developers.google.com/web/tools/lighthouse/audits/budgets)
 is a new feature in Lighthouse that adds support for [performance
-budgets](/fast#enforce-performance-budgets). Performance budgets establish
+budgets](/fast#set-performance-budgets). Performance budgets establish
 standards for the performance of your site. More importantly, they make it is
 easy to identify and fix performance regressions before they ship.
 

--- a/src/site/content/en/fast/fast.11tydata.js
+++ b/src/site/content/en/fast/fast.11tydata.js
@@ -32,6 +32,17 @@ module.exports = {
         ],
       },
       {
+        title: 'Set performance budgets',
+        pathItems: [
+          'performance-budgets-101',
+          'your-first-performance-budget',
+          'incorporate-performance-budgets-into-your-build-tools',
+          'use-lighthouse-for-performance-budgets',
+          'using-bundlesize-with-travis-ci',
+          'using-lighthouse-bot-to-set-a-performance-budget',
+        ],
+      },
+      {
         title: 'Optimize your images',
         pathItems: [
           'use-imagemin-to-compress-images',
@@ -76,17 +87,6 @@ module.exports = {
           'chrome-ux-report-data-studio-dashboard',
           'chrome-ux-report-pagespeed-insights',
           'chrome-ux-report-bigquery',
-        ],
-      },
-      {
-        title: 'Enforce performance budgets',
-        pathItems: [
-          'performance-budgets-101',
-          'your-first-performance-budget',
-          'incorporate-performance-budgets-into-your-build-tools',
-          'use-lighthouse-for-performance-budgets',
-          'using-bundlesize-with-travis-ci',
-          'using-lighthouse-bot-to-set-a-performance-budget',
         ],
       },
     ],


### PR DESCRIPTION
Also renamed section from "Enforce Performance Budgets" to "Set Performance Budgets".
