### PR TITLE
Add firebase performance monitoring

### DIFF
--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -16,6 +16,9 @@ const firebaseConfig = {
 
 firebase.initializeApp(firebaseConfig);
 
+// Initialize performance monitoring
+firebase.performance();
+
 // Listen for the user's signed in state and update the store.
 let firestoreUserUnsubscribe = null;
 firebase.auth().onAuthStateChanged((user) => {

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -27,6 +27,7 @@
     <link rel="icon" type="image/png" href="/images/icon-128x128.png" sizes="128x128" />
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-app.js"></script>
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js"></script>
+    <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js"></script>
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
     <script type="module" src="/bootstrap.js"></script>


### PR DESCRIPTION
Fixes #1734.

----

Also I see that apparently you can use the npm module of firebase instead of script tags: https://firebase.google.com/docs/perf-mon/get-started-web (see "using module bundler")

I can followup with this with if you like.
