### PR TITLE
meta-description: add early mention of HTML tag

### DIFF
--- a/src/site/content/en/lighthouse-seo/meta-description/index.md
+++ b/src/site/content/en/lighthouse-seo/meta-description/index.md
@@ -21,7 +21,7 @@ Lighthouse flags your page when it's missing a meta description:
 
 ## What causes this audit to fail
 
-This audit fails if your page doesn't have a `<meta name=description>`,
+This audit fails if your page doesn't have a `<meta name=description>` element,
 or if the `content` attribute is empty.
 Lighthouse doesn't evaluate the quality of your description.
 

--- a/src/site/content/en/lighthouse-seo/meta-description/index.md
+++ b/src/site/content/en/lighthouse-seo/meta-description/index.md
@@ -21,8 +21,8 @@ Lighthouse flags your page when it's missing a meta description:
 
 ## What causes this audit to fail
 
-This audit fails if your page doesn't have a description,
-or if the `content` attribute of the description is empty.
+This audit fails if your page doesn't have a `<meta name=description>`,
+or if the `content` attribute is empty.
 Lighthouse doesn't evaluate the quality of your description.
 
 {% include 'content/lighthouse-seo/scoring.njk' %}


### PR DESCRIPTION
not a big deal here.
I just wanted to have the html tag mentioned before we mention its attribute.