### PR TITLE
Add body variant to banner component

### DIFF
--- a/src/site/_includes/components/Banner.js
+++ b/src/site/_includes/components/Banner.js
@@ -17,9 +17,11 @@
 const {html} = require('common-tags');
 const md = require('markdown-it')();
 
-module.exports = (content, type='info') => {
+module.exports = (content, type='info', location) => {
+  const locationOverride = location == 'body' ? 'w-banner--body' : '';
+
   return html`
-    <div role="banner" class="w-banner w-banner--${type}">
+    <div role="banner" class="w-banner w-banner--${type} ${locationOverride}">
       ${md.renderInline(content)}
     </div>
   `;

--- a/src/site/_includes/styles.njk
+++ b/src/site/_includes/styles.njk
@@ -15,6 +15,11 @@ web-lighthouse-scores .lh-enterurl .lh-enterurl__close {
   }
 }
 
+.w-banner--body {
+  font: inherit;
+  padding: 24px;
+}
+
 .w-columns .w-compare {
   margin: 0; }
   @media (min-width: 481px) {

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -167,27 +167,27 @@ Use the codelab aside to link to an associated codelab.
 
 ```text
 {% raw %}{% verbatim %}
-{% Banner %}This is an info banner with a [link](#).{% endBanner %}
+{% Banner %}This is an info banner. It supports Markdown.{% endBanner %}
 {% endverbatim %}{% endraw %}
 ```
 
-{% Banner %}This is an info banner with a [link](#).{% endBanner %}
+{% Banner %}This is an info banner. It supports Markdown.{% endBanner %}
 
 ```text
 {% raw %}{% verbatim %}
-{% Banner 'caution' %}This is a caution banner with a [link](#).{% endBanner %}
+{% Banner 'caution' %}This is a caution banner. It supports Markdown.{% endBanner %}
 {% endverbatim %}{% endraw %}
 ```
 
-{% Banner 'caution' %}This is a caution banner with a [link](#).{% endBanner %}
+{% Banner 'caution' %}This is a caution banner. It supports Markdown.{% endBanner %}
 
 ```text
 {% raw %}{% verbatim %}
-{% Banner 'warning' %}This is a warning banner with a [link](#).{% endBanner %}
+{% Banner 'warning' %}This is a warning banner. It supports Markdown.{% endBanner %}
 {% endverbatim %}{% endraw %}
 ```
 
-{% Banner 'warning' %}This is a warning banner with a [link](#).{% endBanner %}
+{% Banner 'warning' %}This is a warning banner. It supports Markdown.{% endBanner %}
 
 ```text
 {% raw %}{% verbatim %}

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -44,9 +44,11 @@ There are several kinds of asides, each for a different purpose.
 ### Note asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside %&#125;
 Use the note aside to provide supplemental information.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside %}
@@ -56,9 +58,11 @@ Use the note aside to provide supplemental information.
 ### Caution asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'caution' %&#125;
 Use the caution aside to indicate a potential pitfall or complication.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'caution' %}
@@ -68,10 +72,12 @@ Use the caution aside to indicate a potential pitfall or complication.
 ### Warning asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'warning' %&#125;
 The warning aside is stronger than a caution aside; use it to tell the reader
 not to do something.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'warning' %}
@@ -82,9 +88,11 @@ not to do something.
 ### Success asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'success' %&#125;
 Use the success aside to describe a successful action or an error-free status.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'success' %}
@@ -94,10 +102,12 @@ Use the success aside to describe a successful action or an error-free status.
 ### Objective asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'objective' %&#125;
 Use the objective aside to define the goal of a process described in the body
 copy.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'objective' %}
@@ -108,10 +118,12 @@ copy.
 ### Gotcha asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'gotchas' %&#125;
 Use the gotcha aside to indicate a common problem that the reader wouldn't know
 without specialized knowledge of the topic.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'gotchas' %}
@@ -122,11 +134,13 @@ without specialized knowledge of the topic.
 ### Key-term asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'key-term' %&#125;
 Use the key-term aside to define a term that's essential to understanding an
 idea in the body copy. Key-term asides should be a single sentence that
 includes the term in italics. For example, "A _portal_ is…"
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'key-term' %}
@@ -138,9 +152,11 @@ includes the term in italics. For example, "A _portal_ is…"
 ### Codelab asides
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Aside 'codelab' %&#125;
 Use the codelab aside to link to an associated codelab.
 &#123;% endAside %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'codelab' %}
@@ -149,11 +165,37 @@ Use the codelab aside to link to an associated codelab.
 
 ## Banner
 
-{% Banner %}This is an info banner with a <a href="#">link</a>.{% endBanner %}
+```text
+{% raw %}{% verbatim %}
+{% Banner %}This is an info banner with a [link](#).{% endBanner %}
+{% endverbatim %}{% endraw %}
+```
 
-{% Banner 'caution' %}This is a caution banner with a <a href="#">link</a>.{% endBanner %}
+{% Banner %}This is an info banner with a [link](#).{% endBanner %}
 
-{% Banner 'warning' %}This is a warning banner with a <a href="#">link</a>.{% endBanner %}
+```text
+{% raw %}{% verbatim %}
+{% Banner 'caution' %}This is a caution banner with a [link](#).{% endBanner %}
+{% endverbatim %}{% endraw %}
+```
+
+{% Banner 'caution' %}This is a caution banner with a [link](#).{% endBanner %}
+
+```text
+{% raw %}{% verbatim %}
+{% Banner 'warning' %}This is a warning banner with a [link](#).{% endBanner %}
+{% endverbatim %}{% endraw %}
+```
+
+{% Banner 'warning' %}This is a warning banner with a [link](#).{% endBanner %}
+
+```text
+{% raw %}{% verbatim %}
+{% Banner 'info', 'body' %}This is an info banner that's used in the body of a post. It has less padding and larger text.{% endBanner %}
+{% endverbatim %}{% endraw %}
+```
+
+{% Banner 'info', 'body' %}This is an info banner that's used in the body of a post. It has less padding and larger text.{% endBanner %}
 
 ## Block quotes
 
@@ -222,6 +264,7 @@ See the [Code](/handbook/markup-code) post.
 ## Compare
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Compare 'worse' %&#125;
 &#96;&#96;&#96;text
 Bad code example
@@ -233,6 +276,7 @@ Bad code example
 Good code example
 &#96;&#96;&#96;
 &#123;% endCompare %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Compare 'worse' %}
@@ -249,8 +293,8 @@ Good code example
 
 ### Compare with caption
 
-````html
-{% raw %}{% Compare 'worse' %}
+````text
+{% raw %}{% verbatim %}{% Compare 'worse' %}
 ```text
 Bad code example
 ```
@@ -270,7 +314,7 @@ Good code example
 Explanation of why `example` is good.
 {% endCompareCaption %}
 
-{% endCompare %}{% endraw %}
+{% endCompare %}{% endverbatim %}{% endraw %}
 ````
 
 {% Compare 'worse' %}
@@ -298,6 +342,7 @@ Explanation of why `example` is good.
 ### Compare with custom labels
 
 ```text
+{% raw %}{% verbatim %}
 &#123;% Compare 'worse', 'Unhelpful' %&#125;
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a
 massa sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus
@@ -309,6 +354,7 @@ Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a
 massa sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus
 nibh varius at.
 &#123;% endCompare %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Compare 'worse', 'Unhelpful' %}
@@ -327,7 +373,7 @@ at.
 
 ````html
 <div class="w-columns">
-{% raw %}{% Compare 'worse' %}
+{% raw %}{% verbatim %}{% Compare 'worse' %}
 ```text
 Bad code example
 ```
@@ -347,7 +393,7 @@ Good code example
 Explanation of why `example` is good.
 {% endCompareCaption %}
 
-{% endCompare %}{% endraw %}
+{% endCompare %}{% endverbatim %}{% endraw %}
 </div>
 ````
 
@@ -384,6 +430,7 @@ assumenda perspiciatis.
 
 ### Basic details component
 ```text
+{% raw %}{% verbatim %}
 &#123;% Details %&#125;
 
 &#123;% DetailsSummary %&#125;
@@ -394,6 +441,7 @@ Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a mas
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
 &#123;% endDetails %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -410,6 +458,7 @@ at.
 
 ### Details component with preview
 ```text/4-5
+{% raw %}{% verbatim %}
 &#123;% Details %&#125;
 
 &#123;% DetailsSummary %&#125;
@@ -422,6 +471,7 @@ Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a mas
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
 &#123;% endDetails %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -449,6 +499,7 @@ For example, if the component is in an `h2` section,
 use an `h3` heading.
 
 ```text/2
+{% raw %}{% verbatim %}
 &#123;% Details %&#125;
 
 &#123;% DetailsSummary 'h3' %&#125;
@@ -459,6 +510,7 @@ Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a mas
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
 &#123;% endDetails %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -479,6 +531,7 @@ If for some reason you want it open,
 add the `open` argument to the `Details` shortcode.
 
 ```text/0
+{% raw %}{% verbatim %}
 &#123;% Details 'open' %&#125;
 
 &#123;% DetailsSummary %&#125;
@@ -489,6 +542,7 @@ Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a mas
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
 &#123;% endDetails %&#125;
+{% endverbatim %}{% endraw %}
 ```
 
 {% Details 'open' %}

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -44,11 +44,9 @@ There are several kinds of asides, each for a different purpose.
 ### Note asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside %&#125;
+{% raw %}{% verbatim %}&#123;% Aside %&#125;
 Use the note aside to provide supplemental information.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside %}

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -58,11 +58,9 @@ Use the note aside to provide supplemental information.
 ### Caution asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'caution' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'caution' %&#125;
 Use the caution aside to indicate a potential pitfall or complication.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'caution' %}
@@ -72,12 +70,10 @@ Use the caution aside to indicate a potential pitfall or complication.
 ### Warning asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'warning' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'warning' %&#125;
 The warning aside is stronger than a caution aside; use it to tell the reader
 not to do something.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'warning' %}
@@ -88,11 +84,9 @@ not to do something.
 ### Success asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'success' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'success' %&#125;
 Use the success aside to describe a successful action or an error-free status.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'success' %}
@@ -102,12 +96,10 @@ Use the success aside to describe a successful action or an error-free status.
 ### Objective asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'objective' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'objective' %&#125;
 Use the objective aside to define the goal of a process described in the body
 copy.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'objective' %}
@@ -118,12 +110,10 @@ copy.
 ### Gotcha asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'gotchas' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'gotchas' %&#125;
 Use the gotcha aside to indicate a common problem that the reader wouldn't know
 without specialized knowledge of the topic.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'gotchas' %}
@@ -134,13 +124,11 @@ without specialized knowledge of the topic.
 ### Key-term asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'key-term' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'key-term' %&#125;
 Use the key-term aside to define a term that's essential to understanding an
 idea in the body copy. Key-term asides should be a single sentence that
 includes the term in italics. For example, "A _portal_ is…"
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'key-term' %}
@@ -152,11 +140,9 @@ includes the term in italics. For example, "A _portal_ is…"
 ### Codelab asides
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Aside 'codelab' %&#125;
+{% raw %}{% verbatim %}&#123;% Aside 'codelab' %&#125;
 Use the codelab aside to link to an associated codelab.
-&#123;% endAside %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endAside %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Aside 'codelab' %}
@@ -166,33 +152,25 @@ Use the codelab aside to link to an associated codelab.
 ## Banner
 
 ```text
-{% raw %}{% verbatim %}
-{% Banner %}This is an info banner. It supports Markdown.{% endBanner %}
-{% endverbatim %}{% endraw %}
+{% raw %}{% verbatim %}{% Banner %}This is an info banner. It supports Markdown.{% endBanner %}{% endverbatim %}{% endraw %}
 ```
 
 {% Banner %}This is an info banner. It supports Markdown.{% endBanner %}
 
 ```text
-{% raw %}{% verbatim %}
-{% Banner 'caution' %}This is a caution banner. It supports Markdown.{% endBanner %}
-{% endverbatim %}{% endraw %}
+{% raw %}{% verbatim %}{% Banner 'caution' %}This is a caution banner. It supports Markdown.{% endBanner %}{% endverbatim %}{% endraw %}
 ```
 
 {% Banner 'caution' %}This is a caution banner. It supports Markdown.{% endBanner %}
 
 ```text
-{% raw %}{% verbatim %}
-{% Banner 'warning' %}This is a warning banner. It supports Markdown.{% endBanner %}
-{% endverbatim %}{% endraw %}
+{% raw %}{% verbatim %}{% Banner 'warning' %}This is a warning banner. It supports Markdown.{% endBanner %}{% endverbatim %}{% endraw %}
 ```
 
 {% Banner 'warning' %}This is a warning banner. It supports Markdown.{% endBanner %}
 
 ```text
-{% raw %}{% verbatim %}
-{% Banner 'info', 'body' %}This is an info banner that's used in the body of a post. It has less padding and larger text.{% endBanner %}
-{% endverbatim %}{% endraw %}
+{% raw %}{% verbatim %}{% Banner 'info', 'body' %}This is an info banner that's used in the body of a post. It has less padding and larger text.{% endBanner %}{% endverbatim %}{% endraw %}
 ```
 
 {% Banner 'info', 'body' %}This is an info banner that's used in the body of a post. It has less padding and larger text.{% endBanner %}
@@ -264,8 +242,7 @@ See the [Code](/handbook/markup-code) post.
 ## Compare
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Compare 'worse' %&#125;
+{% raw %}{% verbatim %}&#123;% Compare 'worse' %&#125;
 &#96;&#96;&#96;text
 Bad code example
 &#96;&#96;&#96;
@@ -275,8 +252,7 @@ Bad code example
 &#96;&#96;&#96;text
 Good code example
 &#96;&#96;&#96;
-&#123;% endCompare %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endCompare %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Compare 'worse' %}
@@ -342,8 +318,7 @@ Explanation of why `example` is good.
 ### Compare with custom labels
 
 ```text
-{% raw %}{% verbatim %}
-&#123;% Compare 'worse', 'Unhelpful' %&#125;
+{% raw %}{% verbatim %}&#123;% Compare 'worse', 'Unhelpful' %&#125;
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a
 massa sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus
 nibh varius at.
@@ -353,8 +328,7 @@ nibh varius at.
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a
 massa sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus
 nibh varius at.
-&#123;% endCompare %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endCompare %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Compare 'worse', 'Unhelpful' %}
@@ -430,8 +404,7 @@ assumenda perspiciatis.
 
 ### Basic details component
 ```text
-{% raw %}{% verbatim %}
-&#123;% Details %&#125;
+{% raw %}{% verbatim %}&#123;% Details %&#125;
 
 &#123;% DetailsSummary %&#125;
 Details _summary_
@@ -440,8 +413,7 @@ Details _summary_
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
-&#123;% endDetails %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endDetails %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -458,8 +430,7 @@ at.
 
 ### Details component with preview
 ```text/4-5
-{% raw %}{% verbatim %}
-&#123;% Details %&#125;
+{% raw %}{% verbatim %}&#123;% Details %&#125;
 
 &#123;% DetailsSummary %&#125;
 Details _summary_
@@ -470,8 +441,7 @@ of your panel text.
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
-&#123;% endDetails %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endDetails %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -499,8 +469,7 @@ For example, if the component is in an `h2` section,
 use an `h3` heading.
 
 ```text/2
-{% raw %}{% verbatim %}
-&#123;% Details %&#125;
+{% raw %}{% verbatim %}&#123;% Details %&#125;
 
 &#123;% DetailsSummary 'h3' %&#125;
 Details _summary_
@@ -509,8 +478,7 @@ Details _summary_
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
-&#123;% endDetails %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endDetails %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Details %}
@@ -531,8 +499,7 @@ If for some reason you want it open,
 add the `open` argument to the `Details` shortcode.
 
 ```text/0
-{% raw %}{% verbatim %}
-&#123;% Details 'open' %&#125;
+{% raw %}{% verbatim %}&#123;% Details 'open' %&#125;
 
 &#123;% DetailsSummary %&#125;
 Details _summary_
@@ -541,8 +508,7 @@ Details _summary_
 Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
 at.
-&#123;% endDetails %&#125;
-{% endverbatim %}{% endraw %}
+&#123;% endDetails %&#125;{% endverbatim %}{% endraw %}
 ```
 
 {% Details 'open' %}

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -35,6 +35,11 @@
   background: $RED_100;
 }
 
+.w-banner--body {
+  font: inherit;
+  padding: 24px;
+}
+
 .w-banner__link {
   text-decoration: underline;
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add an optional `body` argument to the banner component that adds a `w-banner--body` class, which makes the banner look OK when used in the body of a post.
- Add temporary `w-banner--body` styles to `styles.njk` (to be removed after migration off DevSite).
- (Hopefully) fix code samples on `web-dev-components` so they don't break staging.
