### PR TITLE
Fixes #1282. Output tags inside figcaption the same as pure text

### DIFF
--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -119,6 +119,12 @@
   font-size: .875em;
   line-height: 1.5em;
   margin: 16px 0 0;
+
+  > p {
+    font-size: inherit;
+    line-height: inherit;
+    margin: inherit;
+  }
 }
 
 .w-figcaption--fullbleed {


### PR DESCRIPTION
Fixes #1282. Output tags inside figcaption the same as pure text.