### PR TITLE
Change code font-size to rem

### DIFF
--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -25,7 +25,7 @@ $CODE_COLORS: (
 );
 
 code {
-  font-size: .9em;
+  font-size: 1rem;
   font-weight: 400; // DevSite override
   margin: 0 .25em;
   padding: .125em .25em;
@@ -49,7 +49,7 @@ pre {
 // Code block
 pre,
 pre[class*='language-'] {
-  font: 1em / 1.5em $CODE_FONT;
+  font: 1rem / 1.5em $CODE_FONT;
   margin: 32px 0;
   overflow: auto;
   padding: 16px;


### PR DESCRIPTION
`<pre>` elements are currently inheriting the `font-size` of parent elements in some cases (e.g., when inside an `<ol>`). Also, `<code>` elements currently have a fractional `font-size` (16.2px), which can cause minor rendering differences across browsers.

Changes proposed in this pull request:

- Convert code font font sizes to rem.