### PR TITLE
retain previous URL on signin

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -1,7 +1,21 @@
 import {store} from "./store";
 import {saveUserUrl} from "./fb";
 import {runLighthouse, fetchReports} from "./lighthouse-service";
-import "wicg-inert";
+
+export const clearSignedInState = store.action(() => {
+  const {isSignedIn} = store.getState();
+  if (isSignedIn) {
+    return {
+      userUrlSeen: null,
+      userUrl: null,
+      checkingSignedInState: false,
+      isSignedIn: false,
+      user: null,
+      lighthouseResult: null,
+      lighthouseError: null,
+    };
+  }
+});
 
 export const requestRunLighthouse = store.action((state, url) => {
   const p = (async () => {

--- a/src/lib/components/UrlChooserContainer/index.js
+++ b/src/lib/components/UrlChooserContainer/index.js
@@ -1,6 +1,5 @@
 import {html} from "lit-element";
-import {store} from "../../store";
-import {BaseElement} from "../BaseElement";
+import {BaseStateElement} from "../BaseStateElement";
 import {requestRunLighthouse} from "../../actions";
 import "../UrlChooser";
 
@@ -9,9 +8,7 @@ import "../UrlChooser";
  *
  * Invokes Lighthouse when the UrlChooser requests it, possibly with an updated URL.
  */
-
-/* eslint-disable require-jsdoc */
-class UrlChooserContainer extends BaseElement {
+class UrlChooserContainer extends BaseStateElement {
   static get properties() {
     return {
       url: {type: String},
@@ -22,21 +19,9 @@ class UrlChooserContainer extends BaseElement {
 
   constructor() {
     super();
-    this.onStateChanged = this.onStateChanged.bind(this);
 
     this.url = null; // when signed out or waiting for Firestore, this is null
     this.active = false;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    store.subscribe(this.onStateChanged);
-    this.onStateChanged();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    store.unsubscribe(this.onStateChanged);
   }
 
   render() {
@@ -50,9 +35,7 @@ class UrlChooserContainer extends BaseElement {
     `;
   }
 
-  onStateChanged() {
-    const state = store.getState();
-
+  onStateChanged(state) {
     // As userUrl can change (a signed-in user can modify it in another browser
     // window), _prefer_ any URL that's currently being run through Lighthouse.
     // This will prevent e.g. "foo.com" (after a user has hit "Run Audit") being

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -70,8 +70,10 @@ firebase.auth().onAuthStateChanged((user) => {
       // This is the first snapshot from Firebase, but the user has a local URL.
       // The user has run Lighthouse, but then signed in. Save the new run
       // to Firebase.
-      console.warn('updating firebase with local chosen URL');
       saveUserUrl(userUrl, userUrlSeen);
+      lastSavedUrl = userUrl;
+      // Return early as we preempt the Firestore snapshot via lastSavedUrl
+      return;
     } else {
       // Do nothing, as the last remote URL is already up-to-date. This occurs
       // if a snapshot was triggered for a field we don't care about.

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -1,4 +1,5 @@
 import {store} from "./store";
+import {clearSignedInState} from "./actions";
 import firestoreLoader from "./firestore-loader";
 
 /* eslint-disable require-jsdoc */
@@ -19,15 +20,10 @@ firebase.initializeApp(firebaseConfig);
 let firestoreUserUnsubscribe = null;
 firebase.auth().onAuthStateChanged((user) => {
   store.setState({checkingSignedInState: false});
+
   if (firestoreUserUnsubscribe) {
     firestoreUserUnsubscribe();
     firestoreUserUnsubscribe = null;
-
-    // Clear Firestore values here, so they don't persist between signins.
-    store.setState({
-      userUrlSeen: null,
-      userUrl: null,
-    });
   }
 
   // Cache whether the user was signed in, to help prevent FOUC in future, as
@@ -35,20 +31,20 @@ firebase.auth().onAuthStateChanged((user) => {
   window.localStorage["webdev_isSignedIn"] = user ? "probably" : "";
 
   if (!user) {
-    store.setState({
-      isSignedIn: false,
-      user: null,
-    });
+    clearSignedInState();
     return;
   }
 
+  // Don't clear userUrl, as the user might have requested something prior to
+  // signing in.
   store.setState({
     isSignedIn: true,
     user,
   });
+  let lastRemoteUserUrl = null;
+
   const onUserSnapshot = (snapshot) => {
-    const state = store.getState();
-    const isInitialSnapshot = state.userUrl === null;
+    let updateToRemote = false;
 
     // We expect the user snapshot to look like:
     // {
@@ -56,24 +52,37 @@ firebase.auth().onAuthStateChanged((user) => {
     //   urls: {String: Timestamp},  # URL to first time used (including current URL)
     // }
     const data = snapshot.data() || {}; // is empty on new user
+    const remoteUserUrl = data.currentUrl || "";
+    const seen = (data.urls && data.urls[remoteUserUrl]) || null;
+    const remoteUserUrlSeen = seen ? seen.toDate() : null;
 
-    const userUrl = data.currentUrl || "";
-    const prevSeen = (data.urls && data.urls[userUrl]) || null;
-    const userUrlSeen = prevSeen ? prevSeen.toDate() : null;
-
-    // Request results if this is the first snapshot and they have a saved URL.
-    let userUrlResultsPending = isInitialSnapshot && userUrl;
-
-    // But don't request results if there's an active fetch or a URL was set pre-signin.
-    if (state.activeLighthouseUrl || state.userUrl === userUrl) {
-      userUrlResultsPending = false;
+    const {userUrl, activeLighthouseUrl} = store.getState();
+    if (activeLighthouseUrl !== null) {
+      // Do nothing, as the active URL action will eventually write its results.
+    } else if (lastRemoteUserUrl && lastRemoteUserUrl !== remoteUserUrl) {
+      // The user changed their target URL in another browser. Update it.
+      // This doesn't fire on the first snapshot as |lastRemoteUserUrl| begins
+      // as null.
+      updateToRemote = true;
+    } else if (!userUrl) {
+      // Update to remote if there was no URL run before signin.
+      updateToRemote = true;
+    } else {
+      // Do nothing, as the last remote URL is already up-to-date. This occurs
+      // if a snapshot was triggered for a field we don't care about.
     }
+    lastRemoteUserUrl = remoteUserUrl;
 
-    store.setState({
-      userUrlSeen,
-      userUrl,
-      userUrlResultsPending,
-    });
+    // The URL changed, so record it from remote, and indicate that
+    // <web-lighthouse-scores-container> should request new content when it
+    // appears on the page.
+    if (updateToRemote) {
+      store.setState({
+        userUrl: remoteUserUrl,
+        userUrlSeen: remoteUserUrlSeen,
+        userUrlResultsPending: true,
+      });
+    }
   };
 
   // This unsubscribe function is used if the user signs out. However, the user's row cannot be


### PR DESCRIPTION
Related to #1375.

* Retains the active URL if you'd run Lighthouse on it before signing in. This does *not* write that to your profile, however (that wouldn't be _too_ hard, but perhaps a touch racey).

* Clears any previous Lighthouse result on signout. This won't stop an in-flight run (as that's indicated via `activeLighthouseUrl`).

The changes to `fb.js` are a lot of comments, but I think it's definitely worth it.