### PR TITLE
Fix broken and missing dates.

### DIFF
--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -38,7 +38,7 @@ this inline style tag.
       <h1 class="w-headline w-headline--two w-mb--sm">{{ title }}</h1>
       {% if date %}
         <div class="w-author__published">
-          <time>{{page.date | prettyDate}}</time>
+          <time>{{date | prettyDate}}</time>
           {% if updated %} <span class="w-author__separator">•</span> Updated <time>{{ updated | prettyDate }}</time> {% endif %}
         </div>
       {% endif %}

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -33,7 +33,7 @@
 
       {% if date %}
         <div class="w-author__published">
-          <time>{{page.date | prettyDate}}</time>
+          <time>{{date | prettyDate}}</time>
           {% if updated %} <span class="w-author__separator">•</span> Updated <time>{{ updated | prettyDate }}</time> {% endif %}
         </div>
       {% endif %}
@@ -66,7 +66,7 @@
         {% if updated %}
         Last updated: <time>{{ updated | prettyDate }}</time>
         {% else %}
-        Last updated: <time>{{ page.date | prettyDate }}</time>
+        Last updated: <time>{{ date | prettyDate }}</time>
         {% endif %}
       </span>
       <a

--- a/src/site/content/en/fast/adaptive-serving-based-on-network-quality/index.md
+++ b/src/site/content/en/fast/adaptive-serving-based-on-network-quality/index.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Adaptive serving based on network quality
+date: 2019-05-06
 authors:
   - mihajlija
 description: |

--- a/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure accesskey values are unique
 description: |
   Learn about accesskeys audit.
+date: 2019-05-02
 web_lighthouse:
   - accesskeys
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-allowed-attr/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure ARIA attributes are allowed for an element's role
 description: |
   Learn about aria-allowed-attr audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-allowed-attr
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-attr/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure ARIA roles have required states and properties
 description: |
   Learn about aria-required-attr audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-required-attr
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-children/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure parent roles contain required child role(s)
 description: |
   Learn about aria-required-children audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-required-children
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-required-parent/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure child roles are contained within required parent roles
 description: |
   Learn about aria-required-parent audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-required-parent
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-roles/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure ARIA role values are valid
 description: |
   Learn about aria-roles audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-roles
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr-value/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure ARIA attributes have valid values
 description: |
   Learn about aria-valid-attr-value audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-valid-attr-value
 ---

--- a/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-valid-attr/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure ARIA attributes are valid and not misspelled or non-existent
 description: |
   Learn about aria-valid-attr audit.
+date: 2019-05-02
 web_lighthouse:
   - aria-valid-attr
 ---

--- a/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure audio elements have captions
 description: |
   Learn about audio-caption audit.
+date: 2019-05-02
 web_lighthouse:
   - audio-caption
 ---

--- a/src/site/content/en/lighthouse-accessibility/button-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/button-name/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure buttons have discernible text
 description: |
   Learn about button-name audit.
+date: 2019-05-02
 web_lighthouse:
   - button-name
 ---

--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content
 description: |
   Learn about bypass audit.
+date: 2019-05-02
 web_lighthouse:
   - bypass
 ---

--- a/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
+++ b/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure background and foreground colors have a sufficient contrast ratio
 description: |
   Learn about color-contrast audit.
+date: 2019-05-02
 web_lighthouse:
   - color-contrast
 ---

--- a/src/site/content/en/lighthouse-accessibility/custom-control-roles/index.md
+++ b/src/site/content/en/lighthouse-accessibility/custom-control-roles/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check all custom controls have appropriate ARIA roles
 description: |
   Learn about custom-controls-labels audit.
+date: 2019-05-02
 web_lighthouse:
   - custom-controls-labels
 ---

--- a/src/site/content/en/lighthouse-accessibility/custom-controls-labels/index.md
+++ b/src/site/content/en/lighthouse-accessibility/custom-controls-labels/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check all custom interactive controls are keyboard focusable
 description: |
   Learn about custom-controls-labels audit.
+date: 2019-05-02
 web_lighthouse:
   - custom-controls-labels
 ---

--- a/src/site/content/en/lighthouse-accessibility/definition-list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/definition-list/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure dl elements are structured correctly
 description: |
   Learn about definition-list audit.
+date: 2019-05-02
 web_lighthouse:
   - definition-list
 ---

