### PR TITLE
Header style tweaks for v2

### DIFF
--- a/src/lib/components/Header/_styles.scss
+++ b/src/lib/components/Header/_styles.scss
@@ -104,6 +104,10 @@ web-header {
     margin: 0;
     padding: 0 24px;
     position: relative;
+
+    &[active] {
+      box-shadow: 0 -2px 0 $WEB_PRIMARY_COLOR inset;
+    }
   }
 
   .web-header__link:hover,

--- a/src/lib/components/Header/index.js
+++ b/src/lib/components/Header/index.js
@@ -21,8 +21,6 @@
 import {store} from "../../store";
 import {expandSideNav} from "../../actions";
 
-const locationEvents = ["pushstate", "popstate", "replacestate"];
-
 class Header extends HTMLElement {
   connectedCallback() {
     this.hamburgerBtn = this.querySelector(".web-header__hamburger-btn");
@@ -30,34 +28,21 @@ class Header extends HTMLElement {
 
     this.onStateChanged = this.onStateChanged.bind(this);
     store.subscribe(this.onStateChanged);
-
-    this.onUrlChanged = this.onUrlChanged.bind(this);
-    locationEvents.forEach((type) =>
-      window.addEventListener(type, this.onUrlChanged),
-    );
-
-    this.onUrlChanged();
   }
 
   disconnectedCallback() {
     store.unsubscribe(this.onStateChanged);
-
-    locationEvents.forEach((type) =>
-      window.removeEventListener(type, this.onUrlChanged),
-    );
   }
 
-  onStateChanged({isSearchExpanded}) {
+  onStateChanged({isSearchExpanded, currentUrl}) {
     this.classList.toggle("web-header--has-expanded-search", isSearchExpanded);
-  }
 
-  /**
-   * Ensures that the only active link has the "active" attribute applied.
-   */
-  onUrlChanged() {
+    // Ensure that the "active" attribute is applied to any matchind header
+    // link, or to none (for random subpages or articles).
     const active = this.querySelector("[active]");
-    const pathname = window.location.pathname;
-    const updated = this.querySelector(`[href="${pathname}"]`);
+    const updated = this.querySelector(
+      `[href="${currentUrl.replace(/"/g, '\\"')}"]`,
+    );
 
     if (active === updated) {
       return;

--- a/src/lib/components/Header/index.js
+++ b/src/lib/components/Header/index.js
@@ -21,6 +21,8 @@
 import {store} from "../../store";
 import {expandSideNav} from "../../actions";
 
+const locationEvents = ["pushstate", "popstate", "replacestate"];
+
 class Header extends HTMLElement {
   connectedCallback() {
     this.hamburgerBtn = this.querySelector(".web-header__hamburger-btn");
@@ -28,14 +30,46 @@ class Header extends HTMLElement {
 
     this.onStateChanged = this.onStateChanged.bind(this);
     store.subscribe(this.onStateChanged);
+
+    this.onUrlChanged = this.onUrlChanged.bind(this);
+    locationEvents.forEach((type) =>
+      window.addEventListener(type, this.onUrlChanged),
+    );
+
+    this.onUrlChanged();
   }
 
   disconnectedCallback() {
     store.unsubscribe(this.onStateChanged);
+
+    locationEvents.forEach((type) =>
+      window.removeEventListener(type, this.onUrlChanged),
+    );
   }
 
   onStateChanged({isSearchExpanded}) {
     this.classList.toggle("web-header--has-expanded-search", isSearchExpanded);
+  }
+
+  /**
+   * Ensures that the only active link has the "active" attribute applied.
+   */
+  onUrlChanged() {
+    const active = this.querySelector("[active]");
+    const pathname = window.location.pathname;
+    const updated = this.querySelector(`[href="${pathname}"]`);
+
+    if (active === updated) {
+      return;
+    }
+
+    if (active) {
+      active.removeAttribute("active");
+    }
+
+    if (updated) {
+      updated.setAttribute("active", "");
+    }
   }
 
   /**

--- a/src/lib/components/ProfileSwitcher/_styles.scss
+++ b/src/lib/components/ProfileSwitcher/_styles.scss
@@ -21,6 +21,7 @@ web-profile-switcher-container {
 }
 
 .w-profile-signin {
+  background: transparent;
   border: 0;
   box-shadow: none;
   color: $PRIMARY_TEXT_COLOR;
@@ -35,19 +36,18 @@ web-profile-switcher-container {
   @include bp(md) {
     padding: 0 24px;
   }
-}
 
-.w-profile-signin:hover {
-  background-color: rgba($PRIMARY_TEXT_COLOR, .04);
-}
+  &:hover {
+    background-color: rgba($PRIMARY_TEXT_COLOR, .04);
+  }
 
-.w-profile-signin:focus {
-  background-color: rgba($PRIMARY_TEXT_COLOR, .12);
-}
+  &:focus {
+    background-color: rgba($PRIMARY_TEXT_COLOR, .12);
+  }
 
-.w-profile-signin:active {
-  background-color: rgba($PRIMARY_TEXT_COLOR, .16);
-  box-shadow: none; // DevSite override
+  &:active {
+    background-color: rgba($PRIMARY_TEXT_COLOR, .16);
+  }
 }
 
 web-profile-switcher {
@@ -64,7 +64,6 @@ web-profile-switcher {
   justify-content: center;
   overflow: hidden;
   padding: 0;
-  transition: border 0s; // DevSite override
   width: auto;
 }
 

--- a/src/lib/components/ProfileSwitcher/_styles.scss
+++ b/src/lib/components/ProfileSwitcher/_styles.scss
@@ -25,6 +25,7 @@ web-profile-switcher-container {
   border: 0;
   box-shadow: none;
   color: $PRIMARY_TEXT_COLOR;
+  cursor: pointer;
   font-family: $PRIMARY_FONT;
   text-transform: uppercase;
   font-size: 14px;

--- a/src/lib/components/Search/_styles.scss
+++ b/src/lib/components/Search/_styles.scss
@@ -72,6 +72,7 @@ web-search {
 
   .web-search__input-wrapper {
     align-items: center;
+    background: $WHITE;  // This visually hides the top nav links when open
     color: $GREY_700;
     display: none;
     height: 100%;

--- a/src/lib/components/Search/_styles.scss
+++ b/src/lib/components/Search/_styles.scss
@@ -37,6 +37,7 @@ web-search {
     border: none;
     box-shadow: none;
     color: $GREY_700;
+    cursor: pointer;
     padding: 0 8px;
     transition: none;
     background: transparent;

--- a/src/lib/components/Search/_styles.scss
+++ b/src/lib/components/Search/_styles.scss
@@ -39,6 +39,7 @@ web-search {
     color: $GREY_700;
     padding: 0 8px;
     transition: none;
+    background: transparent;
 
     @include bp(md) {
       display: none;

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -67,7 +67,12 @@ async function swapContent(url) {
     window.location.href = window.location.href;
     throw e;
   } finally {
-    store.setState({isPageLoading: false});
+    // We set the currentUrl in global state _after_ the page has loaded. This
+    // is different than the History API itself which transitions immediately.
+    store.setState({
+      isPageLoading: false,
+      currentUrl: url,
+    });
   }
   // Remove the current #content element
   main.querySelector("#content").remove();

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -30,6 +30,7 @@ const initialState = {
   // The most recent error from the Lighthouse CI, if any.
   lighthouseError: null,
 
+  currentUrl: window.location.pathname,
   isSideNavExpanded: false,
   isSearchExpanded: false,
 

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -56,7 +56,7 @@
       <div class="web-header__middle">
         <div class="web-header__links">
           <a
-            href="/learn"
+            href="/learn/"
             class="web-header__link gc-analytics-event"
             data-category="Site-Wide Custom Events"
             data-label="Tab: Learn"
@@ -65,7 +65,7 @@
           </a>
 
           <a
-            href="/measure"
+            href="/measure/"
             class="web-header__link gc-analytics-event"
             data-category="Site-Wide Custom Events"
             data-label="Tab: Measure"
@@ -74,7 +74,7 @@
           </a>
 
           <a
-            href="/blog"
+            href="/blog/"
             class="web-header__link gc-analytics-event"
             data-category="Site-Wide Custom Events"
             data-label="Tab: Blog"
@@ -83,7 +83,7 @@
           </a>
 
           <a
-            href="/about"
+            href="/about/"
             class="web-header__link gc-analytics-event"
             data-category="Site-Wide Custom Events"
             data-label="Tab: About"


### PR DESCRIPTION
@robdodson I think some of these changes might have just been broken in your DevSite code removal.

* Restores the blue underline indicating which top-level page the user is on (JS + CSS changes)
  * This also makes `web-search` have a white background so it covers this while open
* Removes the default grey background in responsive mode for "Sign In" and the search open/close toggle
* Make the "SIGN IN" button have `cursor: pointer` (matchs DevSite, where it's technically a link)