### PR TITLE
Layout Instability API updates for Chrome 77

### DIFF
--- a/src/site/_includes/styles.njk
+++ b/src/site/_includes/styles.njk
@@ -77,4 +77,11 @@ ul:not([class]) > li::before {
   position: absolute;
   width: 8px;
 }
+
+.w-aside pre,
+.w-aside pre code {
+  font-size: .889em;
+  line-height: 1.5;
+  white-space: pre;
+}
 </style>

--- a/src/site/content/en/blog/layout-instability-api/index.md
+++ b/src/site/content/en/blog/layout-instability-api/index.md
@@ -244,7 +244,7 @@ observer.observe({type: 'layout-shift', buffered: true});
 **Note:** The
 [`buffered`](https://w3c.github.io/performance-timeline/#dom-performanceobserverinit-buffered)
 flag in the above example (supported in Chrome 77+) gives you access to entries
-that may have occurred prior to creating the performance observer.
+that may have occurred prior to creating the `PerformanceObserver`.
 
 </div>
 
@@ -252,21 +252,12 @@ that may have occurred prior to creating the performance observer.
 
 **Beware:** The `entryType` value for this API has changed a few times during
 the experimentation period. In Chrome 76 it was `layoutShift` and in Chrome
-74-75 it was `layoutJank`.
-
-Developers implementing the stable API should only need to observe the current
-`layout-shift` value (as shown in the example above), but developers who are
-part of the origin trial may need to observe multiple entry types to cover
-their full user base).
-
-```js
-if (PerformanceObserver.supportedEntryTypes &&
-    PerformanceObserver.supportedEntryTypes.includes('layout-shift')) {
-  observer.observe({type: 'layout-shift', buffered: true});
-} else {
-  observer.observe({entryTypes: ['layoutShift', 'layoutJank']});
-}
-```
+74-75 it was `layoutJank`. Developers implementing the stable API should only
+need to observe the current `layout-shift` value (as shown in the example
+above), but developers who are part of the origin trial may need to observe
+multiple entry types to cover their full user base. See [this
+demo](https://output.jsbin.com/zajamil/quiet) for an example of code that
+works in Chrome 74+.
 
 </div>
 

--- a/src/site/content/en/blog/layout-instability-api/index.md
+++ b/src/site/content/en/blog/layout-instability-api/index.md
@@ -239,19 +239,19 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({type: 'layout-shift', buffered: true});
 ```
 
-<div class="w-aside w-aside--note">
+{% Aside %}
 
 **Note:** The
 [`buffered`](https://w3c.github.io/performance-timeline/#dom-performanceobserverinit-buffered)
 flag in the above example (supported in Chrome 77+) gives you access to entries
 that may have occurred prior to creating the `PerformanceObserver`.
 
-</div>
+{% endAside %}
 
-<div class="w-aside w-aside--warning">
+{% Aside 'caution' %}
 
-**Beware:** The `entryType` value for this API has changed a few times during
-the experimentation period. In Chrome 76 it was `layoutShift` and in Chrome
+The `entryType` value for this API has changed a few times during
+the experimentation period. In Chrome 76 it was `layoutShift`, and in Chrome
 74-75 it was `layoutJank`. Developers implementing the stable API should only
 need to observe the current `layout-shift` value (as shown in the example
 above), but developers who are part of the origin trial may need to observe
@@ -259,7 +259,7 @@ multiple entry types to cover their full user base. See [this
 demo](https://output.jsbin.com/zajamil/quiet) for an example of code that
 works in Chrome 74+.
 
-</div>
+{% endAside %}
 
 If you want to calculate the cumulative layout shift score for your pages and
 track them in your analytics back end, you can declare a variable that stores

--- a/src/site/content/en/blog/layout-instability-api/index.md
+++ b/src/site/content/en/blog/layout-instability-api/index.md
@@ -225,7 +225,7 @@ which will be available until Sept. 3, 2019.
 
 Similar to other performance APIs, Layout Instability can be observed via the
 `PerformanceObserver` interface, where you can subscribe to entries of type
-`layoutShift`.
+`layout-shift`.
 
 The following code logs all layout shift entries as they happen:
 
@@ -236,8 +236,39 @@ const observer = new PerformanceObserver((list) => {
   }
 })
 
-observer.observe({entryTypes: ['layoutShift']});
+observer.observe({type: 'layout-shift', buffered: true});
 ```
+
+<div class="w-aside w-aside--note">
+
+**Note:** The
+[`buffered`](https://w3c.github.io/performance-timeline/#dom-performanceobserverinit-buffered)
+flag in the above example (supported in Chrome 77+) gives you access to entries
+that may have occurred prior to creating the performance observer.
+
+</div>
+
+<div class="w-aside w-aside--warning">
+
+**Beware:** The `entryType` value for this API has changed a few times during
+the experimentation period. In Chrome 76 it was `layoutShift` and in Chrome
+74-75 it was `layoutJank`.
+
+Developers implementing the stable API should only need to observe the current
+`layout-shift` value (as shown in the example above), but developers who are
+part of the origin trial may need to observe multiple entry types to cover
+their full user base).
+
+```js
+if (PerformanceObserver.supportedEntryTypes &&
+    PerformanceObserver.supportedEntryTypes.includes('layout-shift')) {
+  observer.observe({type: 'layout-shift', buffered: true});
+} else {
+  observer.observe({entryTypes: ['layoutShift', 'layoutJank']});
+}
+```
+
+</div>
 
 If you want to calculate the cumulative layout shift score for your pages and
 track them in your analytics back end, you can declare a variable that stores
@@ -253,11 +284,14 @@ let cumulativeLayoutShiftScore = 0;
 // `cumulativeLayoutShiftScore` variable.
 const observer = new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
-    cumulativeLayoutShiftScore += entry.value;
+    // Only count layout shifts without recent user input.
+    if (!entry.hadRecentInput) {
+      cumulativeLayoutShiftScore += entry.value;
+    }
   }
 });
 
