### PR TITLE
Re-enable draft for getInstalledRelatedApps

### DIFF
--- a/src/site/content/en/blog/get-installed-related-apps/index.md
+++ b/src/site/content/en/blog/get-installed-related-apps/index.md
@@ -11,7 +11,7 @@ tags:
   - capabilities
 hero: hero.jpg
 alt: mobile device with app panel open
-# draft: true
+draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/855683929200394241
 ---


### PR DESCRIPTION
Not sure how we missed the fact this wasn't marked as `DRAFT`!
