### PR TITLE
Add shortcode for page meta tags and hide 404/offline pages from Search

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,6 +36,7 @@ const Details = require(`./${componentsDir}/Details`);
 const DetailsSummary = require(`./${componentsDir}/DetailsSummary`);
 const Hero = require(`./${componentsDir}/Hero`);
 const Instruction = require(`./${componentsDir}/Instruction`);
+const Meta = require(`./${componentsDir}/Meta`);
 const PathCard = require(`./${componentsDir}/PathCard`);
 const PostCard = require(`./${componentsDir}/PostCard`);
 const YouTube = require(`./${componentsDir}/YouTube`);
@@ -151,6 +152,7 @@ module.exports = function(config) {
   config.addPairedShortcode('DetailsSummary', DetailsSummary);
   config.addShortcode('Hero', Hero);
   config.addShortcode('Instruction', Instruction);
+  config.addShortcode('Meta', Meta);
   config.addShortcode('PathCard', PathCard);
   config.addShortcode('PostCard', PostCard);
   config.addShortcode('YouTube', YouTube);

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -21,6 +21,7 @@ module.exports = {
   url: "https://web.dev",
   repo: "https://github.com/GoogleChrome/web.dev",
   subscribe: "https://web.dev/subscribe",
+  thumbnail: "/images/social.png",
   isBannerEnabled: true,
   banner: `Can’t make \`#ChromeDevSummit\` this year? Catch all the content
   (and more!) on the livestream or join your peers for a CDS Extended event at

--- a/src/site/_drafts/_template-codelab/index.md
+++ b/src/site/_drafts/_template-codelab/index.md
@@ -1,18 +1,46 @@
 ---
 layout: codelab
 title: Remove unused code
+description: |
+  A description of the codelab that will appear in search results.
+
+# A list of authors. Supports more than one.
 authors:
   - houssein
-description: |
-  In this codelab, learn how to improve the performance of an application by
-  removing any unused and unneeded dependencies.
-date: 2018-11-05
+
+date: 2019-10-31
 # Add an updated date to your post if you edit in the future.
-# updated: 2019-06-27
+# updated: 2019-11-01
+
+# Provide the id for a glitch that will display next to the instruction text.
 glitch: fav-kitties-starter
 # Specify which file the glitch should start on.
 # glitch_path: index.js
+
+# Provide the slug for the post that this codelab is related to. This will be
+# used at the bottom of the codelab for the "Return to article" button.
 related_post: remove-unused-code
+
+# You can provide a custom thumbnail and description for social media cards.
+# Images should be 1200 x 630.
+# If no social thumbnail is provided then the post will attempt to fallback to
+# the post's thumbnail or hero from above. It will also reuse the alt.
+# social:
+#   google:
+#     title: A title for Google search card.
+#     description: A description for Google search card.
+#     thumbnail: google_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
+#   facebook:
+#     title: A title for Facebook card.
+#     description: A description for Facebook card.
+#     thumbnail: facebook_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
+#   twitter:
+#     title: A title for Twitter card.
+#     description: A description for Twitter card.
+#     thumbnail: twitter_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
 ---
 
 In this codelab, improve the performance of the following application by

--- a/src/site/_drafts/_template-post/index.md
+++ b/src/site/_drafts/_template-post/index.md
@@ -1,29 +1,54 @@
 ---
 title: An example blog post
 subhead: A catchy subhead that previews the content.
+description: |
+  A description of the article that will appear in search results.
+
+# A list of authors. Supports more than one.
 authors:
   - robdodson
 
-date: 2019-04-20
+date: 2019-10-31
 # Add an updated date to your post if you edit in the future.
-# updated: 2019-06-27
+# updated: 2019-11-01
 
 hero: hero.jpg
 # You can adjust the fit of your hero image with this property.
 # Values: contain | cover (default)
 # hero_fit: contain
+
 # You can adjust the position of your hero image with this property.
 # Values: top | bottom | center (default)
 # hero_position: bottom
+
 # You can provide an optional cropping of your hero image to be used as a
 # thumbnail. Note the alt text will be the same for both the thumbnail and
 # the hero.
 # thumbnail: thumbnail.jpg
+
 alt: A description of the hero image for screen reader users.
 
-description: |
-  This post is a test to demonstrate all of the components that can go into
-  an article. This description appears in the meta tag.
+# You can provide a custom thumbnail and description for social media cards.
+# Images should be 1200 x 630.
+# If no social thumbnail is provided then the post will attempt to fallback to
+# the post's thumbnail or hero from above. It will also reuse the alt.
+# social:
+#   google:
+#     title: A title for Google search card.
+#     description: A description for Google search card.
+#     thumbnail: google_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
+#   facebook:
+#     title: A title for Facebook card.
+#     description: A description for Facebook card.
+#     thumbnail: facebook_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
+#   twitter:
+#     title: A title for Twitter card.
+#     description: A description for Twitter card.
+#     thumbnail: twitter_thumbnail.jpg
+#     alt: Provide an alt for your thumbnail.
+
 tags:
   - post # post is a required tag for the article to show up in the blog.
   - accessibility

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require("path");
+const site = require("../../_data/site");
+const stripLanguage = require("../../_filters/strip-language");
+const {html} = require("common-tags");
+
+module.exports = (locale, page, collections) => {
+  const pageData = collections.all.find((item) => item.url === page.url).data;
+  const pageUrl = stripLanguage(page.url);
+
+  /**
+   * Find post meta data associated with a social media platform.
+   * Post authors should be able to create a `social` object in their YAML
+   * frontmatter and specify a unique title, description, and image for each
+   * social media platform.
+   * Supported platforms are Google (mostly for Search cards),
+   * Facebook Open Graph, and Twitter.
+   * @param {!string} platform The name of a social media platform.
+   * @return {Object} Meta data object for the social media platform specified.
+   */
+  function getMetaByPlatform(platform) {
+    const social =
+      pageData.social && pageData.social[platform]
+        ? pageData.social[platform]
+        : {};
+
+    const title = social.title || pageData.title;
+    const description = social.description || pageData.description;
+    let thumbnail = social.thumbnail || pageData.thumbnail || pageData.hero;
+    const alt = social.alt || pageData.alt || site.name;
+
+    // If the page doesn't have social media images, a hero, or a thumbnail,
+    // fallback to using the site's default thumbnail.
+    // Return a full path to the image using our image CDN.
+    if (!thumbnail) {
+      thumbnail = new URL(site.thumbnail, site.imageCdn);
+    } else {
+      thumbnail = new URL(path.join(pageUrl, thumbnail), site.imageCdn);
+    }
+    thumbnail.searchParams.set("auto", "format");
+    thumbnail.searchParams.set("fit", "max");
+    thumbnail.searchParams.set("w", 1200);
+    thumbnail = thumbnail.toString();
+
+    return {title, description, thumbnail, alt};
+  }
+
+  function renderGoogleMeta() {
+    const meta = getMetaByPlatform("google");
+    return html`
+      <meta itemprop="name" content="${meta.title}" />
+      <meta itemprop="description" content="${meta.description}" />
+      <meta itemprop="image" content="${meta.thumbnail}" />
+    `;
+  }
+
+  function renderFacebookMeta() {
+    const meta = getMetaByPlatform("facebook");
+    // nb. This will mark pages like /404/ and /offline/ as "article" but that's
+    // probably fine as those shouldn't show up in search results anyway.
+    const type = pageUrl === "/" ? "website" : "article";
+    // Filter out tags that we don't want to show up in Search.
+    // These tags are only used internally to determine which layout a page
+    // should use.
+    let tags = pageData.tags || [];
+    tags = tags.filter((tag) => tag !== "pathItem" && tag !== "post");
+
+    // prettier-ignore
+    return html`
+      <meta property="og:locale" content="${locale}" />
+      <meta property="og:type" content="${type}" />
+      <meta property="og:url" content="${new URL(pageUrl, site.url).href}" />
+      <meta property="og:site_name" content="${site.title}" />
+      <meta property="og:title" content="${meta.title}" />
+      <meta property="og:description" content="${meta.description}" />
+      <meta property="og:image" content="${meta.thumbnail}" />
+      <meta property="og:image:alt" content="${meta.alt}" />
+      ${type === "article" && tags && tags.length ? tags.map((tag) => html`<meta property="tag" content="${tag}" />`) : ""}
+    `;
+  }
+
+  function renderTwitterMeta() {
+    const meta = getMetaByPlatform("twitter");
+    return html`
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content="${meta.title}" />
+      <meta name="twitter:description" content="${meta.description}" />
+      <meta name="twitter:image" content="${meta.thumbnail}" />
+    `;
+  }
+
+  // prettier-ignore
+  return html`
+    <title>${pageData.title}</title>
+    <meta name="description" content="${pageData.description}" />
+
+    ${renderGoogleMeta()}
+    ${renderFacebookMeta()}
+    ${renderTwitterMeta()}
+  `;
+};

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -77,7 +77,7 @@ module.exports = (locale, page, collections) => {
     // Filter out tags that we don't want to show up in Search.
     // These tags are only used internally to determine which layout a page
     // should use.
-    let tags = pageData.tags || [];
+    let tags = (type === "article" ? pageData.tags : null) || [];
     tags = tags.filter((tag) => tag !== "pathItem" && tag !== "post");
 
     // prettier-ignore
@@ -90,7 +90,7 @@ module.exports = (locale, page, collections) => {
       <meta property="og:description" content="${meta.description}" />
       <meta property="og:image" content="${meta.thumbnail}" />
       <meta property="og:image:alt" content="${meta.alt}" />
-      ${type === "article" && tags && tags.length ? tags.map((tag) => html`<meta property="tag" content="${tag}" />`) : ""}
+      ${tags.map((tag) => html`<meta property="tag" content="${tag}" />`)}
     `;
   }
 

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
-<html>
+{% set lang = "en" %}
+{% set locale="en_US" %}
+<html lang="{{lang}}">
   <head>
-    <title>{{title if title else path.title}}</title>
-    <meta name="description" content="{{description if description else path.description}}" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {# Don't index our staging site. #}
-    <meta name="robots" content="noindex">
     <meta charset="utf-8" />
-    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
-    <meta name="full_width" value="true" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% if noindex or draft -%}
+      <meta name="robots" content="noindex">
+    {%- endif %}
+
+    {% Meta locale, page, collections %}
+    
+    <link rel="alternate" href="/feed.xml" type="application/atom+xml" data-title="web.dev feed">
+
     <link rel="preconnect" href="//www.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.googleapis.com" crossorigin="" />

--- a/src/site/content/en/404.njk
+++ b/src/site/content/en/404.njk
@@ -3,6 +3,7 @@ layout: layout
 title: 404
 description: |
   Page Not Found
+noindex: true
 ---
 
 <div class="w-layout-container--large">

--- a/src/site/content/en/blog/index.njk
+++ b/src/site/content/en/blog/index.njk
@@ -3,6 +3,7 @@ layout: layout
 title: Blog
 permalink: /en/blog/index.html
 override:tags: []
+description: Our latest news, updates, and stories for developers
 ---
 
 {# *-landing-page classes are a holdover from devsite. #}

--- a/src/site/content/en/offline.njk
+++ b/src/site/content/en/offline.njk
@@ -3,6 +3,7 @@ layout: layout
 title: Offline
 description: |
   Network Offline
+noindex: true
 ---
 
 <div class="w-layout-container--large">


### PR DESCRIPTION
Fixes #1713

Changes proposed in this pull request:

- Add a new `Meta` shortcode to handle all the fiddly logic associated with meta tags and fallbacks.
- Hide /404/ and /offline/ from search indexing.
- Add missing description to blog 😬
