### PR TITLE
Filter draft posts out of topics and collection counts.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,6 +53,7 @@ const containsTag = require(`./${filtersDir}/contains-tag`);
 const githubLink = require(`./${filtersDir}/github-link`);
 const postsLighthouseJson = require(`./${filtersDir}/posts-lighthouse-json`);
 const prettyDate = require(`./${filtersDir}/pretty-date`);
+const removeDrafts = require(`./${filtersDir}/remove-drafts`);
 const stripBlog = require(`./${filtersDir}/strip-blog`);
 const stripLanguage = require(`./${filtersDir}/strip-language`);
 
@@ -109,6 +110,7 @@ module.exports = function(config) {
   config.addFilter('githubLink', githubLink);
   config.addFilter('postsLighthouseJson', postsLighthouseJson);
   config.addFilter('prettyDate', prettyDate);
+  config.addFilter('removeDrafts', removeDrafts);
   config.addFilter('stripBlog', stripBlog);
   config.addFilter('stripLanguage', stripLanguage);
 

--- a/src/site/_filters/remove-drafts.js
+++ b/src/site/_filters/remove-drafts.js
@@ -1,0 +1,24 @@
+const {findBySlug} = require('./find-by-slug');
+
+/**
+ * Remove any draft posts from a learning path.
+ * If a topic in a learning path contains only draft posts this will remove
+ * the topic as well.
+ * @param {Array} topics An array of posts inside of a learning path topic.
+ * @return {Array}
+ */
+module.exports = function removeDrafts(topics) {
+  return topics.reduce((accumulator, topic) => {
+    // Remove draft posts from a topic.
+    const posts = topic.pathItems.filter((post) => {
+      return !findBySlug(post).data.draft;
+    });
+    // If all of the posts in a topic are drafts then don't add the topic
+    // to the final TOC.
+    if (!posts.length) {
+      return accumulator;
+    }
+    accumulator.push(Object.assign({}, topic, {pathItems: posts}));
+    return accumulator;
+  }, []);
+};

--- a/src/site/_includes/components/PathCard.js
+++ b/src/site/_includes/components/PathCard.js
@@ -15,6 +15,7 @@
  */
 
 const {html} = require('common-tags');
+const removeDrafts = require('../../_filters/remove-drafts');
 
 /* eslint-disable max-len */
 
@@ -24,7 +25,12 @@ const {html} = require('common-tags');
  * @return {number}
  */
 function getPostCount(learningPath) {
-  const count = learningPath.topics.reduce((pathItemsCount, topic) => {
+  // TODO (robdodson): It's annoying to have to removeDrafts both here and
+  // in path.njk. Ideally we should do this in the learningPath .11ty.js files
+  // but eleventy hasn't parsed all of the collections when those files get
+  // initialized so we can't look up posts by slug.
+  const topics = removeDrafts(learningPath.topics);
+  const count = topics.reduce((pathItemsCount, topic) => {
     return pathItemsCount + topic.pathItems.length;
   }, 0);
   const label = count > 1 ? 'resources' : 'resource';

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -2,6 +2,8 @@
 layout: layout
 ---
 
+{% set topics = path.topics | removeDrafts %}
+
 {# *-landing-page classes are a holdover from devsite. #}
 {# It would be great to remove them as part of the v1 migration. #}
 <main class="path-landing-page">
@@ -25,7 +27,7 @@ layout: layout
     <div class="w-path-intro__learn">
       <h2 class="w-headline--three no-link">What you'll learn</h2>
       <ul class="w-icon-list">
-        {% for topic in path.topics %}
+        {% for topic in topics %}
           <li class="w-icon-list__item w-icon-list__item--check">
             {{ topic.title }}
           </li>
@@ -37,7 +39,7 @@ layout: layout
   <hr>
 
   {# <section class="w-grid">
-    {% for topic in path.topics %}
+    {% for topic in topics %}
     <h2 id="{{ topic.title | slug }}" class="no-link w-path-heading w-headline--three">
       {{ topic.title }}
       <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
@@ -53,23 +55,8 @@ layout: layout
 
   <section class="w-layout-container">
     <div class="w-numbered-headers">
-      {#
-        Check to see if the only item within a topic is a draft post.
-        If so, don't render the topic heading and skip the post.
-      #}
-      {% for topic in path.topics %}
-        {% if topic.pathItems.length === 1 %}
-          {% set item = topic.pathItems[0] | findBySlug %}
-          {% if item.data.draft %}
-            {# noop #}
-          {% else %}
-            {# render topic #}
-            {% include 'partials/topic.njk' %}
-          {% endif %}
-        {% else %}
-          {# render topic #}
-          {% include 'partials/topic.njk' %}
-        {% endif %}
+      {% for topic in topics %}
+        {% include 'partials/topic.njk' %}
       {% endfor %}
     </div>
   </section>


### PR DESCRIPTION
Fixes #1265.

Changes proposed in this pull request:

- Adds a `removeDrafts` filter function which can be used to filter an array of learing path topics. For example, if one of the topics arrays in the accessible learning path (https://github.com/GoogleChrome/web.dev/blob/master/src/site/content/en/accessible/accessible.11tydata.js) contained draft posts, it would filter those posts out of the array.
- Updates learning path pages to not show topics if all of the posts within the topic are drafts.
- Updates learning path cards to not count draft posts in the total number of resources.
