### PR TITLE
Add scheduled and draft posts.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -90,7 +90,7 @@ module.exports = function(config) {
   //----------------------------------------------------------------------------
   // COLLECTIONS
   //----------------------------------------------------------------------------
-  config.addCollection('postsDescending', postDescending);
+  config.addCollection('posts', postDescending);
   config.addCollection('postsWithLighthouse', postsWithLighthouse);
   config.addCollection('recentPosts', recentPosts);
   // Turn collection.all into a lookup table so we can use findBySlug

--- a/src/site/_collections/post-descending.js
+++ b/src/site/_collections/post-descending.js
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+const livePosts = require('../_filters/live-posts');
+
 module.exports = (collection) => {
   return collection
     .getFilteredByTag('post')
+    .filter(livePosts)
     .reverse();
 };

--- a/src/site/_collections/posts-with-lighthouse.js
+++ b/src/site/_collections/posts-with-lighthouse.js
@@ -16,12 +16,17 @@
 
 // Return posts that reference a Lighthouse audit.
 // These posts will be displayed in the user's TODO list on the /measure page.
+
+const livePosts = require('../_filters/live-posts');
+
 module.exports = (collection) => {
-  return collection.getFilteredByTag('pathItem').filter((post) => {
-    const audits = post.data.web_lighthouse;
-    if (typeof audits === 'string' && audits !== 'N/A') {
-      return true;
-    }
-    return audits instanceof Array && audits.length;
-  });
+  return collection.getFilteredByTag('pathItem')
+    .filter(livePosts)
+    .filter((post) => {
+      const audits = post.data.web_lighthouse;
+      if (typeof audits === 'string' && audits !== 'N/A') {
+        return true;
+      }
+      return audits instanceof Array && audits.length;
+    });
 };

--- a/src/site/_collections/recent-posts.js
+++ b/src/site/_collections/recent-posts.js
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+const livePosts = require('../_filters/live-posts');
+
 // Return the three most recent blog posts.
 module.exports = (collection) => {
   return collection
     .getFilteredByTag('post')
+    .filter(livePosts)
     .reverse()
     .slice(0, 3);
 };

--- a/src/site/_filters/live-posts.js
+++ b/src/site/_filters/live-posts.js
@@ -1,0 +1,17 @@
+const now = new Date();
+
+/**
+ * Filter scheduled posts and draft posts out from a collection.
+ * This function does produce a side-effect where it adds a draft flag to a
+ * post if it's not scheduled to go live. This is so the page template can
+ * add a meta noindex tag to the post.
+ * @param {object} post An eleventy post object.
+ * @return {boolean} Whether or not the post should go live.
+ */
+module.exports = function livePosts(post) {
+  if (post.date > now) {
+    post.data.draft = true;
+  }
+
+  return !post.data.draft;
+};

--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -15,6 +15,7 @@
  */
 
 const {html} = require('common-tags');
+const {findBySlug} = require('../../_filters/find-by-slug');
 const stripLanguage = require('../../_filters/strip-language');
 
 /* eslint-disable require-jsdoc,max-len */
@@ -34,14 +35,24 @@ function getPathItemsFromTopics(topics) {
 
 /**
  * Find the slug for the next pathItem in a learning path.
+ * This requires grabbing the eleventy object for the post and checking if
+ * it is a draft or not.
  * @param {Object} path A learning path.
  * @param {string} slug The current page slug.
  * @return {string} The next pathItem slug or a terminating empty string.
  */
 function findNextPathItemBySlug(path, slug) {
+  let next = '';
   const items = getPathItemsFromTopics(path.topics);
   const idx = items.indexOf(slug);
-  return items[idx + 1] || '';
+  for (let i = idx + 1; i < items.length; i++) {
+    const item = findBySlug(items[i]);
+    if (!item.data.draft) {
+      next = items[i];
+      break;
+    }
+  }
+  return next;
 }
 
 /**

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -6,7 +6,7 @@
       <meta name="project_path" value="/_project.yaml" />
       <meta name="book_path" value="/_book.yaml" />
       <meta name="full_width" value="true" />
-      {% if noindex -%}
+      {% if noindex or draft -%}
         <meta name="robots" content="noindex">
       {%- endif %}
     </head>

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -87,7 +87,7 @@
     {% ArticleNavigation {
       back: '/blog',
       backLabel: 'Return to all articles',
-      collection: collections.postsDescending,
+      collection: collections.posts,
       slug: page.fileSlug
     } %}
   {% else %}

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -1,0 +1,21 @@
+<h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-numbered-header w-numbered-header--horizontal">
+  {{ topic.title }}
+  <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
+</h2>
+<ul class="w-path-list">
+  {% for slug in topic.pathItems %}
+    {% set item = slug | findBySlug %}
+    {% if item.data.draft %}
+      {# noop #}
+    {% else %}
+      <li class="w-path-listitem">
+        <a
+          class="w-path-link"
+          href="{{ item.url | stripLanguage }}"
+        >
+          {{ item.data.title }}
+        </a>
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -53,25 +53,24 @@ layout: layout
 
   <section class="w-layout-container">
     <div class="w-numbered-headers">
-    {% for topic in path.topics %}
-      <h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-numbered-header w-numbered-header--horizontal">
-        {{ topic.title }}
-        <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
-      </h2>
-      <ul class="w-path-list">
-      {% for slug in topic.pathItems %}
-        {% set item = slug | findBySlug %}
-        <li class="w-path-listitem">
-          <a
-            class="w-path-link"
-            href="{{ item.url | stripLanguage }}"
-          >
-            {{ item.data.title }}
-          </a>
-        </li>
+      {#
+        Check to see if the only item within a topic is a draft post.
+        If so, don't render the topic heading and skip the post.
+      #}
+      {% for topic in path.topics %}
+        {% if topic.pathItems.length === 1 %}
+          {% set item = topic.pathItems[0] | findBySlug %}
+          {% if item.data.draft %}
+            {# noop #}
+          {% else %}
+            {# render topic #}
+            {% include 'partials/topic.njk' %}
+          {% endif %}
+        {% else %}
+          {# render topic #}
+          {% include 'partials/topic.njk' %}
+        {% endif %}
       {% endfor %}
-      </ul>
-    {% endfor %}
     </div>
   </section>
 </main>

--- a/src/site/content/en/blog/index.njk
+++ b/src/site/content/en/blog/index.njk
@@ -25,7 +25,7 @@ permalink: /en/blog/index.html
 
   <section class="w-grid">
     <div class="w-grid__columns w-grid__columns--three" role="list">
-      {% for post in collections.postsDescending %}
+      {% for post in collections.posts %}
         {% PostCard {post: post} %}
       {% endfor %}
     </div>

--- a/src/site/content/en/feed.njk
+++ b/src/site/content/en/feed.njk
@@ -18,12 +18,12 @@ metadata:
   <subtitle>{{ metadata.feed.subtitle }}</subtitle>
   <link href="{{ metadata.feed.url }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
-  <updated>{{ collections.post | rssLastUpdatedDate }}</updated>
+  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.feed.id }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
   </author>
-  {% for post in collections.post -%}
+  {% for post in collections.posts -%}
   {% set absolutePostUrl -%}{{ post.url | stripLanguage | url | absoluteUrl(metadata.url) }}{%- endset %}
   <entry>
     <title>{{ post.data.title }}</title>


### PR DESCRIPTION
Fixes #725

Changes proposed in this pull request:

- Adds a `livePosts` filter. If a post has a `draft: true` flag in its YAML, or its `date` is greater than today then it will be marked as a `draft` and removed from eleventy collections.
- If a post is marked as a `draft` then its layout will get a meta noindex flag to prevent search crawling.

**Caveats**

It's important to note that eleventy will still produce a copy of the post in the `dist/` directory and this copy will still get published on the server. However, nothing will be linking to it. This does mean that if someone is able to _guess_ the URL and type it in manually that they could see the content. But since the post will already be checked in to our GitHub repo at this point that seems like it's not a big deal.

If authors want to _completely_ prevent their post from even generating an output file they should instead add these flags to their YAML frontmatter:

```
eleventyExcludeFromCollections: true
permalink: false
```

Unfortunately there isn't a way (that I know of) to set these flags from within a collection itself which is how we're currently implementing the `draft` flag.