### PR TITLE
[ Bug 1433 ] - typo fixed calcualtes -> calculates

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
@@ -43,7 +43,7 @@ for more on WebP.
   </ul>
 </div>
 
-## How Lighthouse calcualtes potential savings
+## How Lighthouse calculates potential savings
 
 Lighthouse collects each BMP, JPEG, and PNG image on the page,
 and then converts each to WebP,


### PR DESCRIPTION
Fixes #1433

Changes proposed in this pull request:

- Fixed typo ( calcualtes -> calculates ) in uses-webp-images  page.