### PR TITLE
V2+build all rollup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     mocha: true,
     browser: true,
   },
+  parser: "babel-eslint",
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,16 +97,58 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+      "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
+      "requires": {
+        "@babel/types": "^7.6.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "requires": {
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -116,8 +158,72 @@
     "@babel/parser": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-      "dev": true
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
+    },
+    "@babel/template": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+          "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg=="
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+      "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.6.2",
+        "@babel/types": "^7.6.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+          "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -858,6 +964,29 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -1566,7 +1695,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "3.1.0",
@@ -2298,7 +2428,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
@@ -2866,7 +2997,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -2874,8 +3004,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -3952,8 +4081,7 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "5.0.1",
@@ -4013,8 +4141,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -5698,8 +5825,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "5.0.0",
@@ -7261,8 +7387,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -12605,8 +12730,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -12619,22 +12743,6 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "source-map-url": {
@@ -13169,23 +13277,6 @@
         "fork-stream": "^0.0.4",
         "merge-stream": "^1.0.0",
         "through2": "^2.0.1"
-      }
-    },
-    "terser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz",
-      "integrity": "sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==",
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "algoliasearch": "^3.34.0",
     "ansi-colors": "^3.2.4",
     "autoprefixer": "^9.6.1",
+    "babel-eslint": "^10.0.3",
     "chalk": "^2.4.2",
     "chokidar-cli": "^1.2.2",
     "common-tags": "^1.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,13 +4,6 @@ import commonJs from "rollup-plugin-commonjs";
 const isProd = process.env.ELEVENTY_ENV === "prod";
 const webdevConfigName = "webdev_config";
 
