### PR TITLE
Changed `content-heading` to `content-encoding`

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
@@ -68,7 +68,7 @@ To check if a server compressed a response:
 1. Go to the **Network** panel in DevTools.
 1. Click the request that caused the response you're interested in.
 1. Click the **Headers** tab.
-1. Check the `content-heading` header in the **Response Headers** section.
+1. Check the `content-encoding` header in the **Response Headers** section.
 
 <figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="content-encoding.svg" alt="The content-encoding response header">


### PR DESCRIPTION
`content-heading` didn't make sense in this context (it was talking about content encodings, not headers), don't know if it even exists. (in the illustration, it pointed to `content-encoding` too.)

Changes proposed in this pull request:

- Changed `content-heading` to `content-encoding`

Thanks.