### PR TITLE
Add imgix to hero and post cards

### DIFF
--- a/src/site/_includes/components/Hero.js
+++ b/src/site/_includes/components/Hero.js
@@ -15,16 +15,24 @@
  */
 
 const {html} = require("common-tags");
-const path = require("path");
 const stripLanguage = require("../../_filters/strip-language");
+const getImagePath = require("../../_utils/get-image-path");
+const getSrcsetRange = require("../../_utils/get-srcset-range");
 
 /* eslint-disable max-len */
 module.exports = ({page, hero, alt, heroPosition, heroFit = "cover"}) => {
+  const imagePath = getImagePath(hero, stripLanguage(page.url));
+  const srcsetRange = getSrcsetRange();
+
+  // prettier-ignore
   return html`
     <img
-      class="w-hero w-hero--${heroFit}
-      ${heroPosition ? `w-hero--${heroPosition}` : ""}"
-      src="${stripLanguage(path.join(page.url, hero))}"
+      class="w-hero w-hero--${heroFit} ${heroPosition ? `w-hero--${heroPosition}` : ""}"
+      sizes="100vw"
+      srcset="${srcsetRange.map((width) => html`
+        ${imagePath}?auto=format&fit=max&w=${width} ${width}w,
+      `)}"
+      src="${imagePath}"
       alt="${alt}"
     />
   `;

--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -17,6 +17,8 @@
 const {html} = require("common-tags");
 const stripLanguage = require("../../_filters/strip-language");
 const md = require("../../_filters/md");
+const getImagePath = require("../../_utils/get-image-path");
+const getSrcsetRange = require("../../_utils/get-srcset-range");
 
 /* eslint-disable require-jsdoc,indent,max-len */
 
@@ -35,11 +37,21 @@ module.exports = ({post}) => {
   const alt = data.alt || "";
 
   function renderThumbnail(url, img, alt) {
+    debugger;
+    const imagePath = getImagePath(img, url);
+    const srcsetRange = getSrcsetRange(240, 768);
+
     return html`
       <figure class="w-post-card__figure">
         <img
           class="w-post-card__image"
-          src="${url + img}"
+          sizes="365px"
+          srcset="${srcsetRange.map(
+            (width) => html`
+              ${imagePath}?auto=format&fit=max&w=${width} ${width}w,
+            `,
+          )}"
+          src="${imagePath}"
           alt="${alt}"
           width="100%"
           height="240"

--- a/src/site/_includes/components/tags/Image.js
+++ b/src/site/_includes/components/tags/Image.js
@@ -47,12 +47,11 @@
  *
  */
 
-const path = require("path");
 const {oneLine} = require("common-tags");
 const {ifDefined} = require("../helpers");
 const md = require("markdown-it")();
 const stripLanguage = require("../../../_filters/strip-language");
-const imageCdn = require("../../../_data/site").imageCdn;
+const getImagePath = require("../../../_utils/get-image-path");
 
 /* eslint-disable no-invalid-this, max-len */
 
@@ -61,30 +60,13 @@ const imageCdn = require("../../../_data/site").imageCdn;
 // -----------------------------------------------------------------------------
 
 /**
- * Takes a path to an image and converts it to an image CDN path if we're in
- * a production environment.
- * @param {!string} src A path to an image asset.
- * @param {!Object} ctx An eleventy context object for the current page.
- * @return {string} An image path. May be converted to an image CDN path if
- * it's a production environment.
- */
-function getImagePath(src, ctx) {
-  let imagePath = src;
-  if (process.env.ELEVENTY_ENV === "prod") {
-    imagePath = path.join(stripLanguage(ctx.page.url), src);
-    imagePath = new URL(imagePath, imageCdn).href;
-  }
-  return imagePath;
-}
-
-/**
  * Render an image element as an HTML string.
  * @param {!{src: string, alt: string, maxWidth: number}} args
  * @param {!Object} ctx An eleventy context object.
  * @return {string}
  */
 function renderImage({src, alt, maxWidth}, ctx) {
-  const imagePath = getImagePath(src, ctx);
+  const imagePath = getImagePath(src, stripLanguage(ctx.page.url));
   let style;
   if (maxWidth) {
     style = `max-width: ${maxWidth};`;

--- a/src/site/_utils/get-image-path.js
+++ b/src/site/_utils/get-image-path.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require("path");
+const site = require("../_data/site");
+
+/**
+ * Takes a path to an image and converts it to an image CDN path if we're in
+ * a production environment.
+ * @param {!string} src A path to an image asset.
+ * @param {!string} pageUrl The url for the current page.
+ * @return {string} An image path. May be converted to an image CDN path if
+ * it's a production environment.
+ */
+module.exports = function getImagePath(src, pageUrl) {
+  let imagePath = path.join(pageUrl, src);
+  if (site.env === "dev") {
+    imagePath = new URL(imagePath, site.imageCdn).href;
+  }
+  return imagePath;
+};

--- a/src/site/_utils/get-srcset-range.js
+++ b/src/site/_utils/get-srcset-range.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The range of widths that we use when we srcset images.
+// srcset sizes generated using https://www.responsivebreakpoints.com/
+const srcsetRange = [
+  240,
+  480,
+  768,
+  1020,
+  1229,
+  1405,
+  1554,
+  1687,
+  1808,
+  1918,
+  2036,
+  2140,
+  2234,
+  2332,
+  2430,
+  2521,
+  2612,
+  2703,
+  2798,
+  2886,
+  3200,
+];
+
+/**
+ * Take min and max values for an image and return all srcset sizes that fall
+ * within that range.
+ * @param {?number} min A minimum width.
+ * @param {?number} max A maximum width.
+ * @return {Array<number>} An array of srcset widths.
+ */
+module.exports = function getSrcsetRange(min, max) {
+  min = min || srcsetRange[0];
+  max = max || srcsetRange[srcsetRange.length - 1];
+  if (min > max) {
+    throw new Error(
+      `Can't get srcset range. min: ${min} is greater than max: ${max}`,
+    );
+  }
+
+  const range = [];
+  for (let i = 0; i < srcsetRange.length; i++) {
+    if (srcsetRange[i] < min) {
+      continue;
+    }
+    if (srcsetRange[i] > max) {
+      break;
+    }
+    range.push(srcsetRange[i]);
+  }
+  return range;
+};

--- a/src/site/_utils/get-srcset-range.js
+++ b/src/site/_utils/get-srcset-range.js
@@ -16,29 +16,7 @@
 
 // The range of widths that we use when we srcset images.
 // srcset sizes generated using https://www.responsivebreakpoints.com/
-const srcsetRange = [
-  240,
-  480,
-  768,
-  1020,
-  1229,
-  1405,
-  1554,
-  1687,
-  1808,
-  1918,
-  2036,
-  2140,
-  2234,
-  2332,
-  2430,
-  2521,
-  2612,
-  2703,
-  2798,
-  2886,
-  3200,
-];
+const srcsetRange = [240, 480, 768, 1045, 1434, 1730, 1959, 2195, 2880, 3200];
 
 /**
  * Take min and max values for an image and return all srcset sizes that fall


### PR DESCRIPTION
Changes proposed in this pull request:

- Use imgix to srcset hero images and post card images when we're in a prod environment.
- `format=auto` will serve webp images if the browser supports it.
- `fit=max` means imgix won't try to scale up an image if the source is smaller than the requested dimensions (IOW, it won't stretch a 1600px image to be 3200px).
