### PR TITLE
Prettify header and user image

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -9,8 +9,7 @@ import "./analytics";
 import {checkIfUserAcceptsCookies} from "./actions";
 
 // Configures global page state
-function onGlobalStateChanged() {
-  const {isSignedIn, isPageLoading} = store.getState();
+function onGlobalStateChanged({isSignedIn, isPageLoading}) {
   document.body.classList.toggle("lh-signedin", isSignedIn);
 
   const progress = document.querySelector(".w-loading-progress");
@@ -24,7 +23,7 @@ function onGlobalStateChanged() {
   }
 }
 store.subscribe(onGlobalStateChanged);
-onGlobalStateChanged();
+onGlobalStateChanged(store.getState());
 
 // Give elements time to set up before kicking off state changes.
 // This is useful for elements with CSS animations who need to have been

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -1,8 +1,8 @@
 /**
  * @fileoverview Site bootstrap code.
  *
- * This should not import unrelated code, and exists purely to load relevant polyfills and then
- * app.js (or TODO: entrypoints).
+ * This should import minimal site code, as it exists to load relevant polyfills and then the
+ * correct entrypoint via our router.
  */
 
 import config from "./bootstrap-config";

--- a/src/lib/components/ProfileSwitcher/_styles.scss
+++ b/src/lib/components/ProfileSwitcher/_styles.scss
@@ -57,12 +57,16 @@ web-profile-switcher {
 }
 
 .w-profile-toggle {
-  border: 4px solid transparent;
+  background: #F1F3F4;
+  border: 4px solid white;
   border-radius: 50%;
   box-shadow: none;
+  box-sizing: content-box;
   display: flex;
   height: auto;
   justify-content: center;
+  min-height: 32px;
+  min-width: 32px;
   overflow: hidden;
   padding: 0;
   width: auto;
@@ -71,7 +75,6 @@ web-profile-switcher {
 .w-profile-toggle:hover,
 .w-profile-toggle:focus,
 .w-profile-toggle:active {
-  background: transparent;
   box-shadow: none;
 }
 
@@ -79,10 +82,16 @@ web-profile-switcher {
   border-color: rgba($BLACK, .2) !important;
 }
 
+@keyframes w-profile-toggle__appear {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .w-profile-toggle__photo {
   border-radius: 50%;
   height: 32px;
   width: 32px;
+  animation: w-profile-toggle__appear 0.45s;
 }
 
 .w-profile-dialog {

--- a/src/lib/components/ProfileSwitcher/_styles.scss
+++ b/src/lib/components/ProfileSwitcher/_styles.scss
@@ -58,7 +58,7 @@ web-profile-switcher {
 
 .w-profile-toggle {
   background: $GREY_100;
-  border: 4px solid white;
+  border: 4px solid $WHITE;
   border-radius: 50%;
   box-shadow: none;
   box-sizing: content-box;

--- a/src/lib/components/ProfileSwitcher/_styles.scss
+++ b/src/lib/components/ProfileSwitcher/_styles.scss
@@ -57,7 +57,7 @@ web-profile-switcher {
 }
 
 .w-profile-toggle {
-  background: #F1F3F4;
+  background: $GREY_100;
   border: 4px solid white;
   border-radius: 50%;
   box-shadow: none;

--- a/src/lib/components/ProfileSwitcherContainer/index.js
+++ b/src/lib/components/ProfileSwitcherContainer/index.js
@@ -1,11 +1,10 @@
 import {html} from "lit-element";
 import {signIn} from "../../fb";
-import {store} from "../../store";
-import {BaseElement} from "../BaseElement";
+import {BaseStateElement} from "../BaseStateElement";
 import "../ProfileSwitcher";
 
 /* eslint-disable require-jsdoc */
-class ProfileSwitcherContainer extends BaseElement {
+class ProfileSwitcherContainer extends BaseStateElement {
   static get properties() {
     return {
       checkingSignedInState: {type: Boolean},
@@ -14,43 +13,29 @@ class ProfileSwitcherContainer extends BaseElement {
     };
   }
 
-  constructor() {
-    super();
-    this.onStateChanged = this.onStateChanged.bind(this);
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    store.subscribe(this.onStateChanged);
-    this.onStateChanged();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    store.unsubscribe(this.onStateChanged);
-  }
-
   render() {
-    if (this.checkingSignedInState) {
-      return "";
-    }
-
     if (this.isSignedIn) {
+      // nb. web-profile-switcher allows a null user
       return html`
         <web-profile-switcher .user="${this.user}"></web-profile-switcher>
       `;
-    } else {
-      return html`
-        <button class="w-profile-signin" @click="${signIn}">Sign in</button>
-      `;
     }
+
+    return html`
+      <button
+        class="w-profile-signin"
+        .disabled=${this.checkingSignedInState}
+        @click="${signIn}"
+      >
+        Sign in
+      </button>
+    `;
   }
 
-  onStateChanged() {
-    const state = store.getState();
-    this.checkingSignedInState = state.checkingSignedInState;
-    this.isSignedIn = state.isSignedIn;
-    this.user = state.user;
+  onStateChanged({checkingSignedInState, isSignedIn, user}) {
+    this.checkingSignedInState = checkingSignedInState;
+    this.isSignedIn = isSignedIn;
+    this.user = user;
   }
 }
 

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -394,7 +394,7 @@ class Search extends BaseElement {
     // Because focusout fires before click, if we try to wait for the click
     // event (~10's of ms later) then lit will have already deleted the link.
     const {relatedTarget} = e;
-    if (relatedTarget) {
+    if (relatedTarget && this.contains(relatedTarget)) {
       relatedTarget.click();
     }
 

--- a/src/lib/components/SigninButton/index.js
+++ b/src/lib/components/SigninButton/index.js
@@ -16,10 +16,13 @@ class SigninButton extends BaseStateElement {
       return "";
     }
 
+    // We don't set "disabled" attribute on the <button> based on this, because
+    // it causes a visual transition. Just disable the action while checking.
+    const action = this.checkingSignedInState ? null : signIn;
+
     return html`
       <button
-        .disabled=${this.checkingSignedInState}
-        @click=${signIn}
+        @click=${action}
         class="w-button w-button--secondary lh-signin-button gc-analytics-event"
         data-category="web.dev"
         data-label="measure, big sign-in"

--- a/src/lib/components/SigninButton/index.js
+++ b/src/lib/components/SigninButton/index.js
@@ -6,17 +6,19 @@ import {BaseStateElement} from "../BaseStateElement";
 class SigninButton extends BaseStateElement {
   static get properties() {
     return {
-      show: {type: Boolean},
+      checkingSignedInState: {type: Boolean},
+      isSignedIn: {type: Boolean},
     };
   }
 
   render() {
-    if (!this.show) {
+    if (this.isSignedIn) {
       return "";
     }
 
     return html`
       <button
+        .disabled=${this.checkingSignedInState}
         @click=${signIn}
         class="w-button w-button--secondary lh-signin-button gc-analytics-event"
         data-category="web.dev"
@@ -61,7 +63,8 @@ class SigninButton extends BaseStateElement {
   }
 
   onStateChanged({checkingSignedInState, isSignedIn}) {
-    this.show = !checkingSignedInState && !isSignedIn;
+    this.checkingSignedInState = checkingSignedInState;
+    this.isSignedIn = isSignedIn;
   }
 }
 

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -32,7 +32,7 @@ firebase.auth().onAuthStateChanged((user) => {
 
   // Cache whether the user was signed in, to help prevent FOUC in future, as
   // this can be read synchronosly and Firebase's auth takes ~ms to come back.
-  window.localStorage["webdev_isSignedIn"] = Boolean(user);
+  window.localStorage["webdev_isSignedIn"] = user ? "probably" : "";
 
   if (!user) {
     store.setState({

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -30,6 +30,10 @@ firebase.auth().onAuthStateChanged((user) => {
     });
   }
 
+  // Cache whether the user was signed in, to help prevent FOUC in future, as
+  // this can be read synchronosly and Firebase's auth takes ~ms to come back.
+  window.localStorage["webdev_isSignedIn"] = Boolean(user);
+
   if (!user) {
     store.setState({
       isSignedIn: false,

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -10,8 +10,8 @@ const initialState = {
   // don't render incorrect UI.
   checkingSignedInState: true,
 
-  // The user has successfully signed in.
-  isSignedIn: false,
+  // The user has successfully signed in; default to cached value to help prevent FOUC
+  isSignedIn: Boolean(window.localStorage["webdev_isSignedIn"]),
   user: null,
 
   // The most recent URL measured and the Date when it was first analyzed by the user.

--- a/src/styles/components/_page-header.scss
+++ b/src/styles/components/_page-header.scss
@@ -39,5 +39,5 @@
 .w-page-header__copy {
   font: inherit;
   margin: 0 auto 12px;
-  max-width: 512px;
+  max-width: 600px; // fits a top line of text on a large screen to prevent FOUC
 }


### PR DESCRIPTION
This tries to fix causes of FOUC.

* We store whether we think the user was previously signed in inside `localStorage` which propagates to the global state, so it's available before Firebase tells us anything
* Fades in the user's profile picture only after it loads (and shows a placeholder silhouette until then)
* Fixes a bug with `<web-search>` (it would "click" on the thing you focused on _outside_ itself)
* Expands the allowed content on the Measure page so that FOUC is less annoying on large screens (the top line of text now doesn't wrap)
