### PR TITLE
V2+edge misc fixes

### DIFF
--- a/src/lib/bootstrap-config.js
+++ b/src/lib/bootstrap-config.js
@@ -7,6 +7,6 @@
 
 import config from "webdev_config";
 
-window.WebComponents = {path: config.webcomponentsPath};
+window.WebComponents = {root: config.webcomponentsPath};
 
 export default config;

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -14,6 +14,8 @@ import {store} from "./store";
 console.info("web.dev", config.version);
 
 WebComponents.waitFor(async () => {
+  document.body.classList.remove("unresolved");
+
   // Run as long-lived router w/ history & "<a>" bindings
   // Also immediately calls `swapContent()` handler for current location,
   // loading its required JS entrypoint

--- a/src/lib/components/Header/_styles.scss
+++ b/src/lib/components/Header/_styles.scss
@@ -19,6 +19,11 @@
 @import '../../../styles/tools/breakpoints';
 @import '../../../styles/tools/mixins';
 
+// Disable when Web Components aren't loaded; the button does nothing.
+body.unresolved web-header .web-header__hamburger-btn {
+  display: none !important;
+}
+
 web-header {
   align-items: center;
   background: $WHITE;

--- a/src/lib/components/Header/_styles.scss
+++ b/src/lib/components/Header/_styles.scss
@@ -21,7 +21,7 @@
 
 // Disable when Web Components aren't loaded; the button does nothing.
 body.unresolved web-header .web-header__hamburger-btn {
-  display: none !important;
+  visibility: hidden;
 }
 
 web-header {

--- a/src/lib/components/SideNav/_styles.scss
+++ b/src/lib/components/SideNav/_styles.scss
@@ -24,6 +24,7 @@ body.web-side-nav--expanded {
   overflow: hidden;
 }
 
+web-side-nav:not(:defined),
 body.unresolved web-side-nav {
   display: none;
 }
@@ -41,6 +42,7 @@ web-side-nav {
 
 // Prevent FOUC by hiding children until after firstUpdated(), as children are
 // reparented within .web-side-nav__container before use
+// This isn't ":not(:defined)" because firstUpdated occurs after a frame.
 web-side-nav.unresolved * {
   display: none !important;
 }

--- a/src/lib/components/SideNav/_styles.scss
+++ b/src/lib/components/SideNav/_styles.scss
@@ -24,7 +24,8 @@ body.web-side-nav--expanded {
   overflow: hidden;
 }
 
-web-side-nav:not(:defined) {
+// Ideally this would be ":undefined", but that's not supported in old browsers.
+body.unresolved web-side-nav {
   display: none;
 }
 

--- a/src/lib/components/SideNav/_styles.scss
+++ b/src/lib/components/SideNav/_styles.scss
@@ -24,7 +24,6 @@ body.web-side-nav--expanded {
   overflow: hidden;
 }
 
-// Ideally this would be ":undefined", but that's not supported in old browsers.
 body.unresolved web-side-nav {
   display: none;
 }
@@ -38,6 +37,12 @@ web-side-nav {
   overflow: hidden;
   pointer-events: none;
   z-index: 300;
+}
+
+// Prevent FOUC by hiding children until after firstUpdated(), as children are
+// reparented within .web-side-nav__container before use
+web-side-nav.unresolved * {
+  display: none !important;
 }
 
 web-side-nav::before {

--- a/src/lib/components/SideNav/index.js
+++ b/src/lib/components/SideNav/index.js
@@ -91,6 +91,7 @@ class SideNav extends BaseElement {
     this.sideNavContainerEl = this.querySelector(".web-side-nav__container");
     this.addEventListeners();
     this.onStateChanged();
+    this.classList.remove("unresolved");
   }
 
   addEventListeners() {

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -108,7 +108,7 @@
       <web-profile-switcher-container></web-profile-switcher-container>
     </web-header>
 
-    <web-side-nav>
+    <web-side-nav class="unresolved">
       <a
         href="/learn"
         class="web-side-nav__link gc-analytics-event"

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -35,7 +35,6 @@
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js"></script>
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
-    <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', '{{ site.analytics.ids.prod }}');
@@ -44,7 +43,7 @@
     </script>
     <script async src="//www.google-analytics.com/analytics.js"></script>
   </head>
-  <body>
+  <body class="unresolved">
     {#
       Make the snackbar the first item in the DOM so we don't have to steal the
       user's focus on initial visit to show them a cookie banner. Instead, the

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -35,6 +35,7 @@
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js"></script>
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
+    <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', '{{ site.analytics.ids.prod }}');

--- a/src/styles/generic/_page.scss
+++ b/src/styles/generic/_page.scss
@@ -20,7 +20,7 @@ body {
   );
   margin: 0;
   overflow-wrap: break-word;
+  overflow-x: hidden;
   padding: 0;
   word-wrap: break-word;
-  overflow-x: hidden;
 }

--- a/src/styles/generic/_page.scss
+++ b/src/styles/generic/_page.scss
@@ -22,4 +22,5 @@ body {
   overflow-wrap: break-word;
   padding: 0;
   word-wrap: break-word;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
This fixes some issues for older browsers.

* change `path` => `root` for the Web Components loader (oops)
* set `overflow-x: hidden` because Edge was allowing scrolling for some reason ¯‍\‍_‍(‍ツ‍)‍_‍/‍¯
* use `<body class="unresolved">` to work around lack of support for `:defined`—this isn't actually perfect because we lazy-load element code
  * ... so also remove `unresolved` on `<web-side-nav>` on its own until after its first render (prevents screenshot below)

<img width="695" alt="Screen Shot 2019-10-29 at 13 45 58" src="https://user-images.githubusercontent.com/119184/67734156-65957000-fa54-11e9-8975-4155acb337ce.png">

I can't really test this without deploying, so this is done on my Mac first.