### PR TITLE
Makes offline page reload when back online

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ const redirectHandler = (() => {
 // 404 handlers aren't special, they just run last.
 const notFoundHandler = (req, res, next) => {
   const options = {root: "dist/en"};
-  res.sendFile("404/index.html", options, (err) => err && next(err));
+  res.status(404).sendFile("404/index.html", options, (err) => err && next(err));
 };
 
 const handlers = [

--- a/server.js
+++ b/server.js
@@ -38,7 +38,9 @@ const redirectHandler = (() => {
 // 404 handlers aren't special, they just run last.
 const notFoundHandler = (req, res, next) => {
   const options = {root: "dist/en"};
-  res.status(404).sendFile("404/index.html", options, (err) => err && next(err));
+  res
+    .status(404)
+    .sendFile("404/index.html", options, (err) => err && next(err));
 };
 
 const handlers = [

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -22,8 +22,8 @@ WebComponents.waitFor(async () => {
   // If the site becomes online again, and the special offline page was shown,
   // then trigger a reload
   window.addEventListener("online", () => {
-    const {specialPage} = store.getState();
-    if (specialPage === "offline") {
+    const {isOffline} = store.getState();
+    if (isOffline) {
       router.reload();
     }
   });

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -9,6 +9,7 @@ import config from "./bootstrap-config";
 import "@webcomponents/webcomponentsjs/webcomponents-loader.js";
 import {swapContent} from "./loader";
 import * as router from "./utils/router";
+import {store} from "./store";
 
 console.info("web.dev", config.version);
 
@@ -17,6 +18,16 @@ WebComponents.waitFor(async () => {
   // Also immediately calls `swapContent()` handler for current location,
   // loading its required JS entrypoint
   router.listen(swapContent);
+
+  // If the site becomes online again, and the special offline page was shown,
+  // then trigger a reload
+  window.addEventListener("online", () => {
+    const {specialPage} = store.getState();
+    console.info('got online event', specialPage);
+    if (specialPage === "offline") {
+      router.reload();
+    }
+  });
 });
 
 if ("serviceWorker" in navigator) {

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -23,7 +23,6 @@ WebComponents.waitFor(async () => {
   // then trigger a reload
   window.addEventListener("online", () => {
     const {specialPage} = store.getState();
-    console.info('got online event', specialPage);
     if (specialPage === "offline") {
       router.reload();
     }

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -137,7 +137,6 @@ export async function swapContent(url, isFirstRun) {
 
   // Determine if this was a special page
   const specialPage = meta("special", page);
-  debugger;
 
   store.setState({
     isPageLoading: false,

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -1,5 +1,6 @@
 import {store} from "./store";
 import "./utils/underscore-import-polyfill";
+import meta from "./utils/meta";
 
 const domparser = new DOMParser();
 
@@ -20,13 +21,19 @@ async function loadEntrypoint(url) {
 /**
  * Fetch a page as an html string.
  * @param {string} url url of the page to fetch.
- * @return {Promise<string>}
+ * @return {!HTMLDocument}
  */
 async function getPage(url) {
-  const res = await fetch(url);
-  if (!res.ok) {
+  // Pass a custom header so that the Service Worker knows this request is
+  // actually for a document, this is used to reply with an offline page
+  const headers = new Headers();
+  headers.set("X-Document", "1");
+
+  const res = await fetch(url, {headers});
+  if (!res.ok && res.status !== 404) {
     throw res.status;
   }
+
   const text = await res.text();
   return domparser.parseFromString(text, "text/html");
 }
@@ -117,6 +124,7 @@ export async function swapContent(url, isFirstRun) {
       currentUrl: url,
     });
   }
+
   // Remove the current #content element
   main.querySelector("#content").remove();
   main.appendChild(page.querySelector("#content"));
@@ -127,5 +135,12 @@ export async function swapContent(url, isFirstRun) {
   // Focus on the first title (or fallback to content itself)
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);
 
-  store.setState({isPageLoading: false});
+  // Determine if this was a special page
+  const specialPage = meta("special", page);
+  debugger;
+
+  store.setState({
+    isPageLoading: false,
+    specialPage,
+  });
 }

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -1,6 +1,6 @@
 import {store} from "./store";
 import "./utils/underscore-import-polyfill";
-import meta from "./utils/meta";
+import getMeta from "./utils/meta";
 
 const domparser = new DOMParser();
 
@@ -135,11 +135,11 @@ export async function swapContent(url, isFirstRun) {
   // Focus on the first title (or fallback to content itself)
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);
 
-  // Determine if this was a special page
-  const specialPage = meta("special", page);
+  // Determine if this was the offline page
+  const isOffline = Boolean(getMeta("offline", page));
 
   store.setState({
     isPageLoading: false,
-    specialPage,
+    isOffline,
   });
 }

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,5 +1,6 @@
 import createStore from "unistore";
 import devtools from "unistore/devtools";
+import meta from "./utils/meta";
 
 /* eslint-disable require-jsdoc */
 
@@ -31,6 +32,7 @@ const initialState = {
   lighthouseError: null,
 
   currentUrl: window.location.pathname,
+  specialPage: meta("special"),
   isOffline: false,
   isSideNavExpanded: false,
   isSearchExpanded: false,

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,6 +1,6 @@
 import createStore from "unistore";
 import devtools from "unistore/devtools";
-import meta from "./utils/meta";
+import getMeta from "./utils/meta";
 
 /* eslint-disable require-jsdoc */
 
@@ -32,8 +32,7 @@ const initialState = {
   lighthouseError: null,
 
   currentUrl: window.location.pathname,
-  specialPage: meta("special"),
-  isOffline: false,
+  isOffline: Boolean(getMeta("offline")),
   isSideNavExpanded: false,
   isSearchExpanded: false,
 

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -23,9 +23,12 @@ workbox.routing.registerRoute(
 );
 
 workbox.routing.setCatchHandler(({event}) => {
-  if (event.request.destination === "document") {
-    // TODO(samthor): Annotate this page so the client knows it's being displayed because the user
-    // is offline, and force it to rerequest when navigator.onLine is true.
+  // Destination is set by loading this content normally; it's not set for fetch(), so look for our
+  // custom header.
+  const isDocumentRequest =
+    event.request.destination === "document" ||
+    event.request.headers.get("X-Document");
+  if (isDocumentRequest) {
     return caches.match("/offline/");
   }
 });

--- a/src/lib/utils/meta.js
+++ b/src/lib/utils/meta.js
@@ -3,7 +3,7 @@
  * @param {!HTMLDocument=} target to read from
  * @return {?string} value or null for no node
  */
-export default function meta(name, target = document) {
+export default function getMeta(name, target = document) {
   const node = target.head.querySelector(`meta[name="${name}"]`);
   if (!node) {
     return null;

--- a/src/lib/utils/meta.js
+++ b/src/lib/utils/meta.js
@@ -1,0 +1,12 @@
+/**
+ * @param {string} name of meta tag to read
+ * @param {!HTMLDocument=} target to read from
+ * @return {?string} value or null for no node
+ */
+export default function meta(name, target = document) {
+  const node = target.head.querySelector(`meta[name="${name}"]`);
+  if (!node) {
+    return null;
+  }
+  return node.getAttribute("content") || node.getAttribute("value");
+}

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -8,6 +8,9 @@
     {% if noindex or draft -%}
       <meta name="robots" content="noindex">
     {%- endif %}
+    {% if offline %}
+      <meta name="offline" content="true" />
+    {%- endif %}
 
     {% Meta locale, page, collections %}
     
@@ -15,9 +18,6 @@
 
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
     <meta name="full_width" value="true" />
-    {% if special %}
-    <meta name="special" content="{{ special }}" />
-    {%- endif %}
     <link rel="preconnect" href="//www.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.googleapis.com" crossorigin="" />

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -13,6 +13,11 @@
     
     <link rel="alternate" href="/feed.xml" type="application/atom+xml" data-title="web.dev feed">
 
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="full_width" value="true" />
+    {% if special %}
+    <meta name="special" content="{{ special }}" />
+    {%- endif %}
     <link rel="preconnect" href="//www.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.gstatic.com" crossorigin="" />
     <link rel="preconnect" href="//fonts.googleapis.com" crossorigin="" />

--- a/src/site/content/en/404.njk
+++ b/src/site/content/en/404.njk
@@ -4,7 +4,6 @@ title: 404
 description: |
   Page Not Found
 noindex: true
-special: 404
 ---
 
 <div class="w-layout-container--large">

--- a/src/site/content/en/404.njk
+++ b/src/site/content/en/404.njk
@@ -4,6 +4,7 @@ title: 404
 description: |
   Page Not Found
 noindex: true
+special: 404
 ---
 
 <div class="w-layout-container--large">

--- a/src/site/content/en/offline.njk
+++ b/src/site/content/en/offline.njk
@@ -4,6 +4,7 @@ title: Offline
 description: |
   Network Offline
 noindex: true
+special: offline
 ---
 
 <div class="w-layout-container--large">

--- a/src/site/content/en/offline.njk
+++ b/src/site/content/en/offline.njk
@@ -4,7 +4,7 @@ title: Offline
 description: |
   Network Offline
 noindex: true
-special: offline
+offline: true
 ---
 
 <div class="w-layout-container--large">


### PR DESCRIPTION
Fixes #1749.

* Actually makes our 404's return as 404's (they were 200-ing)
* Marks 404 and offline pages as "special" via meta tag
* Returns the offline page properly for `fetch()`-loading
* Ensures that only one request via router can be pending at once
* Reloads the offline page if we detect the `online` event.