### PR TITLE
Disable scheduled posts.

### DIFF
--- a/src/site/_filters/live-posts.js
+++ b/src/site/_filters/live-posts.js
@@ -1,17 +1,16 @@
-const now = new Date();
-
 /**
- * Filter scheduled posts and draft posts out from a collection.
- * This function does produce a side-effect where it adds a draft flag to a
- * post if it's not scheduled to go live. This is so the page template can
- * add a meta noindex tag to the post.
+ * Filter draft posts out from a collection.
  * @param {object} post An eleventy post object.
  * @return {boolean} Whether or not the post should go live.
  */
 module.exports = function livePosts(post) {
-  if (post.date > now) {
-    post.data.draft = true;
-  }
+  // If we ever wanted to enable featured posts we could uncomment these lines.
+  // See https://github.com/GoogleChrome/web.dev/pull/1222#issuecomment-516621561
+  // for an explanation on why this feature is currently disabled.
+  // const now = new Date();
+  // if (post.date > now) {
+  //   post.data.draft = true;
+  // }
 
   return !post.data.draft;
 };


### PR DESCRIPTION
Context: https://github.com/GoogleChrome/web.dev/pull/1222#issuecomment-516343087

Previously if you set a `date` for your post that was in the future it would not show up on the site. This is a "feature" but it also feels like a bug. Because we have to manually publish the site anyway it doesn't seem like we get a lot of value out of a scheduled posts feature and it is potentially confusing for authors. Let's disable it and just keep the `draft` flag.

Changes proposed in this pull request:

- Disables the scheduled posts feature added in #1169.  
- Keep the `draft: true` functionality since that's opt-in.