--- a/src/site/content/en/lighthouse-accessibility/dlitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/dlitem/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure all child dd and dt elements have a dl parent
 description: |
   Learn about dlitem audit.
+date: 2019-05-02
 web_lighthouse:
   - dlitem
 ---

--- a/src/site/content/en/lighthouse-accessibility/document-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/document-title/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure that each HTML document contains a title
 description: |
   Learn about document-title audit.
+date: 2019-05-02
 web_lighthouse:
   - document-title
 ---

--- a/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
+++ b/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure every ID attribute value is unique
 description: |
   Learn about duplicate-id audit.
+date: 2019-05-02
 web_lighthouse:
   - duplicate-id
 ---

--- a/src/site/content/en/lighthouse-accessibility/focus-traps/index.md
+++ b/src/site/content/en/lighthouse-accessibility/focus-traps/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check users can't accidentally trap their focus
 description: |
   Learn about focus-traps audit.
+date: 2019-05-02
 web_lighthouse:
   - focus-traps
 ---

--- a/src/site/content/en/lighthouse-accessibility/focusable-controls/index.md
+++ b/src/site/content/en/lighthouse-accessibility/focusable-controls/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check custom interactive controls are keyboard focusable and display a focus indicator
 description: |
   Learn about focusable-controls audit.
+date: 2019-05-02
 web_lighthouse:
   - focusable-controls
 ---

--- a/src/site/content/en/lighthouse-accessibility/frame-title/index.md
+++ b/src/site/content/en/lighthouse-accessibility/frame-title/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure IFrame and frame elements contain a non-empty title attribute
 description: |
   Learn about frame-title audit.
+date: 2019-05-02
 web_lighthouse:
   - frame-title
 ---

--- a/src/site/content/en/lighthouse-accessibility/heading-levels/index.md
+++ b/src/site/content/en/lighthouse-accessibility/heading-levels/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check that headings don't skip levels
 description: |
   Learn about heading-levels audit.
+date: 2019-05-02
 web_lighthouse:
   - heading-levels
 ---

--- a/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-has-lang/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure every HTML document has a lang attribute
 description: |
   Learn about html-has-lang audit.
+date: 2019-05-02
 web_lighthouse:
   - html-has-lang
 ---

--- a/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
+++ b/src/site/content/en/lighthouse-accessibility/html-lang-valid/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure the lang attribute of the html element has a valid value
 description: |
   Learn about html-lang-valid audit.
+date: 2019-05-02
 web_lighthouse:
   - html-lang-valid
 ---

--- a/src/site/content/en/lighthouse-accessibility/image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/image-alt/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure img elements have alternate text or a role of none or presentation
 description: |
   Learn about image-alt audit.
+date: 2019-05-02
 web_lighthouse:
   - image-alt
 ---

--- a/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/input-image-alt/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure input types with a value "image" have alternate text
 description: |
   Learn about input-image audit.
+date: 2019-05-02
 web_lighthouse:
   - input-image-alt
 ---

--- a/src/site/content/en/lighthouse-accessibility/interactive-element-affordance/index.md
+++ b/src/site/content/en/lighthouse-accessibility/interactive-element-affordance/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check interactive elements indicate their purpose and state
 description: |
   Learn about interactive-element-affordance audit.
+date: 2019-05-02
 web_lighthouse:
   - interactive-element-affordance
 ---

--- a/src/site/content/en/lighthouse-accessibility/label/index.md
+++ b/src/site/content/en/lighthouse-accessibility/label/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure every form element has a label
 description: |
   Learn about label audit.
+date: 2019-05-02
 web_lighthouse:
   - label
 ---

--- a/src/site/content/en/lighthouse-accessibility/layout-table/index.md
+++ b/src/site/content/en/lighthouse-accessibility/layout-table/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure layout tables do not use data table elements
 description: |
   Learn about layout-table audit.
+date: 2019-05-02
 web_lighthouse:
   - layout-table
 ---

--- a/src/site/content/en/lighthouse-accessibility/link-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/link-name/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure links have discernible text
 description: |
   Learn about link-name audit.
+date: 2019-05-02
 web_lighthouse:
   - link-name
 ---

--- a/src/site/content/en/lighthouse-accessibility/list/index.md
+++ b/src/site/content/en/lighthouse-accessibility/list/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure lists are structured correctly
 description: |
   Learn about list audit.
+date: 2019-05-02
 web_lighthouse:
   - list
 ---

