### PR TITLE
travis: adjust git depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 sudo: false
 dist: trusty
 git:
-  depth: 1
   submodules: false
 cache:
   directories:


### PR DESCRIPTION
the default is 50.
depth of only 1 breaks a ancestor hash lookup we do in lhci

this shouldn't matter much for CI time either. (especially now that lhci added ~3min to the total times 😉)