### PR TITLE
Change verb to correct grammar

### DIFF
--- a/src/site/content/en/accessible/style-focus/index.md
+++ b/src/site/content/en/accessible/style-focus/index.md
@@ -76,7 +76,7 @@ for a summary of which browsers and operating systems will apply focus to
 `<button>` elements.
 {% endAside %}
 
-Because the behavior of focus be inconsistent, it may require a bit of testing
+Because the behavior of focus is inconsistent, it may require a bit of testing
 on different devices to ensure your focus styles are acceptable to your users.
 
 ## Use `:focus-visible` to selectively show a focus indicator


### PR DESCRIPTION
Fixes grammar issue in 2e2ef6204ff7416433ac5ebfd2aeae547a87e17b.

The updated information to fix #1047 looks great, but I noticed a tiny grammar issue that this PR fixes. 🙂 

> "Because the behavior of focus ~~be~~ **is** inconsistent, ..."

---

Here's a reference from Grammarly:
![grammarly-help](https://user-images.githubusercontent.com/35671299/61371091-3d627680-a894-11e9-81a8-dd5c58df1d56.png)