### PR TITLE
V2+reload pages new arch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6768,6 +6768,11 @@
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
+    "idb-keyval": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.2.0.tgz",
+      "integrity": "sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "escape-string-regexp": "^2.0.0",
     "express": "^4.16.4",
     "focus-visible": "^5.0.2",
+    "idb-keyval": "^3.2.0",
     "js-yaml": "^3.13.1",
     "lit-element": "^2.2.0",
     "rollup-plugin-virtual": "^1.0.1",

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -39,13 +39,18 @@ async function getPage(url) {
 }
 
 function normalizeUrl(url) {
-  if (url.endsWith("/index.html")) {
+  const u = new URL(url, window.location);
+  let pathname = u.pathname;
+
+  if (pathname.endsWith("/index.html")) {
     // If an internal link refers to "/foo/index.html", strip "index.html" and load.
-    return url.slice(0, -"index.html".length);
-  } else if (!url.endsWith("/")) {
+    pathname = pathname.slice(0, -"index.html".length);
+  } else if (!pathname.endsWith("/")) {
     // All web.dev pages end with "/".
-    return `${url}/`;
+    pathname = `${url}/`;
   }
+
+  return pathname + u.search;
 }
 
 /**

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -39,8 +39,12 @@ self.addEventListener("activate", (event) => {
     const previousArchitecture = await idb.get("arch");
     if (previousArchitecture === undefined && replacingPreviousServiceWorker) {
       // We're replacing a Service Worker that didn't have architecture info. Force reload.
-    } else if (previousArchitecture === serviceWorkerArchitecture) {
-      // The architecture didn't change, don't force a reload, upgrades will happen in due course.
+    } else if (
+      !replacingPreviousServiceWorker ||
+      previousArchitecture === serviceWorkerArchitecture
+    ) {
+      // The architecture didn't change (or this is a brand new install), don't force a reload,
+      // upgrades will happen in due course.
       return;
     }
     console.debug(

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -43,6 +43,12 @@ self.addEventListener("activate", (event) => {
       // The architecture didn't change, don't force a reload, upgrades will happen in due course.
       return;
     }
+    console.debug(
+      "SW upgrade from",
+      previousArchitecture,
+      "to arch",
+      serviceWorkerArchitecture,
+    );
 
     await self.clients.claim();
 
@@ -55,11 +61,7 @@ self.addEventListener("activate", (event) => {
 
     // It's impossible to 'await' this navigation because this event would literally be blocking
     // our fetch handlers from running. These navigates must be 'fire-and-forget'.
-    windowClients.map((client) => {
-      const u = new URL(client.url);
-      u.searchParams.set("reloaded_by_evil_sw", serviceWorkerArchitecture);
-      client.navigate(u.toString());
-    });
+    windowClients.map((client) => client.navigate(client.url));
 
     await idb.set("arch", serviceWorkerArchitecture);
   });

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -1,3 +1,8 @@
+// Architecture revision of the Service Worker. If the previously saved revision doesn't match,
+// then this will cause clients to be aggressively claimed and reloaded on install/activate.
+// Used when the design of the SW changes dramatically, e.g. from DevSite to v2.
+const serviceWorkerArchitecture = "v2";
+
 const normalizeIndexCacheKeyPlugin = {
   cacheKeyWillBeUsed({request, mode}) {
     // Take advantage of Workbox's built-in handling of .../index.html routes and ensure that its
@@ -10,11 +15,56 @@ const normalizeIndexCacheKeyPlugin = {
   },
 };
 
+import * as idb from "idb-keyval";
 import manifest from "cache-manifest";
 
 importScripts(
   "https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js",
 );
+
+let replacingPreviousServiceWorker = false;
+
+self.addEventListener("install", (event) => {
+  // This is non-null if there was a previous Service Worker registered. Record for "activate", so
+  // that a lack of current architecture can be seen as a reason to reload our clients.
+  if (self.registration.active) {
+    replacingPreviousServiceWorker = true;
+  }
+
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  const p = Promise.resolve().then(async () => {
+    const previousArchitecture = await idb.get("arch");
+    if (previousArchitecture === undefined && replacingPreviousServiceWorker) {
+      // We're replacing a Service Worker that didn't have architecture info. Force reload.
+    } else if (previousArchitecture === serviceWorkerArchitecture) {
+      // The architecture didn't change, don't force a reload, upgrades will happen in due course.
+      return;
+    }
+
+    await self.clients.claim();
+
+    // Reload all open pages (includeUncontrolled shouldn't be needed as we've _just_ claimed
+    // clients, but include it anyway for sanity).
+    const windowClients = await self.clients.matchAll({
+      includeUncontrolled: true,
+      type: "window",
+    });
+
+    // It's impossible to 'await' this navigation because this event would literally be blocking
+    // our fetch handlers from running. These navigates must be 'fire-and-forget'.
+    windowClients.map((client) => {
+      const u = new URL(client.url);
+      u.searchParams.set("reloaded_by_evil_sw", serviceWorkerArchitecture);
+      client.navigate(u.toString());
+    });
+
+    await idb.set("arch", serviceWorkerArchitecture);
+  });
+  event.waitUntil(p);
+});
 
 workbox.googleAnalytics.initialize();
 

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -44,7 +44,7 @@ self.addEventListener("activate", (event) => {
       return;
     }
     console.debug(
-      "SW upgrade from",
+      "web.dev SW upgrade from",
       previousArchitecture,
       "to arch",
       serviceWorkerArchitecture,


### PR DESCRIPTION
Forces a claim and reload of all clients if the Service Worker "architecture" changes.

This doesn't stop e.g. SPA router fetch navigation from possibly breaking a bit, but I think in both DevSite and our code, failures in routing just cause a real reload.

I quite like how this has worked out. It tests well from the current v2 branch (SW with no arch version) to this branch, causing all pages to reload.

Also fixes `normalizeUrl` as it was trying to normalize a URL even if it had a search param. e.g., "/foo?blah=1" was becoming "/foo?blah=1/".