### PR TITLE
send pageview for new pages

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -47,10 +47,3 @@ document.addEventListener("click", (e) => {
 
   trackEvent(data);
 });
-
-/**
- * Configure tracking events for page changes. Emitted in `router.js`.
- */
-document.addEventListener("pageview", () => {
-  ga("send", "pageview");
-});

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -90,7 +90,6 @@ function forceFocus(el) {
  * @return {!Promise<void>}
  */
 export async function swapContent(url, isFirstRun) {
-  document.dispatchEvent(new CustomEvent("pageview", {detail: url}));
   const entrypointPromise = loadEntrypoint(url);
 
   // If we disagree with the URL we're loaded at, then replace it inline
@@ -129,6 +128,9 @@ export async function swapContent(url, isFirstRun) {
       currentUrl: url,
     });
   }
+
+  ga("set", "page", window.location.pathname);
+  ga("send", "pageview");
 
   // Remove the current #content element
   main.querySelector("#content").remove();

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -33,7 +33,6 @@
     <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js"></script>
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
-    <script type="module" src="/bootstrap.js"></script>
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', '{{ site.analytics.ids.prod }}');
@@ -42,6 +41,7 @@
       ga('send', 'pageview');
     </script>
     <script async src="//www.google-analytics.com/analytics.js"></script>
+    <script type="module" src="/bootstrap.js"></script>
   </head>
   <body class="unresolved">
     {#


### PR DESCRIPTION
Possibly fixes #1795.

Simplifies the GA behavior.

* Moves the Analytics code above importing our code (I think this would never be a problem because modules are deferred, but it just seems less ambiguous about whether `ga` is available)
* Sets the new page as we change URL and explicitly call `ga("set", "page", ...)`, which I think is needed (cc @philipwalton )