### PR TITLE
Add blurb for future Houdini articles.

### DIFF
--- a/src/site/_includes/content/houdini.njk
+++ b/src/site/_includes/content/houdini.njk
@@ -1,0 +1,5 @@
+{% Aside 'key-term' %}
+Houdini is a set of JavaScript APIs that let developers extend CSS by directly
+controlling a browser’s rendering engine. It also lets developers create new CSS
+features without waiting for standardization and browser implementation. For more information, see [css-houdini.rocks](https://css-houdini.rocks/).
+{% endAside %}


### PR DESCRIPTION
This is an industry-wide project name. (https://developer.mozilla.org/en-US/docs/Web/Houdini). The first article that will need this will be part of Chrome 77, so this will need to be merged before Aug 8.