--- a/src/site/content/en/lighthouse-accessibility/listitem/index.md
+++ b/src/site/content/en/lighthouse-accessibility/listitem/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure list items are contained within a parent list
 description: |
   Learn about listitem audit.
+date: 2019-05-02
 web_lighthouse:
   - listitem
 ---

--- a/src/site/content/en/lighthouse-accessibility/logical-tab-order/index.md
+++ b/src/site/content/en/lighthouse-accessibility/logical-tab-order/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check the tab order follows the DOM order
 description: |
   Learn about logical-tab-order audit.
+date: 2019-05-02
 web_lighthouse:
   - logical-tab-order
 ---

--- a/src/site/content/en/lighthouse-accessibility/managed-focus/index.md
+++ b/src/site/content/en/lighthouse-accessibility/managed-focus/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check user's focus is directed to new content
 description: |
   Learn about managed-focus audit.
+date: 2019-05-02
 web_lighthouse:
   - managed-focus
 ---

--- a/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-refresh/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure timed refreshes do not exist
 description: |
   Learn about meta-refresh audit.
+date: 2019-05-02
 web_lighthouse:
   - meta-refresh
 ---

--- a/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
+++ b/src/site/content/en/lighthouse-accessibility/meta-viewport/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure the viewport doesn't disable text scaling and zooming
 description: |
   Learn about meta-viewport audit.
+date: 2019-05-02
 web_lighthouse:
   - meta-viewport
 ---

--- a/src/site/content/en/lighthouse-accessibility/object-alt/index.md
+++ b/src/site/content/en/lighthouse-accessibility/object-alt/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure object elements have alternative text
 description: |
   Learn about object-alt audit.
+date: 2019-05-02
 web_lighthouse:
   - object-alt
 ---

--- a/src/site/content/en/lighthouse-accessibility/offscreen-content-hidden/index.md
+++ b/src/site/content/en/lighthouse-accessibility/offscreen-content-hidden/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check offscreen content is hidden from assistive technology
 description: |
   Learn about offscreen-content-hidden audit.
+date: 2019-05-02
 web_lighthouse:
   - offscreen-content-hidden
 ---

--- a/src/site/content/en/lighthouse-accessibility/tabindex/index.md
+++ b/src/site/content/en/lighthouse-accessibility/tabindex/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure tabindex attribute values are not greater than 0
 description: |
   Learn about tabindex audit.
+date: 2019-05-02
 web_lighthouse:
   - tabindex
 ---

--- a/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
+++ b/src/site/content/en/lighthouse-accessibility/td-headers-attr/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure there's only one table header per table column
 description: |
   Learn about td-headers-attr audit.
+date: 2019-05-02
 web_lighthouse:
   - td-headers-attr
 ---

--- a/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
+++ b/src/site/content/en/lighthouse-accessibility/th-has-data-cells/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure each table header has data cells
 description: |
   Learn about th-has-data-cells audit.
+date: 2019-05-02
 web_lighthouse:
   - th-has-data-cells
 ---

--- a/src/site/content/en/lighthouse-accessibility/use-landmarks/index.md
+++ b/src/site/content/en/lighthouse-accessibility/use-landmarks/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check landmark elements improve navigation
 description: |
   Learn about managed-focus audit.
+date: 2019-05-02
 web_lighthouse:
   - use-landmarks
   - managed-focus

--- a/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
+++ b/src/site/content/en/lighthouse-accessibility/valid-lang/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure all lang attributes have a valid value
 description: |
   Learn about valid-lang audit.
+date: 2019-05-02
 web_lighthouse:
   - valid-lange
 ---

--- a/src/site/content/en/lighthouse-accessibility/video-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-caption/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure video elements have captions
 description: |
   Learn about video-caption audit.
+date: 2019-05-02
 web_lighthouse:
   - video-caption
 ---

--- a/src/site/content/en/lighthouse-accessibility/video-description/index.md
+++ b/src/site/content/en/lighthouse-accessibility/video-description/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure video elements have audio descriptions
 description: |
   Learn about video-description audit.
+date: 2019-05-02
 web_lighthouse:
   - video-description
 ---

--- a/src/site/content/en/lighthouse-accessibility/visual-order-follows-dom/index.md
+++ b/src/site/content/en/lighthouse-accessibility/visual-order-follows-dom/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check the visual layout of the page matches the DOM
 description: |
   Learn about visual-order-follows-dom audit.
