### PR TITLE
Create a single entrypoint for banners. Enable CDS banner.

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -21,4 +21,8 @@ module.exports = {
   url: 'https://web.dev',
   repo: 'https://github.com/GoogleChrome/web.dev',
   subscribe: 'https://web.dev/subscribe',
+  isBannerEnabled: true,
+  banner: `Register for this year's \`#ChromeDevSummit\` happening on Nov. 11-12
+  in San Francisco to learn about the latest features and tools coming to the
+  Web. [Request an invite here](https://developer.chrome.com/devsummit/).`,
 };

--- a/src/site/_includes/components/Banner.js
+++ b/src/site/_includes/components/Banner.js
@@ -15,11 +15,12 @@
  */
 
 const {html} = require('common-tags');
+const md = require('markdown-it')();
 
 module.exports = (content, type='info') => {
   return html`
     <div role="banner" class="w-banner w-banner--${type}">
-      ${content}
+      ${md.renderInline(content)}
     </div>
   `;
 };

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -12,6 +12,11 @@
     </head>
     <body>
       {% include 'styles.njk' %}
+      {% if site.isBannerEnabled and site.banner %}
+        {% Banner %}
+          {{site.banner}}
+        {% endBanner %}
+      {% endif %}
       {{ content | safe }}
       <link rel="alternate" href="/feed.xml" title="web.dev feed" type="application/atom+xml">
       <devsite-content-footer
@@ -73,6 +78,11 @@
                 <article class="devsite-article-inner">
                   <div class="devsite-article-body clearfix">
                     {% include 'styles.njk' %}
+                    {% if site.isBannerEnabled and site.banner %}
+                      {% Banner %}
+                        {{site.banner}}
+                      {% endBanner %}
+                    {% endif %}
                     {{ content | safe }}
                   </div>
                 </article>


### PR DESCRIPTION
Changes proposed in this pull request:

- Creates a single entrypoint in site.js to enable banners. 
- Adds a banner for CDS sign ups.
