### PR TITLE
Update LH a11y navigation audit posts

### DIFF
--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -15,10 +15,6 @@ built-in for free. If you're building _custom_ interactive components, use the
 `tabindex` attribute to ensure that they're keyboard accessible.
 
 {% Aside %}
-{% include 'content/origin-trials.njk' %}
-{% endAside %}
-
-{% Aside %}
 Whenever possible, use a native HTML element rather than building your
 own custom version. `<button>`, for example, is very easy to style and
 already has full keyboard support. This will save you from needing to manage

--- a/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accesskeys/index.md
@@ -10,12 +10,13 @@ web_lighthouse:
   - accesskeys
 ---
 
-Access keys let users quickly focus or activate an element on your page
+Access keys let users quickly [focus](/keyboard-access/#focus-and-the-tab-order)
+or activate an element on your page
 by pressing the specified key, usually in combination with the `Alt` key
 (or `Control+Alt` on Mac).
 
 Duplicating `accesskey` values creates unexpected effects
-for users navigating using the keyboard.
+for users navigating via the keyboard.
 
 ## How the Lighthouse access key audit fails
 
@@ -25,17 +26,41 @@ Lighthouse flags pages with duplicate access keys:
   <img class="w-screenshot" src="accesskeys.png" alt="Lighthouse: Access keys are not unique">
 </figure>
 
+For example, these links both have `g` as their access key:
+```html
+<a href="google.com" accesskey="g">Link to Google</a>
+<a href="github.com" accesskey="g">Link to GitHub</a>
+```
+
+
 {% include 'content/lighthouse-accessibility/scoring.njk' %}
 
 ## How to fix duplicate access keys
 
-First identify duplicate `accesskey` values
-using the Lighthouse report.
-Then make each `accesskey` value unique.
+Evaluate the duplicate `accesskey` values flagged by Lighthouse
+and make each `accesskey` value unique.
+For example, to fix the example above,
+you can change the value for the GitHub link:
+```html/1
+<a href="google.com" accesskey="g">Link to Google</a>
+<a href="github.com" accesskey="h">Link to GitHub</a>
+```
 
 For each defined `accesskey`,
 make sure the value doesn't conflict with any default browser
 or screen reader shortcut keys.
+
+{% Aside 'caution' %}
+Unless you're building a complex app (for example, a desktop publishing app),
+it's generally best to avoid access keys because of their limitations:
+- Not all browsers support access keys.
+- It's challenging to avoid conflicts with shortcut keys
+  across all operating systems and browsers.
+- Some access key values may not be present on all keyboards, particularly
+  if your app is intended for an international audience.
+- If users aren't aware of access keys, they may accidentally activate app
+  functionality, causing confusion.
+{% endAside %}
 
 ## Resources
 

--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -10,38 +10,55 @@ web_lighthouse:
   - bypass
 ---
 
-Adding ways to bypass repetitive content
-lets keyboard users navigate the page more efficiently.
+For users who cannot use a mouse,
+content that's repeated on pages across your site
+can make navigation difficult.
+For example, screen reader users may have to move through many links in a navigation menu
+to get to the main content of the page.
+
+Providing a way to bypass repetitive content makes non-mouse navigation easier.
 
 ## How this Lighthouse audit fails
 
-Lighthouse flags pages that don't contain a heading, [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links),
-or landmark region:
+Lighthouse flags pages that don't provide a way to skip repetitive content:
 
 <figure class="w-figure">
   <img class="w-screenshot" src="bypass.png" alt="Lighthouse audit showing page doesn't contain a heading, skip link, or landmark region">
 </figure>
 
+Lighthouse checks that the page contains at least one of the following:
+- A `<heading>` element
+- A [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links)
+- A [landmark](/headings-and-landmarks/#use-landmarks-to-aid-navigation)
+
 {% include 'content/lighthouse-accessibility/scoring.njk' %}
 
 ## How to improve keyboard navigation
 
-It's simple to pass the Lighthouse audit:
-include either an internal [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links),
-a heading, or a landmark region.
+Passing the Lighthouse audit is straightforward:
+add a heading,
+a [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links),
+or a [landmark](/headings-and-landmarks/#use-landmarks-to-aid-navigation)
+to your page.
 
-But to truly fix the problem,
-use correct heading and landmark elements on the entire page.
-By doing this,
-you are greatly improving the navigation experience
-for users of assistive technology.
-See [Headings and landmarks](/headings-and-landmarks).
+However, to meaningfully improve the navigational experience
+for assistive technology users,
+- Place all page content inside a landmark element.
+- Make sure each landmark accurately reflects the kind of content it contains.
+- Provide a skip link.
+
+{% Aside %}
+While most screen readers allow users to navigate by landmarks,
+other assistive technologies, like [switch devices](https://en.wikipedia.org/wiki/Switch_access),
+only allow users to move through each element in the tab order one at a time.
+So, it's important to provide both landmarks and skip links whenever possible.
+{% endAside %}
 
 In this example,
-all content is inside of a landmark,
-headings outline the page,
+all content is inside a landmark,
+the headings create an outline of the page's content,
 no headings are skipped,
-and repetitive content is bypassed:
+and a skip link is provided to skip the navigation menu:
 
 ```html
 <!DOCTYPE html>
@@ -85,6 +102,10 @@ and repetitive content is bypassed:
 </html>
 ```
 
+You usually don't want to show the skip link to mouse users,
+so it's conventional to use CSS to hide it offscreen until it receives
+[focus](/keyboard-access/#focus-and-the-tab-order):
+
 ```css
 /* style.css */
 .skip-link {
@@ -101,6 +122,9 @@ and repetitive content is bypassed:
   top: 0;
 }
 ```
+
+See the [Headings and landmarks](/headings-and-landmarks) post for more
+information.
 
 ## Resources
 

--- a/src/site/content/en/lighthouse-accessibility/tabindex/index.md
+++ b/src/site/content/en/lighthouse-accessibility/tabindex/index.md
@@ -12,13 +12,14 @@ web_lighthouse:
 
 Although technically valid,
 using a `tabindex` greater than `0` is considered an anti-pattern because
-it jumps the affected element to the end of the tab order.
+it shifts the affected element to the end of the
+[tab order](/keyboard-access/#focus-and-the-tab-order).
 This unexpected behavior can make it seem like some elements can't be accessed
 via keyboard, which is frustrating for users who rely on assistive technologies.
 
 ## How the Lighthouse `tabindex` audit fails
 
-Lighthouse flags elements that have a `tabindex` value greater than 0:
+Lighthouse flags elements that have a `tabindex` value greater than `0`:
 
 <figure class="w-figure">
   <img class="w-screenshot" src="tabindex.png" alt="Lighthouse audit showing some elements have a tabindex value greater than 0">
@@ -29,8 +30,8 @@ Lighthouse flags elements that have a `tabindex` value greater than 0:
 ## How to fix problematic `tabindex` values
 
 If you have a `tabindex` greater than `0`,
-and you're using a native element,
-remove the `tabindex` all together.
+and you're using a native link or form element,
+remove the `tabindex`.
 Native HTML elements such as `<button>` or `<input>`
 have keyboard accessibility built-in for free.
 
@@ -42,8 +43,8 @@ For example:
 <div tabindex="0">Focus me with the TAB key</div>
 ```
 
-If you need an element to come sooner in the tab order,
-it should be moved to an earlier spot in the DOM.
+If you need an element to come sooner or later in the tab order,
+it should be moved to a different spot in the DOM.
 Learn more in
 [Control focus with tabindex](/control-focus-with-tabindex).
 


### PR DESCRIPTION
Fixes #1721.

Changes proposed in this pull request:

- Quality pass on `accesskeys`, `tabindex`, and `bypass`. (`duplicate-id-active` and `heading-order` are new posts that were recently reviewed.)
- Remove the origin-trial aside from `control-focus-with-tabindex`.
