### PR TITLE
Update the handbook overview and re-order the handbook homepage

### DIFF
--- a/src/site/content/en/handbook/handbook.11tydata.js
+++ b/src/site/content/en/handbook/handbook.11tydata.js
@@ -7,45 +7,69 @@ module.exports = {
     slug: 'handbook',
     cover: '/images/collections/handbook.svg',
     title: 'Content handbook',
-    updated: 'Jun 24, 2019',
-    description: 'Create great content for web.dev.',
-    overview: `This handbook helps contributors to web.dev create effective,
-      engaging content and get it published as easily as possible. This is a
-      living document that will evolve as we learn more about what works.`,
+    updated: 'Aug 26, 2019',
+    description: 'How to write great content and get it published on web.dev.',
+    overview: `The goal of this handbook is to provide web.dev content contributors with
+      everything they could possibly need to know in order to write great content and
+      get it published on web.dev. As a contributor you don't have to read the whole handbook, but
+      the more you do, the faster your content will likely get published. Note that this handbook
+      is also the web.dev editorial team's single source of truth on how to maintain content
+      quality across the site.`,
     topics: [
       {
-        title: 'Content process',
+        title: 'Propose your content',
         pathItems: [
           'quick-start',
-          'content-checklist',
+          'audience',
+          'content-types',
           'third-party-contributions',
         ],
       },
       {
-        title: 'Content guidelines',
+        title: 'Draft high-quality content',
         pathItems: [
-          'content-types',
           'style',
           'voice',
-          'audience',
-          'grammar',
           'inclusion-and-accessibility',
           'effective-instruction',
           'write-code-samples',
           'use-media',
-          'word-list',
           'tooling-and-libraries',
+          'markup-sample-app',
+        ],
+      },
+
+      {
+        title: 'Get your content reviewed',
+        pathItems: [
+          'content-checklist',
         ],
       },
       {
-        title: 'web.dev markup',
+        title: 'Copyedit your content',
         pathItems: [
-          'contributor-profile',
+          'word-list',
+          'grammar',
+        ],
+      },
+      {
+        title: 'Format your content',
+        pathItems: [
           'markup-post-codelab',
           'web-dev-components',
+          'contributor-profile',
           'markup-media',
           'markup-code',
-          'markup-sample-app',
+        ],
+      },
+      {
+        title: 'Get your content published',
+        pathItems: [
+        ],
+      },
+      {
+        title: 'Maintain your content',
+        pathItems: [
         ],
       },
     ],

--- a/src/site/content/en/handbook/handbook.11tydata.js
+++ b/src/site/content/en/handbook/handbook.11tydata.js
@@ -9,12 +9,13 @@ module.exports = {
     title: 'Content handbook',
     updated: 'Aug 26, 2019',
     description: 'How to write great content and get it published on web.dev.',
-    overview: `The goal of this handbook is to provide web.dev content contributors with
-      everything they could possibly need to know in order to write great content and
-      get it published on web.dev. As a contributor you don't have to read the whole handbook, but
-      the more you do, the faster your content will likely get published. Note that this handbook
-      is also the web.dev editorial team's single source of truth on how to maintain content
-      quality across the site.`,
+    overview: `The goal of this handbook is to provide web.dev content 
+      contributors with everything they could possibly need to know in order
+      to write great content and get it published on web.dev. As a contributor
+      you don't have to read the whole handbook, but the more you do, the
+      faster your content will likely get published. Note that this handbook
+      is also the web.dev editorial team's single source of truth on how to
+      maintain content quality across the site.`,
     topics: [
       {
         title: 'Propose your content',

--- a/src/site/content/en/handbook/handbook.11tydata.js
+++ b/src/site/content/en/handbook/handbook.11tydata.js
@@ -63,16 +63,6 @@ module.exports = {
           'markup-code',
         ],
       },
-      {
-        title: 'Get your content published',
-        pathItems: [
-        ],
-      },
-      {
-        title: 'Maintain your content',
-        pathItems: [
-        ],
-      },
     ],
   },
 };


### PR DESCRIPTION
Changes proposed in this pull request:

* Updates the overview of the handbook homepage
* Re-orders the section titles of the handbook homepage to match the phases of the contribution process

On 12 August 2019 the web.dev writer team decided that the audience for the handbook is *any* potential web.dev contributor. Since web.dev welcomes external contributions this decision means that the handbook needs to err on the side of comprehensiveness. Hypothetically, if a contributor studies the handbook intensely, they should be able to propose content and get immediate approval with no requested changes, and they should be able to draft content that gets approval with no requested changes. That's what "comprehensive" means in this context.

## Change to handbook overview

This PR updates the handbook's overview to attempt to be a bit more explicit about the purpose of the handbook, as decided in the writer meeting. This is important for making sure that the writer team stays aligned on the purpose of the handbook over time.

## Homepage re-ordering

The PR also re-orders the sections of the handbook homepage. Currently the homepage has 3 sections:

* Content process
* Content guidelines
* web.dev markup

The proposed re-ordering is:

* Propose your content
* Draft high-quality content
* Get your content reviewed
* Copyedit your content
* Format your content

There's a few reasons for this change:

* The current organization suggests that contributors need to consider some topics earlier than they really need to. 
  * For example, currently [Grammar, mechanics, and usage](https://web.dev/handbook/grammar/) is listed under [Content guidelines](https://web.dev/handbook#content-guidelines). In the initial draft the reviewer is first and foremost making sure that the content is useful, well-structured, and so on. Many reviewers only start to correct grammar and mechanics when it's clear that the content will actually get published to web.dev. In the current organization it's not clear when the contributor should start worrying about grammar and mechanics. In the new organization it's clear that grammar and mechanics become important once we're all in agreement that the content is a good fit for web.dev.
* The new section titles are more action-oriented.
* I can think of a few more possible sections for the homepage. Such as information about the publishing process, and policies around maintaining content. We can cross that bridge when we get there, but the proposed new organization also sets us up to easily add in those new sections.