### PR TITLE
Hide codelab footer on devsite.

### DIFF
--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -23,6 +23,16 @@ this inline style tag.
 {% endif %}
 
 <main class="codelab-landing-page">
+  {% if site.env === 'prod' %}
+    <style>
+      devsite-content-footer,
+      devsite-footer-promos,
+      devsite-footer-linkboxes,
+      devsite-footer-utility {
+        display: none;
+      }
+    </style>
+  {% endif %}
   <web-codelab glitch="{{ glitch }}" path="{{ glitchPath }}" attribution-hidden>
     <div class="web-codelab-instructions">
       <h1 class="w-headline w-headline--two w-mb--sm">{{ title }}</h1>


### PR DESCRIPTION
Fixes #807, #404.

Changes proposed in this pull request:

- Force-hide the codelab footer on devsite using an inline style element.

On DevSite every page uses the same layout so we don't have a good signifier of when a codelab is displaying. We could use client-side JS to add a class to the body but devsite tends to load its JS quite slow so there would potentially be some weird FOUC issues with this. When we migrate off of devsite we should be able to remove this workaround.
