### PR TITLE
include the webcomponents polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,8 +68,7 @@ gulp.task('copy-content-assets', () => {
 gulp.task('copy-node_modules-assets', () => {
   return gulp
     .src([
-      `./node_modules/@webcomponents/webcomponentsjs/**/*.js`,
-      `!./node_modules/@webcomponents/webcomponentsjs/src/**`,
+      `./node_modules/@webcomponents/webcomponentsjs/bundles/*.js`,
     ])
     .pipe(gulp.dest('./dist/lib/webcomponents/'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,9 +65,19 @@ gulp.task('copy-content-assets', () => {
     .pipe(gulp.dest('./dist/en'));
 });
 
+gulp.task('copy-node_modules-assets', () => {
+  return gulp
+    .src([
+      `./node_modules/@webcomponents/webcomponentsjs/**/*.js`,
+      `!./node_modules/@webcomponents/webcomponentsjs/src/**`,
+    ])
+    .pipe(gulp.dest('./dist/lib/webcomponents/'));
+});
+
 gulp.task('build', gulp.parallel(
   'copy-global-assets',
   'copy-content-assets',
+  'copy-node_modules-assets',
 ));
 
 gulp.task('watch', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,11 @@
         "@types/node": "*"
       }
     },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.3.0.tgz",
+      "integrity": "sha512-sR6FOrNnnncRuoJDqq9QxtRsJMbIvASw4vnJwIYKVlKO3AMc+NAr/bIQNnUiTTE9pBDTJkFpVaUdjJaRdsjmyA=="
+    },
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@webcomponents/webcomponentsjs": "^2.3.0",
     "express": "^4.16.4",
     "focus-visible": "^5.0.2",
     "lit-element": "^2.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,4 +48,23 @@ module.exports = [
       }),
     ],
   },
+  {
+    input: "src/lib/bootstrap.js",
+    output: {
+      dir: "dist",
+      format: "iife",
+      entryFileNames: outputPattern,
+      chunkFileNames: outputPattern,
+      sourcemap: true,
+    },
+    watch: {
+      clearScreen: false,
+    },
+    plugins: [
+      resolve(),
+      commonJs({
+        include: "node_modules/**",
+      }),
+    ],
+  },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import resolve from "rollup-plugin-node-resolve";
 import commonJs from "rollup-plugin-commonjs";
 
 const isProd = process.env.ELEVENTY_ENV === "prod";
+const webdevConfigName = "webdev_config";
 
 let outputPattern;
 if (isProd) {
@@ -9,6 +10,32 @@ if (isProd) {
 } else {
   outputPattern = "[name].js";
 }
+
+const config = {
+  prod: isProd,
+  webcomponentsPath: isProd
+    ? "lib/webcomponents"
+    : "node_modules/@webcomponents/webcomponentsjs/bundles",
+  version:
+    "v" +
+    new Date()
+      .toISOString()
+      .replace(/[\D]/g, "")
+      .slice(0, 12),
+};
+
+const configPlugin = {
+  load(id) {
+    if (id === webdevConfigName) {
+      return `export default ${JSON.stringify(config)};`;
+    }
+  },
+  resolveId(importee, importer) {
+    if (importee === webdevConfigName) {
+      return importee;
+    }
+  },
+};
 
 module.exports = [
   {
@@ -61,6 +88,7 @@ module.exports = [
       clearScreen: false,
     },
     plugins: [
+      configPlugin,
       resolve(),
       commonJs({
         include: "node_modules/**",

--- a/src/lib/bootstrap-config.js
+++ b/src/lib/bootstrap-config.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Configures global overrides.
+ *
+ * Needed to ensure that globals are configured before polyfill loaders are run, as `import`
+ * statements are hoisted to the top of the file they're run in.
+ */
+
+import config from "webdev_config";
+
+window.WebComponents = {path: config.webcomponentsPath};
+
+export default config;

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -5,6 +5,7 @@
  * app.js (or TODO: entrypoints).
  */
 
+import config from "./bootstrap-config";
 import "@webcomponents/webcomponentsjs/webcomponents-loader.js";
 
 WebComponents.waitFor(async () => {

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -8,6 +8,8 @@
 import config from "./bootstrap-config";
 import "@webcomponents/webcomponentsjs/webcomponents-loader.js";
 
+console.info("web.dev", config.version);
+
 WebComponents.waitFor(async () => {
   return new Promise((resolve, reject) => {
     // nb. import() is fairly well supported (although not as much as raw modules), but we just

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Site bootstrap code.
+ *
+ * This should not import unrelated code, and exists purely to load relevant polyfills and then
+ * app.js (or TODO: entrypoints).
+ */
+
+import "@webcomponents/webcomponentsjs/webcomponents-loader.js";
+
+WebComponents.waitFor(async () => {
+  return new Promise((resolve, reject) => {
+    // nb. import() is fairly well supported (although not as much as raw modules), but we just
+    // don't need it
+    const s = document.createElement("script");
+    s.type = "module";
+    s.onerror = reject;
+    s.onload = () => resolve();
+    s.src = "/app.js";
+    document.head.appendChild(s);
+  });
+});

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -34,6 +34,8 @@
         });
       });
     </script>
+    <link rel="modulepreload" href="/app.js" />
+    <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', 'UA-126406676-2');

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -20,20 +20,8 @@
     <link rel="stylesheet" href="/app.css" />
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-app.js"></script>
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js"></script>
+    {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
-    {# Module code is loaded deferred (the "asynchronous" case in the polyfill docs) but we only load other module code anyway. #}
-    <script type="module" src="/lib/webcomponents/webcomponents-loader.js"></script>
-    <script type="module">
-      WebComponents.waitFor(async () => {
-        return new Promise((resolve, reject) => {
-          const s = document.createElement('script');
-          s.onerror = reject;
-          s.onload = () => resolve();
-          s.src = "/app.js";
-          document.head.appendChild(s);
-        });
-      });
-    </script>
     <link rel="modulepreload" href="/app.js" />
     <script type="module" src="/bootstrap.js"></script>
     <script>

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -23,7 +23,17 @@
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
     {# Module code is loaded deferred (the "asynchronous" case in the polyfill docs) but we only load other module code anyway. #}
     <script type="module" src="/lib/webcomponents/webcomponents-loader.js"></script>
-    <script type="module" src="/app.js"></script>
+    <script type="module">
+      WebComponents.waitFor(async () => {
+        return new Promise((resolve, reject) => {
+          const s = document.createElement('script');
+          s.onerror = reject;
+          s.onload = () => resolve();
+          s.src = "/app.js";
+          document.head.appendChild(s);
+        });
+      });
+    </script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', 'UA-126406676-2');

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -21,6 +21,8 @@
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-app.js"></script>
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js"></script>
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
+    {# Module code is loaded deferred (the "asynchronous" case in the polyfill docs) but we only load other module code anyway. #}
+    <script type="module" src="/lib/webcomponents/webcomponents-loader.js"></script>
     <script type="module" src="/app.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
Adds the Web Components loader to our source tree. Resolves #1376.

Note that our JS actually isn't being loaded now either (since it has a `.hexcode.js`) suffix. That's a separate issue.