### PR TITLE
Add more file types to codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,13 @@ content/en/angular/ @mgechev @kaycebasques
 # File types
 # These should appear last so they override docs directory owners.
 *.js @robdodson @samthor
+*.json @robdodson @samthor
 *.css @robdodson @samthor
+*.scss @robdodson @samthor
 *.html @robdodson @samthor
 *.htm @robdodson @samthor
 *.njk @robdodson @samthor
+*.yml @robdodson @samthor
+*.yaml @robdodson @samthor
+*.toml @robdodson @samthor
+*.sh @robdodson @samthor


### PR DESCRIPTION
@kaycebasques @samthor fyi. Adding a few I missed after poking around the repo more. In general the top level rule should tag sam and I as required reviewers for most things. But I'd like to try as much as possible to avoid scenarios where a malicious actor tries to sneak a protected file type into the content directory.