### PR TITLE
Add registration link to origin trial blurb.

### DIFF
--- a/src/site/_includes/content/origin-trials.njk
+++ b/src/site/_includes/content/origin-trials.njk
@@ -1,6 +1,8 @@
 {% Aside 'note' %}
-Origin Trials allow you to try new features and give feedback on their
+Origin trials allow you to try new features and give feedback on their
 usability, practicality, and effectiveness to the web standards community. For
 more information, see the
 [Origin Trials Guide for Web Developers][https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md].
+To sign up for this or another origin trial visit the
+[registration page](https://developers.chrome.com/origintrials/#/trials/active).
 {% endAside %}


### PR DESCRIPTION
Fixes #1183

Changes proposed in this pull request:

- Adds a link to the origin trials registration page to the origin trials blurb.
