### PR TITLE
Let authors provide a thumbnail for posts. Addresses #1199.

### DIFF
--- a/src/site/_drafts/_template-post/index.md
+++ b/src/site/_drafts/_template-post/index.md
@@ -10,7 +10,11 @@ hero: hero.jpg
 # You can adjust the position of your hero image with this property.
 # Values: top | bottom | center (default)
 # hero_position: bottom
-alt: A description of the hero image for screen reader users.
+hero_alt: A description of the hero image for screen reader users.
+# You can give your post an optional thumbnail for when it appears on the /blog
+# page. If you skip this, the hero image will be reused as the thumbnail.
+# thumbnail: thumbnail.jpg
+# thumbnail_alt: A description of the thumbnail image for screen reader users.
 description: |
   This post is a test to demonstrate all of the components that can go into
   an article. This description appears in the meta tag.

--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -17,7 +17,7 @@
 const {html} = require('common-tags');
 const stripLanguage = require('../../_filters/strip-language');
 
-/* eslint-disable require-jsdoc,indent */
+/* eslint-disable require-jsdoc, indent, max-len */
 
 /**
  * PostCard used to preview posts.
@@ -27,12 +27,29 @@ const stripLanguage = require('../../_filters/strip-language');
 module.exports = ({post}) => {
   const url = stripLanguage(post.url);
   const data = post.data;
-  const hero = data && data.hero;
+  const {
+    hero,
+    thumbnail,
+    hero_alt: heroAlt,
+    thumbnail_alt: thumbnailAlt,
+  } = data;
 
-  function renderHero(post, url) {
+  // Check to see if the author has provided a thumbnail image.
+  // If not, reuse the hero image for the card's cover.
+  let coverImage = null;
+  let coverAlt = null;
+  if (thumbnail) {
+    coverImage = thumbnail;
+    coverAlt = thumbnailAlt;
+  } else if (hero) {
+    coverImage = hero;
+    coverAlt = heroAlt;
+  }
+
+  function renderCoverImage(url, image, alt) {
     return html`
       <figure class="w-post-card__figure">
-        <img class="w-post-card__image" src="${url + hero}" alt="${data.alt}" />
+        <img class="w-post-card__image" src="${url + image}" alt="${alt}" />
       </figure>
     `;
   }
@@ -56,11 +73,11 @@ module.exports = ({post}) => {
     <a href="${url}" class="w-card">
       <article class="w-post-card">
         <div
-          class="w-post-card__cover ${hero && `w-post-card__cover--with-image`}"
+          class="w-post-card__cover ${coverImage && `w-post-card__cover--with-image`}"
         >
-          ${hero && renderHero(post, url)}
+          ${coverImage && renderCoverImage(url, coverImage, coverAlt)}
           <h2
-            class="${hero
+            class="${coverImage
               ? `w-post-card__headline--with-image`
               : `w-post-card__headline`}"
           >


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds new `thumbnail` and `thumbnail_alt` YAML properties.
- Renames `alt` to `hero_alt`.
- Updates post template with new properties.

Note, before landing this we should update all of the existing posts to use `hero_alt`.
