### PR TITLE
Removing bounce stat from defer non-critical CSS article.

### DIFF
--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -9,7 +9,7 @@ description: |
 date: 2019-02-17
 ---
 
-CSS files are [render-blocking resources](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources): they must be loaded and processed before the browser renders the page. Web pages that contain unnecessarily large styles take longer to render, increasing the likelihood that users bounce: 53% of mobile visits bounce if the page does not load [in 3 seconds or less](https://www.thinkwithgoogle.com/intl/en-154/insights-inspiration/research-data/need-mobile-speed-how-mobile-latency-impacts-publisher-revenue/).
+CSS files are [render-blocking resources](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources): they must be loaded and processed before the browser renders the page. Therefore, web pages that contain unnecessarily large styles take longer to render.
 
 In this guide, you'll learn how to defer non-critical CSS with the goal of optimizing the [Critical Rendering Path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/), and improving [FCP (First Contentful Paint)](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).
 


### PR DESCRIPTION
Removing reference to [this article](https://www.thinkwithgoogle.com/intl/en-154/insights-inspiration/research-data/need-mobile-speed-how-mobile-latency-impacts-publisher-revenue/), which contains an incorrect stat.

cc // @robdodson 