+date: 2019-05-02
 web_lighthouse:
   - visual-order-follows-dom
 ---

--- a/src/site/content/en/lighthouse-best-practices/appcache-manifest/index.md
+++ b/src/site/content/en/lighthouse-best-practices/appcache-manifest/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Uses application cache
 description: |
   Learn about `appcache-manifest` audit.
+date: 2019-05-02
 web_lighthouse:
   - appcache-manifest
 ---

--- a/src/site/content/en/lighthouse-best-practices/deprecations/index.md
+++ b/src/site/content/en/lighthouse-best-practices/deprecations/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page uses deprecated APIs
 description: |
   Learn about `deprecations` audit.
+date: 2019-05-02
 web_lighthouse:
   - deprecations
 ---

--- a/src/site/content/en/lighthouse-best-practices/doctype/index.md
+++ b/src/site/content/en/lighthouse-best-practices/doctype/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document missing doctype
 description: |
   Learn about `doctype` audit.
+date: 2019-05-02
 web_lighthouse:
   - doctype
 ---

--- a/src/site/content/en/lighthouse-best-practices/errors-in-console/index.md
+++ b/src/site/content/en/lighthouse-best-practices/errors-in-console/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Browser errors were logged to the console
 description: |
   Learn about `errors-in-console` audit.
+date: 2019-05-02
 web_lighthouse:
   - errors-in-console
 ---

--- a/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
+++ b/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Links to cross-origin destinations are unsafe
 description: |
   Learn about `external-anchors-use-rel-noopener` audit.
+date: 2019-05-02
 web_lighthouse:
   - external-anchors-use-rel-noopener
 ---

--- a/src/site/content/en/lighthouse-best-practices/geolocation-on-start/index.md
+++ b/src/site/content/en/lighthouse-best-practices/geolocation-on-start/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page requests geolocation on load
 description: |
   Learn about `geolocation-on-start` audit.
+date: 2019-05-02
 web_lighthouse:
   - geolocation-on-start
 ---

--- a/src/site/content/en/lighthouse-best-practices/image-aspect-ratio/index.md
+++ b/src/site/content/en/lighthouse-best-practices/image-aspect-ratio/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Images display with incorrect aspect ratio
 description: |
   Learn about `image-aspect-ration` audit.
+date: 2019-05-02
 web_lighthouse:
   - image-aspect-ration
 ---

--- a/src/site/content/en/lighthouse-best-practices/js-libraries/index.md
+++ b/src/site/content/en/lighthouse-best-practices/js-libraries/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Diagnostic audit that lists all JavaScript libraries
 description: |
   Learn about `js-libraries` audit.
+date: 2019-05-02
 web_lighthouse:
   - js-libraries
 ---

--- a/src/site/content/en/lighthouse-best-practices/no-document-write/index.md
+++ b/src/site/content/en/lighthouse-best-practices/no-document-write/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page uses document.write()
 description: |
   Learn about `no-document-write` audit.
+date: 2019-05-02
 web_lighthouse:
   - no-document-write
 ---

--- a/src/site/content/en/lighthouse-best-practices/no-vulnerable-libraries/index.md
+++ b/src/site/content/en/lighthouse-best-practices/no-vulnerable-libraries/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Includes front-end JavaScript libraries with known security vulnerabilities
 description: |
   Learn about `no-vulnerable-libraries` audit.
+date: 2019-05-02
 web_lighthouse:
   - no-vulnerable-libraries
 ---

--- a/src/site/content/en/lighthouse-best-practices/notification-on-start/index.md
+++ b/src/site/content/en/lighthouse-best-practices/notification-on-start/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page requests notification permissions on load
 description: |
   Learn about `notification-on-start` audit.
+date: 2019-05-02
 web_lighthouse:
   - notification-on-start
 ---

--- a/src/site/content/en/lighthouse-best-practices/password-inputs-can-be-pasted-into/index.md
+++ b/src/site/content/en/lighthouse-best-practices/password-inputs-can-be-pasted-into/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page stops users from pasting into password fields
 description: |
   Learn about `password-inputs-can-be-pasted-into` audit.
+date: 2019-05-02
 web_lighthouse:
   - password-inputs-can-be-pasted-into
 ---

--- a/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
+++ b/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page doesn't use HTTP/2 for its own resources
 description: |
   Learn about `uses-http2` audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-http2
 ---

