### PR TITLE
Update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,24 +1,28 @@
 ---
 name: Bug report
 about: Found a bug? Let us know!
-title: ''
+title: 'bug: <description>'
 labels: bug
-assignees: ''
-
+assignees: 'robdodson'
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/collection_proposal.md
+++ b/.github/ISSUE_TEMPLATE/collection_proposal.md
@@ -3,12 +3,12 @@ name: Propose a new collection
 about: Use this ticket when you are submitting a new collection for review.
 title: 'collection: <Add your title>'
 labels: content proposal
-assignees: ''
-
+assignees: 'kaycebasques'
 ---
 
-**Author**: @[Author's GitHub username.]
-**Reviewer**: [Leave blank. web.dev team will assign a reviewer.]
+**Author**: @[Author's GitHub username]
+**SME Reviewer**: @[SME's GitHub username]
+**web.dev Reviewer**: @[web.dev team will fill this out]
 
 **Process**
 

--- a/.github/ISSUE_TEMPLATE/content_proposal.md
+++ b/.github/ISSUE_TEMPLATE/content_proposal.md
@@ -3,16 +3,16 @@ name: Propose a new post/codelab
 about: Use this ticket when you are submitting a new post or codelab for review.
 title: 'content: <Add your title>'
 labels: content proposal
-assignees: ''
-
+assignees: 'kaycebasques'
 ---
 
-**Author**: @[Author's GitHub username.]
-**Reviewer**: [Leave blank. web.dev team will assign a reviewer.]
+**Author**: @[Author's GitHub username]
+**SME Reviewer**: @[SME's GitHub username]
+**web.dev Reviewer**: @[web.dev team will fill this out]
 
 **Target publish date:** <yyyy-mm-dd>
-- [ ] Check this box if this is a hard deadline.
 
+- [ ] Check this box if this is a hard deadline.
 - [ ] Check this box if you'd like your reviewer to fix grammar and punctuation issues for you.
 
 **Process**

--- a/.github/ISSUE_TEMPLATE/content_update.md
+++ b/.github/ISSUE_TEMPLATE/content_update.md
@@ -1,0 +1,28 @@
+---
+name: Update content
+about: Propose content updates.
+title: 'content: Update <pages>'
+labels: content
+assignees: 'kaycebasques'
+---
+
+**Author**: @[Author's GitHub username]
+**SME Reviewer**: @[SME's GitHub username]
+**web.dev Reviewer**: @[web.dev team will fill this out]
+
+**Target publish date:** <yyyy-mm-dd>
+
+- [ ] Check this box if this is a hard deadline.
+- [ ] Check this box if you'd like your reviewer to fix grammar and punctuation issues for you.
+
+**Affected URLs**
+
+List all pages that will be affected by the change here.
+
+**Context**
+
+Why does this content need to be updated?
+
+**Changes**
+
+What's going to change?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,18 +3,22 @@ name: Feature request
 about: Suggest an idea for this project.
 title: ''
 labels: feature request
-assignees: ''
+assignees: 'robdodson'
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
+
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds Rob as assignee for engineering topics, and me as assignee for content topics
- Adds a template for content updates
- General cleanup of the Markdown in the templates
- Adds an SME reviewer field, which seems like a good idea but haven't thought through all scenarios fully, so I can drop this if half-baked
