### PR TITLE
Add support for specifying anchors in headers

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -87,7 +87,7 @@ module.exports = function(config) {
   const markdownItAttrsOpts = {
     leftDelimiter: '{:',
     rightDelimiter: '}',
-    allowedAttributes: [],
+    allowedAttributes: ['id', 'class', /^data\-.*$/],
   };
   config.setLibrary(
     'md',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,7 @@ const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
+const markdownItAttrs = require('markdown-it-attrs');
 const slugify = require('slugify');
 
 const componentsDir = 'src/site/_includes/components';
@@ -83,9 +84,16 @@ module.exports = function(config) {
       });
     },
   };
+  const markdownItAttrsOpts = {
+    leftDelimiter: '{:',
+    rightDelimiter: '}',
+    allowedAttributes: [],
+  };
   config.setLibrary(
     'md',
-    markdownIt(markdownItOptions).use(markdownItAnchor, markdownItAnchorOptions)
+    markdownIt(markdownItOptions)
+      .use(markdownItAnchor, markdownItAnchorOptions)
+      .use(markdownItAttrs, markdownItAttrsOpts)
   );
 
   //----------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1336,8 +1336,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4399,8 +4398,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4421,14 +4419,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4441,20 +4437,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4569,8 +4562,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4582,7 +4574,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4597,7 +4588,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4708,8 +4698,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4721,7 +4710,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4842,7 +4830,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4862,7 +4849,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4891,8 +4877,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -7761,6 +7746,12 @@
       "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
       "dev": true
     },
+    "markdown-it-attrs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-3.0.0.tgz",
+      "integrity": "sha512-DTIDzAQuQ9eEqq0y8GhdWB458vt0zYMp3M1R+IBMYlsMGY+oFOlZ/Gwk5Lg74v1ffYQ0kbDULqEbIbCowerJOA==",
+      "dev": true
+    },
     "markdown-table": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
@@ -7862,8 +7853,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
@@ -8028,7 +8018,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -8038,8 +8027,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "luxon": "^1.12.1",
     "markdown-it": "^8.4.2",
     "markdown-it-anchor": "^5.0.2",
+    "markdown-it-attrs": "^3.0.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.3.0",
     "node-sass": "^4.11.0",


### PR DESCRIPTION
Fixes #1257 

Adds support for specifying custom anchors in headers using the same style as WebFu 

`## hello {: #anchor }`

This PR adds a new node dependency ([markdown-it-attrs](https://www.npmjs.com/package/markdown-it-attrs)), which is designed explicitly for this purpose. I customized the default use so that it matches the same syntax as WebFu (`{: #anchor }`).