### PR TITLE
Remove 'draft' from Fugu articles

### DIFF
--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -9,14 +9,13 @@ updated: 2019-10-08
 tags:
   - post
   - capabilities
+  - fugu
   - badging
   - progressive-web-apps
   - notifications
-  - origintrials
-  - fugu
+  - origin-trial
 hero: hero.jpg
 alt: Phone showing several notification badges
-draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/-5354779956943519743
 ---

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -7,13 +7,14 @@ description: Access to the user's contacts has been a feature of native apps sin
 date: 2019-08-07
 updated: 2019-10-10
 tags:
-  - post # post is a required tag for the article to show up in the blog.
+  - post
   - capabilities
+  - fugu
   - contacts
   - chrome77
+  - origin-trial
 hero: hero.jpg
 alt: Telephone on yellow background.
-draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/85568392920039425
 ---

--- a/src/site/content/en/blog/get-installed-related-apps/index.md
+++ b/src/site/content/en/blog/get-installed-related-apps/index.md
@@ -9,9 +9,10 @@ updated: 2019-10-15
 tags:
   - post
   - capabilities
+  - fugu
+  - origin-trial
 hero: hero.jpg
 alt: mobile device with app panel open
-draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/855683929200394241
 ---

--- a/src/site/content/en/blog/image-support-for-async-clipboard/index.md
+++ b/src/site/content/en/blog/image-support-for-async-clipboard/index.md
@@ -7,8 +7,9 @@ description: Chrome 76 adds expands the functionality of the Async Clipboard API
 date: 2019-07-03
 updated: 2019-10-11
 tags:
-  - post # post is a required tag for the article to show up in the blog.
+  - post
   - capabilities
+  - fugu
   - chrome76
   - cutandcopy
   - execcommand
@@ -16,7 +17,6 @@ tags:
   - clipboard
 hero: hero.jpg
 alt: Clipboard with shopping list
-draft: true
 ---
 
 Chrome 66 added support for the

--- a/src/site/content/en/blog/native-file-system/index.md
+++ b/src/site/content/en/blog/native-file-system/index.md
@@ -9,12 +9,13 @@ updated: 2019-10-08
 tags:
   - post
   - capabilities
+  - fugu
+  - origin-trial
   - file
   - filesystem
   - native-file-system
 hero: hero.jpg
 alt: Image of hard disk platters
-draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/3868592079911256065
 ---

--- a/src/site/content/en/blog/shape-detection/index.md
+++ b/src/site/content/en/blog/shape-detection/index.md
@@ -9,12 +9,13 @@ updated: 2019-10-08
 tags:
   - post
   - capabilities
+  - fugu
+  - origin-trial
   - shape-detection
   - progressive-web-apps
   - webapp
 hero: hero.jpg
 alt: QR code being scanned by a mobile phone
-draft: true
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/-2341871806232657919
 ---

--- a/src/site/content/en/blog/wakelock/index.md
+++ b/src/site/content/en/blog/wakelock/index.md
@@ -10,8 +10,9 @@ updated: 2019-10-17
 tags:
   - post
   - capabilities
+  - fugu
+  - behind-a-flag
   - wake-lock
-draft: true
 ---
 
 {% Aside %}


### PR DESCRIPTION
Changes proposed in this pull request:
- Removes `draft: true` from Fugu articles
- Updates post `tag`s for consistency

Needs to go live in conjunction with https://github.com/google/WebFundamentals/pull/8252