--- a/src/site/content/en/lighthouse-best-practices/uses-passive-event-listeners/index.md
+++ b/src/site/content/en/lighthouse-best-practices/uses-passive-event-listeners/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page doesn't use passive event listeners to improve scrolling performance
 description: |
   Learn about `uses-passive-event-listeners` audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-passive-event-listeners
 ---

--- a/src/site/content/en/lighthouse-performance/bootup-time/index.md
+++ b/src/site/content/en/lighthouse-performance/bootup-time/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Reduce JavaScript execution time
 description: |
   Learn about the bootup-time audit.
+date: 2019-05-02
 web_lighthouse:
   - bootup-time
 ---

--- a/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
+++ b/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Minimize critical requests depth
 description: |
   Learn about the critical-request-chains audit.
+date: 2019-05-02
 web_lighthouse:
   - critical-request-chains
 ---

--- a/src/site/content/en/lighthouse-performance/dom-size/index.md
+++ b/src/site/content/en/lighthouse-performance/dom-size/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Avoid an excessive DOM size
 description: |
   Learn about the dom-size audit.
+date: 2019-05-02
 web_lighthouse:
   - dom-size
 ---

--- a/src/site/content/en/lighthouse-performance/efficient-animated-content/index.md
+++ b/src/site/content/en/lighthouse-performance/efficient-animated-content/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Use video formats for animated content
 description: |
   Learn about the efficient-animated-content audit.
+date: 2019-05-02
 web_lighthouse:
   - efficient-animated-content
 ---

--- a/src/site/content/en/lighthouse-performance/estimated-input-latency/index.md
+++ b/src/site/content/en/lighthouse-performance/estimated-input-latency/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Estimated Input Latency
 description: |
   Learn about the estimated-input-latency audit.
+date: 2019-05-02
 web_lighthouse:
   - estimated-input-latency
 ---

--- a/src/site/content/en/lighthouse-performance/first-contentful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/first-contentful-paint/index.md
@@ -3,6 +3,7 @@ layout: post
 title: First Contentful Paint
 description: |
   Learn about the first-contentful-paint audit.
+date: 2019-05-02
 web_lighthouse:
   - first-contentful-paint
 ---

--- a/src/site/content/en/lighthouse-performance/first-cpu-idle/index.md
+++ b/src/site/content/en/lighthouse-performance/first-cpu-idle/index.md
@@ -3,6 +3,7 @@ layout: post
 title: First CPU Idle
 description: |
   Learn about the first-cpu-idle audit.
+date: 2019-05-02
 web_lighthouse:
   - first-cpu-idle
 ---

--- a/src/site/content/en/lighthouse-performance/first-meaningful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/first-meaningful-paint/index.md
@@ -3,6 +3,7 @@ layout: post
 title: First Meaningful Paint
 description: |
   Learn about the first-meaningful-paint audit.
+date: 2019-05-02
 web_lighthouse:
   - first-meaningful-paint
 ---

--- a/src/site/content/en/lighthouse-performance/font-display/index.md
+++ b/src/site/content/en/lighthouse-performance/font-display/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Ensure text remains visible during webfont loads
 description: |
   Learn about the font-display audit.
+date: 2019-05-02
 web_lighthouse:
   - font-display
 ---

--- a/src/site/content/en/lighthouse-performance/interactive/index.md
+++ b/src/site/content/en/lighthouse-performance/interactive/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Time to Interactive
 description: |
   Learn about the Time to Interactive audit.
+date: 2019-05-02
 web_lighthouse:
   - interactive
 ---

--- a/src/site/content/en/lighthouse-performance/mainthread-work-breakdown/index.md
+++ b/src/site/content/en/lighthouse-performance/mainthread-work-breakdown/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Minimize main-thread work
 description: |
   Learn about the mainthread-work-breakdown audit.
+date: 2019-05-02
 web_lighthouse:
   - mainthread-work-breakdown
 ---

--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Defer offscreen images
 description: |
   Learn about the offscreen-images audit.
+date: 2019-05-02
 web_lighthouse:
   - offscreen-images
 ---

--- a/src/site/content/en/lighthouse-performance/redirects/index.md
+++ b/src/site/content/en/lighthouse-performance/redirects/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Avoid multiple page redirects
 description: |
   Learn about the redirects audit.
+date: 2019-05-02
 web_lighthouse:
   - redirects
 ---

--- a/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
+++ b/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Eliminate render-blocking resources
 description: |
   Learn about the render-blocking-resources audit.
