### PR TITLE
fix wrong npm package name in angular preloading article

### DIFF
--- a/src/site/content/en/angular/route-preloading-in-angular/index.md
+++ b/src/site/content/en/angular/route-preloading-in-angular/index.md
@@ -75,7 +75,7 @@ The [quicklink](https://github.com/GoogleChromeLabs/quicklink) library provides 
 You can add quicklink to an Angular app by using the [ngx-quicklink](https://www.npmjs.com/package/ngx-quicklink) package. Start by installing the package from npm:
 
 ```
-npm install --save quicklink
+npm install --save ngx-quicklink
 ```
 
 Once it's available in your project, you can use `QuicklinkStrategy` by specifying the router's `preloadingStrategy` and importing the `QuicklinkModule`:


### PR DESCRIPTION
@mgechev there's a typo in the article, should be the Angular quicklink wrapper `ngx-quicklink` 😃 