### PR TITLE
Fix all instances of "resilient/resilience"

### DIFF
--- a/src/site/content/en/about/index.njk
+++ b/src/site/content/en/about/index.njk
@@ -144,7 +144,7 @@ description: |
             Load speed
           </li>
           <li>
-            Network resilience
+            Network reliability
           </li>
           <li>
             Data security

--- a/src/site/content/en/reliable/codelab-service-workers/index.md
+++ b/src/site/content/en/reliable/codelab-service-workers/index.md
@@ -5,7 +5,7 @@ authors:
   - jeffposnick
 date: 2018-11-05
 description: |
-  In this codelab, learn how to make an application network resilient by
+  In this codelab, learn how to make an application reliable by
   registering a service worker.
 glitch: working-with-sw
 related_post: service-workers-cache-storage

--- a/src/site/content/en/reliable/reliable.11tydata.js
+++ b/src/site/content/en/reliable/reliable.11tydata.js
@@ -6,7 +6,7 @@ module.exports = {
     // Because it affects urls, the slug should never be translated.
     slug: 'reliable',
     cover: '/images/collections/reliable.svg',
-    title: 'Network resilience',
+    title: 'Network reliability',
     updated: 'May 24, 2018',
     description: `See consistent, reliable performance regardless of network
     quality.`,
@@ -16,7 +16,7 @@ module.exports = {
     wherever and however they access the internet.`,
     topics: [
       {
-        title: 'How to measure network resilience',
+        title: 'How to measure network reliability',
         pathItems: [
           'network-connections-unreliable',
           'identify-resources-via-network-panel',

--- a/src/site/content/en/reliable/runtime-caching-with-workbox/index.md
+++ b/src/site/content/en/reliable/runtime-caching-with-workbox/index.md
@@ -124,7 +124,7 @@ instance.
 By using a network-first strategy inside of a service worker, instead of just
 going against the network directly, you have the benefit of being able to fall
 back to _something_, even if it's a potentially stale response. You won't be
-reliably fast, but at least you'll be resilient while offline.
+reliably fast, but at least you'll be reliable while offline.
 
 ### Use cache-first for versioned URLs
 

--- a/src/site/content/en/reliable/service-workers-cache-storage/index.md
+++ b/src/site/content/en/reliable/service-workers-cache-storage/index.md
@@ -63,7 +63,7 @@ It's still recommended that you configure the `Cache-Control` headers on your we
 server, even when you know that you're using the Cache Storage API. You can
 usually get away with setting `Cache-Control: no-cache` for unversioned URLs,
 and/or `Cache-Control: max-age=31536000` for URLs that contain versioning
-information, like hashes. 
+information, like hashes.
 
 When populating the Cache Storage API cache, the browser
 [defaults to checking for existing entries](https://jakearchibald.com/2016/caching-best-practices/#the-service-worker-the-http-cache-play-well-together-dont-make-them-fight)
@@ -119,7 +119,7 @@ and the related
 syntax, before diving in.
 
 {% Aside 'codelab' %}
-[Make an application network resilient by registering a service worker](/codelab-service-workers).
+[Make an application reliable by registering a service worker](/codelab-service-workers).
 {% endAside %}
 
 ## Don't deploy that code… yet


### PR DESCRIPTION
Changes proposed in this pull request:

- Consistently use "reliable/reliability" rather than "resilient/resilience" across the site.