### PR TITLE
Let paths be marked as drafts.

### DIFF
--- a/src/site/_data/postHost.js
+++ b/src/site/_data/postHost.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const data = require('../content/en/learn/learn.11tydata.js');
+const data = require('../content/en/learn/learn.11tydata.js')();
 
 // =============================================================================
 // POST HOST

--- a/src/site/_filters/live-paths.js
+++ b/src/site/_filters/live-paths.js
@@ -1,0 +1,15 @@
+const {env} = require('../_data/site');
+
+/**
+ * Filter draft learning paths out.
+ * @param {object} path An eleventy path object.
+ * @return {boolean} Whether or not the path should go live.
+ */
+module.exports = function livePaths(path) {
+  // If we're in dev mode, force draft learning paths to show up.
+  if (env === 'dev') {
+    return true;
+  }
+
+  return !path.draft;
+};

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -19,6 +19,12 @@ layout: layout
     </div>
   </header>
 
+  {% if path.draft and site.env === 'dev' %}
+    <div class="w-banner w-banner--warning w-banner--body">
+      🚨 This path is a draft! 🚨
+    </div>
+  {% endif %}
+
   <section class="w-layout-container w-path-intro">
     <div class="w-path-intro__overview">
       <h2 class="w-headline--three no-link">Overview</h2>

--- a/src/site/content/en/en.11tydata.js
+++ b/src/site/content/en/en.11tydata.js
@@ -1,3 +1,4 @@
+const livePaths = require('../../_filters/live-paths');
 const fast = require('./fast/fast.11tydata.js').path;
 const accessible = require('./accessible/accessible.11tydata.js').path;
 const reliable = require('./reliable/reliable.11tydata.js').path;
@@ -13,15 +14,19 @@ const installable = require('./installable/installable.11tydata.js').path;
 //
 // =============================================================================
 
-module.exports = {
-  home: {
-    paths: [
-      fast,
-      accessible,
-      reliable,
-      secure,
-      discoverable,
-      installable,
-    ],
-  },
+module.exports = function() {
+  const paths = [
+    fast,
+    accessible,
+    reliable,
+    secure,
+    discoverable,
+    installable,
+  ].filter(livePaths);
+
+  return {
+    home: {
+      paths,
+    },
+  };
 };

--- a/src/site/content/en/learn/learn.11tydata.js
+++ b/src/site/content/en/learn/learn.11tydata.js
@@ -1,3 +1,5 @@
+const livePaths = require('../../../_filters/live-paths');
+
 const fast = require('../fast/fast.11tydata.js').path;
 const accessible = require('../accessible/accessible.11tydata.js').path;
 const reliable = require('../reliable/reliable.11tydata.js').path;
@@ -33,26 +35,34 @@ const lighthouseSeo = require(
 //
 // =============================================================================
 
-module.exports = {
-  learn: {
-    paths: [
-      fast,
-      accessible,
-      reliable,
-      secure,
-      discoverable,
-      installable,
-    ],
-    frameworks: [
-      react,
-      angular,
-    ],
-    audits: [
-      lighthousePerformance,
-      lighthousePwa,
-      lighthouseBestPractices,
-      lighthouseAccessibility,
-      lighthouseSeo,
-    ],
-  },
+module.exports = function() {
+  const paths = [
+    fast,
+    accessible,
+    reliable,
+    secure,
+    discoverable,
+    installable,
+  ].filter(livePaths);
+
+  const frameworks = [
+    react,
+    angular,
+  ].filter(livePaths);
+
+  const audits = [
+    lighthousePerformance,
+    lighthousePwa,
+    lighthouseBestPractices,
+    lighthouseAccessibility,
+    lighthouseSeo,
+  ].filter(livePaths);
+
+  return {
+    learn: {
+      paths,
+      frameworks,
+      audits,
+    },
+  };
 };


### PR DESCRIPTION
Related to #1656

Changes proposed in this pull request:

- Quick fix to let paths be marked as drafts. To mark a learning path as a draft, add `draft: true` to the learning path's `path` property in its 11tydata.js file.

Example:

```
module.exports = {
  // Tags are inherited by all posts.
  tags: ['pathItem', 'accessible'],
  path: {
    draft: true,
    ...
  },
};
```
