### PR TITLE
Fix typo in lighthouse-performance / redirects

### DIFF
--- a/src/site/content/en/lighthouse-performance/redirects/index.md
+++ b/src/site/content/en/lighthouse-performance/redirects/index.md
@@ -37,7 +37,7 @@ of the resource by hundreds of milliseconds.
 
 ## How to eliminate redirects
 
-Eliminate the redirects by uptading the links to these resources.
+Eliminate the redirects by updating the links to these resources.
 Update the links to these resources.
 The links should point to the current locations of the resources.
 It's especially important to avoid redirects in resources

--- a/src/site/content/en/lighthouse-performance/redirects/index.md
+++ b/src/site/content/en/lighthouse-performance/redirects/index.md
@@ -37,7 +37,7 @@ of the resource by hundreds of milliseconds.
 
 ## How to eliminate redirects
 
-Eliminate the redirects by upading the links to these resources.
+Eliminate the redirects by uptading the links to these resources.
 Update the links to these resources.
 The links should point to the current locations of the resources.
 It's especially important to avoid redirects in resources


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- fix typo `upading` in section "How to eliminate redirects"