### PR TITLE
Copy edit and suggestions for the writing handbook

### DIFF
--- a/src/site/content/en/handbook/audience/index.md
+++ b/src/site/content/en/handbook/audience/index.md
@@ -28,7 +28,7 @@ Alice is a developer working in a team for a large e-commerce website. The site'
 * **Goal:** Find a solution to a low Lighthouse score that is directly applicable to her existing project as quickly as possible.
 
 ### Goal-driven problem solver (Damir)
-Damir is a developer at a small fintech startup. His boss has asked him to help turn their company's site into a PWA. After trying to enable some offline functionality, Damir realizes through a StackOverflow post ([for example, a post about PWA offline capability on data that frecuently changes ](https://stackoverflow.com/questions/50777677/pwa-offline-capability-on-data-that-frecuently-changes)) that the best bet to solving his problem is to create a service worker. He needs to learn how to create a service worker that will work with his company's existing site and the dynamic data that it handles.
+Damir is a developer at a small fintech startup. His boss has asked him to help turn their company's site into a PWA. After trying to enable some offline functionality, Damir realizes through a StackOverflow post ([for example, a post about PWA offline capability on data that frecuently changes ](https://stackoverflow.com/questions/50777677/pwa-offline-capability-on-data-that-frecuently-changes)) that the best way to solve his problem is to create a service worker. He needs to learn how to create a service worker that works with his company's existing site and the dynamic data that it handles.
 
 * **Prior knowledge:** Damir is a more advanced developer. He can quickly skim documentation to find the code snippets and examples relevant to his use case.
 * **Entry point:** Damir searches for "service worker for PWA", and one of the first search results is a post in the web.dev [Installable](/installable) collection.
@@ -59,7 +59,7 @@ Jaimie first took a web development class at their local community college and i
 When you're writing a post or codelab, keep the web.dev personas in mind (or more, if their needs overlap). How do you do that in a given piece, especially when the needs of different readers compete? One way to address multiple audience segments is to provide multiple paths for a given topic. For example, you might write:
 * A post using vanilla JavaScript, with associated codelabs using common frameworks to solve the same problem
 * A post about optimizing images in general, with associated codelabs showing how to integrate image optimization into different build processes
-* A post about how to address an issue most web developers will encounter, with sections at the end focused on solving the problem as it appears in particular business verticals
+* A post about how to address an issue most web developers encounter, with sections at the end focused on solving the problem as it appears in particular business verticals
 
 Be mindful of your [voice](/handbook/voice). You want readers to feel they can trust the guidance you're giving. They should feel neither talked down to nor overwhelmed. Check out [Instruction for adult learners](/handbook/effective-instruction#instruction-for-adult-learners) in the [Writing effective instruction](/handbook/effective-instruction) post.
 

--- a/src/site/content/en/handbook/audience/index.md
+++ b/src/site/content/en/handbook/audience/index.md
@@ -7,17 +7,18 @@ date: 2019-06-26
 description: |
   Definitions of the the key personas for web.dev and advice about how to write for them.
 ---
+When you're writing for web.dev, it's important to consider the key personas so that each piece you write helps readers learn or accomplish something.
 
 ## Who is the web.dev audience?
 web.dev readers come with a variety of needs and preferences based on several characteristics:
-* Prior knowledge about the domains of web development (accessibility, performance, etc.)
-* Role (hobbyist, student, data scientist, frontend engineer, etc.)
-* Organization (independent contractor, startup, large company in a non-tech industry, etc.)
-* Focus on a business vertical (e-commerce, etc.)
-* Preferences for frameworks and tools (e.g., React, Gulp, webpack, etc.)
-* Purpose for reading (fix a Lighthouse audit, solve a specific problem, improve general skills, etc.)
+* Prior knowledge about the domains of web development (for example, accessibility or performance)
+* Role (for example, hobbyist, student, data scientist, frontend engineer)
+* Organization (for example, independent contractor, startup, large company in a non-tech industry)
+* Focus on a business vertical (for example, e-commerce)
+* Preferences for frameworks and tools (for example, React, Gulp, webpack)
+* Purpose for reading (for example, fix a Lighthouse audit, solve a specific problem, improve general skills)
 
-Trying to address all permutations of those characteristics would be unmanageable, so we've captured the most common clusters in several personas.
+Trying to address all permutations of those characteristics is unmanageable, so we've captured the most common clusters in several personas.
 
 ### Metrics-initiated problem solver (Alice)
 Alice is a developer working in a team for a large e-commerce website. The site's homepage received a low Lighthouse score for performance. Alice has been assigned to resolve the top three opportunities for improving the performance in the next two weeks, with the first solution due later today.
