### PR TITLE
fix: Remove td tag from yaml file

### DIFF
--- a/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
+++ b/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
@@ -128,7 +128,7 @@ install:
 before_script:
   - npm install -g firebase-tools
 script:
-  - webpack</td>
+  - webpack
 ```
 
 The YAML file tells Travis to install all the dependencies and build your app.
@@ -183,7 +183,7 @@ Now whenever you make changes to your app, they will be automatically deployed t
 
 ## 5. Setting up Lighthouse Bot
 
-Friendly Lighthouse Bot updates you on your app's Lighthouse scores. 
+Friendly Lighthouse Bot updates you on your app's Lighthouse scores.
 It just needs an invitation to your repo.
 
 On GitHub, go to your project's settings and **add "lighthousebot" as a collaborator** (Settings>Collaborators):


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes the `td` closing tag from the [yaml file example](https://web.dev/using-lighthouse-bot-to-set-a-performance-budget/) 


### Preview
Current:
![Screenshot from 2019-10-05 00-24-21](https://user-images.githubusercontent.com/13482373/66243914-90ff9600-e706-11e9-857e-3eb682a9e622.png)


Fix: https://deploy-preview-1606--web-dev-staging.netlify.com/using-lighthouse-bot-to-set-a-performance-budget/