### PR TITLE
V2+historic data

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -21,18 +21,6 @@ export const requestRunLighthouse = store.action((state, url) => {
     const auditedOn = new Date(run.auditedOn);
     state = store.getState(); // might change during runLighthouse
 
-    // Replace last run for signed out users.
-    if (!state.isSignedIn) {
-      return {
-        userUrl: url,
-        activeLighthouseUrl: null,
-        lighthouseResult: {
-          url,
-          runs: [run],
-        },
-      };
-    }
-
     // Don't just replace last run for signed in users to avoid double rendering / outdated
     // sparkline data. Instead, call fetchReports() to repopulate the graphs with the latest data.
     // Yes, this means that signed-in users have two network requests.

--- a/src/lib/lighthouse-service.js
+++ b/src/lib/lighthouse-service.js
@@ -1,5 +1,6 @@
 // export const LH_HOST = "https://lighthouse-dot-webdotdevsite.appspot.com";
-export const LH_HOST = "https://20191018t150919-dot-lighthouse-dot-webdotdevsite.appspot.com/";
+export const LH_HOST =
+  "https://20191018t150919-dot-lighthouse-dot-webdotdevsite.appspot.com/";
 
 /**
  * Fetches recent median values for various Lighthouse categories. This is used as a baseline for

--- a/src/lib/lighthouse-service.js
+++ b/src/lib/lighthouse-service.js
@@ -1,4 +1,5 @@
-export const LH_HOST = "https://lighthouse-dot-webdotdevsite.appspot.com";
+// export const LH_HOST = "https://lighthouse-dot-webdotdevsite.appspot.com";
+export const LH_HOST = "https://20191018t150919-dot-lighthouse-dot-webdotdevsite.appspot.com/";
 
 /**
  * Fetches recent median values for various Lighthouse categories. This is used as a baseline for


### PR DESCRIPTION
Fixes #1375 

Changes proposed in this pull request:

- Let signed out users get access to historic data for a url.

TODO:

- If a user signs in, compare the URLs and promote whichever one is in the input field.