### PR TITLE
migrate to supporting /measure/ (trailing slash) pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,37 +17,9 @@
 const express = require('express');
 const app = express();
 
-// Match e.g., "/hello", "/hello/foo", but not "/blah/foo.svg". Does not match "/": this is checked
-// in the conditional below on its own.
-const contentPageMatch = /^(\/\w+)+$/;
-
-// Disallow requests to "index.html" in any subdirectory (send a 302) along with
-// requests to a subdirectory that end with "/". This means that e.g., the
-// measure page, technically at "https://web.dev/measure/index.html", will
-// only be served under "https://web.dev/measure".
-// This resolves ambiguity for Service Workers and the Navaid router (which
-// internally trims trailing slashes for JS-based routing).
-const contentHandler = (req, res, next) => {
-  if (req.url === '/') {
-    req.url = '/index.html';
-  } else if (req.url.endsWith('/index.html') || req.url.endsWith('/')) {
-    const index = req.url.lastIndexOf('/');
-    const redir = req.url.substr(0, index);
-
-    // 301 means that Chrome and friends don't put the incorrect URL in the browser's history.
-    res.writeHead(301, {Location: redir});
-    return res.end();
-  } else if (contentPageMatch.exec(req.url)) {
-    req.url += '/index.html';
-  }
-
-  return next();
-};
-
 app.use(
-  express.static('dist', {index: false}),
-  contentHandler,
-  express.static('dist/en', {index: false, redirect: false}),
+  express.static('dist', {index: false, redirect: false}),
+  express.static('dist/en'),
 );
 
 const listener = app.listen(process.env.PORT || 8080, () => {

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const express = require('express');
 const app = express();
 
 app.use(
-  express.static('dist', {index: false, redirect: false}),
+  express.static('dist'),
   express.static('dist/en'),
 );
 

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -10,7 +10,7 @@ const domparser = new DOMParser();
  * @return {Promise<string>}
  */
 async function getPage(url) {
-  const res = await fetch(`/${url}`);
+  const res = await fetch(url);
   if (!res.ok) {
     throw res.status;
   }
@@ -52,10 +52,23 @@ async function swapContent(url) {
 
 router
   .on("/", async () => {
-    return swapContent("index.html");
+    return swapContent("/");
   })
   .on("/*", async (params) => {
-    return swapContent(params.wild);
+    if (params.wild.endsWith("/index.html")) {
+      // If an internal link refers to "/foo/index.html", strip "index.html" and load.
+      const stripped = params.wild.slice(0, -"index.html".length);
+      return swapContent(`/${stripped}`);
+    } else if (window.location.pathname.endsWith("/")) {
+      // Navaid strips a trailing "/" on its own, so ensure it is added again before loading.
+      return swapContent(`/${params.wild}/`);
+    }
+
+    // Otherwise, this is a request for e.g. "/measure". By calling history.replaceState() to
+    // re-add the trailing slash, Navaid will re-run this code and trigger the latter conditional
+    // above. (If we also call swapContent(), two requests will fire.)
+    // This doesn't modify the back stack, so further navigation works fine.
+    window.history.replaceState(null, null, window.location.pathname + "/");
   });
 
 export {router};

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -64,10 +64,7 @@ router
       return swapContent(`/${params.wild}/`);
     }
 
-    // Otherwise, this is a request for e.g. "/measure". By calling history.replaceState() to
-    // re-add the trailing slash, Navaid will re-run this code and trigger the latter conditional
-    // above. (If we also call swapContent(), two requests will fire.)
-    // This doesn't modify the back stack, so further navigation works fine.
+    // This triggers Navaid again, so calling swapContent() here would cause a double load.
     window.history.replaceState(null, null, window.location.pathname + "/");
   });
 

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -48,6 +48,8 @@ async function swapContent(url) {
   main.querySelector("#content").remove();
   // Swap in the new #content element
   main.appendChild(page.querySelector("#content"));
+  // Update the page title
+  document.title = page.title;
 }
 
 router


### PR DESCRIPTION
As per your requests, Rob :)

We still have to work around Navaid's awkwardness. To be fair, if you remove all links to "/foo" (and "/foo/index.html", although I don't they actually exist anywhere) inside our codebase, some of this isn't needed—but I feel like folks might accidentally add them back in.