### PR TITLE
fix: Use authors instead of author in content source file

### DIFF
--- a/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
+++ b/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incorporate performance budgets into your build process
-author:
+authors:
   - mihajlija
 description: |
   The best way to keep an eye on your performance budget is to automate it. Find
@@ -158,7 +158,7 @@ If the scores for a pull request on GitHub fall below the threshold you've set, 
 <figure class="w-figure">
   <img class="screenshot" src="./lighthouse-check.png" alt="Lighthouse Bot check status on Github">
   <figcaption class="w-figcaption">
-    Lighthouse Bot check status on Github  
+    Lighthouse Bot check status on Github
   </figcaption>
 </figure>
 


### PR DESCRIPTION
Changes proposed in this pull request:

-  Updates `author` to `authors` in the [Incorporate performance budgets into your build process](https://github.com/GoogleChrome/web.dev/blob/master/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md) so the author(@mihajlija) shows in the article.

The screenshots below show the issue that this PR is tackling.

### Preview

![Screenshot from 2019-10-04 23-06-10](https://user-images.githubusercontent.com/13482373/66240005-986d7200-e6fb-11e9-9872-8ac7d00b4809.png)
![Screenshot from 2019-10-04 23-05-42](https://user-images.githubusercontent.com/13482373/66240009-9acfcc00-e6fb-11e9-9ed9-dd31e7ea9efd.png)