@@ -27,17 +28,17 @@ Alice is a developer working in a team for a large e-commerce website. The site'
 * **Goal:** Find a solution to a low Lighthouse score that is directly applicable to her existing project as quickly as possible.
 
 ### Goal-driven problem solver (Damir)
-Damir is a developer at a small fintech startup. His boss has asked him to help turn their company's site into a PWA. After trying to enable some offline functionality, Damir realizes through a StackOverflow post ([example](https://stackoverflow.com/questions/50777677/pwa-offline-capability-on-data-that-frecuently-changes)) that the best bet to solving his problem is to create a service worker. He needs to learn how to create a service worker that will work with his company's existing site and the dynamic data that it handles.
+Damir is a developer at a small fintech startup. His boss has asked him to help turn their company's site into a PWA. After trying to enable some offline functionality, Damir realizes through a StackOverflow post ([for example, a post about PWA offline capability on data that frecuently changes ](https://stackoverflow.com/questions/50777677/pwa-offline-capability-on-data-that-frecuently-changes)) that the best bet to solving his problem is to create a service worker. He needs to learn how to create a service worker that will work with his company's existing site and the dynamic data that it handles.
 
 * **Prior knowledge:** Damir is a more advanced developer. He can quickly skim documentation to find the code snippets and examples relevant to his use case.
-* **Entry point:** Damir searches for "service worker for PWA," and one of the first search results is a post in the web.dev "[Installable](/installable)" collection.
+* **Entry point:** Damir searches for "service worker for PWA", and one of the first search results is a post in the web.dev [Installable](/installable) collection.
 * **Goal:** Find a specific, implementable solution to an issue as quickly as possible. (Unlike Alice, Damir is trying to fix a problem identified by his team or manager rather than by Lighthouse.)
 
 ### Topic deep-diver (Andrew)
 Andrew is a frontend developer at a startup whose main product is a peer-to-peer resource sharing web app.  He wants to become the go-to accessibility person on the engineering team since accessibility is an issue he feels is important but knows very little about. Andrew has signed up to give a 30-minute accessibility introductory talk to his team in two weeks.
 
 * **Prior knowledge:** Andrew has heard of accessibility and knows that it's about helping users with special needs, but he doesn't have a fully accurate sense of who those users are or how they interact with his product.
-* **Entry point:** Andrew's searches for accessibility, and one of the first search results is the landing page for the "[Accessible to all](/accessible)" collection.
+* **Entry point:** Andrew's searches for accessibility, and one of the first search results is the landing page for the [Accessible to all](/accessible) collection.
 * **Goal:** Master the basics of web accessibility and find high-quality resources to learn from and share with fellow engineers.
 
 ### Demo builder (Emily)
@@ -55,17 +56,15 @@ Jaimie first took a web development class at their local community college and i
 * **Goal:** Learn about the most recent web development tools and best practices to create a personal site from scratch to apply for industry jobs.
 
 ## Writing to the audience
-All posts and codelabs should be targeted to one of our personas (or more, if their needs overlap).
-
-That said, we want our content to address as much of our audience as we can. How do you do that in a given piece, especially when the needs of different readers compete? One way to address multiple audience segments is to provide multiple paths for a given topic. For example, you might write:
+When you're writing a post or codelab, keep the web.dev personas in mind (or more, if their needs overlap). How do you do that in a given piece, especially when the needs of different readers compete? One way to address multiple audience segments is to provide multiple paths for a given topic. For example, you might write:
 * A post using vanilla JavaScript, with associated codelabs using common frameworks to solve the same problem
 * A post about optimizing images in general, with associated codelabs showing how to integrate image optimization into different build processes
 * A post about how to address an issue most web developers will encounter, with sections at the end focused on solving the problem as it appears in particular business verticals
 
-Be mindful of your [voice](/handbook/voice). You want readers to feel they can trust the guidance you're giving. They should feel neither talked down to nor overwhelmed. Check out "[Instruction for adult learners](/handbook/effective-instruction#instruction-for-adult-learners)" in the "[Writing effective instruction](/handbook/effective-instruction)" post.
+Be mindful of your [voice](/handbook/voice). You want readers to feel they can trust the guidance you're giving. They should feel neither talked down to nor overwhelmed. Check out [Instruction for adult learners](/handbook/effective-instruction#instruction-for-adult-learners) in the [Writing effective instruction](/handbook/effective-instruction) post.
 
 ### Value propositions
