### PR TITLE
Make ul bullet color match text color

### DIFF
--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -62,15 +62,12 @@ ul:not([class]) > li {
 }
 
 ul:not([class]) > li::before {
-  background: $GREY_700;
-  border-radius: $GLOBAL_ROUNDED;
-  color: $WHITE;
-  content: '';
-  height: 8px;
-  left: 0;
-  margin: 12px 0 0;
+  color: inherit;
+  content: '•';
+  font-size: 2em;
+  left: -2px;
+  margin: 2px 0 0;
   position: absolute;
-  width: 8px;
 }
 
 ul:not([class]) > li > p,


### PR DESCRIPTION
Changes proposed in this pull request:

- Make unordered list bullets inherit the color of surrounding text.

Rationale:
Currently, unordered list item bullets are always gray. When used in asides, that breaks visual cohesion. Also, because of the style used for default hyperlinks (underline only on hover), it makes it less immediately obvious that unordered lists in asides aren't hyperlinks, especially when they're proximal to a list of hyperlinks in the main body text (e.g., at the end of Lighthouse audit posts).
