### PR TITLE
Fix broken mp4s and gif conversion instructions.

### DIFF
--- a/src/site/content/en/blog/backdrop-filter/index.md
+++ b/src/site/content/en/blog/backdrop-filter/index.md
@@ -3,6 +3,7 @@ title: "Create OS-style backgrounds with backdrop-filter"
 subhead: |
   Blurring and color shifting behind an element.
 date: 2019-07-26
+updated: 2019-08-29
 authors:
   - adamargyle
   - joemedley
@@ -29,7 +30,8 @@ Historically, these techniques were difficult to implement on the web, requiring
 
 <figure class="w-figure w-figure--fullbleed">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-kitchen_sink.mp4" type="video/mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-kitchen_sink2.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-kitchen_sink2.mp4" type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption w-figcaption--fullbleed">
     A demonstration of the filter functions for <code>backdrop-filter</code>. Try the example on <a href="https://codepen.io/robinrendle/pen/LmzLEL" target="_blank">CodePen</a>.
@@ -111,7 +113,8 @@ In the following example, the frosted effect is achieved by combining color and 
 
 <figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-rgb.mp4" type="video/mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-rgb2.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-rgb2.mp4" type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption">
     Try this example for yourself in <a href="https://codepen.io/netsi1964/pen/JqBLPK" target="_blank">CodePen</a>.
@@ -132,7 +135,8 @@ In the following example, each of the four panes has a different combination of 
 
 <figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-ambient_blur.mp4" type="video/mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-ambient_blur2.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-ambient_blur2.mp4" type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption">
     Try this example for yourself in <a href="https://codepen.io/pepf/pen/GqZkdj" target="_blank">CodePen</a>.
@@ -152,7 +156,8 @@ This example shows how to blur a semi-transparent background to make text readab
 
 <figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-modal.mp4" type="video/mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-modal2.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-modal2.mp4" type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption">
     Try this <a href="https://mfreed7.github.io/backdrop-filter-feature/examples/scrollable.html" target="_blank">example</a> for yourself.
@@ -178,7 +183,8 @@ As stated earlier, `backdrop-filter` allows performant effects that would be dif
 
 <figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-invert_color.mp4" type="video/mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-invert_color2.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/backdrop-filter/backdrop_filter-invert_color2.mp4" type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption">
     Try this example from <a href="https://www.chenhuijing.com/#%F0%9F%91%9F">Chen Hui Jing</a> in <a href="https://tympanus.net/codrops-playground/huijing/Qqpwg5Iy/editor" target="_blank">Codrops</a>.

--- a/src/site/content/en/blog/hands-on-portals/index.md
+++ b/src/site/content/en/blog/hands-on-portals/index.md
@@ -3,6 +3,7 @@ title: "Hands-on with Portals: seamless navigation on the Web"
 subhead: |
   Learn how to build good navigation UX with the Portals API.
 date: 2019-05-06
+updated: 2019-08-29
 authors:
   - uskay
 hero: hero.png
@@ -27,8 +28,8 @@ site. See Portals in action:
 
 <figure class="w-figure w-figure--fullbleed">
   <video controls autoplay loop muted class="w-screenshot">
-    <source src="https://storage.googleapis.com/web-dev-assets/portals_vp9.webm" type="video/webm; codecs=vp8">
-    <source src="https://storage.googleapis.com/web-dev-assets/portals_h264.mp4" type="video/mp4; codecs=h264">
+    <source src="https://storage.googleapis.com/web-dev-assets/hands-on-portals/portals_vp9.webm" type="video/webm; codecs=vp8">
+    <source src="https://storage.googleapis.com/web-dev-assets/hands-on-portals/portals_h264.mp4" type="video/mp4; codecs=h264">
   </video>
  <figcaption class="w-figcaption w-figcaption--fullbleed">
     Seamless embeds and navigation with Portals. Created by <a href="https://twitter.com/argyleink">Adam Argyle</a>.

--- a/src/site/content/en/blog/layout-instability-api/index.md
+++ b/src/site/content/en/blog/layout-instability-api/index.md
@@ -4,6 +4,7 @@ subhead: Detect unexpected layout shifts in JavaScript.
 authors:
   - philipwalton
 date: 2019-06-11
+updated: 2019-08-29
 hero: hero.jpg
 # You can adjust the position of your hero image with this property.
 # Values: top | bottom | center (default)
@@ -34,10 +35,10 @@ frustration. But in some cases, they can actually cause real damage or harm.
     poster="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability-poster.png"
     width="658" height="510">
     <source
-      src="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability.webm"
+      src="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability2.webm"
       type="video/webm; codecs=vp8">
     <source
-      src="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability.mp4"
+      src="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability2.mp4"
       type="video/mp4; codecs=h264">
   </video>
   <figcaption class="w-figcaption w-figcaption--fullbleed">

--- a/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
+++ b/src/site/content/en/fast/codelab-replace-gifs-with-video/index.md
@@ -4,6 +4,7 @@ title: Replace GIFs with video
 authors:
   - robdodson
 date: 2018-11-05
+updated: 2019-08-29
 description: |
   In this codelab, learn how to improve performance by replacing an animated GIF
   with a video.
@@ -71,7 +72,7 @@ cat-herd.gif
 - In the console, run:
 
 ```bash
-ffmpeg -i cat-herd.gif cat-herd.mp4
+ffmpeg -i cat-herd.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p cat-herd.mp4
 ```
 
 This tells FFmpeg to take the **input**, signified by the `-i` flag, of

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -9,6 +9,7 @@ description: |
   There's a good reason for that. Animated GIFs can be downright huge! By
   converting large GIFs to videos, you can save big on users' bandwidth.
 date: 2018-11-05
+updated: 2019-08-29
 codelabs:
   - codelab-replace-gifs-with-video
 ---
@@ -43,7 +44,7 @@ To use FFmpeg to convert the GIF, `my-animation.gif` to an MP4 video, run the
 following command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif my-animation.mp4
+ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
 ```
 
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the


### PR DESCRIPTION
Fixes #1407

Changes proposed in this pull request:

- Updates the replace-animated-gifs article with mp4 instructions that work in Safari.
- Updates any articles relying on mp4s to ones that actually work :)