-A value proposition is a promise to readers that a piece of content will be useful—that is, provide value—to them. Create a value proposition for everything you write by crafting titles, subtitles, and descriptions that tell your target audience why your post or codelab is worth reading. Some common strategies:
-* Say what readers will learn or understand by reading the piece
-* Say what a piece will let readers do
-* Say how a technique or tool will improve the experience of readers' users
+A value proposition is a promise to readers that a piece of content will be useful and provide value to them. Create a value proposition for everything you write by crafting titles, subtitles, and descriptions that tell your target audience why your post or codelab is worth reading. Here are some common strategies:
+* State what readers will learn or understand by reading the piece
+* Explain what a piece helps readers do
+* Describe how a technique or tool improves the user experience

--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -10,9 +10,9 @@ description: |
 This is a checklist for web.dev content reviews. It includes critical high-level issues and lower-level issues that commonly appear in drafts.
 
 ## Basics
-1. Is the piece providing value for one or more of the web.dev [personas](/handbook/audience)?
-1. Do the title, subtitle, and description convey the value proposition?
-1. Is the piece 1,000 words or less—or is there a good reason for it to be longer?
+1. Does the piece provide value for one or more of the web.dev [personas](/handbook/audience)?
+1. Do the title, subtitle, and description convey a [value proposition](/handbook/audience/#value-propositions)?
+1. Is the piece 1,000 words or less? If it's longer, is there a good reason for it to be longer?
 1. Are all statements and advice accurate and aligned with best practices?
 
 ## Style and voice
@@ -27,19 +27,19 @@ This is a checklist for web.dev content reviews. It includes critical high-level
 ## Instruction
 1. If the piece expects readers to have prior knowledge, is that made clear up front?
 1. Does the piece explain why the process being taught matters?
-1. Are examples provided to support all key claims and ideas?
-1. Are instructions in second person (_you/your_), not first person (_we/our_)?
-1. Are common instructions provided using the web.dev [Instruction components](/handbook/web-dev-components/#instruction)?
+1. Do the examples support all key claims and ideas?
+1. Are instructions written in second person (_you/your_), not first person (_we/our_)?
+1. Do the common instructions follow the web.dev [Instruction components](/handbook/web-dev-components/#instruction)?
 
 ## Media
-1. Are images and videos used to clarify ideas that would be difficult to understand from text alone?
-1. Are any images or videos included that don't directly relate to ideas in the text?
+1. Do the images and videos clarify ideas that would be difficult to understand from text alone?
+1. Are there any images or videos that don't directly relate to ideas in the text?
 1. Are [image captions](/handbook/use-media/#image-captions) correctly formatted?
 1. Do all images have [alt text](/image-alt)?
 
 ## Code
 1. Are code blocks and sample apps as simple as possible while still conveying the core concept?
-1. Is a brief description of a sample app's functionality provided before the app itself?
+1. Is there a brief description of a sample app's functionality before the app itself?
 1. Is [code highlighting](/handbook/markup-code/#code-highlighting) used to indicate lines that have been added or changed?
 1. Is all sample code [accessible](/inclusion-and-accessibility/#create-accessible-code-blocks)?
 
@@ -48,7 +48,7 @@ This is a checklist for web.dev content reviews. It includes critical high-level
 1. Are all links to web.dev pages and assets relative?
 
 ## Mechanics
-1. Is the text free of spelling and capitalization errors? (Check the [word list](/word-list).)
+1. Is the text free of spelling and capitalization errors? Check the [word list](/word-list).
 1. Are [dashes and hyphens](/handbook/grammar/#dashes-and-hyphens) used correctly?
 1. Are titles and headings in sentence case with no terminal period?
 1. Are [keyboard key commands](/handbook/grammar/#ui-elements-and-interaction) correctly formatted?

--- a/src/site/content/en/handbook/content-types/index.md
+++ b/src/site/content/en/handbook/content-types/index.md
@@ -9,20 +9,20 @@ description: |
 ---
 
 ## Posts
-**Format:** primarily informational with instructions included as appropriate
+**Format:** Primarily informational with instructions included as appropriate
 
 **Typical use cases:**
 * A description of a problem detected by a Lighthouse audit and an explanation of how to fix it
 * An explanation of how to accomplish a widely applicable web development task—or an explanation of why that task is important
-* An explanation of a web development issue relevant to a specific industry (e.g., e-commerce)
-* An explanation of how or when to use a common framework (e.g., React, Vue)
-* A news announcement relevant to the web.dev audience (e.g., a new API, a recent conference talk)
+* An explanation of a web development issue relevant to a specific industry (for example, e-commerce)
+* An explanation of how or when to use a common framework (for example, React, Vue)
+* A news announcement relevant to the web.dev audience (for example, a new API, a recent conference talk)
 
 **Placement on the site:**
 * Always appears on the [blog](/blog), organized chronologically
-* May transition into a collection in the "[Learn](/learn)" section, organized thematically with other posts
+* May transition into a collection in the [Learn](/learn) section, organized thematically with other posts
 
-**Length:** typically less than 1,000–1,500 words
+**Length:** Typically less than 1,000–1,500 words
 
 **[Template](https://github.com/GoogleChrome/web.dev/tree/master/src/site/_drafts/_template-post)**
 
@@ -33,14 +33,14 @@ description: |
 ## Codelabs
 **Format:** Multi-step instructions paired with an embedded [sample app](/handbook/markup-sample-app)
 
-**Typical use case:** showing how to do small, fairly discrete development tasks
+**Typical use case:** Showing how to do small, fairly distinct development tasks
 
-**Placement on the site:** always associated with a post, which serves as the landing page for the codelab
+**Placement on the site:** Always associated with a post, which serves as the landing page for the codelab
 
-**Length:** typically less than 1,000–1,500 words
+**Length:** Typically less than 1,000–1,500 words
 
 **[Template](https://github.com/GoogleChrome/web.dev/tree/master/src/site/_drafts/_template-codelab)**
 
 **Examples:**
-* Creating WebP images with the command line
-* Minify and compress network payloads with gzip
+* [Creating WebP images with the command line](/codelab-serve-images-webp)
+* [Minify and compress network payloads with gzip](/reduce-network-payloads-using-text-compression)

--- a/src/site/content/en/handbook/effective-instruction/index.md
+++ b/src/site/content/en/handbook/effective-instruction/index.md
@@ -5,22 +5,22 @@ authors:
   - mfriesenhahn
 date: 2019-06-26
 description: |
-  Strategies for writing effective instruction on web.dev, especially for adult learners.
+  Learn strategies for writing effective instruction on web.dev, especially for adult learners.
 ---
 
 Most web.dev content includes at least some instruction. These guidelines help make your instruction easy to follow.
 
-Explain _why_ to do something before explaining _how_ to do it. Knowing what they're trying to accomplish helps readers understand the purpose of individual steps.
+Explain _why_ to do something before explaining _how_ to do it. Knowing the end goal helps readers understand the purpose of individual steps.
 
 Keep the scope of instruction manageable. If a task is complex, find ways to chunk the steps. For example, provide the essential pieces in a post and put the ancillary pieces in one or more codelabs.
 
-Always provide examples for complex or abstract concepts. If you're debating whether to give an example, do.
+Always provide examples for complex or abstract concepts. If you're debating whether to give an example, add one.
 
-Use web.dev's built-in [Instruction components](/handbook/web-dev-components#instruction) for instructing common tasks in the tools often referenced on the site (e.g., Glitch, Chrome DevTools). This approach provides a consistent user experience and makes it easy to update instructions across the site when needed.
+Use web.dev's built-in [Instruction components](/handbook/web-dev-components#instruction) for common tasks that are often referenced on the site (for example, instructions about opening Glitch or Chrome DevTools). This approach provides a consistent user experience and makes it easy to update instructions across the site when needed.
 
 ## Instruction for adult learners
-Adult learners bring a lot experience. It's important to honor that experience while acknowledging the challenges of the tasks you're teaching.
+Adult learners bring a lot experience. It's important to honor that experience while acknowledging the challenges of the tasks you're teaching. 
 
-Be mindful of [voice](/handbook/voice). Try to strike a balance between showing expertise and humility to avoid alienating your readers.
+Be mindful of [voice](/handbook/voice). To avoid alienating your readers, try to strike a balance between showing expertise and humility.
 
-Avoid words and phrases that make it sound like a concept or task is easy or obvious—it may not be! Words and phrases like _obviously_, _simply_, _of course_, _clearly_, _everyone knows_, and _easy_ usually shouldn't be in your instruction.
+Avoid words and phrases that make it sound like a concept or task is easy or obvious—it may not be! For example, the following words and phrases can frustrate readers when a task turns out to be harder: _obviously_, _simply_, _of course_, _clearly_, _just_, _everyone knows_, and _easy_.

--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -20,10 +20,16 @@ description: |
   }
 </style>
 
-Grammar and mechanics are important for making writing clear, but don't let them get in the way of putting text on the page! Content reviewers will always support you with editorial stuff. That said, here are a few conventions to be aware of.
+Grammar and mechanics are important for making writing clear. Content reviewers review posts and codelabs for editorial issues covered in this post. If a piece is already error free, the entire review process goes faster. To keep things simple, web.dev uses the following resources:
+* The [Google Developer Documentation Style Guide](https://developers.google.com/style/) (GDDSG) is the primary reference for writing style issues.
+* If a style issue isn't covered in the GDDGS, check the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/home.html).
+* [Merriam-Webster](http://www.m-w.com) is the primary reference for spelling and capitalization.
+* The [Word list](/handbook/word-list) provides spelling and capitalization conventions specific to web.dev.
+
+The rest of this post describes grammar styles that are specific to web.dev and are different from the core resources.
 
 ## Instructions
-Use second person (_you_) rather than first person (_we_) except in rare cases where you're providing a rationale for a recommendation (e.g., "We chose this library because…").
+Use second person (_you_) rather than first person (_we_) except in rare cases where you're providing a rationale for a recommendation (for example, "We chose this library because…").
 
 Begin instructions with the objective rather than the action.
 
@@ -64,9 +70,9 @@ Don't include preceding articles (_a_, _an_, _the_) or surrounding punctuation i
 
 {% endCompare %}
 
-When referring to webpages, either on web.dev or elsewhere, hyperlink the webpage title and put double quotation marks outside the hyperlink. (See example above.)
+When referring to webpages, either on web.dev or elsewhere, hyperlink the webpage title and put double quotation marks outside the hyperlink.
 
-Libraries and tools should be linked the first time they're mentioned.
+Link to libraries and tools on the first time they're mentioned.
 
 ## Lists
 Use an ordered list (numbers) when instructing the reader to perform a series of actions.
@@ -94,8 +100,8 @@ Use an unordered list item for a standalone action.
 
 ## Numbers
 In general, spell out integers from one to nine unless:
-* The integer is attached to a unit (e.g., _3 KB_, _page 3_).
-* The integer is in the same sentence as a number larger than nine (e.g., "The menu contains 15 options, but 6 of them are disabled.")
+* The integer is attached to a unit (for example, _3 KB_, _page 3_).
+* The integer is in the same sentence as a number larger than nine (for example, "The menu contains 15 options, but 6 of them are disabled.")
 
 Use numerals for decimals and numbers higher than nine.
 
@@ -127,11 +133,11 @@ Use the serial comma before the last item in a list.
 {% endCompare %}
 
 ### Dashes and hyphens
-Use hyphens (-) with no surrounding space to link words together (e.g., _two-year-old_).
+Use hyphens (-) with no surrounding space to link words together (for example, _two-year-old_).
 
 Use em dashes (—) with no surrounding space—like this—to set off an aside.
 
-Use an en dash (–) for ranges (e.g., _10–100 KB_).
+Use an en dash (–) for ranges (for example, _10–100 KB_).
 
 ### Quotation marks and apostrophes
 Use straight quotation marks and apostrophes, not smart (curly).
@@ -161,7 +167,7 @@ Periods and commas always go inside quotation marks. Question marks and exclamat
 ## Text formatting
 Bold words for emphasis sparingly. (The primary use for bolding is [indicating UI element names](/handbook/grammar/#ui-elements-and-interaction).)
 
-Avoid mixing code font and standard font in a single word.
+Don't mix code font and standard font in a single word.
 
 {% Compare 'worse', 'Don’t' %}
 > `integer`s
@@ -259,7 +265,7 @@ Add a space before units.
 ## Usage
 Use consistent vocabulary throughout a piece and the collection it lives in.
 
-Acronyms should be spelled out the first time they're used, with the acronym following immediately after in parentheses.
+Spell out acronyms the first time they're used, with the acronym following immediately after in parentheses.
 
 {% Compare 'worse', 'Don’t' %}
 > WICG
@@ -270,10 +276,3 @@ Acronyms should be spelled out the first time they're used, with the acronym fol
 > Web Incubation Community Groups (WICG)
 
 {% endCompare %}
-
-## References
-These are the references content reviewers use when reviewing posts and codelabs for editorial issues beyond the ones covered in this post. They worry about this stuff so you don't have to!
-* The [Google Developer Documentation Style Guide](https://developers.google.com/style/) (GDDSG) is the primary reference for writing style issues.
-* If a style issue isn't covered in the GDDGS, check the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/home.html).
-* [Merriam-Webster](http://www.m-w.com) is the primary reference for spelling and capitalization.
-* The [Word list](/handbook/word-list) provides spelling and capitalization conventions specific to web.dev.

--- a/src/site/content/en/handbook/inclusion-and-accessibility/index.md
+++ b/src/site/content/en/handbook/inclusion-and-accessibility/index.md
@@ -5,7 +5,7 @@ authors:
   - mfriesenhahn
 date: 2019-06-26
 description: |
-  Learn how to write for an international audience.
+  Learn how to write for an international audience with varying needs and preferences.
 ---
 
 web.dev has a large international audience. We want members of that audience to access and understand web.dev content, and they should feel included in the ways we speak to our readers.

--- a/src/site/content/en/handbook/inclusion-and-accessibility/index.md
+++ b/src/site/content/en/handbook/inclusion-and-accessibility/index.md
@@ -5,20 +5,19 @@ authors:
   - mfriesenhahn
 date: 2019-06-26
 description: |
-  This handbook helps contributors to web.dev create effective, engaging content
-  and get it published as easily as possible.
+  Learn how to write for an international audience.
 ---
 
-web.dev has a large international audience. Members of that audience should be able to access and understand web.dev content, and they should feel included in the ways we speak to our readers.
+web.dev has a large international audience. We want members of that audience to access and understand web.dev content, and they should feel included in the ways we speak to our readers.
 
 ## Use readable language
-Aim for a grade 8 reading level when possible. If you don't have a feel for what grade 8 texts look like, check out some [examples on Newsela](https://newsela.com/articles/#/rule/latest?grade_levels=8.0). If you're feeling frisky, you can also run your text through a readability test.
-* [TextEvaluator](http://textevaluator.ets.org/TextEvaluator/) can be used for pieces up to 1,600 words.
-* You can also use [Lexile](https://lexile.com/educators/tools-to-support-reading-at-school/tools-to-determine-a-books-complexity/the-lexile-analyzer/) for pieces up to 1,000 words.
+Aim for a grade 8 reading level when possible. If you don't have a feel for what grade 8 texts look like, check out some [examples on Newsela](https://newsela.com/articles/#/rule/latest?grade_levels=8.0). You can also run your text through a readability test.
+* For pieces up to 1,600 words, use [TextEvaluator](http://textevaluator.ets.org/TextEvaluator/).
+* For pieces up to 1,000 words, use [Lexile](https://lexile.com/educators/tools-to-support-reading-at-school/tools-to-determine-a-books-complexity/the-lexile-analyzer/).
 
-Admittedly, web.dev tends to deal with technical content, so the reading level will sometimes be high. But the following guidelines will help keep your language as accessible as it can be.
+It can be difficult to write technical content for a grade 8 reading level. The following guidelines help keep your language as accessible as it can be.
 
-Prefer shorter, simpler sentences.
+Write shorter, simpler sentences.
 
 {% Compare 'worse', 'Don’t' %}
 > We also include an HTML table of buttons for accessibility reasons that is on top of the canvases but is made invisible using opacity: 0.
@@ -30,7 +29,7 @@ Prefer shorter, simpler sentences.
 
 {% endCompare %}
 
-Prefer commonly used words that your [audience](/handbook/audience) is likely to be familiar with over specialized vocabulary. If you need help finding a more accessible alternative, the [Merriam-Webster Learner's Dictionary](http://learnersdictionary.com/) is a handy tool.
+Use commonly used words that your [audience](/handbook/audience) is likely to be familiar with instead of specialized vocabulary. If you need help finding a more accessible alternative, the [Merriam-Webster Learner's Dictionary](http://learnersdictionary.com/) is a handy tool.
 
 {% Compare 'worse', 'Don’t' %}
 > In some scripts, graphemes can be visually joined when they're adjacent.
@@ -47,23 +46,23 @@ While _written language_ and _character_ are slightly less precise, they should 
 If you must use a word that your audience is unlikely to know, provide a definition using the [Key-term Aside component](/handbook/web-dev-components#asides).
 
 ## Make information easy to find
-Headings [shouldn't skip levels](/heading-levels). Also, don't add custom styles to headings—it makes the page hierarchy more difficult to follow for sighted readers.
+[Don't skip heading levels](/heading-levels). Don't add custom styles to headings—it makes the page hierarchy more difficult to follow.
 
 Spell out acronyms the first time they're used. For example: _Web Incubation Community Groups (WICG)_.
 
-Exceptions, edge cases, and other kinds of supplemental information should be right next to the primary content they're related to.
+Place exceptions, edge cases, and other kinds of supplemental information right next to the primary content they're related to.
 
 ## Use inclusive images
 Always provide [alt text](/image-alt).
 
 If you're creating an illustration, the parts that are essential for understanding the illustration should have a contrast ratio of at least 3:1. You can verify the contrast using checkers like the ones from [WeAIM](https://webaim.org/resources/contrastchecker/) or the [Paciello Group](https://developer.paciellogroup.com/resources/contrastanalyser/).
 
-Avoid images that may exclude certain audience members. Just like when we _write_ about people, we must remain inclusive when we _show_ people and the things they do and make. For example, avoid stock photos that show only male developers.
+Avoid images that may exclude certain audience members. Just like when you _write_ about people, remember to be inclusive when you _show_ people and the things they do and make. For example, avoid stock photos that show only male developers.
 
 ## Create accessible code blocks
-While code blocks should be as [simple as possible](/handbook/style#keep-it-simple), they must always include accessibility best practices. At a minimum:
-* Form elements should have [labels](/labels-and-text-alternatives/#label-form-elements).
-* Images should have [alt text](/image-alt).
+Make sure code blocks are [simple](/handbook/style#keep-it-simple) and follow  accessibility best practices. At a minimum:
+* Add [labels](/labels-and-text-alternatives/#label-form-elements) to form elements.
+* Include [alt text](/image-alt) for every image.
 
 In the rare case that you need to omit an accessibility detail to better convey what you're teaching,
 1. Add a note explaining that the developer needs to include accessibility features.
@@ -72,7 +71,7 @@ In the rare case that you need to omit an accessibility detail to better convey 
 ## Writing about people
 There are several excellent online guides for using inclusive language when writing about groups of people. The [Content Guide](https://content-guide.18f.gov/inclusive-language/) from 18F (a U.S. government office that helps other agencies improve their user experience) is a great place to start.
 
-To be more gender inclusive, use _they/them_ for singular personal pronouns instead of _he/him_ and _she/her_. However, if you can use a plural pronoun instead, that's ideal.
+To be more gender inclusive, use _they/them_ for singular personal pronouns instead of _he/him_ and _she/her_. However, it's ideal to make it plural.
 
 {% Compare 'better', 'Good' %}
 > If the reader is interested in diving deeper after reading web.dev, they can turn to other sources.
@@ -85,7 +84,7 @@ To be more gender inclusive, use _they/them_ for singular personal pronouns inst
 {% endCompare %}
 
 ## Writing for an international audience
-Avoid idioms. If non-native speakers aren't familiar with the idiom, they may be confused.
+Avoid idioms. If non-native speakers aren't familiar with the idiom, they may be confused. Also, idioms are often lost in translation.
 
 {% Compare 'worse', 'Don’t' %}
 > The sample app should work now. Give it a shot!

--- a/src/site/content/en/handbook/markup-sample-app/index.md
+++ b/src/site/content/en/handbook/markup-sample-app/index.md
@@ -39,4 +39,4 @@ Use the license headers for HTML, CSS, and JS files:
 // SPDX-License-Identifier: Apache-2.0
 ```
 
-Manage the dependencies in your Glitch by adding them to the `package.json` file. Otherwise, dependencies can get out of date and break the Glitch. (Or you can ask readers to add dependencies to the Glitch's `package.json` themselves if that's relevant to what you're teaching. Any time the `package.json` file is edited, Glitch will automatically run `npm` again.)
+Manage the dependencies in your Glitch by adding them to the `package.json` file. Otherwise, dependencies can get out of date and break the Glitch. (Or you can ask readers to add dependencies to the Glitch's `package.json` themselves if that's relevant to what you're teaching. Any time the `package.json` file is edited, Glitch automatically runs `npm` again.)

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -11,7 +11,7 @@ description: |
 Content creation for web.dev has three phases: planning, writing, and publishing.
 
 ## Planning
-1. Start a content proposal issue on GitHub using [this issue template](https://github.com/GoogleChrome/web.dev/issues/new?assignees=&labels=content+request&template=content_request.md&title=). The checklist in your issue will guide you through the rest of the process.
+1. Start a content proposal issue on GitHub using [this issue template](https://github.com/GoogleChrome/web.dev/issues/new?assignees=&labels=content+request&template=content_request.md&title=). The checklist in your issue guides you through the rest of the process.
 1. Create a copy of [this document template](https://docs.google.com/document/d/1ydauCufwwavStaKxhIDHuNivVxgQBOdDno4uLjGIjmE/edit?usp=sharing) to briefly write up your content idea. Put the link to your doc in your GitHub issue.
 1. The web.dev team will take a look to see if the idea fits with the [goals of the site](/about). If the idea is approved, it gets slated for a publication date!
 
@@ -25,9 +25,9 @@ If the piece you'd like to publish is time sensitive, make sure to submit the is
 1. The tech writer will review using the [web.dev content checklist](/handbook/content-checklist) and work with you to polish the piece.
 
 ## Publishing
-1. Once you and the tech writer think the piece is good to go, submit a pull request on GitHub with your content authored in Markdown. (Check out the "[web.dev markup](/handbook/#web.dev-markup)" section for details.)
+1. Once you and the tech writer think the piece is good to go, submit a pull request on GitHub with your content authored in Markdown. Check out the [web.dev markup](/handbook/#web.dev-markup) section for details.
 1. The web.dev team will give your Markdown a once over. If everything looks good, your pull request is merged, and your piece is published! 🎉
 
 {% Aside %}
-Googlers: if you'd like to see our process in more detail, check out the [web.dev Process Document](https://docs.google.com/document/d/1Vxgrgxtz4OeJcrYJF5lpK9bVhTcGpXOXeeL4GZCV8KY).
+Googlers: If you'd like to see our process in more detail, check out the [web.dev Process Document](https://docs.google.com/document/d/1Vxgrgxtz4OeJcrYJF5lpK9bVhTcGpXOXeeL4GZCV8KY).
 {% endAside %}

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -1,6 +1,6 @@
 ---
 layout: handbook
-title: Quick start guide
+title: Content quick start guide
 authors:
   - mfriesenhahn
 date: 2019-06-26

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -13,7 +13,7 @@ Content creation for web.dev has three phases: planning, writing, and publishing
 ## Planning
 1. Start a content proposal issue on GitHub using [this issue template](https://github.com/GoogleChrome/web.dev/issues/new?assignees=&labels=content+request&template=content_request.md&title=). The checklist in your issue guides you through the rest of the process.
 1. Create a copy of [this document template](https://docs.google.com/document/d/1ydauCufwwavStaKxhIDHuNivVxgQBOdDno4uLjGIjmE/edit?usp=sharing) to briefly write up your content idea. Put the link to your doc in your GitHub issue.
-1. The web.dev team will take a look to see if the idea fits with the [goals of the site](/about). If the idea is approved, it gets slated for a publication date!
+1. The web.dev team takes a look to see if the idea fits with the [goals of the site](/about). If the idea is approved, it gets slated for a publication date!
 
 {% Aside 'caution' %}
 If the piece you'd like to publish is time sensitive, make sure to submit the issue at least two weeks before the target publication date so there's enough time to move it through the writing process.
@@ -22,11 +22,11 @@ If the piece you'd like to publish is time sensitive, make sure to submit the is
 ## Writing
 1. Write a draft in the Google doc you used to propose your piece. (Before you start, read our [style guidelines](/handbook/style).)
 1. When you're ready, request a content review in the GitHub issue.
-1. The tech writer will review using the [web.dev content checklist](/handbook/content-checklist) and work with you to polish the piece.
+1. The tech writer reviews using the [web.dev content checklist](/handbook/content-checklist) and work with you to polish the piece.
 
 ## Publishing
 1. Once you and the tech writer think the piece is good to go, submit a pull request on GitHub with your content authored in Markdown. Check out the [web.dev markup](/handbook/#web.dev-markup) section for details.
-1. The web.dev team will give your Markdown a once over. If everything looks good, your pull request is merged, and your piece is published! 🎉
+1. The web.dev team gives your Markdown a once over. If everything looks good, your pull request is merged, and your piece is published! 🎉
 
 {% Aside %}
 Googlers: If you'd like to see our process in more detail, check out the [web.dev Process Document](https://docs.google.com/document/d/1Vxgrgxtz4OeJcrYJF5lpK9bVhTcGpXOXeeL4GZCV8KY).

--- a/src/site/content/en/handbook/style/index.md
+++ b/src/site/content/en/handbook/style/index.md
@@ -39,7 +39,7 @@ This sentence includes unnecessary words in some places (e.g., multiple phrases 
 {% Compare 'better', 'Do' %}
 > Absolute and fixed positioning are now more compliant with W3C specifications and better match the behavior in other browsers.
 
-This revision gives detail readers will likely need (e.g., the relevant specification) while omitting unnecessary words.
+This revision gives detail readers likely need (e.g., the relevant specification) while omitting unnecessary words.
 {% endCompare %}
 
 Keep posts and codelabs short—typically 1,000 words or less.


### PR DESCRIPTION
There's a lot of repetition between the web.dev handbook and the google dev style guide. I suggest removing the stuff that's the same, and making a shorter highlight reel (like this https://developers.google.com/style/highlights) for people to scan. Then document where web.dev is different. 

The google dev style guide is more flushed out and provides more examples, so I'd prefer to use that one as a writer. No need to reinvent the wheel.