### PR TITLE
Add "by screenname" to tweets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -52,6 +52,7 @@ const {memoize, findBySlug} = require(`./${filtersDir}/find-by-slug`);
 const pathSlug = require(`./${filtersDir}/path-slug`);
 const containsTag = require(`./${filtersDir}/contains-tag`);
 const githubLink = require(`./${filtersDir}/github-link`);
+const expandContributors = require(`./${filtersDir}/expand-contributors`);
 const postsLighthouseJson = require(`./${filtersDir}/posts-lighthouse-json`);
 const prettyDate = require(`./${filtersDir}/pretty-date`);
 const removeDrafts = require(`./${filtersDir}/remove-drafts`);
@@ -116,6 +117,7 @@ module.exports = function(config) {
   config.addFilter('pathSlug', pathSlug);
   config.addFilter('containsTag', containsTag);
   config.addFilter('githubLink', githubLink);
+  config.addFilter('expandContributors', expandContributors);
   config.addFilter('postsLighthouseJson', postsLighthouseJson);
   config.addFilter('prettyDate', prettyDate);
   config.addFilter('removeDrafts', removeDrafts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6309,6 +6309,12 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "intl-list-format": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/intl-list-format/-/intl-list-format-1.0.3.tgz",
+      "integrity": "sha512-VNF1Mh0K1xALXkz/5QsK1gfKRvEQO/jWaniTGAzQvbzGr5uyGDskQrRjnf6Qnbc9/JRbNE8BQtTg6iWuFrZorw==",
+      "dev": true
+    },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "husky": "^1.3.1",
     "imagemin-mozjpeg": "^8.0.0",
     "imagemin-pngquant": "^7.0.0",
+    "intl-list-format": "^1.0.3",
     "luxon": "^1.12.1",
     "markdown-it": "^8.4.2",
     "markdown-it-anchor": "^5.0.2",

--- a/src/site/_filters/expand-contributors.js
+++ b/src/site/_filters/expand-contributors.js
@@ -1,0 +1,5 @@
+const contributors = require('../_data/contributors.json');
+
+module.exports = (contributorSlugs = []) => {
+  return contributorSlugs.map((slug) => contributors[slug]);
+};

--- a/src/site/_includes/components/Actions.js
+++ b/src/site/_includes/components/Actions.js
@@ -16,6 +16,8 @@
 
 const {html} = require('common-tags');
 const site = require('../../_data/site');
+require('intl-list-format');
+require('intl-list-format/locale-data/en');
 
 /* eslint-disable require-jsdoc,max-len */
 

--- a/src/site/_includes/components/Actions.js
+++ b/src/site/_includes/components/Actions.js
@@ -35,9 +35,10 @@ const Actions = (children) =>
  * @param {string} title The page title to Tweet.
  * @param {string} url The URL to share. This will look like '/some-post'
  * because eleventy doesn't attach the domain or protocol.
+ * @param {array} authors Authors of the page.
  * @return {string}
  */
-const ShareAction = (title, url) => {
+const ShareAction = (title, url, authors = []) => {
   if (!title) {
     throw new Error(`Can't create ShareButton without a title.`);
   }
@@ -47,7 +48,7 @@ const ShareAction = (title, url) => {
   }
 
   const twitter = `https://twitter.com/share`;
-  const encodedText = encodeURIComponent(title);
+  const encodedText = encodeURIComponent(`${title}${by(authors)}`);
   const encodedUrl = encodeURIComponent(`${site.url}${url}`);
 
   return html`
@@ -62,6 +63,17 @@ const ShareAction = (title, url) => {
       <span>Share</span>
     </a>
   `;
+};
+
+const by = (authors) => {
+  const screenNames = authors.map((author) => author.twitter)
+    .filter(Boolean)
+    .map((author) => `@${author}`);
+  if (screenNames.length) {
+    const il = new Intl.ListFormat('en');
+    return ` by ${il.format(screenNames)}`;
+  }
+  return '';
 };
 
 const SubscribeAction = () => {

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -13,7 +13,7 @@
   {# Make sure Actions are first in the tab order. #}
   <web-actions-controller page="post"></web-actions-controller>
   {% Actions %}
-    {% ShareAction title, page.url | stripLanguage %}
+    {% ShareAction title, page.url | stripLanguage, authors | expandContributors %}
     {% SubscribeAction %}
   {% endActions %}
 


### PR DESCRIPTION
Update Twitter share text to mention authors.

    Native lazy-loading for the web by @hdjirdeh, @addyosmani, and @mathias https://web.dev/native-lazy-loading/

Examples of posts with 1, 2, and 3 authors:

![Screenshot from 2019-08-19 15-44-21](https://user-images.githubusercontent.com/3341/63298787-f18f5c80-c299-11e9-8d11-d34d9bb4f531.png)
![Screenshot from 2019-08-19 15-44-41](https://user-images.githubusercontent.com/3341/63298801-f3f1b680-c299-11e9-9013-be4099d508f3.png)
![Screenshot from 2019-08-19 15-44-58](https://user-images.githubusercontent.com/3341/63298806-f6541080-c299-11e9-83fe-19e3b6ce0cf1.png)
