### PR TITLE
update/ .web-progress-bar (Progress bar in front of card dividers)

### DIFF
--- a/src/styles/pages/_measure.scss
+++ b/src/styles/pages/_measure.scss
@@ -8,6 +8,8 @@ body.lh-signedin [data-lh-signin='hide'] {
 
 web-progress-bar {
   visibility: hidden;
+  z-index: 1;
+  background-color: #fff;
 }
 // sass-lint:enable class-name-format
 


### PR DESCRIPTION
Fixes #1794

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:
- This PR puts the web-progress-bar in front of the card dividers

![Screen Shot 2019-11-01 at 3 02 32 AM](https://user-images.githubusercontent.com/21496039/67969266-ac51b880-fc54-11e9-9e09-a9e9bb6d884b.png)


CLA Name : Dali Haeusler

Excited to  contribute to a google product even if it's small cheers
