### PR TITLE
Make inline code work in next article widget and headings.

### DIFF
--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -17,6 +17,7 @@
 const {html} = require('common-tags');
 const {findBySlug} = require('../../_filters/find-by-slug');
 const stripLanguage = require('../../_filters/strip-language');
+const md = require('markdown-it')();
 
 /* eslint-disable require-jsdoc,max-len */
 
@@ -118,7 +119,7 @@ module.exports = ({back, backLabel, collection, path, slug}) => {
         data-action="click"
         href="${link}"
       >
-        ${label}
+        ${md.renderInline(label)}
       </a>
     `;
   }
@@ -134,7 +135,7 @@ module.exports = ({back, backLabel, collection, path, slug}) => {
       >
         <div class="w-article-navigation__column">
           <h3 class="w-article-navigation__heading">Next article</h3>
-          ${label}
+          ${md.renderInline(label)}
         </div>
       </a>
     `;

--- a/src/styles/components/_article-navigation.scss
+++ b/src/styles/components/_article-navigation.scss
@@ -106,3 +106,10 @@
 .w-article-navigation__heading {
   margin: 0 0 4px;
 }
+
+.w-article-navigation code {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 0;
+}

--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -77,6 +77,9 @@ h4 code,
 h5 code,
 h6 code {
   border: 0;
+  color: inherit;
+  margin: 0;
+  padding: 0;
 }
 
 // Github-like theme for Prism.js


### PR DESCRIPTION
Fixes #1594

Changes proposed in this pull request:

- Ensure next article shortcode renders markdown for code snippets.
- Add CSS to make next article widget inline code look nice.
- Tweak heading styles to also make inline code look nice.
