### PR TITLE
update/ .web-progress-bar (Progress bar in front of card dividers)

### DIFF
--- a/src/styles/pages/_measure.scss
+++ b/src/styles/pages/_measure.scss
@@ -7,9 +7,9 @@ body.lh-signedin [data-lh-signin='hide'] {
 }
 
 web-progress-bar {
+  background-color: #fff;
   visibility: hidden;
   z-index: 1;
-  background-color: #fff;
 }
 // sass-lint:enable class-name-format
 

--- a/src/styles/pages/_measure.scss
+++ b/src/styles/pages/_measure.scss
@@ -8,6 +8,8 @@ body.lh-signedin [data-lh-signin='hide'] {
 
 web-progress-bar {
   visibility: hidden;
+  z-index: 1;
+  background-color: #fff;
 }
 // sass-lint:enable class-name-format
 


### PR DESCRIPTION
Fixes #1794 


Changes proposed in this pull request:

- This PR puts the web-progress-bar in front of the card dividers
![Screen Shot 2019-11-01 at 3 02 32 AM](https://user-images.githubusercontent.com/21496039/67970116-351d2400-fc56-11e9-9d5e-7b7ae63c50c2.png)

CLA Name : Dali Haeusler

Excited to contribute to a google product even if it's small cheers