### PR TITLE
V2+sw stuff

### DIFF
--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -63,7 +63,6 @@ async function swapContent(url) {
     await entrypointPromise;
   } catch (e) {
     // If something fails, just make a browser URL change
-    // TODO(robdodson): In future, failure pages might be HTML themselves
     window.location.href = window.location.href;
     throw e;
   } finally {

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -21,20 +21,6 @@ async function loadEntrypoint(url) {
 }
 
 /**
- * Fetch a page as an html string.
- * @param {string} url url of the page to fetch.
- * @return {Promise<string>}
- */
-async function getPage(url) {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw res.status;
-  }
-  const text = await res.text();
-  return domparser.parseFromString(text, "text/html");
-}
-
-/**
  * Swap the current page for a new one.
  * @param {string} url url of the page to swap.
  * @return {Promise}
@@ -56,14 +42,37 @@ async function swapContent(url) {
 
   const main = document.querySelector("main");
 
-  // Grab the new page content
+  // Grab the new page content.
   let page;
   try {
-    page = await getPage(url);
-    await entrypointPromise;
+    let offlineResponse = false;
+    let response;
+    try {
+      response = await fetch(url);
+      store.setState({isOffline: false});
+    } catch (e) {
+      // Assume raw fetch exceptions are network failures.
+      store.setState({isOffline: true});
+
+      // This should be handled by the Service Worker. If it also fails, the SW
+      // isn't installed or isn't working, so cause a real error.
+      response = await fetch("/offline/");
+      offlineResponse = true;
+    }
+
+    if (!response.ok) {
+      throw response.status;
+    }
+    const text = await response.text();
+    page = domparser.parseFromString(text, "text/html");
+
+    // If this wasn't the offline page, wait for the entrypoint, which has been
+    // happily loading in the background.
+    if (!offlineResponse) {
+      await entrypointPromise;
+    }
   } catch (e) {
-    // If something fails, just make a browser URL change
-    // TODO(robdodson): In future, failure pages might be HTML themselves
+    // If something fails, just make a browser URL change.
     window.location.href = window.location.href;
     throw e;
   } finally {
@@ -74,6 +83,7 @@ async function swapContent(url) {
       currentUrl: url,
     });
   }
+
   // Remove the current #content element
   main.querySelector("#content").remove();
   // Swap in the new #content element

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -31,6 +31,7 @@ const initialState = {
   lighthouseError: null,
 
   currentUrl: window.location.pathname,
+  isOffline: false,
   isSideNavExpanded: false,
   isSearchExpanded: false,
 

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -6,6 +6,10 @@ importScripts(
 
 console.log("Got cache manifest", manifest);
 
+workbox.precaching.precache([
+  "/offline/",
+]);
+
 /**
  * Match /foo-bar/ and "/foo-bar/as/many/of-these-as-you-like/".
  *
@@ -19,3 +23,9 @@ workbox.routing.registerRoute(
   new RegExp("/([\\w-]+/)*$"),
   new workbox.strategies.StaleWhileRevalidate(),
 );
+
+workbox.routing.setCatchHandler(({event}) => {
+  if (event.request.destination === 'document') {
+    return caches.match('/offline/');
+  }
+});

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -6,9 +6,7 @@ importScripts(
 
 console.log("Got cache manifest", manifest);
 
-workbox.precaching.precache([
-  "/offline/",
-]);
+workbox.precaching.precache(["/offline/"]);
 
 /**
  * Match /foo-bar/ and "/foo-bar/as/many/of-these-as-you-like/".
@@ -25,9 +23,9 @@ workbox.routing.registerRoute(
 );
 
 workbox.routing.setCatchHandler(({event}) => {
-  if (event.request.destination === 'document') {
+  if (event.request.destination === "document") {
     // TODO(samthor): Annotate this page so the client knows it's being displayed because the user
     // is offline, and force it to rerequest when navigator.onLine is true.
-    return caches.match('/offline/');
+    return caches.match("/offline/");
   }
 });

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -26,6 +26,8 @@ workbox.routing.registerRoute(
 
 workbox.routing.setCatchHandler(({event}) => {
   if (event.request.destination === 'document') {
+    // TODO(samthor): Annotate this page so the client knows it's being displayed because the user
+    // is offline, and force it to rerequest when navigator.onLine is true.
     return caches.match('/offline/');
   }
 });

--- a/src/site/content/en/404.njk
+++ b/src/site/content/en/404.njk
@@ -1,0 +1,15 @@
+---
+layout: layout
+title: 404
+description: |
+  Page Not Found
+---
+
+<div class="w-layout-container--large">
+  <header class="w-page-header">
+    <h1 class="w-page-header__headline code">{{ title }}</h1>
+    <p class="w-page-header__copy">
+      Sorry, we couldn't find that page.
+    </p>
+  </header>
+</div>

--- a/src/site/content/en/404.njk
+++ b/src/site/content/en/404.njk
@@ -7,7 +7,7 @@ description: |
 
 <div class="w-layout-container--large">
   <header class="w-page-header">
-    <h1 class="w-page-header__headline code">{{ title }}</h1>
+    <h1 class="w-page-header__headline w-code">{{ title }}</h1>
     <p class="w-page-header__copy">
       Sorry, we couldn't find that page.
     </p>

--- a/src/site/content/en/offline.njk
+++ b/src/site/content/en/offline.njk
@@ -1,0 +1,15 @@
+---
+layout: layout
+title: Offline
+description: |
+  Network Offline
+---
+
+<div class="w-layout-container--large">
+  <header class="w-page-header">
+    <h1 class="w-page-header__headline code">{{ title }}</h1>
+    <p class="w-page-header__copy">
+      There is no Internet connection. We'll try to reload automatically once you're back online! 📶
+    </p>
+  </header>
+</div>

--- a/src/site/content/en/offline.njk
+++ b/src/site/content/en/offline.njk
@@ -7,7 +7,7 @@ description: |
 
 <div class="w-layout-container--large">
   <header class="w-page-header">
-    <h1 class="w-page-header__headline code">{{ title }}</h1>
+    <h1 class="w-page-header__headline w-code">{{ title }}</h1>
     <p class="w-page-header__copy">
       There is no Internet connection. We'll try to reload automatically once you're back online! 📶
     </p>

--- a/src/styles/components/_page-header.scss
+++ b/src/styles/components/_page-header.scss
@@ -30,6 +30,10 @@
 
 .w-page-header__headline {
   margin: 0 auto 11px;
+
+  &.code {
+    font: 400 64px/64px 'Roboto Mono', monospace;
+  }
 }
 
 .w-page-header__copy {

--- a/src/styles/components/_page-header.scss
+++ b/src/styles/components/_page-header.scss
@@ -31,7 +31,7 @@
 .w-page-header__headline {
   margin: 0 auto 11px;
 
-  &.code {
+  &.w-code {
     font: 400 64px/64px 'Roboto Mono', monospace;
   }
 }


### PR DESCRIPTION
Adds a 404 and offline page. Serves the offline page via SW only.

Notes:

* this is a bit hard to test because the SW only responds to "/foo/", yet most links are still "/foo". (Express is doing the redirect)—see TODOs in sw
* we serve the 404 html for things like missing PNG assets
* we should later annotate the offline page so that the frontend code can re-request when it gets an 'online' event.