+date: 2019-05-02
 web_lighthouse:
   - render-blocking-resources
 ---

--- a/src/site/content/en/lighthouse-performance/resource-summary/index.md
+++ b/src/site/content/en/lighthouse-performance/resource-summary/index.md
@@ -4,6 +4,7 @@ title: Keep request counts low and transfer sizes small
 description: |
   An overview of how high resource counts and large transfer sizes affect load performance, 
   and strategies for reducing request counts and transfer sizes.
+date: 2019-05-02
 web_lighthouse:
   - resource-summary
 ---

--- a/src/site/content/en/lighthouse-performance/speed-index/index.md
+++ b/src/site/content/en/lighthouse-performance/speed-index/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Speed Index
 description: |
   Learn about the speed-index audit.
+date: 2019-05-02
 web_lighthouse:
   - speed-index
 ---

--- a/src/site/content/en/lighthouse-performance/third-party-summary/index.md
+++ b/src/site/content/en/lighthouse-performance/third-party-summary/index.md
@@ -4,6 +4,7 @@ title: Reduce the impact of third-party code
 description: |
   Learn how third-party code, like advertising networks and analytics services, affects page load performance,
   and how you can optimize third-party code.
+date: 2019-05-02
 web_lighthouse:
   - third-party-summary
 ---

--- a/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
+++ b/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Reduce server response times (TTFB)
 description: |
   Learn about the time-to-first-byte audit.
+date: 2019-05-02
 web_lighthouse:
   - time-to-first-byte
 ---

--- a/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
+++ b/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Avoid enormous network payloads
 description: |
   Learn about the total-byte-weight audit.
+date: 2019-05-02
 web_lighthouse:
   - total-byte-weight
 ---

--- a/src/site/content/en/lighthouse-performance/unminified-css/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-css/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Minify CSS
 description: |
   Learn about the unminified-css audit.
+date: 2019-05-02
 web_lighthouse:
   - unminified-css
 ---

--- a/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Minify JavaScript
 description: |
   Learn about the unminified-javascript audit.
+date: 2019-05-02
 web_lighthouse:
   - unminified-javascript
 ---

--- a/src/site/content/en/lighthouse-performance/unused-css-rules/index.md
+++ b/src/site/content/en/lighthouse-performance/unused-css-rules/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Remove unused CSS
 description: |
   Learn about the unused-css-rules audit.
+date: 2019-05-02
 web_lighthouse:
   - unused-css-rules
 ---

--- a/src/site/content/en/lighthouse-performance/user-timings/index.md
+++ b/src/site/content/en/lighthouse-performance/user-timings/index.md
@@ -3,6 +3,7 @@ layout: post
 title: User Timing marks and measures
 description: |
   Learn about the user-timings audit.
+date: 2019-05-02
 web_lighthouse:
   - user-timings
 ---

--- a/src/site/content/en/lighthouse-performance/uses-long-cache-ttl/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-long-cache-ttl/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Serve static assets with an efficient cache policy
 description: |
   Learn about the uses-long-cache-ttl audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-long-cache-ttle
 ---

--- a/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Efficiently encode images
 description: |
   Learn about the uses-optimized-images audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-optimized-images
 ---

--- a/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Preconnect to required origins
 description: |
   Learn about the uses-rel-preconnect audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-rel-preconnect
 ---

--- a/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Preload key requests
 description: |
   Learn about the uses-rel-preload audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-rel-preload
 ---

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Properly size images
 description: |
   Learn about the uses-responsive-images audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-responsive-images
 ---

--- a/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Enable text compression
 description: |
   Learn about the uses-text-compression audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-text-compression
 ---

--- a/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Serve images in next-gen formats
 description: |
   Learn about the uses-webp-images audit.
+date: 2019-05-02
 web_lighthouse:
   - uses-webp-images
 ---

--- a/src/site/content/en/lighthouse-pwa/apple-touch-icon/index.md
+++ b/src/site/content/en/lighthouse-pwa/apple-touch-icon/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Does not provide a valid apple-touch-icon
 description: |
   How to specify what icon should appear on iOS home screens for your Progressive Web App.
+date: 2019-08-26
 web_lighthouse:
   - apple-touch-icon
 codelabs: codelab-apple-touch-icon

--- a/src/site/content/en/lighthouse-pwa/content-width/index.md
+++ b/src/site/content/en/lighthouse-pwa/content-width/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Content is not sized correctly for the viewport
 description: |
   Learn about `content-width` audit.