-let outputPattern;
-if (isProd) {
-  outputPattern = "[name].[hash].js";
-} else {
-  outputPattern = "[name].js";
-}
-
 const config = {
   prod: isProd,
   webcomponentsPath: isProd
@@ -39,18 +32,20 @@ const configPlugin = {
 
 module.exports = [
   {
-    input: "src/lib/app.js",
+    input: "src/lib/bootstrap.js",
     output: {
       dir: "dist",
-      format: "iife",
-      entryFileNames: outputPattern,
-      chunkFileNames: outputPattern,
+      format: "esm",
+      chunkFileNames: "_[hash].js",
+      entryFileNames: "[name].js", // this will only be "bootstrap.js"
       sourcemap: true,
+      dynamicImportFunction: "polyfillImport",
     },
     watch: {
       clearScreen: false,
     },
     plugins: [
+      configPlugin,
       resolve(),
       commonJs({
         include: "node_modules/**",
@@ -62,33 +57,11 @@ module.exports = [
     output: {
       dir: "dist/test",
       format: "iife",
-      entryFileNames: outputPattern,
-      chunkFileNames: outputPattern,
     },
     watch: {
       clearScreen: false,
     },
     plugins: [
-      resolve(),
-      commonJs({
-        include: "node_modules/**",
-      }),
-    ],
-  },
-  {
-    input: "src/lib/bootstrap.js",
-    output: {
-      dir: "dist",
-      format: "iife",
-      entryFileNames: outputPattern,
-      chunkFileNames: outputPattern,
-      sourcemap: true,
-    },
-    watch: {
-      clearScreen: false,
-    },
-    plugins: [
-      configPlugin,
       resolve(),
       commonJs({
         include: "node_modules/**",

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -1,16 +1,4 @@
-import {router} from "./router";
 import "./components/ProfileSwitcherContainer";
-import "./components/ProgressBar";
-import "./components/SparklineChart";
-import "./components/LighthouseGauge";
-import "./components/LighthouseScoresAudits";
-import "./components/LighthouseScoresContainer";
-import "./components/LighthouseScoresMeta";
-import "./components/LighthouseScoresMetrics";
-import "./components/LighthouseScoresStats";
-import "./components/UrlChooser";
-import "./components/UrlChooserContainer";
-import "./components/Codelab";
 import "./components/Header";
 import "./components/SideNav";
 import "./components/SnackbarContainer";
@@ -18,10 +6,6 @@ import {store} from "./store";
 import "focus-visible";
 import "./analytics";
 import {checkIfUserAcceptsCookies} from "./actions";
-
-// Run as long-lived router w/ history & "<a>" bindings
-// Also immediately calls `run()` handler for current location
-router.listen();
 
 // Configures global page state
 function onGlobalStateChanged() {

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -7,18 +7,18 @@
 
 import config from "./bootstrap-config";
 import "@webcomponents/webcomponentsjs/webcomponents-loader.js";
+import {router, entrypointLoaded} from "./router";
+import entrypointForRoute from "./entrypoint-for-route";
 
 console.info("web.dev", config.version);
 
 WebComponents.waitFor(async () => {
-  return new Promise((resolve, reject) => {
-    // nb. import() is fairly well supported (although not as much as raw modules), but we just
-    // don't need it
-    const s = document.createElement("script");
-    s.type = "module";
-    s.onerror = reject;
-    s.onload = () => resolve();
-    s.src = "/app.js";
-    document.head.appendChild(s);
-  });
+  // ... only load the first entrypoint if the user hasn't changed URLs in the meantime
+  if (!entrypointLoaded) {
+    await entrypointForRoute(window.location.pathname.substr(1));
+  }
 });
+
+// Run as long-lived router w/ history & "<a>" bindings
+// Also immediately calls `run()` handler for current location
+router.listen();

--- a/src/lib/entrypoint-for-route.js
+++ b/src/lib/entrypoint-for-route.js
@@ -1,0 +1,22 @@
+
+import "./polyfill/import";
+
+/**
+ * Imports the entrypoint for the given site URL.
+ *
+ * @param {string} url following "/", e.g. "measure" or "learn"
+ * @return {!Promise<void>}
+ */
+export default function entrypointForRoute(url) {
+  let p;
+
+  if (url.match(/^measure($|\/)/)) {
+    /* eslint-disable-next-line */
+    p = import("./pages/measure.js");
+  } else {
+    /* eslint-disable-next-line */
+    p = import("./pages/default.js");
+  }
+  console.info('loading entrypoint for', url);
+  return p;
+}

--- a/src/lib/entrypoint-for-route.js
+++ b/src/lib/entrypoint-for-route.js
@@ -1,4 +1,3 @@
-
 import "./polyfill/import";
 
 /**
@@ -11,12 +10,9 @@ export default function entrypointForRoute(url) {
   let p;
 
   if (url.match(/^measure($|\/)/)) {
-    /* eslint-disable-next-line */
     p = import("./pages/measure.js");
   } else {
-    /* eslint-disable-next-line */
     p = import("./pages/default.js");
   }
-  console.info('loading entrypoint for', url);
   return p;
 }

--- a/src/lib/pages/default.js
+++ b/src/lib/pages/default.js
@@ -1,0 +1,3 @@
+import "../components/Codelab";
+
+import "../app";

--- a/src/lib/pages/measure.js
+++ b/src/lib/pages/measure.js
@@ -1,0 +1,12 @@
+import "../components/ProgressBar";
+import "../components/SparklineChart";
+import "../components/LighthouseGauge";
+import "../components/LighthouseScoresAudits";
+import "../components/LighthouseScoresContainer";
+import "../components/LighthouseScoresMeta";
+import "../components/LighthouseScoresMetrics";
+import "../components/LighthouseScoresStats";
+import "../components/UrlChooser";
+import "../components/UrlChooserContainer";
+
+import "../app";

--- a/src/lib/polyfill/import.js
+++ b/src/lib/polyfill/import.js
@@ -1,0 +1,35 @@
+/**
+ * Simple polyfill for the `import()` function.
+ *
+ * Limitations:
+ *   - doesn't support exports from the passed module (but right now it's only used for entrypoints
+ *     ...which have none)
+ *   - won't resolve relative paths (which is the major "problem" with import() polyfills), but it
+ *     is only used after a Rollup build which flattens all JS output
+ *   - must be defined as a global on `window`
+ *
+ * @param {string} f to import
+ * @return {!Promise<void>}
+ */
+window["polyfillImport"] = (function() {
+  const cache = {};
+
+  return (src) => {
+    if (src in cache) {
+      return cache["src"];
+    }
+
+    const p = new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.type = "module";
+      s.onerror = reject;
+      s.onload = () => resolve();
+      s.src = src;
+      document.head.appendChild(s);
+    });
+    cache[src] = p;
+    return p;
+  };
+})();
+
+export default window["polyfillImport"];

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -1,7 +1,9 @@
 import navaid from "navaid";
+import entrypointForRoute from "./entrypoint-for-route";
 
 const router = navaid();
 let isFirstRun = true;
+export let entrypointLoaded = false;
 const domparser = new DOMParser();
 
 /**
@@ -33,6 +35,10 @@ async function swapContent(url) {
     return;
   }
 
+  // Load the entrypoint simultaneously with content.
+  const entrypointPromise = entrypointForRoute(url);
+  entrypointLoaded = true;
+
   const main = document.querySelector("main");
   // Grab the new page content
   let page;
@@ -44,6 +50,9 @@ async function swapContent(url) {
     window.location.href = window.location.href;
     throw e;
   }
+
+  // Wait for code to be ready
+  await entrypointPromise;
   // Remove the current #content element
   main.querySelector("#content").remove();
   // Swap in the new #content element
@@ -52,7 +61,7 @@ async function swapContent(url) {
 
 router
   .on("/", async () => {
-    return swapContent("index.html");
+    return swapContent("");
   })
   .on("/*", async (params) => {
     return swapContent(params.wild);

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -25,7 +25,6 @@
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js"></script>
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
-    <link rel="modulepreload" href="/app.js" />
     <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
Here's an alternative to #1581.

I do like using Rollup's built-in `import()` splitting support. It's easy^.

^ except we need a polyfill for Edge

But fundamentally we can't include the generated chunk names in the JS for `modulepreload`. Options are:
* don't do `modulepreload` at all
* modify every HTML page, risking cache invalidations for **every** article the second we touch a byte of JS
* ship another JS file that we `import()` or include, which could be `modulepreload`-ed (same number of request chains as #1581) but this is a whole different type of complexity.