### PR TITLE
Add github link to contributors for gernberg

### DIFF
--- a/src/site/_data/contributors.json
+++ b/src/site/_data/contributors.json
@@ -1546,6 +1546,8 @@
         "given": "Gustav",
         "family": "Ernberg von Heijne"
       },
+      "github": "gernberg",
+      "country": "SE",
       "org": {
         "name": "Google",
         "unit": "Technical Solutions Consultant"


### PR DESCRIPTION
Changes proposed in this pull request:

- Add github account for user "gernberg"