+date: 2019-05-02
 web_lighthouse:
   - content-width
 ---

--- a/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
+++ b/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
@@ -3,6 +3,7 @@ layout: post
 title: User can be prompted to install the web app
 description: |
   Learn about `installable-manifest` audit.
+date: 2019-05-02
 web_lighthouse:
   - installable-manifest
 ---

--- a/src/site/content/en/lighthouse-pwa/is-on-https/index.md
+++ b/src/site/content/en/lighthouse-pwa/is-on-https/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Uses HTTPS
 description: |
   Learn about `is-on-https` audit.
+date: 2019-05-02
 web_lighthouse:
   - is-on-https
 ---

--- a/src/site/content/en/lighthouse-pwa/load-fast-enough-for-pwa/index.md
+++ b/src/site/content/en/lighthouse-pwa/load-fast-enough-for-pwa/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page load is fast enough on mobile
 description: |
   Learn about `load-fast-enough-for-pwa` audit.
+date: 2019-05-02
 web_lighthouse:
   - load-fast-enough-for-pwa
 ---

--- a/src/site/content/en/lighthouse-pwa/offline-start-url/index.md
+++ b/src/site/content/en/lighthouse-pwa/offline-start-url/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Start URL responds with a 200 when offline
 description: |
   Learn about `offline-start-url` audit.
+date: 2019-05-02
 web_lighthouse:
   - offline-start-url
 ---

--- a/src/site/content/en/lighthouse-pwa/pwa-cross-browser/index.md
+++ b/src/site/content/en/lighthouse-pwa/pwa-cross-browser/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Site works cross-browser
 description: |
   Learn about `pwa-cross-browser` audit.
+date: 2019-05-02
 web_lighthouse:
   - pwa-cross-browser
 ---

--- a/src/site/content/en/lighthouse-pwa/pwa-each-page-has-url/index.md
+++ b/src/site/content/en/lighthouse-pwa/pwa-each-page-has-url/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Each page has a URL
 description: |
   Learn about `pwa-each-page-has-url` audit.
+date: 2019-05-02
 web_lighthouse:
   - pwa-each-page-has-url
 ---

--- a/src/site/content/en/lighthouse-pwa/pwa-page-transitions/index.md
+++ b/src/site/content/en/lighthouse-pwa/pwa-page-transitions/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page transitions don't feel like they block on the network
 description: |
   Learn about `pwa-page-transitions` audit.
+date: 2019-05-02
 web_lighthouse:
   - pwa-page-transitions
 ---

--- a/src/site/content/en/lighthouse-pwa/redirects-http/index.md
+++ b/src/site/content/en/lighthouse-pwa/redirects-http/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Avoid multiple page redirects
 description: |
   Learn about `redirects-http` audit.
+date: 2019-05-02
 web_lighthouse:
   - redirects-http
 ---

--- a/src/site/content/en/lighthouse-pwa/service-worker/index.md
+++ b/src/site/content/en/lighthouse-pwa/service-worker/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Registers a service worker that controls page and start_url
 description: |
   Learn about `service-worker` audit.
+date: 2019-05-02
 web_lighthouse:
   - service-worker
 ---

--- a/src/site/content/en/lighthouse-pwa/splash-screen/index.md
+++ b/src/site/content/en/lighthouse-pwa/splash-screen/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Configured for a custom splash screen
 description: |
   Learn about `splash-screen` audit.
+date: 2019-05-02
 web_lighthouse:
   - splash-screen
 ---

--- a/src/site/content/en/lighthouse-pwa/themed-omnibox/index.md
+++ b/src/site/content/en/lighthouse-pwa/themed-omnibox/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Sets an address-bar theme color
 description: |
   Learn about `themed-omnibox` audit.
+date: 2019-05-02
 web_lighthouse:
   - themed-omnibox
 ---

--- a/src/site/content/en/lighthouse-pwa/viewport/index.md
+++ b/src/site/content/en/lighthouse-pwa/viewport/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Has a viewport tag with width or initial-scale
 description: |
   Learn about `viewport` audit.
+date: 2019-05-02
 web_lighthouse:
   - viewport
 ---

--- a/src/site/content/en/lighthouse-pwa/without-javascript/index.md
+++ b/src/site/content/en/lighthouse-pwa/without-javascript/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Contains some content when JavaScript is not available
 description: |
   Learn about `without-javascript` audit.
