### PR TITLE
Update link formatting

### DIFF
--- a/src/site/content/en/angular/accessible-angular-with-codelyzer/index.md
+++ b/src/site/content/en/angular/accessible-angular-with-codelyzer/index.md
@@ -24,7 +24,7 @@ In this post you'll learn how to add [codelyzer's](https://github.com/mgechev/co
 
 [codelyzer](https://github.com/mgechev/codelyzer) is a tool that sits on top of [TSLint](https://palantir.github.io/tslint/) and checks whether Angular TypeScript projects follow a set of linting rules. Projects set up with the [Angular command line interface (CLI)](https://cli.angular.io/) include codelyzer by default.
 
-codelyzer has over 50 rules for checking if an Angular application follows best practices. Of those, there are about 10 rules for enforcing accessibility criteria. To learn about the various accessibility checks provided by codelyzer and their rationales, see the "[New Accessibility rules in Codelyzer](https://medium.com/ngconf/new-accessibility-rules-in-codelyzer-v5-0-0-85eec1d3e9bb)" article.
+codelyzer has over 50 rules for checking if an Angular application follows best practices. Of those, there are about 10 rules for enforcing accessibility criteria. To learn about the various accessibility checks provided by codelyzer and their rationales, see the [New Accessibility rules in Codelyzer](https://medium.com/ngconf/new-accessibility-rules-in-codelyzer-v5-0-0-85eec1d3e9bb) article.
 
 Currently, all the accessibility rules are experimental and disabled by default. You can enable them by adding them to the TSLint configuration file (`tslint.json`):
 

--- a/src/site/content/en/angular/get-started-optimize-angular/index.md
+++ b/src/site/content/en/angular/get-started-optimize-angular/index.md
@@ -32,7 +32,7 @@ Each post in the collection will describe techniques that you can directly apply
 
 ## What's *not* in this collection?
 
-This collection assumes that you're already familiar with Angular and TypeScript. If you're not feeling confident with them yet, check out the TypeScript [documentation](https://www.typescriptlang.org/docs/home.html) and the "[Getting Started with Angular](https://angular.io/start)" guide on [angular.io](https://angular.io).
+This collection assumes that you're already familiar with Angular and TypeScript. If you're not feeling confident with them yet, check out the TypeScript [documentation](https://www.typescriptlang.org/docs/home.html) and the [Getting Started with Angular](https://angular.io/start) guide on [angular.io](https://angular.io).
 
 ## Start a project
 

--- a/src/site/content/en/angular/precaching-with-the-angular-service-worker/index.md
+++ b/src/site/content/en/angular/precaching-with-the-angular-service-worker/index.md
@@ -20,7 +20,7 @@ tags:
 
 When users have limited network access—or none at all—web app functionality can significantly degrade and often fails. Using a [service worker](https://developers.google.com/web/fundamentals/primers/service-workers/) to provide precaching lets you intercept network requests and deliver responses directly from a local cache instead of retrieving them from the network. Once your app's assets have been cached, this approach can really speed up an app and make it work when the user is offline.
 
-This post walks through how to set up precaching in an Angular app. It assumes you're already familiar with precaching and service workers in general. If you need a refresher, check out the "[Service workers and the Cache Storage API](https://web.dev/service-workers-cache-storage/)" post.
+This post walks through how to set up precaching in an Angular app. It assumes you're already familiar with precaching and service workers in general. If you need a refresher, check out the [Service workers and the Cache Storage API](https://web.dev/service-workers-cache-storage/) post.
 
 {% Aside %}
 

--- a/src/site/content/en/blog/predictive-prefetching/index.md
+++ b/src/site/content/en/blog/predictive-prefetching/index.md
@@ -13,7 +13,7 @@ tags:
   - performance
 ---
 
-In my "[Faster Web Navigation with Predictive Prefetching](https://www.youtube.com/watch?v=0jB4YWgAxUo)" session at Google I/O 2019, I began by talking about optimizing web apps with code-splitting and the potential performance implications for subsequent page navigation. In the second part of the talk, I discussed how to improve navigation speed by using Guess.js to set up predictive prefetching:
+In my [Faster Web Navigation with Predictive Prefetching](https://www.youtube.com/watch?v=0jB4YWgAxUo) session at Google I/O 2019, I began by talking about optimizing web apps with code-splitting and the potential performance implications for subsequent page navigation. In the second part of the talk, I discussed how to improve navigation speed by using Guess.js to set up predictive prefetching:
 
 {% YouTube '0jB4YWgAxUo' %}
 

--- a/src/site/content/en/handbook/audience/index.md
+++ b/src/site/content/en/handbook/audience/index.md
@@ -30,14 +30,14 @@ Alice is a developer working in a team for a large e-commerce website. The site'
 Damir is a developer at a small fintech startup. His boss has asked him to help turn their company's site into a PWA. After trying to enable some offline functionality, Damir realizes through a StackOverflow post ([example](https://stackoverflow.com/questions/50777677/pwa-offline-capability-on-data-that-frecuently-changes)) that the best bet to solving his problem is to create a service worker. He needs to learn how to create a service worker that will work with his company's existing site and the dynamic data that it handles.
 
 * **Prior knowledge:** Damir is a more advanced developer. He can quickly skim documentation to find the code snippets and examples relevant to his use case.
-* **Entry point:** Damir searches for "service worker for PWA," and one of the first search results is a post in the web.dev "[Installable](/installable)" collection.
+* **Entry point:** Damir searches for "service worker for PWA," and one of the first search results is a post in the web.dev [Installable](/installable) collection.
 * **Goal:** Find a specific, implementable solution to an issue as quickly as possible. (Unlike Alice, Damir is trying to fix a problem identified by his team or manager rather than by Lighthouse.)
 
 ### Topic deep-diver (Andrew)
 Andrew is a frontend developer at a startup whose main product is a peer-to-peer resource sharing web app.  He wants to become the go-to accessibility person on the engineering team since accessibility is an issue he feels is important but knows very little about. Andrew has signed up to give a 30-minute accessibility introductory talk to his team in two weeks.
 
 * **Prior knowledge:** Andrew has heard of accessibility and knows that it's about helping users with special needs, but he doesn't have a fully accurate sense of who those users are or how they interact with his product.
-* **Entry point:** Andrew's searches for accessibility, and one of the first search results is the landing page for the "[Accessible to all](/accessible)" collection.
+* **Entry point:** Andrew's searches for accessibility, and one of the first search results is the landing page for the [Accessible to all](/accessible) collection.
 * **Goal:** Master the basics of web accessibility and find high-quality resources to learn from and share with fellow engineers.
 
 ### Demo builder (Emily)
@@ -62,7 +62,7 @@ That said, we want our content to address as much of our audience as we can. How
 * A post about optimizing images in general, with associated codelabs showing how to integrate image optimization into different build processes
 * A post about how to address an issue most web developers will encounter, with sections at the end focused on solving the problem as it appears in particular business verticals
 
-Be mindful of your [voice](/handbook/voice). You want readers to feel they can trust the guidance you're giving. They should feel neither talked down to nor overwhelmed. Check out "[Instruction for adult learners](/handbook/effective-instruction#instruction-for-adult-learners)" in the "[Writing effective instruction](/handbook/effective-instruction)" post.
+Be mindful of your [voice](/handbook/voice). You want readers to feel they can trust the guidance you're giving. They should feel neither talked down to nor overwhelmed. Check out [Instruction for adult learners](/handbook/effective-instruction#instruction-for-adult-learners) in the [Writing effective instruction](/handbook/effective-instruction) post.
 
 ### Value propositions
 A value proposition is a promise to readers that a piece of content will be useful—that is, provide value—to them. Create a value proposition for everything you write by crafting titles, subtitles, and descriptions that tell your target audience why your post or codelab is worth reading. Some common strategies:

--- a/src/site/content/en/handbook/content-types/index.md
+++ b/src/site/content/en/handbook/content-types/index.md
@@ -20,7 +20,7 @@ description: |
 
 **Placement on the site:**
 * Always appears on the [blog](/blog), organized chronologically
-* May transition into a collection in the "[Learn](/learn)" section, organized thematically with other posts
+* May transition into a collection in the [Learn](/learn) section, organized thematically with other posts
 
 **Length:** typically less than 1,000–1,500 words
 

--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -60,11 +60,11 @@ Don't include preceding articles (_a_, _an_, _the_) or surrounding punctuation i
 {% endCompare %}
 
 {% Compare 'better', 'Do' %}
-> See the "[Easily discoverable](/discoverable)" collection for more information.
+> See the [Easily discoverable](/discoverable) collection for more information.
 
 {% endCompare %}
 
-When referring to webpages, either on web.dev or elsewhere, hyperlink the webpage title and put double quotation marks outside the hyperlink. (See example above.)
+When referring to webpages, either on web.dev or elsewhere, hyperlink the webpage title only, without quotation marks. (See example above.)
 
 Libraries and tools should be linked the first time they're mentioned.
 

--- a/src/site/content/en/handbook/inclusion-and-accessibility/index.md
+++ b/src/site/content/en/handbook/inclusion-and-accessibility/index.md
@@ -67,7 +67,7 @@ While code blocks should be as [simple as possible](/handbook/style#keep-it-simp
 
 In the rare case that you need to omit an accessibility detail to better convey what you're teaching,
 1. Add a note explaining that the developer needs to include accessibility features.
-1. Link to the relevant post in the web.dev "[Accessible to all](/accessible)" collection.
+1. Link to the relevant post in the web.dev [Accessible to all](/accessible) collection.
 
 ## Writing about people
 There are several excellent online guides for using inclusive language when writing about groups of people. The [Content Guide](https://content-guide.18f.gov/inclusive-language/) from 18F (a U.S. government office that helps other agencies improve their user experience) is a great place to start.

--- a/src/site/content/en/handbook/markup-code/index.md
+++ b/src/site/content/en/handbook/markup-code/index.md
@@ -8,7 +8,7 @@ description: |
   Learn how to create well-formatted code samples for web.dev.
 ---
 
-This post is about how to get sample code to look right in your piece and follow site conventions. For guidance about how to use code samples to support your writing goals, see the "[Write useful code samples](/handbook/write-code-samples/)" post.
+This post is about how to get sample code to look right in your piece and follow site conventions. For guidance about how to use code samples to support your writing goals, see the [Write useful code samples](/handbook/write-code-samples/) post.
 
 ## All code
 Make all code samples [accessible](/handbook/inclusion-and-accessibility/#create-accessible-code-blocks).

--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -8,7 +8,7 @@ description: |
   Learn how to create the Markdown for images and video for web.dev.
 ---
 
-This post is about how to format and store images on web.dev. For guidance about how to select or create images to support your writing goals, see the "[Use images and video effectively](/handbook/use-media)" post.
+This post is about how to format and store images on web.dev. For guidance about how to select or create images to support your writing goals, see the [Use images and video effectively](/handbook/use-media) post.
 
 ## All images
 Images that appear in a post should live in the same directory as the post's `index.md` file.
@@ -98,12 +98,12 @@ To include an entire screenshot, add the `w-screenshot-filled` class to the `img
 
 ## Screenshots
 To take a screenshot on Windows:
-1. Check out Microsoft's "[Use Snipping Tool to capture screenshots](https://support.microsoft.com/en-us/help/13776/windows-use-snipping-tool-to-capture-screenshots)" page.
+1. Check out Microsoft's [Use Snipping Tool to capture screenshots](https://support.microsoft.com/en-us/help/13776/windows-use-snipping-tool-to-capture-screenshots) page.
 1. In the Snipping Tool, use the pen to add a red box around any highlighted areas.
 1. Click **Save Snip** and choose the desired options.
 
 To take a screenshot on Mac:
-1. Check out Apple's "[How to take a screenshot on your Mac](https://support.apple.com/en-us/HT201361)" page.
+1. Check out Apple's [How to take a screenshot on your Mac](https://support.apple.com/en-us/HT201361) page.
 1. In Mac Preview, indicate any highlighted areas by adding a red box with borders set to the medium thickness.
 1. Close Mac Preview. The screenshot image will appear on your desktop.
 
@@ -113,7 +113,7 @@ To take a screenshot on Mac:
 To embed a YouTube video, use the web.dev `YouTube` [component](/handbook/web-dev-components).
 
 ### Video hosted on web.dev
-Always use video, not animated GIFs. (Check out the "[Replace animated GIFs with video for faster page loads](/replace-gifs-with-videos/)" post to learn how to use [FFmpeg](https://www.ffmpeg.org/) to convert GIFs to video.)
+Always use video, not animated GIFs. (Check out the [Replace animated GIFs with video for faster page loads](/replace-gifs-with-videos/) post to learn how to use [FFmpeg](https://www.ffmpeg.org/) to convert GIFs to video.)
 
 Once you have a video ready, message your content reviewer, and they'll help you upload it to the web.dev Google Cloud Storage bucket.
 

--- a/src/site/content/en/handbook/markup-post-codelab/index.md
+++ b/src/site/content/en/handbook/markup-post-codelab/index.md
@@ -8,7 +8,7 @@ description: |
   Learn how to create the Markdown for posts and codelabs on web.dev.
 ---
 
-This post is about how to set up a new post or codelab so it works correctly on web.dev. For guidelines about what to put _in_ your post, see the "[Content guidelines](/handbook/#content-guidelines)" section.
+This post is about how to set up a new post or codelab so it works correctly on web.dev. For guidelines about what to put _in_ your post, see the [Content guidelines](/handbook/#content-guidelines) section.
 
 ## Get started
 1. Create a new branch of the web.dev repository.

--- a/src/site/content/en/handbook/markup-sample-app/index.md
+++ b/src/site/content/en/handbook/markup-sample-app/index.md
@@ -8,7 +8,7 @@ description: |
   Learn how to create sample apps for web.dev using Glitch.
 ---
 
-This post is about how to get sample apps to work right in your post and follow site conventions. For guidance about how to use sample apps to support your writing goals, see the "[Write useful code samples](/handbook/write-code-samples)" post.
+This post is about how to get sample apps to work right in your post and follow site conventions. For guidance about how to use sample apps to support your writing goals, see the [Write useful code samples](/handbook/write-code-samples) post.
 
 web.dev uses [Glitch](https://glitch.com/) to embed web-based sample apps and development environments in its posts and codelabs. Glitch is handy because it lets you demonstrate both frontend and backend code.
 

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -25,7 +25,7 @@ If the piece you'd like to publish is time sensitive, make sure to submit the is
 1. The tech writer will review using the [web.dev content checklist](/handbook/content-checklist) and work with you to polish the piece.
 
 ## Publishing
-1. Once you and the tech writer think the piece is good to go, submit a pull request on GitHub with your content authored in Markdown. (Check out the "[web.dev markup](/handbook/#web.dev-markup)" section for details.)
+1. Once you and the tech writer think the piece is good to go, submit a pull request on GitHub with your content authored in Markdown. (Check out the [web.dev markup](/handbook/#web.dev-markup) section for details.)
 1. The web.dev team will give your Markdown a once over. If everything looks good, your pull request is merged, and your piece is published! 🎉
 
 {% Aside %}

--- a/src/site/content/en/handbook/style/index.md
+++ b/src/site/content/en/handbook/style/index.md
@@ -67,15 +67,15 @@ Include examples and figures. (See the next guideline.)
 ## Use figures when text won't do
 Aside from breaking up long sections of prose, media can be better than text for conveying some concepts and instructions. A key question to ask as you write is: "Would this idea be easier to understand if I provided a figure?"
 
-web.dev supports the following figures, which you can include in your post or codelab by following the examples in the "[web.dev components](/handbook/web-dev-components)" post.
+web.dev supports the following figures, which you can include in your post or codelab by following the examples in the [web.dev components](/handbook/web-dev-components) post.
 * Tables (Use tables sparingly—they don't resize well on mobile.)
 * Comparisons
-* Images and video (See the "[Use images and video effectively](/handbook/use-media)" post.)
+* Images and video (See the [Use images and video effectively](/handbook/use-media) post.)
 * Code blocks
-* Sample apps (See the "[Write useful code samples](/handbook/write-code-samples)" post.)
+* Sample apps (See the [Write useful code samples](/handbook/write-code-samples) post.)
 
 ## Help readers get things done
-Focus on readers and the concrete task they're trying to complete. While an introductory paragraph can provide important [context](#give-useful-context), get to the instructional content as soon as possible. The "[Use Imagemin to compress images](/use-imagemin-to-compress-images)" post is a great example.
+Focus on readers and the concrete task they're trying to complete. While an introductory paragraph can provide important [context](#give-useful-context), get to the instructional content as soon as possible. The [Use Imagemin to compress images](/use-imagemin-to-compress-images) post is a great example.
 
 When providing instruction, favor the imperative mood.
 
@@ -122,9 +122,9 @@ Using second person helps convey that we think this information is relevant to r
 Provide a way to measure success. How can developers test that they've followed your instruction correctly?
 
 ## Keep it simple
-Focus on essential details when explaining a tool or technique. Avoid overwhelming the reader with "real-world" examples that include complexities that aren't required to understand the basic concept. Save those details for supplemental codelabs or follow-up posts. See the "[Code splitting with React.lazy and Suspense](/code-splitting-suspense)" post for an example.
+Focus on essential details when explaining a tool or technique. Avoid overwhelming the reader with "real-world" examples that include complexities that aren't required to understand the basic concept. Save those details for supplemental codelabs or follow-up posts. See the [Code splitting with React.lazy and Suspense](/code-splitting-suspense) post for an example.
 
-Avoid jargon. If you absolutely _must_ use a term most web.dev readers are unlikely to know, define it in a short aside. See the "[web.dev components](/handbook/web-dev-components#asides)" post for how to include asides. Also check out the "[Inclusion and accessibility](/handbook/inclusion-and-accessibility#use-readable-language)" post for more info about writing readable language.
+Avoid jargon. If you absolutely _must_ use a term most web.dev readers are unlikely to know, define it in a short aside. See the [web.dev components](/handbook/web-dev-components#asides) post for how to include asides. Also check out the [Inclusion and accessibility](/handbook/inclusion-and-accessibility#use-readable-language) post for more info about writing readable language.
 
 {% Compare 'worse', 'Don’t' %}
 > In some scripts, graphemes can be visually joined when they're adjacent.
@@ -142,11 +142,11 @@ While _written language_ and _character_ are slightly less precise, they should 
 Make sure your information aligns to current documentation, standards, and best practices. If you're writing about a topic that isn't in your area of expertise (or even if it is!), get input from other experts.
 
 ## Give useful context
-Tell readers what you're expecting them to know up front—and provide links to where they can learn it if you can. See the "[Get started: optimize your React app](/get-started-optimize-react/#what-will-you-learn)" post for an example.
+Tell readers what you're expecting them to know up front—and provide links to where they can learn it if you can. See the [Get started: optimize your React app](/get-started-optimize-react/#what-will-you-learn) post for an example.
 
-Explain why what you're teaching matters before jumping into the instruction. This context can be provided in a collection via an introductory post (see the "[Accessible to all](/accessible)" collection for an example) or in a post via an introductory paragraph (the "[Use Imagemin to compress images](/use-imagemin-to-compress-images)" post is a nice example).
+Explain why what you're teaching matters before jumping into the instruction. This context can be provided in a collection via an introductory post (see the [Accessible to all](/accessible) collection for an example) or in a post via an introductory paragraph (the [Use Imagemin to compress images](/use-imagemin-to-compress-images) post is a nice example).
 
-Indicate which details are relevant in longer code blocks by providing explanations and code highlighting. If readers don't need to understand everything about the code, tell them that—it makes the task less intimidating, especially for less experienced developers. See the "[Serve responsive images](/serve-responsive-images)" post for an example.
+Indicate which details are relevant in longer code blocks by providing explanations and code highlighting. If readers don't need to understand everything about the code, tell them that—it makes the task less intimidating, especially for less experienced developers. See the [Serve responsive images](/serve-responsive-images) post for an example.
 
 When there's more than one way to solve a problem, organize them in order of simplest to most complex.
 
@@ -155,4 +155,4 @@ Acknowledge browser complexity. Clearly state browser support (e.g., link to the
 
 Use well-known, well-established tooling. Strike a balance between what's most commonly used and what's best practice (in terms of compatibility, accessibility, functionality, etc.). Choosing tooling can be one of the most overwhelming and time consuming aspects of web development. Rather than providing exhaustive lists of options, suggest tooling and libraries to help readers feel confident in their choices.
 
-When appropriate, provide multiple paths, frameworks, or tools to achieve a goal. Attaching a codelab for each path to a post is often a good way to do this. To see an example, check out the codelab callout at the end of the "[Use Imagemin to compress images](/use-imagemin-to-compress-images/#imagemin-npm-module)" post.
+When appropriate, provide multiple paths, frameworks, or tools to achieve a goal. Attaching a codelab for each path to a post is often a good way to do this. To see an example, check out the codelab callout at the end of the [Use Imagemin to compress images](/use-imagemin-to-compress-images/#imagemin-npm-module) post.

--- a/src/site/content/en/handbook/use-media/index.md
+++ b/src/site/content/en/handbook/use-media/index.md
@@ -8,7 +8,7 @@ description: |
   Strategies for using images and video to support the author's purpose on web.dev.
 ---
 
-This post is about how to use images and video to support your writing goals. If you're looking for technical details about how to create images and video for web.dev, see the "[Images and video](/handbook/markup-media)" post.
+This post is about how to use images and video to support your writing goals. If you're looking for technical details about how to create images and video for web.dev, see the [Images and video](/handbook/markup-media) post.
 
 web.dev has two types of images:
 * **Hero images** appear at the start of a post and in the post previews on the [blog](/blog).
@@ -19,7 +19,7 @@ Both types of images should be [accessible](/handbook/inclusion-and-accessibilit
 ## Hero images
 A hero image should represent the main idea of the post in some way. It often works well to find a visual metaphor. For example, a [post about the Layout Instability API](/layout-instability-api) uses an image of a precariously balanced tower of rocks to suggest the fragile layouts that the API detects.
 
-Take a look at the "[Stock photos that don't suck](https://medium.com/@dustin/stock-photos-that-dont-suck-62ae4bcbe01b)" post on Medium for a list of sites that offer public domain or Creative Commons-licensed images.
+Take a look at the [Stock photos that don't suck](https://medium.com/@dustin/stock-photos-that-dont-suck-62ae4bcbe01b) post on Medium for a list of sites that offer public domain or Creative Commons-licensed images.
 
 ## Body images
 Body images should be related to body content in some way. Typically, an image illustrates an idea that immediately precedes it in the text of the post or codelab. Avoid including a body image just to break up text. Just as irrelevant text can be confusing, so too can an irrelevant image, especially for readers with cognitive differences.

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -143,7 +143,7 @@ To see how to use each component, [view this page's source on GitHub](https://gi
 
 ## Code
 
-See the "[Code](/handbook/markup-code)" post.
+See the [Code](/handbook/markup-code) post.
 
 ## Compare
 
@@ -211,7 +211,7 @@ at.
 
 ## Images
 
-See the "[Images and video](/handbook/markup-media)" post.
+See the [Images and video](/handbook/markup-media) post.
 
 ## Instruction
 
@@ -584,4 +584,4 @@ assumenda perspiciatis.
 </div>
 
 ## Video
-See the "[Images and video](/handbook/markup-media#video)" post.
+See the [Images and video](/handbook/markup-media#video) post.

--- a/src/site/content/en/handbook/write-code-samples/index.md
+++ b/src/site/content/en/handbook/write-code-samples/index.md
@@ -8,9 +8,9 @@ description: |
   Strategies for using code blocks and sample apps to support the author's purpose on web.dev.
 ---
 
-This post is about how to use code blocks and sample apps to support your writing goals. If you're looking for how to author code blocks in Markdown, see the "[Code](/handbook/markup-code)" post.
+This post is about how to use code blocks and sample apps to support your writing goals. If you're looking for how to author code blocks in Markdown, see the [Code](/handbook/markup-code) post.
 
-web.dev uses embedded [Glitches](https://glitch.com/) to embed sample apps in posts and codelabs. See the "[Sample apps](/handbook/markup-sample-app)" post for information about how to set up a Glitch.
+web.dev uses embedded [Glitches](https://glitch.com/) to embed sample apps in posts and codelabs. See the [Sample apps](/handbook/markup-sample-app) post for information about how to set up a Glitch.
 
 ## Typical use cases
 Use code blocks when the key concept you want to convey can be understood by looking at code alone. For example, a code block would make sense if you wanted to show the [markup for a well-structured set of HTML heading elements](/headings-and-landmarks/#use-headings-to-outline-the-page).

--- a/src/site/content/en/reliable/codelab-http-cache/codelab-http-cache.md
+++ b/src/site/content/en/reliable/codelab-http-cache/codelab-http-cache.md
@@ -42,8 +42,8 @@ These are the key files you will be working with in the sample project:
 {% Aside %}
 In the "real world", the process of assigning hashes and updating HTML
 files to include references to the latest versioned URL would be handled by a
-build tool, like 
-[webpack](https://webpack.js.org/guides/caching/#output-filenames). 
+build tool, like
+[webpack](https://webpack.js.org/guides/caching/#output-filenames).
 For the purposes of this codelab, assume that the hashes were generated as part
 of a build process that already took place.
 {% endAside %}


### PR DESCRIPTION
Remove quotation marks around linked article titles, [per GDDSC](https://developers.google.com/style/cross-references#formatting-cross-references). (A misleading example on another GDDSC page made it seem like quotation marks were desired. That example has since been removed.)