### PR TITLE
add web-url-chooser{,-container} to choose audit URL

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -6,6 +6,7 @@ import "./components/SparklineChart";
 import "./components/LighthouseGauge";
 import "./components/LighthouseScoresAudits";
 import "./components/UrlChooser";
+import "./components/UrlChooserContainer";
 import {store} from "./store";
 
 // Run as long-lived router w/ history & "<a>" bindings

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -5,6 +5,7 @@ import "./components/ProgressBar";
 import "./components/SparklineChart";
 import "./components/LighthouseGauge";
 import "./components/LighthouseScoresAudits";
+import "./components/UrlChooser";
 import {store} from "./store";
 
 // Run as long-lived router w/ history & "<a>" bindings

--- a/src/lib/components/UrlChooser/_styles.scss
+++ b/src/lib/components/UrlChooser/_styles.scss
@@ -8,24 +8,18 @@
 //
 // =============================================================================
 
-$border-radius: 6px;
-
 web-url-chooser {
-  $padding: 16px;
-  $cardsHeight: 219px;
-  $inputHeight: 56px;
+  $INPUT_HEIGHT: 56px;
 
   display: block;
-  border-radius: $border-radius;
+  border-radius: 6px;
 
-  &[switching] {
-    .lh-enterurl--switch {
-      display: block;
-    }
+  &:not([switching]) .lh-enterurl--switch {
+    display: none;
+  }
 
-    .lh-enterurl--selected {
-      display: none;
-    }
+  &[switching] .lh-enterurl--selected {
+    display: none;
   }
 
   .report_header_enterurl {
@@ -35,35 +29,37 @@ web-url-chooser {
   .lh-enterurl {
     position: relative;
     align-self: center;
+  }
 
-    .lh-enterurl__close {
-      position: absolute;
-      right: 0;
-      top: 0;
-      height: 100%;
-      padding: 0;
-      background: none;
-      box-shadow: none;
-      display: flex;
-      align-items: center;
+  /** The "X" button that appears to the right of a URL. */
+  .lh-enterurl .lh-enterurl__close {
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    padding: 0;
+    background: none;
+    box-shadow: none;
+    display: flex;
+    align-items: center;
 
-      &::after {
-        @include font-material-icon();
-        content: 'close';
-        color: $GREY_400;
-      }
+    &::after {
+      @include font-material-icon();
+      content: 'close';
+      color: $GREY_400;
+    }
 
-      &:focus,
-      &::-moz-focus-inner {
-        outline: 0;
-      }
+    &:focus,
+    &::-moz-focus-inner {
+      outline: 0;
+    }
 
-      &:focus::after {
-        color: $GREY_900;
-      }
+    &:focus::after {
+      color: $GREY_900;
     }
   }
 
+  /** The currently selected URL, not in editing mode. */
   .lh-enterurl--selected {
     font-weight: 500;
     padding-left: 24px;
@@ -77,12 +73,8 @@ web-url-chooser {
     }
   }
 
-  .lh-enterurl--switch {
-    display: none;
-  }
-
   .lh-input {
-    height: $inputHeight;
+    height: $INPUT_HEIGHT;
     width: 100%;
     transition: border 200ms ease-in-out;
     outline: none;
@@ -97,16 +89,21 @@ web-url-chooser {
     display: flex;
     flex-wrap: wrap;
     margin-top: 8px;
-
-    .w-button {
-      // List all vals so autoprefixer doesn't rewrite this to flex: 1 1 0%
-      // and make "switch url" text ellipsis.
-      flex: 1 1 auto;
-      height: $inputHeight;
-      justify-content: center;
-    }
   }
 
+  .lh-controls .w-button {
+    // List all vals so autoprefixer doesn't rewrite this to flex: 1 1 0%
+    // and make "switch url" text ellipsis.
+    flex: 1 1 auto;
+    height: $INPUT_HEIGHT;
+    justify-content: center;
+  }
+}
+
+web-url-chooser {
+  /// @deprecated
+  // TODO(robdodson): This should be replaced with the @media rules from breakpoints.scss, but the
+  // Measure page is special and currently does not have a matching value.
   @media screen and (min-width: $BREAKPOINT_VALUE_TABLET) {
     .report_header_enterurl {
       display: flex;

--- a/src/lib/components/UrlChooser/_styles.scss
+++ b/src/lib/components/UrlChooser/_styles.scss
@@ -1,0 +1,129 @@
+@import '../../../styles/settings/colors';
+@import '../../../styles/tools/mixins';
+
+// =============================================================================
+// URL CHOOSER
+//
+// Lets the user select a URL and trigger an audit.
+//
+// =============================================================================
+
+$border-radius: 6px;
+
+web-url-chooser {
+  $padding: 16px;
+  $cardsHeight: 219px;
+  $inputHeight: 56px;
+
+  display: block;
+  border-radius: $border-radius;
+
+  &[switching] {
+    .lh-enterurl--switch {
+      display: block;
+    }
+
+    .lh-enterurl--selected {
+      display: none;
+    }
+  }
+
+  .report_header_enterurl {
+    position: relative;
+  }
+
+  .lh-enterurl {
+    position: relative;
+    align-self: center;
+
+    .lh-enterurl__close {
+      position: absolute;
+      right: 0;
+      top: 0;
+      height: 100%;
+      padding: 0;
+      background: none;
+      box-shadow: none;
+      display: flex;
+      align-items: center;
+
+      &::after {
+        @include font-material-icon();
+        content: 'close';
+        color: $GREY_400;
+      }
+
+      &:focus,
+      &::-moz-focus-inner {
+        outline: 0;
+      }
+
+      &:focus::after {
+        color: $GREY_900;
+      }
+    }
+  }
+
+  .lh-enterurl--selected {
+    font-weight: 500;
+    padding-left: 24px;
+    // image is duplicated in lh-input.scss
+    background: url('data:image/svg+xml;utf8,<svg width="18px" height="18px" xmlns="http://www.w3.org/2000/svg"><path fill="%23212121" d="M7.992,0 C3.576,0 0,3.584 0,8 C0,12.416 3.576,16 7.992,16 C12.416,16 16,12.416 16,8 C16,3.584 12.416,0 7.992,0 Z M13.536,4.8 L11.176,4.8 C10.92,3.8 10.552,2.84 10.072,1.952 C11.544,2.456 12.768,3.48 13.536,4.8 Z M8,1.632 C8.664,2.592 9.184,3.656 9.528,4.8 L6.472,4.8 C6.816,3.656 7.336,2.592 8,1.632 Z M1.808,9.6 C1.68,9.088 1.6,8.552 1.6,8 C1.6,7.448 1.68,6.912 1.808,6.4 L4.512,6.4 C4.448,6.928 4.4,7.456 4.4,8 C4.4,8.544 4.448,9.072 4.512,9.6 L1.808,9.6 Z M2.464,11.2 L4.824,11.2 C5.08,12.2 5.448,13.16 5.928,14.048 C4.456,13.544 3.232,12.528 2.464,11.2 Z M4.824,4.8 L2.464,4.8 C3.232,3.472 4.456,2.456 5.928,1.952 C5.448,2.84 5.08,3.8 4.824,4.8 Z M8,14.368 C7.336,13.408 6.816,12.344 6.472,11.2 L9.528,11.2 C9.184,12.344 8.664,13.408 8,14.368 Z M9.872,9.6 L6.128,9.6 C6.056,9.072 6,8.544 6,8 C6,7.456 6.056,6.92 6.128,6.4 L9.872,6.4 C9.944,6.92 10,7.456 10,8 C10,8.544 9.944,9.072 9.872,9.6 Z M10.072,14.048 C10.552,13.16 10.92,12.2 11.176,11.2 L13.536,11.2 C12.768,12.52 11.544,13.544 10.072,14.048 Z M11.488,9.6 C11.552,9.072 11.6,8.544 11.6,8 C11.6,7.456 11.552,6.928 11.488,6.4 L14.192,6.4 C14.32,6.912 14.4,7.448 14.4,8 C14.4,8.552 14.32,9.088 14.192,9.6 L11.488,9.6 Z" id="icon/action/language_24px"></path></svg>') no-repeat 0 50%;
+
+    &::before {
+      // include zero-width space to force minimum height
+      content: '\200b';
+      user-select: none;
+    }
+  }
+
+  .lh-enterurl--switch {
+    display: none;
+  }
+
+  .lh-input {
+    height: $inputHeight;
+    width: 100%;
+    transition: border 200ms ease-in-out;
+    outline: none;
+    background-color: $WHITE;
+
+    &::-ms-clear {
+      display: none;
+    }
+  }
+
+  .lh-controls {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 8px;
+
+    .w-button {
+      // List all vals so autoprefixer doesn't rewrite this to flex: 1 1 0%
+      // and make "switch url" text ellipsis.
+      flex: 1 1 auto;
+      height: $inputHeight;
+      justify-content: center;
+    }
+  }
+
+  @media screen and (min-width: $BREAKPOINT_VALUE_TABLET) {
+    .report_header_enterurl {
+      display: flex;
+    }
+
+    .lh-controls {
+      margin-top: 0;
+      flex-wrap: nowrap;
+    }
+
+    .lh-enterurl {
+      margin-right: 32px;
+      width: 100%;
+    }
+
+    .lh-input {
+      width: 100%;
+    }
+  }
+}

--- a/src/lib/components/UrlChooser/_styles.scss
+++ b/src/lib/components/UrlChooser/_styles.scss
@@ -22,7 +22,7 @@ web-url-chooser {
     display: none;
   }
 
-  .report_header_enterurl {
+  .lh-report-header-enterurl {
     position: relative;
   }
 
@@ -32,7 +32,7 @@ web-url-chooser {
   }
 
   /** The "X" button that appears to the right of a URL. */
-  .lh-enterurl .lh-enterurl__close {
+  .lh-enterurl__close {
     position: absolute;
     right: 0;
     top: 0;
@@ -42,6 +42,11 @@ web-url-chooser {
     box-shadow: none;
     display: flex;
     align-items: center;
+    justify-content: center;
+
+    &[disabled] {
+      display: none;
+    }
 
     &::after {
       @include font-material-icon();
@@ -61,7 +66,7 @@ web-url-chooser {
 
   /** The currently selected URL, not in editing mode. */
   .lh-enterurl--selected {
-    font-weight: 500;
+    font-weight: $FONT_WEIGHT_MEDIUM;
     padding-left: 24px;
     // image is duplicated in lh-input.scss
     background: url('data:image/svg+xml;utf8,<svg width="18px" height="18px" xmlns="http://www.w3.org/2000/svg"><path fill="%23212121" d="M7.992,0 C3.576,0 0,3.584 0,8 C0,12.416 3.576,16 7.992,16 C12.416,16 16,12.416 16,8 C16,3.584 12.416,0 7.992,0 Z M13.536,4.8 L11.176,4.8 C10.92,3.8 10.552,2.84 10.072,1.952 C11.544,2.456 12.768,3.48 13.536,4.8 Z M8,1.632 C8.664,2.592 9.184,3.656 9.528,4.8 L6.472,4.8 C6.816,3.656 7.336,2.592 8,1.632 Z M1.808,9.6 C1.68,9.088 1.6,8.552 1.6,8 C1.6,7.448 1.68,6.912 1.808,6.4 L4.512,6.4 C4.448,6.928 4.4,7.456 4.4,8 C4.4,8.544 4.448,9.072 4.512,9.6 L1.808,9.6 Z M2.464,11.2 L4.824,11.2 C5.08,12.2 5.448,13.16 5.928,14.048 C4.456,13.544 3.232,12.528 2.464,11.2 Z M4.824,4.8 L2.464,4.8 C3.232,3.472 4.456,2.456 5.928,1.952 C5.448,2.84 5.08,3.8 4.824,4.8 Z M8,14.368 C7.336,13.408 6.816,12.344 6.472,11.2 L9.528,11.2 C9.184,12.344 8.664,13.408 8,14.368 Z M9.872,9.6 L6.128,9.6 C6.056,9.072 6,8.544 6,8 C6,7.456 6.056,6.92 6.128,6.4 L9.872,6.4 C9.944,6.92 10,7.456 10,8 C10,8.544 9.944,9.072 9.872,9.6 Z M10.072,14.048 C10.552,13.16 10.92,12.2 11.176,11.2 L13.536,11.2 C12.768,12.52 11.544,13.544 10.072,14.048 Z M11.488,9.6 C11.552,9.072 11.6,8.544 11.6,8 C11.6,7.456 11.552,6.928 11.488,6.4 L14.192,6.4 C14.32,6.912 14.4,7.448 14.4,8 C14.4,8.552 14.32,9.088 14.192,9.6 L11.488,9.6 Z" id="icon/action/language_24px"></path></svg>') no-repeat 0 50%;
@@ -105,7 +110,7 @@ web-url-chooser {
   // TODO(robdodson): This should be replaced with the @media rules from breakpoints.scss, but the
   // Measure page is special and currently does not have a matching value.
   @media screen and (min-width: $BREAKPOINT_VALUE_TABLET) {
-    .report_header_enterurl {
+    .lh-report-header-enterurl {
       display: flex;
     }
 

--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -10,8 +10,8 @@ class UrlChooser extends BaseElement {
   static get properties() {
     return {
       url: {type: String},
-      active: {type: Boolean},
-      switching: {type: Boolean, reflect: true}, // FIXME: internal but must reflect as [switching]
+      switching: {type: Boolean, reflect: true},
+      disabled: {type: Boolean},
     };
   }
 
@@ -19,7 +19,7 @@ class UrlChooser extends BaseElement {
     super();
     this.url = null; // when signed out or waiting for Firestore, this is null
     this.switching = true; // controls whether the user is editing the URL
-    this.active = false; // disables buttons (because Lighthouse is active)
+    this.disabled = false; // disables buttons (because Lighthouse is active)
 
     // non-properties (stolen DOM nodes)
     this._urlInput = null;
@@ -28,10 +28,11 @@ class UrlChooser extends BaseElement {
 
   render() {
     return html`
-      <div class="report_header_enterurl">
+      <div class="lh-report-header-enterurl">
         <div class="lh-enterurl lh-enterurl--selected">${this.url}</div>
         <div class="lh-enterurl lh-enterurl--switch">
           <input
+            ?disabled=${this.disabled}
             type="url"
             class="lh-input"
             placeholder="Enter a web page URL"
@@ -40,24 +41,25 @@ class UrlChooser extends BaseElement {
             @keyup="${this.onUrlKeyup}"
           />
           <button
+            ?disabled=${this.disabled}
             class="lh-enterurl__close"
             aria-label="Remove URL"
-            @click=${this.clearInput}
+            @click=${this.onClearInput}
           ></button>
         </div>
         <div class="lh-controls">
           <button
-            ?disabled=${this.active}
+            ?disabled=${this.disabled}
             class="w-button w-button--secondary"
-            @click=${this.switchUrl}
+            @click=${this.onSwitchUrl}
           >
             Switch URL
           </button>
           <button
-            ?disabled=${this.active}
+            ?disabled=${this.disabled}
             class="w-button w-button--primary"
             id="run-lh-button"
-            @click=${this.requestAudit}
+            @click=${this.onRequestAudit}
           >
             Run Audit
           </button>
@@ -66,91 +68,85 @@ class UrlChooser extends BaseElement {
     `;
   }
 
-  updated(changedProperties) {
+  firstUpdated(changedProperties) {
     this._urlInput = this.renderRoot.querySelector('input[type="url"]');
     this._runLighthouseButton = this.renderRoot.querySelector("#run-lh-button");
+  }
 
-    if (!changedProperties.has("url")) {
+  updated(changedProperties) {
+    const input = this._urlInput;
+
+    if (changedProperties.has("switching") && this.switching) {
+      input.setSelectionRange(0, input.value.length);
+      input.focus();
+    }
+    if (changedProperties.has("url")) {
+      // Note: This behavior can't be performed in a setter as the <input /> might not have been
+      // rendered yet.
+      const url = this.url;
+      if (this.switching && url && !input.value) {
+        // if the user has just signed in, the element was in an initial state,
+        // AND the user hasn't typed anything, reset element with URL
+        input.value = url;
+        this.switching = false;
+      } else if (url == null && !this.switching) {
+        // if the user has signed out, clear the href and enter switching mode
+        input.value = null;
+        this.switching = true;
+      } else if (!this.switching) {
+        // in all other cases, only update the URL if ther user isn't switching
+        input.value = url;
+      }
+    }
+  }
+
+  onRequestAudit() {
+    // Even if the user isn't switching URLs, fix and verify the saved URL which is inserted into
+    // the <input /> inside this element.
+    this.fixUpUrl();
+    if (!this._urlInput.validity.valid) {
+      const detail = `Invalid URL. Please enter a full URL starting with https://.`;
+      const event = new CustomEvent("web-error", {bubbles: true, detail});
+      this.dispatchEvent(event);
       return;
     }
 
-    const inputValue = this._urlInput.value;
-    const updateUrl = this.url;
+    // "Request Audit" finishes editing the URL.
+    this.switching = false;
 
-    if (this.switching && updateUrl && !inputValue) {
-      // if the user has just signed in, the element was in an initial state,
-      // AND the user hasn't typed anything, reset element with URL
-      this._urlInput.value = updateUrl;
-      this.switching = false;
-    } else if (updateUrl == null && !this.switching) {
-      // if the user has signed out, clear the href and enter switching mode
-      this._urlInput.value = null;
-      this.switching = true;
-    } else if (!this.switching) {
-      // in all other cases, only update the URL if ther user isn't switching
-      this._urlInput.value = updateUrl;
-    }
-  }
-
-  requestAudit() {
-    let url = this.url;
-
-    if (this.switching) {
-      this.fixUpUrl();
-
-      if (!this._urlInput.validity.valid) {
-        const detail = `Invalid URL. Please enter a full URL starting with https://.`;
-        const event = new CustomEvent("web-error", {bubbles: true, detail});
-        this.dispatchEvent(event);
-        return;
-      }
-
-      // if Request was pressed as part of switching, "url" still reflects prior state, so request
-      // audit based on the typed URL
-      this.switching = false;
-      url = this._urlInput.value;
-    }
-
-    const event = new CustomEvent("audit", {detail: url});
+    const event = new CustomEvent("audit", {detail: this._urlInput.value});
     this.dispatchEvent(event);
   }
 
-  switchUrl() {
+  onSwitchUrl() {
     this.switching = true;
 
-    const input = this._urlInput;
-    input.setSelectionRange(0, input.value.length);
-    input.focus();
-
-    if (document.activeElement !== input) {
-      // nb. will fail in Shadow DOM mode
-      window.requestAnimationFrame(() => {
-        input.focus();
-      });
-    }
+    // Focus won't occur if switching is already true, so trigger it here too.
+    this._urlInput.focus();
   }
 
   onUrlKeyup(e) {
     if (e.key === "Escape") {
-      this.clearInput();
+      this.onClearInput();
     } else if (e.key === "Enter") {
       this._runLighthouseButton.click();
     }
   }
 
+  /**
+   * Performs basic sanity fixes on the URL in the <input />.
+   */
   fixUpUrl() {
     let url = this._urlInput.value.trim();
     if (!url.startsWith("https://") && !url.startsWith("http://")) {
       url = `http://${url}`;
     }
-
-    this.url = url;
     if (url !== this._urlInput.value) {
       this._urlInput.value = url;
     }
   }
 
-  clearInput() {
+  onClearInput() {
     this._urlInput.value = null;
   }
 }

--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -15,7 +15,7 @@ class UrlChooser extends BaseElement {
 
   constructor() {
     super();
-    this.href = null;  // when signed out or waiting for Firestore, this is null
+    this.href = null; // when signed out or waiting for Firestore, this is null
     this.switching = true;
     this.active = false;
 
@@ -29,22 +29,48 @@ class UrlChooser extends BaseElement {
 
   render() {
     return html`
-    <div class="report_header_enterurl">
-      <div class="lh-enterurl lh-enterurl--selected">${this.href}</div>
-      <div class="lh-enterurl lh-enterurl--switch">
-        <input type="url" class="lh-input" .value="${this.href}" placeholder="Enter a web page URL" pattern="https?://.*" minlength="7" required @keyup="${this.onUrlKeyup}" />
-        <button class="lh-enterurl__close" aria-label="Remove URL" @click=${this.clearInput}></button>
+      <div class="report_header_enterurl">
+        <div class="lh-enterurl lh-enterurl--selected">${this.href}</div>
+        <div class="lh-enterurl lh-enterurl--switch">
+          <input
+            type="url"
+            class="lh-input"
+            .value="${this.href}"
+            placeholder="Enter a web page URL"
+            pattern="https?://.*"
+            minlength="7"
+            required
+            @keyup="${this.onUrlKeyup}"
+          />
+          <button
+            class="lh-enterurl__close"
+            aria-label="Remove URL"
+            @click=${this.clearInput}
+          ></button>
+        </div>
+        <div class="lh-controls">
+          <button
+            ?disabled=${this.active}
+            class="w-button w-button--secondary"
+            @click=${this.switchUrl}
+          >
+            Switch URL
+          </button>
+          <button
+            ?disabled=${this.active}
+            class="w-button w-button--primary"
+            id="run-lh-button"
+            @click=${this.runAudit}
+          >
+            Run Audit
+          </button>
+        </div>
       </div>
-      <div class="lh-controls">
-        <button ?disabled=${this.active} class="w-button w-button--secondary" @click=${this.switchUrl}>Switch URL</button>
-        <button ?disabled=${this.active} class="w-button w-button--primary" id="run-lh-button" @click=${this.runAudit}>Run Audit</button>
-      </div>
-    </div>
     `;
   }
 
   updated() {
-    this.urlInput = this.renderRoot.querySelector("input[type=\"url\"]");
+    this.urlInput = this.renderRoot.querySelector('input[type="url"]');
     this.runLighthouseButton = this.renderRoot.querySelector("#run-lh-button");
   }
 
@@ -53,7 +79,12 @@ class UrlChooser extends BaseElement {
 
     if (this.active) {
       // do nothing, the URL is being run through Lighthouse
-    } else if (this.href == null && this.switching && state.userUrl && !this.urlInput.value) {
+    } else if (
+      this.href == null &&
+      this.switching &&
+      state.userUrl &&
+      !this.urlInput.value
+    ) {
       // if the user has just signed in, the element was in an initial state,
       // AND the user hasn"t typed anything, reset element with URL
       this.href = state.userUrl;
@@ -76,7 +107,7 @@ class UrlChooser extends BaseElement {
     // TODO: actually run Lighthouse. Currently just freezes the page.
     this.switching = false;
     this.active = true;
-    console.warn("web-url-chooser in terminal state: should run Lighthouse")
+    console.warn("web-url-chooser in terminal state: should run Lighthouse");
   }
 
   switchUrl(ev) {
@@ -115,18 +146,20 @@ class UrlChooser extends BaseElement {
     }
 
     if (!this.urlInput.validity.valid) {
-      this.dispatchEvent(new CustomEvent("web-error", {
-        bubbles: true,
-        detail: `Invalid URL. Please enter a full URL starting with https://.`,
-      }))
+      const detail = `Invalid URL. Please enter a full URL starting with https://.`;
+      const ce = new CustomEvent("web-error", {bubbles: true, detail});
+      this.dispatchEvent(ce);
       return false;
     }
-  
+
     const ref = userRef();
-    const p = ref.set({
-      userUrl: url || null,
-      userUrlUpdate: firebase.firestore.FieldValue.serverTimestamp(),
-    }, {merge: true});
+    const p = ref.set(
+      {
+        userUrl: url || null,
+        userUrlUpdate: firebase.firestore.FieldValue.serverTimestamp(),
+      },
+      {merge: true},
+    );
     p.catch((err) => {
       // TODO: Firestore errors are problematic but we can still run with the new URL.
       console.warn("could not write URL", err);

--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -1,0 +1,143 @@
+import {html} from "lit-element";
+import {store} from "../../store";
+import {BaseElement} from "../BaseElement";
+import {userRef, firebase} from "../../fb";
+
+/* eslint-disable require-jsdoc */
+class UrlChooser extends BaseElement {
+  static get properties() {
+    return {
+      href: {type: String},
+      switching: {type: Boolean, reflect: true},
+      active: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.href = null;  // when signed out or waiting for Firestore, this is null
+    this.switching = true;
+    this.active = false;
+
+    // non-properties
+    this.urlInput = null;
+    this.runLighthouseButton = null;
+
+    store.subscribe(this.onStateChanged.bind(this));
+    this.onStateChanged();
+  }
+
+  render() {
+    return html`
+    <div class="report_header_enterurl">
+      <div class="lh-enterurl lh-enterurl--selected">${this.href}</div>
+      <div class="lh-enterurl lh-enterurl--switch">
+        <input type="url" class="lh-input" .value="${this.href}" placeholder="Enter a web page URL" pattern="https?://.*" minlength="7" required @keyup="${this.onUrlKeyup}" />
+        <button class="lh-enterurl__close" aria-label="Remove URL" @click=${this.clearInput}></button>
+      </div>
+      <div class="lh-controls">
+        <button ?disabled=${this.active} class="w-button w-button--secondary" @click=${this.switchUrl}>Switch URL</button>
+        <button ?disabled=${this.active} class="w-button w-button--primary" id="run-lh-button" @click=${this.runAudit}>Run Audit</button>
+      </div>
+    </div>
+    `;
+  }
+
+  updated() {
+    this.urlInput = this.renderRoot.querySelector("input[type=\"url\"]");
+    this.runLighthouseButton = this.renderRoot.querySelector("#run-lh-button");
+  }
+
+  onStateChanged() {
+    const state = store.getState();
+
+    if (this.active) {
+      // do nothing, the URL is being run through Lighthouse
+    } else if (this.href == null && this.switching && state.userUrl && !this.urlInput.value) {
+      // if the user has just signed in, the element was in an initial state,
+      // AND the user hasn"t typed anything, reset element with URL
+      this.href = state.userUrl;
+      this.switching = false;
+    } else if (state.userUrl == null && !this.switching) {
+      // if the user has signed out, clear the href and enter switching mode
+      this.href = null;
+      this.switching = true;
+    } else if (state.userUrl && !this.switching) {
+      // in all other cases, only update the URL if ther user isn"t switching
+      this.href = state.userUrl;
+    }
+  }
+
+  runAudit(ev) {
+    if (!this.fixUpAndValidateUrl()) {
+      return;
+    }
+
+    // TODO: actually run Lighthouse. Currently just freezes the page.
+    this.switching = false;
+    this.active = true;
+    console.warn("web-url-chooser in terminal state: should run Lighthouse")
+  }
+
+  switchUrl(ev) {
+    this.switching = true;
+
+    const input = this.urlInput;
+    input.setSelectionRange(0, input.value.length);
+    input.focus();
+
+    if (document.activeElement !== input) {
+      // nb. will fail in Shadow DOM mode
+      window.requestAnimationFrame(() => {
+        input.focus();
+      });
+    }
+  }
+
+  onUrlKeyup(e) {
+    if (e.keyCode === /* ESC */ 27) {
+      this.clearInput();
+    } else if (e.keyCode === /* ENTER */ 13) {
+      this.runLighthouseButton.click();
+    }
+  }
+
+  fixUpAndValidateUrl() {
+    let url = this.urlInput.value.trim();
+    if (!url.startsWith("https://") && !url.startsWith("http://")) {
+      url = `http://${url}`;
+    }
+
+    this.href = url;
+    if (url !== this.urlInput.value) {
+      // Could also call this.update() here, this just short-circuits the change.
+      this.urlInput.value = url;
+    }
+
+    if (!this.urlInput.validity.valid) {
+      this.dispatchEvent(new CustomEvent("web-error", {
+        bubbles: true,
+        detail: `Invalid URL. Please enter a full URL starting with https://.`,
+      }))
+      return false;
+    }
+  
+    const ref = userRef();
+    const p = ref.set({
+      userUrl: url || null,
+      userUrlUpdate: firebase.firestore.FieldValue.serverTimestamp(),
+    }, {merge: true});
+    p.catch((err) => {
+      // TODO: Firestore errors are problematic but we can still run with the new URL.
+      console.warn("could not write URL", err);
+    });
+
+    return true;
+  }
+
+  clearInput() {
+    this.href = "";
+  }
+}
+
+customElements.define("web-url-chooser", UrlChooser);

--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -39,7 +39,6 @@ class UrlChooser extends BaseElement {
             placeholder="Enter a web page URL"
             pattern="https?://.*"
             minlength="7"
-            required
             @keyup="${this.onUrlKeyup}"
           />
           <button
@@ -100,7 +99,7 @@ class UrlChooser extends BaseElement {
     }
   }
 
-  runAudit(ev) {
+  runAudit() {
     if (this.switching) {
       if (!this.fixUpAndValidateUrl()) {
         return;
@@ -132,7 +131,7 @@ class UrlChooser extends BaseElement {
     console.warn("web-url-chooser in terminal state: should run Lighthouse");
   }
 
-  switchUrl(ev) {
+  switchUrl() {
     this.switching = true;
 
     const input = this.urlInput;
@@ -148,9 +147,9 @@ class UrlChooser extends BaseElement {
   }
 
   onUrlKeyup(e) {
-    if (e.keyCode === /* ESC */ 27) {
+    if (e.key === "Escape") {
       this.clearInput();
-    } else if (e.keyCode === /* ENTER */ 13) {
+    } else if (e.key === "Enter") {
       this.runLighthouseButton.click();
     }
   }

--- a/src/lib/components/UrlChooserContainer/index.js
+++ b/src/lib/components/UrlChooserContainer/index.js
@@ -1,0 +1,78 @@
+import {html} from "lit-element";
+import {store} from "../../store";
+import {BaseElement} from "../BaseElement";
+import {userRef, firebase} from "../../fb";
+import "../UrlChooser";
+
+/**
+ * @fileoverview Manages state interaction with UrlChooser.
+ *
+ * Invokes Lighthouse when the UrlChooser requests it, possibly with an updated URL.
+ */
+
+/* eslint-disable require-jsdoc */
+class UrlChooserContainer extends BaseElement {
+  static get properties() {
+    return {
+      url: {type: String},
+      active: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.url = null; // when signed out or waiting for Firestore, this is null
+    this.active = false;
+
+    store.subscribe(this.onStateChanged.bind(this));
+    this.onStateChanged();
+  }
+
+  render() {
+    return html`
+      <web-url-chooser
+        .url=${this.url}
+        .active=${this.active}
+        @audit=${this.runAudit}
+      ></web-url-chooser>
+    `;
+  }
+
+  onStateChanged() {
+    const state = store.getState();
+
+    // if Lighthouse is active, ignore changes to the URL from Firestore
+    this.url = state.activeLighthouseUrl || state.userUrl;
+    this.active = state.activeLighthouseUrl !== null;
+  }
+
+  runAudit(e) {
+    const url = e.detail;
+
+    // write URL to firestore and local
+    // TODO(samthor): This should happen in a controller setting.
+    store.setState({
+      userUrl: url,
+      activeLighthouseUrl: url,
+    });
+    const ref = userRef();
+    if (ref) {
+      const p = ref.set(
+        {
+          userUrl: url,
+          userUrlUpdate: firebase.firestore.FieldValue.serverTimestamp(),
+        },
+        {merge: true},
+      );
+      p.catch((err) => {
+        // TODO: Firestore errors are problematic but we can still run with the new URL.
+        console.warn("could not write URL", err);
+      });
+    }
+
+    // TODO: actually run Lighthouse. Currently just freezes the page.
+    console.warn("web-url-chooser in terminal state: should run Lighthouse");
+  }
+}
+
+customElements.define("web-url-chooser-container", UrlChooserContainer);

--- a/src/lib/components/_all.scss
+++ b/src/lib/components/_all.scss
@@ -3,3 +3,4 @@
 @import './SparklineChart/styles';
 @import './LighthouseGauge/styles';
 @import './LighthouseScoresAudits/styles';
+@import './UrlChooser/styles';

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -3,8 +3,6 @@ import "firebase/auth";
 import "firebase/firestore";
 import {store} from "./store";
 
-export {firebase};
-
 /* eslint-disable require-jsdoc */
 
 const firebaseConfig = {
@@ -61,6 +59,28 @@ export function userRef() {
     return null;
   }
   return firestore.collection("users").doc(state.user.uid);
+}
+
+export function updateUrl(url) {
+  const ref = userRef();
+  if (!ref) {
+    // TODO(samthor): This doesn't really inform whether the user is signed-in or not
+    return null;
+  }
+
+  const p = ref.set(
+    {
+      userUrl: url,
+      userUrlUpdate: firebase.firestore.FieldValue.serverTimestamp(),
+    },
+    {merge: true},
+  );
+  p.catch((err) => {
+    // Note: We don't plan to do anything here. If we can't write to Firebase, we can still
+    // try to invoke Lighthouse with the new URL.
+    console.warn("could not write URL to Firestore", err);
+  });
+  return p;
 }
 
 // Sign in the user

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -3,7 +3,7 @@ import "firebase/auth";
 import "firebase/firestore";
 import {store} from "./store";
 
-export {firebase as firebase};  // yes really
+export {firebase};
 
 /* eslint-disable require-jsdoc */
 
@@ -42,9 +42,9 @@ firebase.auth().onAuthStateChanged((user) => {
       user,
     });
     firestoreUserUnsubscribe = userRef().onSnapshot((snapshot) => {
-      const data = snapshot.data() || {};  // is empty on new user
+      const data = snapshot.data() || {}; // is empty on new user
       store.setState({
-        userUrl: data.userUrl || '',
+        userUrl: data.userUrl || "",
       });
     });
   } else {

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -17,6 +17,9 @@ const initialState = {
   // The most recent URL measured. Null for unknown/not signed in, blank is
   // unset.
   userUrl: null,
+
+  // The URL currently being run through Lighthouse.
+  activeLighthouseUrl: null,
 };
 
 const store = devtools(createStore(initialState));

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -14,7 +14,8 @@ const initialState = {
   isSignedIn: false,
   user: null,
 
-  // The most recent URL measured.
+  // The most recent URL measured. Null for unknown/not signed in, blank is
+  // unset.
   userUrl: null,
 };
 

--- a/src/site/content/en/measure/index.njk
+++ b/src/site/content/en/measure/index.njk
@@ -71,6 +71,7 @@ to remove them as part of the v1 migration. #}
     <div class="w-layout-container">
       <web-lighthouse-gauge score="0.4"></web-lighthouse-gauge>
       <web-profile></web-profile>
+      <web-url-chooser></web-url-chooser>
       <web-lighthouse-scores-audits demo></web-lighthouse-scores-audits>
     </div>
   </div>

--- a/src/site/content/en/measure/index.njk
+++ b/src/site/content/en/measure/index.njk
@@ -73,6 +73,7 @@ to remove them as part of the v1 migration. #}
       <web-profile></web-profile>
       <web-url-chooser></web-url-chooser>
       <web-lighthouse-scores-audits demo></web-lighthouse-scores-audits>
+      <web-url-chooser-container></web-url-chooser-container>
     </div>
   </div>
 


### PR DESCRIPTION
Adds `web-url-chooser` and `web-url-chooser-container` to choose URL to Audit. Pulls and saves to Firestore.

This diverges from the DevSite model a bit. Entering a URL has a reasonably complex state machine (e.g., once you "Switch URL", you cannot get your old URL back), and now it's tied to real-time storage (as opposed to in DevSite, which polled occasionally).