+date: 2019-05-02
 web_lighthouse:
   - without-javascript
 ---

--- a/src/site/content/en/lighthouse-pwa/works-offline/index.md
+++ b/src/site/content/en/lighthouse-pwa/works-offline/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Current page responds with a 200 when offline
 description: |
   Learn about `works-offline` audit.
+date: 2019-05-02
 web_lighthouse:
   - works-offline
 ---

--- a/src/site/content/en/lighthouse-seo/canonical/index.md
+++ b/src/site/content/en/lighthouse-seo/canonical/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document doesn't have a valid rel=canonical
 description: |
   Learn about the canonical audit.
+date: 2019-05-02
 web_lighthouse:
   - canonical
 ---

--- a/src/site/content/en/lighthouse-seo/font-size/index.md
+++ b/src/site/content/en/lighthouse-seo/font-size/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document doesn't use legible font sizes
 description: |
   Learn about font-size audit.
+date: 2019-05-02
 web_lighthouse:
   - font-size
 ---

--- a/src/site/content/en/lighthouse-seo/hreflang/index.md
+++ b/src/site/content/en/lighthouse-seo/hreflang/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document doesn't have a valid hreflang
 description: |
   Learn about hreflang audit.
+date: 2019-05-02
 web_lighthouse:
   - hreflang
 ---

--- a/src/site/content/en/lighthouse-seo/http-status-code/index.md
+++ b/src/site/content/en/lighthouse-seo/http-status-code/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page has unsuccessful HTTP status code
 description: |
   Learn about http-status-code audit.
+date: 2019-05-02
 web_lighthouse:
   - http-status-code
 ---

--- a/src/site/content/en/lighthouse-seo/is-crawable/index.md
+++ b/src/site/content/en/lighthouse-seo/is-crawable/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Page is blocked from indexing
 description: |
   Learn about is-crawable audit.
+date: 2019-05-02
 web_lighthouse:
   - is-crawable
 ---

--- a/src/site/content/en/lighthouse-seo/link-text/index.md
+++ b/src/site/content/en/lighthouse-seo/link-text/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Links do not have descriptive text
 description: |
   Learn about link-text audit.
+date: 2019-05-02
 web_lighthouse:
   - link-text
 ---

--- a/src/site/content/en/lighthouse-seo/meta-description/index.md
+++ b/src/site/content/en/lighthouse-seo/meta-description/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document doesn't have a meta description
 description: |
   Learn about the the "Document Does Not Have A Meta Description" Lighthouse audit.
+date: 2019-05-02
 web_lighthouse:
   - meta-description
 ---

--- a/src/site/content/en/lighthouse-seo/plugins/index.md
+++ b/src/site/content/en/lighthouse-seo/plugins/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Document uses plugins
 description: |
   Learn about plugins audit.
+date: 2019-05-02
 web_lighthouse:
   - plugins
 ---

--- a/src/site/content/en/lighthouse-seo/robots-txt/index.md
+++ b/src/site/content/en/lighthouse-seo/robots-txt/index.md
@@ -3,6 +3,7 @@ layout: post
 title: robots.txt is not valid
 description: |
   Learn about robots-txt audit.
+date: 2019-05-02
 web_lighthouse:
   - robots-txt
 ---

--- a/src/site/content/en/lighthouse-seo/structured-data/index.md
+++ b/src/site/content/en/lighthouse-seo/structured-data/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Manually check structured data is valid
 description: |
   Learn about structured-data audit.
+date: 2019-05-02
 web_lighthouse:
   - structured-data
 ---

--- a/src/site/content/en/lighthouse-seo/tap-targets/index.md
+++ b/src/site/content/en/lighthouse-seo/tap-targets/index.md
@@ -3,6 +3,7 @@ layout: post
 title: Tap targets are not sized appropriately
 description: |
   Learn about tap-targets audit.
+date: 2019-05-02
 web_lighthouse:
   - tap-targets
 ---


### PR DESCRIPTION
Changes proposed in this pull request:

- Switches posts and codelabs over to using the `date` YAML field, instead of the `page.date` eleventy field. `page.date` checks the modified date of the file _on the local machine_. This means if you did a fresh clone of the repo it would think that each file was created that day. It's important to land this change, otherwise no one else can deploy the site.
- Updates a number of LH audit posts that were missing their publish date. With the exception of Kayce's recent apple touch icon post, I set all of the others to May 2nd which is when Meggin originally landed them.