-observer.observe({entryTypes: ['layoutShift']});
+observer.observe({type: 'layout-shift', buffered: true});
 
 // Sends the final score to your analytics back end once
 // the page's lifecycle state becomes hidden.
@@ -272,18 +306,6 @@ document.addEventListener('visibilitychange', () => {
   }
 });
 ```
-
-<div class="w-aside w-aside--note">
-  <p><strong>Note:</strong>
-  The Layout Instability API does not currently expose whether a layout shift
-  entry occurred shortly after a user input event. The goal is to eventually
-  expose it, but the exact format and duration is still being discussed.</p>
-  <p>In the meantime, developers wanting to track CLS scores themselves can
-  manually ignore specific layout shift entries by comparing `event.timeStamp`
-  with `entry.startTime` for events they expect to cause layout shifts. For
-  consistency with the CLS scores reported to CrUX, you can ignore entries that
-  occur within 500 milliseconds of user input.</p>
-</div>
 
 ## How to avoid unexpected layout shifts
 

--- a/src/styles/components/_asides.scss
+++ b/src/styles/components/_asides.scss
@@ -159,7 +159,7 @@ $KEY_POINT_COLOR: #6001ff;
 .w-aside pre,
 .w-aside pre code {
   font-size: .889em;
-  line-height: 1;
+  line-height: 1.5;
   white-space: pre;
 }
 


### PR DESCRIPTION
This PR includes changes to the Layout Instability API in Chrome 77, including:

- Renaming the `entryType` value to `layout-shift`
- Adding the `buffered: true` flag
- Using `type` instead of `entryTypes` (required for the buffered flag)
- Adding `entry.hadRecentInput` to the example

It also includes a small change to the `_asides.scss` partial to fix some issues with styling code blocks within asides.

/cc @skobes @npm1 @ericandrewlewis