### PR TITLE
Add rel="noopener" to external links using target="_blank"

### DIFF
--- a/src/site/_drafts/intrinsic-layout-overview/index.md
+++ b/src/site/_drafts/intrinsic-layout-overview/index.md
@@ -126,7 +126,7 @@ intrinsic layout.**
     <img loading="lazy" src="https://storage.googleapis.com/web-dev-assets/intrinsic-layout-overview/home.jpg" alt="TenHundred store home page" class="screenshot">
   </picture>
   <figcaption class="w-figcaption w-figcaption--fullbleed">
-    <a href="https://intrinsic-layout-guide.glitch.me" target="_blank">Preview the final layout demo page</a>
+    <a href="https://intrinsic-layout-guide.glitch.me" target="_blank" rel="noopener noreferrer">Preview the final layout demo page</a>
   </figcaption>
 </figure>
 

--- a/src/site/content/en/blog/backdrop-filter/index.md
+++ b/src/site/content/en/blog/backdrop-filter/index.md
@@ -22,7 +22,7 @@ Translucence, blurring, and other effects are useful ways of creating depth whil
 <figure class="w-figure w-figure--center">
   <img src="weather_app.jpg" alt="An example of a frosted glass effect.">
   <figcaption class="w-figcaption">
-    An example of a frosted glass effect. <a href="https://dribbble.com/shots/733714-Weather-App?list=tags&tag=android" target="_blank">Source</a>.
+    An example of a frosted glass effect. <a href="https://dribbble.com/shots/733714-Weather-App?list=tags&tag=android" target="_blank" rel="noopener noreferrer">Source</a>.
   </figcaption>
 </figure>
 

--- a/src/site/content/en/blog/use-thumbor/index.md
+++ b/src/site/content/en/blog/use-thumbor/index.md
@@ -14,7 +14,7 @@ tags:
   - images
 ---
 
-[Thumbor](http://thumbor.org/) is a free, open source image CDN that makes it easy to compress, resize, and transform images. This post lets you try out Thumbor firsthand without needing to install anything. We've set up a sandbox Thumbor server for you to try out at `http://34.67.235.246:8888`. The image that you're going to experiment with is available at <a href="http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg</a>.
+[Thumbor](http://thumbor.org/) is a free, open source image CDN that makes it easy to compress, resize, and transform images. This post lets you try out Thumbor firsthand without needing to install anything. We've set up a sandbox Thumbor server for you to try out at `http://34.67.235.246:8888`. The image that you're going to experiment with is available at <a href="http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer noopener">http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg</a>.
 
 
 ## Prequisites
@@ -99,7 +99,7 @@ This section focuses on the Thumbor functionalities most relevant to performance
 
 ### Compression
 
-The [quality](https://thumbor.readthedocs.io/en/latest/quality.html) filter compresses JPEG images to the desired image quality level (1-100). If no quality level is provided, Thumbor compresses the image to a quality level of 80. This is a good default: quality levels 80-85 typically have little noticeable effect on image quality, but usually decrease image size by 30-40%.  
+The [quality](https://thumbor.readthedocs.io/en/latest/quality.html) filter compresses JPEG images to the desired image quality level (1-100). If no quality level is provided, Thumbor compresses the image to a quality level of 80. This is a good default: quality levels 80-85 typically have little noticeable effect on image quality, but usually decrease image size by 30-40%.
 
 Try it now:
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds rel="noopener" to external links using target="_blank" due to it's [performance and security benefits](https://developers.google.com/web/tools/lighthouse/audits/noopener)