### PR TITLE
Deep merge tag data.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -142,6 +142,9 @@ module.exports = function(config) {
   config.addShortcode('SubscribeAction', SubscribeAction);
   config.addShortcode('YouTube', YouTube);
 
+  https://www.11ty.io/docs/config/#data-deep-merge
+  config.setDataDeepMerge(true);
+
   // https://www.11ty.io/docs/config/#configuration-options
   return {
     dir: {

--- a/src/site/content/en/blog/index.njk
+++ b/src/site/content/en/blog/index.njk
@@ -2,6 +2,7 @@
 layout: layout
 title: Blog
 permalink: /en/blog/index.html
+override:tags: []
 ---
 
 {# *-landing-page classes are a holdover from devsite. #}


### PR DESCRIPTION
Fixes #1327 

Changes proposed in this pull request:

- Use eleventy's [data deep merge](https://www.11ty.io/docs/config/#data-deep-merge) to merge tags data. Previously if a post contained its own tags it would override the tags inherited from its directory and would break prev/next navigation.
- Prevent the blog landing page itself from inheriting the `post` tag and appearing as a pseudo-post on the blog.