### PR TITLE
bad variable name in webshare

### DIFF
--- a/src/lib/components/Actions/index.js
+++ b/src/lib/components/Actions/index.js
@@ -56,7 +56,7 @@ class Actions extends BaseElement {
         const il = new Intl.ListFormat("en");
         authorText = ` by ${il.format(authors)}`;
       } else {
-        authorText = ` by ${il.join(", ")}`;
+        authorText = ` by ${authors.join(", ")}`;
       }
     }
 


### PR DESCRIPTION
Web Share was crashing.

also, Web Share on Safari for Desktop is amazingly limited—I have all the options turned off so all I see is AirDrop and Messages, neither of which I use. 🤨

cc @robdodson 