### PR TITLE
Tweaks style of search box

### DIFF
--- a/src/lib/components/Search/_styles.scss
+++ b/src/lib/components/Search/_styles.scss
@@ -101,6 +101,16 @@ web-search {
     border: none;
     padding: 8px 8px 8px 40px;
     width: 100%;
+    font: inherit;
+    font-size: 16px;
+    line-height: 20px;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 2px 0 0 $WEB_SECONDARY_COLOR;
+    }
   }
 
   .web-search__input:focus {


### PR DESCRIPTION
Just my opinion but I think we can make this look nicer.

* we were using the default `<input>` font—migrate to use the page's font (matches DevSite)
* replace the blue focus outline with an _underline_

Looks a bit like this:

<img width="1155" alt="Screen Shot 2019-10-16 at 17 39 10" src="https://user-images.githubusercontent.com/119184/66894396-03904000-f03c-11e9-9ba5-f223206802c3.png">

Using an underline rather than a surrounding box for focus makes the appear animation less jarring—if it's a whole box, you don't see the right side of the focus until the animation is done. The underline makes the input box seem more like it's growing. (DevSite grows the `<input>` itself but we don't, for whatever reason).