### PR TITLE
Add Image and Figure custom tags.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -42,6 +42,9 @@ const PathCard = require(`./${componentsDir}/PathCard`);
 const PostCard = require(`./${componentsDir}/PostCard`);
 const YouTube = require(`./${componentsDir}/YouTube`);
 
+const tagsDir = 'src/site/_includes/components/tags';
+const {Image, Figure} = require(`./${tagsDir}/Image`);
+
 const collectionsDir = 'src/site/_collections';
 const postDescending = require(`./${collectionsDir}/post-descending`);
 const postsWithLighthouse = require(`./${collectionsDir}/posts-with-lighthouse`);
@@ -143,6 +146,12 @@ module.exports = function(config) {
   config.addShortcode('ShareAction', ShareAction);
   config.addShortcode('SubscribeAction', SubscribeAction);
   config.addShortcode('YouTube', YouTube);
+
+  //----------------------------------------------------------------------------
+  // CUSTOM TAGS
+  //----------------------------------------------------------------------------
+  config.addNunjucksTag('Image', Image);
+  config.addNunjucksTag('Figure', Figure);
 
   https://www.11ty.io/docs/config/#data-deep-merge
   config.setDataDeepMerge(true);

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -25,5 +25,8 @@ module.exports = {
   banner: `Register for this year's \`#ChromeDevSummit\` happening on Nov. 11-12
   in San Francisco to learn about the latest features and tools coming to the
   Web. [Request an invite here](https://developer.chrome.com/devsummit/).`,
+  // Note that the imageCdn value is only used when we do a production build
+  // of the site. Otherwise all image paths are local. This means you can
+  // develop locally without having to mess with the CDN at all.
   imageCdn: 'https://webdev.imgix.net',
 };

--- a/src/site/_includes/components/helpers.js
+++ b/src/site/_includes/components/helpers.js
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-module.exports = {
-  env: process.env.ELEVENTY_ENV || 'dev',
-  title: 'web.dev',
-  titleVariation: 'Home',
-  url: 'https://web.dev',
-  repo: 'https://github.com/GoogleChrome/web.dev',
-  subscribe: 'https://web.dev/subscribe',
-  isBannerEnabled: true,
-  banner: `Register for this year's \`#ChromeDevSummit\` happening on Nov. 11-12
-  in San Francisco to learn about the latest features and tools coming to the
-  Web. [Request an invite here](https://developer.chrome.com/devsummit/).`,
-  imageCdn: 'https://webdev.imgix.net',
+/**
+ * If a value is present, then this will return an attribute in the format
+ * attr="val". Otherwise, returns the empty string.
+ * @param {!string} attr An attribute name.
+ * @param {?string|?Array<string>} val An attribute value. Can be an array of
+ * values. Arrays will be converted to a space separated string.
+ * @return {string}
+ */
+const ifDefined = (attr, val) => {
+  if (val) {
+    if (typeof val === 'string') {
+      val = [val];
+    }
+    return `${attr}="${val.join(' ')}"`;
+  }
+  return '';
 };
+
+module.exports = {ifDefined};

--- a/src/site/_includes/components/tags/Image.js
+++ b/src/site/_includes/components/tags/Image.js
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adds two new shortcodes to Eleventy: Image and Figure.
+ * These shortcodes will convert local image paths to image CDN paths depending
+ * on the build environment. This allows authors to dev with local images but
+ * switch to using image CDN images with srcset and other fanciness during
+ * production.
+ *
+ * We use the custom tags API instead of Eleventy's universal shortcodes here
+ * because we need access to the page context object (specifically the URL for
+ * the page that's being rendered). Unfortunately Eleventy's universal
+ * shortcodes don't have access to this information, so custom tags it is!
+ *
+ * Example usage:
+ *
+ * {%
+ *  Image
+ *  src="./label-a11y-lint.png",
+ *  alt="hello",
+ *  maxWidth="300px"
+ * %}
+ *
+ * {%
+ *  Figure
+ *  src="./label-a11y-lint.png",
+ *  alt="hello",
+ *  type="fullbleed screenshot",
+ *  maxWidth="300px"
+ * %}
+ *  Figcaption text goes here! Can be `markdown`.
+ * {% endFigure %}
+ *
+ */
+
+const path = require('path');
+const {oneLine} = require('common-tags');
+const {ifDefined} = require('../helpers');
+const md = require('markdown-it')();
+const stripLanguage = require('../../../_filters/strip-language');
+const imageCdn = require('../../../_data/site').imageCdn;
+
+/* eslint-disable no-invalid-this, max-len */
+
+// -----------------------------------------------------------------------------
+// IMAGE
+// -----------------------------------------------------------------------------
+
+/**
+ * Takes a path to an image and converts it to an image CDN path if we're in
+ * a production environment.
+ * @param {!string} src A path to an image asset.
+ * @param {!Object} ctx An eleventy context object for the current page.
+ * @return {string} An image path. May be converted to an image CDN path if
+ * it's a production environment.
+ */
+function getImagePath(src, ctx) {
+  let imagePath = src;
+  if (process.env.ELEVENTY_ENV === 'prod') {
+    imagePath = path.join(stripLanguage(ctx.page.url), src);
+    imagePath = new URL(imagePath, imageCdn).href;
+  }
+  return imagePath;
+}
+
+/**
+ * Render an image element as an HTML string.
+ * @param {!Object} args An args object containing src and optional alt and
+ * maxWidth.
+ * @param {!Object} ctx An eleventy context object.
+ * @return {string}
+ */
+function renderImage({src, alt, maxWidth}, ctx) {
+  const imagePath = getImagePath(src, ctx);
+  let style;
+  if (maxWidth) {
+    style = `max-width: ${maxWidth};`;
+  }
+  // Using oneLine seems to make Nunjucks' SafeString function happy.
+  return oneLine`
+    <img
+      src="${imagePath}"
+      alt="${alt}"
+      ${ifDefined('style', style)}
+    />
+  `;
+}
+
+/**
+ * Define an Image shortcode to be used in page templates.
+ * @param {!Object} nunjucksEngine
+ * @return {function}
+ */
+const Image = (nunjucksEngine) => {
+  return new function() {
+    this.tags = ['Image'];
+
+    this.parse = function(parser, nodes, lexer) {
+      const tok = parser.nextToken();
+
+      const args = parser.parseSignature(null, true);
+      parser.advanceAfterBlockEnd(tok.value);
+
+      return new nodes.CallExtensionAsync(this, 'run', args);
+    };
+
+    this.run = function({ctx}, args, callback) {
+      const ret = new nunjucksEngine.runtime.SafeString(
+        renderImage(args, ctx)
+      );
+      callback(null, ret);
+    };
+  }();
+};
+
+// -----------------------------------------------------------------------------
+// FIGURE
+// -----------------------------------------------------------------------------
+
+/**
+ * Render a figcaption element as an HTML string.
+ * @param {?string} caption A markdown string of caption text.
+ * @param {Array<string>} figCaptionClasses An Array of classes to apply to the
+ * figcaption element.
+ * @return {string}
+ */
+function renderFigCaption(caption, figCaptionClasses) {
+  if (!caption) {
+    return '';
+  }
+
+  // Needs to be one long line, else we get white space inside of the
+  // figcaption element.
+  return oneLine`
+    <figcaption class="${figCaptionClasses.join(' ')}">${md.renderInline(caption.trim())}</figcaption>
+  `;
+}
+
+/**
+ * Render a figure element as an HTML string.
+ * @param {!string} image An HTML string for an image element.
+ * @param {?Object} args An args object containing an optional type field.
+ * @param {?string} caption An optional caption string in markdown.
+ * @return {string}
+ */
+function renderFigure(image, {type}, caption) {
+  const figClasses = ['w-figure'];
+  const figCaptionClasses = ['w-figcaption'];
+
+  if (type) {
+    type.split(' ').forEach((entry) => {
+      figClasses.push(`w-figure--${entry}`);
+      // w-figure--fulbleed is the only modifier class we use on figcaption.
+      if (entry === 'fullbleed') {
+        figCaptionClasses.push(`w-figure--${entry}`);
+      }
+    });
+  }
+
+  return oneLine`
+    <figure class="${figClasses.join(' ')}">
+      ${image}
+      ${renderFigCaption(caption, figCaptionClasses)}
+    </figure>
+  `;
+}
+
+/**
+ * Define a Figure shortcode to be used in page templates.
+ * @param {!Object} nunjucksEngine
+ * @return {function}
+ */
+const Figure = (nunjucksEngine) => {
+  return new function() {
+    this.tags = ['Figure'];
+
+    this.parse = function(parser, nodes, lexer) {
+      const tok = parser.nextToken();
+
+      const args = parser.parseSignature(null, true);
+      parser.advanceAfterBlockEnd(tok.value);
+      const caption = parser.parseUntilBlocks('endFigure');
+      parser.advanceAfterBlockEnd();
+
+      return new nodes.CallExtensionAsync(this, 'run', args, [caption]);
+    };
+
+    this.run = function({ctx}, args, caption, callback) {
+      const ret = new nunjucksEngine.runtime.SafeString(
+        renderFigure(renderImage(args, ctx), args, caption())
+      );
+      callback(null, ret);
+    };
+  }();
+};
+
+module.exports = {Image, Figure};

--- a/src/site/_includes/components/tags/Image.js
+++ b/src/site/_includes/components/tags/Image.js
@@ -79,8 +79,7 @@ function getImagePath(src, ctx) {
 
 /**
  * Render an image element as an HTML string.
- * @param {!Object} args An args object containing src and optional alt and
- * maxWidth.
+ * @param {!{src: string, alt: string, maxWidth: number}} args
  * @param {!Object} ctx An eleventy context object.
  * @return {string}
  */
@@ -134,7 +133,7 @@ const Image = (nunjucksEngine) => {
 /**
  * Render a figcaption element as an HTML string.
  * @param {?string} caption A markdown string of caption text.
- * @param {Array<string>} figCaptionClasses An Array of classes to apply to the
+ * @param {!Array<string>} figCaptionClasses An Array of classes to apply to the
  * figcaption element.
  * @return {string}
  */
@@ -153,7 +152,7 @@ function renderFigCaption(caption, figCaptionClasses) {
 /**
  * Render a figure element as an HTML string.
  * @param {!string} image An HTML string for an image element.
- * @param {?Object} args An args object containing an optional type field.
+ * @param {{type: string}} args
  * @param {?string} caption An optional caption string in markdown.
  * @return {string}
  */

--- a/src/site/_includes/components/tags/README.md
+++ b/src/site/_includes/components/tags/README.md
@@ -1,0 +1,11 @@
+Various template engines can be extended with custom tags.
+
+Custom Tags are unrelated to Eleventy's Collections using Tags feature.
+Unfortunately we've inherited this name from various upstream template
+languages.
+
+Custom Tags give us the ability to write components similar to Eleventy's
+Shortcodes but with much more power because they have full access to the
+page context and the parser.
+
+<https://www.11ty.io/docs/custom-tags/>

--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -35,17 +35,30 @@
 // a white background.
 // -----------------------------------------------------------------------------
 
-.w-screenshot {
+// FIXME:
+// The duplication of the screenshot styles on figure are a temporary fix while
+// we transition elements over to the Figure shortcode.
+// After we transition all elements over to the shortcode, we should remove the
+// w-screenshot & w-screenshot--filled classes.
+// These figure classes *do* violate BEM style by using a child selector, but
+// it makes working with the shortcode much more ergonomic.
+
+.w-screenshot,
+.w-figure--screenshot > img {
   border: 1px solid $GREY_300;
   padding: 4px;
 }
 
-.w-screenshot--filled {
+.w-screenshot--filled,
+.w-figure--screenshot > img {
   background-color: $GREY_50;
   padding: 16px;
 }
 
-.w-screenshot + .w-screenshot {
+.w-screenshot + .w-screenshot,
+.w-screenshot--filled + .w-screenshot--filled,
+.w-figure--screenshot > img + .w-figure--screenshot > img,
+.w-figure--screenshot-filled > img + .w-figure--screenshot-filled > img {
   margin-top: 32px;
 }
 


### PR DESCRIPTION
Adding @samthor as a reviewer since it'll be Monday his time tomorrow :)

Changes proposed in this pull request:

- Add `Image` and `Figure` custom tags so we can migrate to using an image CDN with srcset and webp fanciness.

To keep things from getting super complicated, I'd like to land this PR first. Then follow up with a second PR to add srcset/webp goodness. And then follow up with a final PR that converts all existing images over to the new tags.

Example usage in Markdown files:

```
{%
  Image
  src="./label-a11y-lint.png",
  alt="hello",
  maxWidth="300px"
%}
```

```
{%
  Figure
  src="./label-a11y-lint.png",
  alt="hello",
  type="fullbleed screenshot",
  maxWidth="300px"
%}
Figcaption text goes here! Can be **markdown**.
{% endFigure %}
```