### PR TITLE
Avoid duplicating paths from merged data.

### DIFF
--- a/src/site/_data/postHost.js
+++ b/src/site/_data/postHost.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const learn = require('../content/en/learn/learn.11tydata.js');
+const data = require('../content/en/learn/learn.11tydata.js');
 
 // =============================================================================
 // POST HOST
@@ -28,7 +28,7 @@ const learn = require('../content/en/learn/learn.11tydata.js');
 module.exports = function() {
   const out = {};
 
-  const paths = learn.paths;
+  const paths = data.learn.paths;
   paths.forEach((path) => {
     path.topics.forEach((topic) => {
       (topic.pathItems || []).forEach((id) => {

--- a/src/site/content/en/en.11tydata.js
+++ b/src/site/content/en/en.11tydata.js
@@ -14,12 +14,14 @@ const installable = require('./installable/installable.11tydata.js').path;
 // =============================================================================
 
 module.exports = {
-  paths: [
-    fast,
-    accessible,
-    reliable,
-    discoverable,
-    secure,
-    installable,
-  ],
+  home: {
+    paths: [
+      fast,
+      accessible,
+      reliable,
+      discoverable,
+      secure,
+      installable,
+    ],
+  },
 };

--- a/src/site/content/en/index.njk
+++ b/src/site/content/en/index.njk
@@ -101,7 +101,7 @@ description: |
     </div>
     <div class="w-grid w-pb--std">
       <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
-        {% for path in paths %}
+        {% for path in home.paths %}
           {% PathCard path %}
         {% endfor %}
       </div>

--- a/src/site/content/en/learn/index.njk
+++ b/src/site/content/en/learn/index.njk
@@ -26,7 +26,7 @@ description: |
       </h3>
     </div>
     <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
-      {% for path in paths %}
+      {% for path in learn.paths %}
         {% PathCard path %}
       {% endfor %}
     </div>
@@ -39,7 +39,7 @@ description: |
       </h3>
     </div>
     <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
-      {% for framework in frameworks %}
+      {% for framework in learn.frameworks %}
         {% PathCard framework %}
       {% endfor %}
     </div>
@@ -52,7 +52,7 @@ description: |
       </h3>
     </div>
     <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
-      {% for audit in audits %}
+      {% for audit in learn.audits %}
         {% PathCard audit %}
       {% endfor %}
     </div>

--- a/src/site/content/en/learn/learn.11tydata.js
+++ b/src/site/content/en/learn/learn.11tydata.js
@@ -34,23 +34,25 @@ const lighthouseSeo = require(
 // =============================================================================
 
 module.exports = {
-  paths: [
-    fast,
-    accessible,
-    reliable,
-    discoverable,
-    secure,
-    installable,
-  ],
-  frameworks: [
-    react,
-    angular,
-  ],
-  audits: [
-    lighthousePerformance,
-    lighthousePwa,
-    lighthouseBestPractices,
-    lighthouseAccessibility,
-    lighthouseSeo,
-  ],
+  learn: {
+    paths: [
+      fast,
+      accessible,
+      reliable,
+      discoverable,
+      secure,
+      installable,
+    ],
+    frameworks: [
+      react,
+      angular,
+    ],
+    audits: [
+      lighthousePerformance,
+      lighthousePwa,
+      lighthouseBestPractices,
+      lighthouseAccessibility,
+      lighthouseSeo,
+    ],
+  },
 };


### PR DESCRIPTION
Fixes an issue introduced by #1329. Because there were multiple directory files that used the term `paths` they were all getting merged together. This would show duplicate paths on the /learn page.

Changes proposed in this pull request:

- Scope directory data files so they refer to their page name.