### PR TITLE
Add custom dimensions to analytics.

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -34,6 +34,9 @@ module.exports = {
   analytics: {
     ids: {
       prod: "UA-126406676-2",
+      // TODO (robdodson): These properties exist in GA but we don't use them.
+      // Adding a note to inject these into pages when we create a fancier
+      // staging environment.
       staging: "UA-126406676-3",
       notFound: "UA-126406676-4",
     },

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -31,4 +31,16 @@ module.exports = {
   // of the site. Otherwise all image paths are local. This means you can
   // develop locally without having to mess with the CDN at all.
   imageCdn: "https://webdev.imgix.net",
+  analytics: {
+    ids: {
+      prod: "UA-126406676-2",
+      staging: "UA-126406676-3",
+      notFound: "UA-126406676-4",
+    },
+    dimensions: {
+      SIGNED_IN: "dimension1",
+      TRACKING_VERSION: "dimension5",
+    },
+    version: 3,
+  },
 };

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -32,8 +32,9 @@
     <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-      ga('create', 'UA-126406676-2');
+      ga('create', '{{ site.analytics.ids.prod }}');
       ga('set', 'transport', 'beacon');
+      ga('set', '{{ site.analytics.dimensions.TRACKING_VERSION }}', '{{ site.analytics.version }}');
     </script>
     <script async src="//www.google-analytics.com/analytics.js"></script>
   </head>


### PR DESCRIPTION
Changes proposed in this pull request:

- Add custom dimensions to analytics. Our property already has dimensions specified by devsite but we probably won't use those immediately or possibly ever:

![image](https://user-images.githubusercontent.com/1066253/67727277-0e38c680-f9a6-11e9-8e09-87b49af785c6.png)

- Revs the tracking version to 3 (it's currently at '2' for the live version of web.dev).
