### PR TITLE
Fix stat alignment

### DIFF
--- a/src/styles/components/_stats.scss
+++ b/src/styles/components/_stats.scss
@@ -31,6 +31,7 @@
   margin-bottom: 32px;
 
   @include bp(sm) {
+    flex: 1;
     margin: 0 8px;
   }
 }


### PR DESCRIPTION
Improve horizontal spacing of the stats widget on desktop when there are >3 stats. See PR #1335 for a use case.