### PR TITLE
update axe links to axe 3.3

### DIFF
--- a/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
@@ -47,4 +47,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Access key values are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/accesskeys.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
@@ -47,4 +47,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Access key values are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/accesskeys.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
@@ -36,7 +36,7 @@ by pressing the specified key (usually in combination with the `<kbd>alt></kbd>`
 Duplicating `accesskey` values creates unexpected effects
 for users navigating with keys.
 Learn more in
-[accesskey attribute value must be unique](https://dequeuniversity.com/rules/axe/3.2/accesskeys).
+[accesskey attribute value must be unique](https://dequeuniversity.com/rules/axe/3.3/accesskeys).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -47,4 +47,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Access key values are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/accesskeys.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
@@ -68,4 +68,4 @@ see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com
 
 - [ARIA attributes match their roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-allowed-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
@@ -68,4 +68,4 @@ see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com
 
 - [ARIA attributes match their roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-allowed-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
@@ -68,4 +68,3 @@ see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com
 
 - [ARIA attributes match their roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-allowed-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
@@ -61,4 +61,4 @@ see [Required ARIA attributes must be provided](https://dequeuniversity.com/rule
 
 - [ARIA roles have required states and properties audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
@@ -61,4 +61,4 @@ see [Required ARIA attributes must be provided](https://dequeuniversity.com/rule
 
 - [ARIA roles have required states and properties audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
@@ -61,4 +61,3 @@ see [Required ARIA attributes must be provided](https://dequeuniversity.com/rule
 
 - [ARIA roles have required states and properties audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
@@ -59,10 +59,10 @@ and check the required child roles.
 Make sure to include a child role for that parent role.
 
 For more information on this audit,
-see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com/rules/axe/3.2/aria-required-children).
+see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com/rules/axe/3.3/aria-required-children).
 
 ## More information
 
 - [Ensure parent role includes required children audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-children.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
@@ -65,4 +65,4 @@ see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com
 
 - [Ensure parent role includes required children audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-children.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
@@ -65,4 +65,3 @@ see [Elements must only use allowed ARIA attributes](https://dequeuniversity.com
 
 - [Ensure parent role includes required children audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-children.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
@@ -60,10 +60,10 @@ and check the "required context role".
 Make sure to include a parent role for that child role.
 
 For more information on this audit,
-see [Certain ARIA roles must be contained by particular parent elements](https://dequeuniversity.com/rules/axe/3.2/aria-required-parent).
+see [Certain ARIA roles must be contained by particular parent elements](https://dequeuniversity.com/rules/axe/3.3/aria-required-parent).
 
 ## More information
 
 - [ARIA child roles are contained within parent roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-parent.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
@@ -66,4 +66,3 @@ see [Certain ARIA roles must be contained by particular parent elements](https:/
 
 - [ARIA child roles are contained within parent roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-parent.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
@@ -66,4 +66,4 @@ see [Certain ARIA roles must be contained by particular parent elements](https:/
 
 - [ARIA child roles are contained within parent roles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-required-parent.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
@@ -59,4 +59,4 @@ see [ARIA roles used must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA role values are vailid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-roles.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
@@ -59,4 +59,4 @@ see [ARIA roles used must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA role values are vailid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-roles.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
@@ -59,4 +59,3 @@ see [ARIA roles used must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA role values are vailid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-roles.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
@@ -66,4 +66,4 @@ see [ARIA attributes must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA attributes have valid values audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr-value.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
@@ -60,10 +60,10 @@ ARIA defines a role's allowable attributes, and the valid values for those attri
 Check that you are using the correct values for any attributes you use in your roles.
 
 For more information on this audit,
-see [ARIA attributes must conform to valid values](https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr-value).
+see [ARIA attributes must conform to valid values](https://dequeuniversity.com/rules/axe/3.3/aria-valid-attr-value).
 
 ## More information
 
 - [ARIA attributes have valid values audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr-value.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
@@ -66,4 +66,3 @@ see [ARIA attributes must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA attributes have valid values audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr-value.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
@@ -58,4 +58,3 @@ see [ARIA attributes must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA attributes are valid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
@@ -58,4 +58,4 @@ see [ARIA attributes must conform to valid values](https://dequeuniversity.com/r
 
 - [ARIA attributes are valid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
@@ -52,10 +52,10 @@ Check the role definition that the attribute describes,
 and then check the values for that attribute.
 
 For more information on this audit,
-see [ARIA attributes must conform to valid values](https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr-value).
+see [ARIA attributes must conform to valid values](https://dequeuniversity.com/rules/axe/3.3/aria-valid-attr-value).
 
 ## More information
 
 - [ARIA attributes are valid audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/aria-valid-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
@@ -41,7 +41,7 @@ with attribute `kind="captions"`:
 ```
 
 Learn more in
-[`<audio>` elements must have a captions `<track>`](https://dequeuniversity.com/rules/axe/3.2/audio-caption).
+[`<audio>` elements must have a captions `<track>`](https://dequeuniversity.com/rules/axe/3.3/audio-caption).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -52,4 +52,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Audio elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/audit-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
@@ -52,4 +52,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Audio elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/audit-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
@@ -52,4 +52,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Audio elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/audit-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/button-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/button-name/index.md
@@ -42,7 +42,7 @@ to anyone using a screen reader, for example:
 ```
 
 Learn more in
-[Buttons must have discernible text](https://dequeuniversity.com/rules/axe/3.2/button-name).
+[Buttons must have discernible text](https://dequeuniversity.com/rules/axe/3.3/button-name).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -53,4 +53,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure buttons have accessible name audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/button-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/button-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/button-name/index.md
@@ -53,4 +53,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure buttons have accessible name audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/button-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/button-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/button-name/index.md
@@ -53,4 +53,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure buttons have accessible name audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/button-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -96,7 +96,7 @@ and repetitive content is bypassed:
 ```
 
 Learn more in
-[Page must have means to bypass repeated blocks](https://dequeuniversity.com/rules/axe/3.2/bypass).
+[Page must have means to bypass repeated blocks](https://dequeuniversity.com/rules/axe/3.3/bypass).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -107,4 +107,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Use headings, landmarks, and skip-link audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/bypass.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -107,4 +107,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Use headings, landmarks, and skip-link audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/bypass.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -107,4 +107,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Use headings, landmarks, and skip-link audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/bypass.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
+++ b/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
@@ -33,7 +33,7 @@ Ensure color contrast of at least 4.5:1 for small text or 3:1 for large text.
 Large text is defined as 18pt or 14pt bold.
 
 Try the Color Contrast Analyser in
-[Text elements must have sufficient color contrast against the background](https://dequeuniversity.com/rules/axe/3.2/color-contrast).
+[Text elements must have sufficient color contrast against the background](https://dequeuniversity.com/rules/axe/3.3/color-contrast).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -44,4 +44,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure background and foreground colors have sufficient contrast ratio audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/color-contrast.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
+++ b/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
@@ -44,4 +44,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure background and foreground colors have sufficient contrast ratio audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/color-contrast.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
+++ b/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
@@ -44,4 +44,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure background and foreground colors have sufficient contrast ratio audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/color-contrast.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/definition-list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/definition-list/index.md
@@ -54,4 +54,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/definition-list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/definition-list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/definition-list/index.md
@@ -54,4 +54,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/definition-list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/definition-list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/definition-list/index.md
@@ -43,7 +43,7 @@ For example:
 ```
 
 Learn more in
-[`<dl>` elements must only directly contain properly-ordered `<dt>` and `<dd>` groups, `<script>`, or `<template>` elements](https://dequeuniversity.com/rules/axe/3.2/definition-list).
+[`<dl>` elements must only directly contain properly-ordered `<dt>` and `<dd>` groups, `<script>`, or `<template>` elements](https://dequeuniversity.com/rules/axe/3.3/definition-list).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -54,4 +54,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/definition-list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/dlitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/dlitem/index.md
@@ -49,4 +49,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list items are wrapped in parent `<dl>` element audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/dlitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/dlitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/dlitem/index.md
@@ -49,4 +49,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list items are wrapped in parent `<dl>` element audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/dlitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/dlitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/dlitem/index.md
@@ -49,4 +49,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure defintion list items are wrapped in parent `<dl>` element audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/dlitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/document-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/document-title/index.md
@@ -68,4 +68,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure HTML document has a title audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/document-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/document-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/document-title/index.md
@@ -68,4 +68,3 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure HTML document has a title audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/document-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/document-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/document-title/index.md
@@ -44,7 +44,7 @@ and that title provides context about the page:
 
 Learn more in
 [Write descriptive titles, descriptions, and link text for every page](/write-descriptive-text)
-and [Documents must contain a title element to aid in navigation](https://dequeuniversity.com/rules/axe/3.2/document-title).
+and [Documents must contain a title element to aid in navigation](https://dequeuniversity.com/rules/axe/3.3/document-title).
 
 
 ## Tips for creating great titles
@@ -68,4 +68,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure HTML document has a title audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/document-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
+++ b/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
@@ -40,4 +40,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [ID attributes on a page are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/duplicate-id.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
+++ b/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
@@ -29,7 +29,7 @@ Assistive technologies typically only reference the first one accurately.
 To remove duplicate IDs,
 change an ID value if it is used more than once to be sure each is unique.
 Learn more in
-[ID attribute values must be unique](https://dequeuniversity.com/rules/axe/3.2/duplicate-id).
+[ID attribute values must be unique](https://dequeuniversity.com/rules/axe/3.3/duplicate-id).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -40,4 +40,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [ID attributes on a page are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/duplicate-id.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
+++ b/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
@@ -40,4 +40,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [ID attributes on a page are unique audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/duplicate-id.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/frame-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/frame-title/index.md
@@ -34,7 +34,7 @@ For example:
 <iframe title="My Daily Marathon Tracker" src="https://www.mydailymarathontracker.com/"></iframe>
 ```
 
-Learn more in [Frames must have title attribute](https://dequeuniversity.com/rules/axe/3.2/frame-title).
+Learn more in [Frames must have title attribute](https://dequeuniversity.com/rules/axe/3.3/frame-title).
 
 ## Tips for creating descriptive frame titles
 
@@ -55,4 +55,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure frames have titles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/frame-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/frame-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/frame-title/index.md
@@ -55,4 +55,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure frames have titles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/frame-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/frame-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/frame-title/index.md
@@ -55,4 +55,3 @@ Todo. I have no idea how accessibility scoring is working!
 - [Label documents and frames](/labels-and-text-alternatives#label-documents-and-frames)
 - [Ensure frames have titles audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/frame-title.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
@@ -46,4 +46,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure every HTML document has a `lang` attribute](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-has-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
@@ -46,4 +46,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure every HTML document has a `lang` attribute](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-has-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
@@ -35,7 +35,7 @@ If the language is not specified,
 it is impossible to understand anything
 when screen readers are using the wrong language library.
 
-Learn more in [`<html>` element must have a lang attribute](https://dequeuniversity.com/rules/axe/3.2/html-has-lang).
+Learn more in [`<html>` element must have a lang attribute](https://dequeuniversity.com/rules/axe/3.3/html-has-lang).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -46,4 +46,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure every HTML document has a `lang` attribute](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-has-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
@@ -36,7 +36,7 @@ For example, this sets the language of the document to English:
 <html lang="en">
 ```
 
-Learn more in [lang attribute must have a valid value](https://dequeuniversity.com/rules/axe/3.2/valid-lang).
+Learn more in [lang attribute must have a valid value](https://dequeuniversity.com/rules/axe/3.3/valid-lang).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -47,4 +47,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute of `<html>` element has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-lang-valid.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
@@ -47,4 +47,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute of `<html>` element has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-lang-valid.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
@@ -47,4 +47,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute of `<html>` element has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/html-lang-valid.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/image-alt/index.md
@@ -71,4 +71,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure images have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/image-alt/index.md
@@ -42,7 +42,7 @@ give it an empty `alt=""` attribute to remove it from the accessibility tree:
 <img src="background.png" alt="">
 ```
 
-Learn more in [Images must have alternate text](https://dequeuniversity.com/rules/axe/3.2/image-alt?application=lighthouse).
+Learn more in [Images must have alternate text](https://dequeuniversity.com/rules/axe/3.3/image-alt?application=lighthouse).
 
 {% Aside 'note' %}
 You can also use ARIA labels to describe your images, for example,
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure images have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/image-alt/index.md
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure images have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
@@ -71,4 +71,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure image buttons have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/input-image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure image buttons have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/input-image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
@@ -40,7 +40,7 @@ in the `alt` text
 
 Even if the image contains only text, provide alternate text.
 Screen readers can't translate images of words into output.
-Learn more in [Image buttons must have alternate text](https://dequeuniversity.com/rules/axe/3.2/input-image-alt).
+Learn more in [Image buttons must have alternate text](https://dequeuniversity.com/rules/axe/3.3/input-image-alt).
 
 {% Aside 'note' %}
 You can also use ARIA labels to describe your image buttons,
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure image buttons have `alt` text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/input-image-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/label/index.md
+++ b/src/site/content/en/lighthouse-accessibility/label/index.md
@@ -63,7 +63,7 @@ Todo. I have no idea how accessibility scoring is working!
 
 ## More information
 -->
-- [Form `<input>` elements must have labels](https://dequeuniversity.com/rules/axe/3.2/label)
+- [Form `<input>` elements must have labels](https://dequeuniversity.com/rules/axe/3.3/label)
 - [Ensure every form element has a label audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/label.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/label/index.md
+++ b/src/site/content/en/lighthouse-accessibility/label/index.md
@@ -66,4 +66,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Form `<input>` elements must have labels](https://dequeuniversity.com/rules/axe/3.3/label)
 - [Ensure every form element has a label audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/label.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/label/index.md
+++ b/src/site/content/en/lighthouse-accessibility/label/index.md
@@ -66,4 +66,3 @@ Todo. I have no idea how accessibility scoring is working!
 - [Form `<input>` elements must have labels](https://dequeuniversity.com/rules/axe/3.3/label)
 - [Ensure every form element has a label audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/label.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/layout-table/index.md
+++ b/src/site/content/en/lighthouse-accessibility/layout-table/index.md
@@ -32,7 +32,7 @@ the better fix is to remove the table all together,
 and use cascading style sheets (CSS) to control layout instead.
 
 Learn more in
-[Layout tables must not use data table elements](https://dequeuniversity.com/rules/axe/3.2/layout-table).
+[Layout tables must not use data table elements](https://dequeuniversity.com/rules/axe/3.3/layout-table).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -43,4 +43,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Layout tables must not use data table elements audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/layout-table.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/layout-table/index.md
+++ b/src/site/content/en/lighthouse-accessibility/layout-table/index.md
@@ -43,4 +43,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Layout tables must not use data table elements audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/layout-table.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/layout-table/index.md
+++ b/src/site/content/en/lighthouse-accessibility/layout-table/index.md
@@ -43,4 +43,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Layout tables must not use data table elements audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/layout-table.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/link-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/link-name/index.md
@@ -46,4 +46,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Links must have discernible text](https://dequeuniversity.com/rules/axe/3.3/link-name)
 - [Ensure links have discernible text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/link-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/link-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/link-name/index.md
@@ -43,7 +43,7 @@ Todo. I have no idea how accessibility scoring is working!
 -->
 ## More information
 
-- [Links must have discernible text](https://dequeuniversity.com/rules/axe/3.2/link-name)
+- [Links must have discernible text](https://dequeuniversity.com/rules/axe/3.3/link-name)
 - [Ensure links have discernible text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/link-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/link-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/link-name/index.md
@@ -46,4 +46,3 @@ Todo. I have no idea how accessibility scoring is working!
 - [Links must have discernible text](https://dequeuniversity.com/rules/axe/3.3/link-name)
 - [Ensure links have discernible text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/link-name.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/list/index.md
@@ -40,4 +40,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure lists are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/list/index.md
@@ -40,4 +40,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure lists are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/list/index.md
@@ -29,7 +29,7 @@ Ordered and unordered lists must only contain `<li>`, `<script>` or `<template>`
 Valid lists must have parent elements (`ul` or `ol` elements) and child elements (`li` elements).
 Any other content elements are invalid.
 Learn more in
-[`<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>` elements](https://dequeuniversity.com/rules/axe/3.2/list).
+[`<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>` elements](https://dequeuniversity.com/rules/axe/3.3/list).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -40,4 +40,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure lists are structured correctly audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/list.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/listitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/listitem/index.md
@@ -30,7 +30,7 @@ they notify users how many items are within the list.
 If you don't mark up lists using proper the proper list hierarchy,
 the screen reader can't set user expectations accordingly.
 Learn more in
-[`<li>` elements must be contained in a `<ul>` or `<ol>`](https://dequeuniversity.com/rules/axe/3.2/listitem).
+[`<li>` elements must be contained in a `<ul>` or `<ol>`](https://dequeuniversity.com/rules/axe/3.3/listitem).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -41,4 +41,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure list items are contained within a parent list audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/listitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/listitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/listitem/index.md
@@ -41,4 +41,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure list items are contained within a parent list audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/listitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/listitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/listitem/index.md
@@ -41,4 +41,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure list items are contained within a parent list audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/listitem.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
@@ -43,4 +43,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not use `<meta http-equiv="refresh">` audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-refresh.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
@@ -32,7 +32,7 @@ away from the user's focus.
 To avoid automatically refreshing the page,
 remove `<meta http-equiv="refresh">` from the page.
 Learn more in
-[Timed refresh must not exist](https://dequeuniversity.com/rules/axe/3.2/meta-refresh?application=lighthouse).
+[Timed refresh must not exist](https://dequeuniversity.com/rules/axe/3.3/meta-refresh?application=lighthouse).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -43,4 +43,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not use `<meta http-equiv="refresh">` audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-refresh.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
@@ -43,4 +43,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not use `<meta http-equiv="refresh">` audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-refresh.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
@@ -30,7 +30,7 @@ Both are problematic for people with low vision who rely on screen magnifiers
 to properly see the contents of a web page.
 
 Learn more in
-[Zooming and scaling must not be disabled](https://dequeuniversity.com/rules/axe/3.2/meta-viewport).
+[Zooming and scaling must not be disabled](https://dequeuniversity.com/rules/axe/3.3/meta-viewport).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -41,4 +41,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not disable text scaling and zooming audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-viewport.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
@@ -41,4 +41,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not disable text scaling and zooming audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-viewport.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
@@ -41,4 +41,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Do not disable text scaling and zooming audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/meta-viewport.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/object-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/object-alt/index.md
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `object` elements have alternative text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/object-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/object-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/object-alt/index.md
@@ -71,4 +71,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `object` elements have alternative text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/object-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/object-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/object-alt/index.md
@@ -49,7 +49,7 @@ Learn more in [Include text alternatives for images and objects](/labels-and-tex
 You can also use `alt` and ARIA labels to describe object elements,
 for example,
 `<object type="application/pdf" data="/report.pdf alt="2019 Web Accessibility Report">`
-(see [&lt;object> elements must have alternate text](https://dequeuniversity.com/rules/axe/3.2/object-alt))
+(see [&lt;object> elements must have alternate text](https://dequeuniversity.com/rules/axe/3.3/object-alt))
 {% endAside %}
 
 ## Tips for writing effective `alt` text
@@ -71,4 +71,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `object` elements have alternative text audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/object-alt.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/tabindex/index.md
+++ b/src/site/content/en/lighthouse-accessibility/tabindex/index.md
@@ -56,4 +56,4 @@ Todo. I have no idea how accessibility scoring is working!
 - [Elements should not have tabindex greater than zero](https://dequeuniversity.com/rules/axe/3.3/tabindex)
 - [Ensure `tabindex` values aren't greater than 0 audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/tabindex.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/tabindex/index.md
+++ b/src/site/content/en/lighthouse-accessibility/tabindex/index.md
@@ -56,4 +56,3 @@ Todo. I have no idea how accessibility scoring is working!
 - [Elements should not have tabindex greater than zero](https://dequeuniversity.com/rules/axe/3.3/tabindex)
 - [Ensure `tabindex` values aren't greater than 0 audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/tabindex.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/tabindex/index.md
+++ b/src/site/content/en/lighthouse-accessibility/tabindex/index.md
@@ -53,7 +53,7 @@ Todo. I have no idea how accessibility scoring is working!
 -->
 ## More information
 
-- [Elements should not have tabindex greater than zero](https://dequeuniversity.com/rules/axe/3.2/tabindex)
+- [Elements should not have tabindex greater than zero](https://dequeuniversity.com/rules/axe/3.3/tabindex)
 - [Ensure `tabindex` values aren't greater than 0 audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/tabindex.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
@@ -70,7 +70,7 @@ The scope attribute tells the browser and screen reader that everything under th
 is related to the header at the top,
 and everything to the right of the row header is related to that header.
 Learn more in
-[All cells in a `<table>` element that use the headers attribute must only refer to other cells of that same `<table>`](https://dequeuniversity.com/rules/axe/3.2/td-headers-attr).
+[All cells in a `<table>` element that use the headers attribute must only refer to other cells of that same `<table>`](https://dequeuniversity.com/rules/axe/3.3/td-headers-attr).
 
 Also add the missing `<td>` to the first row in the body,
 so that the table data aligns correctly with the table headers:
@@ -116,4 +116,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure there's only one table header per table column audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/td-headers-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
@@ -116,4 +116,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure there's only one table header per table column audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/td-headers-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
@@ -116,4 +116,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure there's only one table header per table column audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/td-headers-attr.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
+++ b/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
@@ -113,4 +113,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure each table header has data cells audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/th-has-data-cells.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
+++ b/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
@@ -102,7 +102,7 @@ Screen readers announce the table headers when it comes to each table data cell.
 If the headers and data cells don't match up,
 it's very confusing to screen reader users.
 Learn more in
-[All `<th>` elements and elements with `role="columnheader"` or `role="rowheader"` must have data cells they describe](https://dequeuniversity.com/rules/axe/3.2/th-has-data-cells).
+[All `<th>` elements and elements with `role="columnheader"` or `role="rowheader"` must have data cells they describe](https://dequeuniversity.com/rules/axe/3.3/th-has-data-cells).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -113,4 +113,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure each table header has data cells audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/th-has-data-cells.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
+++ b/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
@@ -113,4 +113,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure each table header has data cells audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/th-has-data-cells.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
@@ -27,7 +27,7 @@ To fix this problem,
 Use only valid language codes in the `lang` attribute.
 The language specified in the HTML document must be one of the valid languages
 to ensure text is pronounced correctly for screen reader users.
-Learn more in [lang attribute must have a valid value](https://dequeuniversity.com/rules/axe/3.2/valid-lang).
+Learn more in [lang attribute must have a valid value](https://dequeuniversity.com/rules/axe/3.3/valid-lang).
 
 <!--
 ## How this audit impacts overall Lighthouse score
@@ -38,4 +38,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/valid-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
@@ -38,4 +38,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/valid-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
@@ -38,4 +38,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Ensure `lang` attribute has valid value audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/valid-lang.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-caption/index.md
@@ -66,4 +66,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-caption/index.md
@@ -66,4 +66,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-caption/index.md
@@ -48,7 +48,7 @@ with attribute `kind="captions"`:
 ```
 
 Learn more in
-[`<video>` elements must have a `<track>` for captions](https://dequeuniversity.com/rules/axe/3.2/video-caption).
+[`<video>` elements must have a `<track>` for captions](https://dequeuniversity.com/rules/axe/3.3/video-caption).
 
 {% Aside 'note' %}
 The example above includes both captions for hearing impaired users,
@@ -66,4 +66,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have captions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-caption.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-description/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-description/index.md
@@ -42,7 +42,7 @@ with attribute `kind="descriptions"`:
 ```
 
 Learn more in
-[`<video>` elements must have an audio description `<track>`](https://dequeuniversity.com/rules/axe/3.2/video-description).
+[`<video>` elements must have an audio description `<track>`](https://dequeuniversity.com/rules/axe/3.3/video-description).
 
 {% Aside 'note' %}
 The example above includes both audio descriptions for visually impaired users
@@ -60,4 +60,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have audio descriptions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-description.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.2)
+- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-description/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-description/index.md
@@ -60,4 +60,4 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have audio descriptions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-description.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.2 rules](https://dequeuniversity.com/rules/axe/3.3)
+- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)

--- a/src/site/content/en/lighthouse-accessibility/video-description/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-description/index.md
@@ -60,4 +60,3 @@ Todo. I have no idea how accessibility scoring is working!
 
 - [Video elements have audio descriptions audit source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/video-description.js)
 - [axe-core rule descriptions](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
-- [List of axe 3.3 rules](https://dequeuniversity.com/rules/axe/3.3)


### PR DESCRIPTION
to avoid seeing this header when clicking through


![Screen Shot 2019-08-21 at 1 17 18 PM](https://user-images.githubusercontent.com/39191/63465399-08f35480-c416-11e9-8aa5-41468ac74de0.png)
