### PR TITLE
Cookies without a `SameSite` default fix

### DIFF
--- a/src/site/content/en/blog/samesite-cookies-explained/index.md
+++ b/src/site/content/en/blog/samesite-cookies-explained/index.md
@@ -290,7 +290,7 @@ and provide users with a safer experience, the IETF proposal,
 [Incrementally Better Cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00)
 lays out two key changes:
 
-- Cookies without a `SameSite` attribute will be treated as `SameSite=None`.
+- Cookies without a `SameSite` attribute will be treated as `SameSite=Lax`.
 - Cookies with `SameSite=None` must also specify `Secure`.
 
 Both


### PR DESCRIPTION
Cookies without a `SameSite` attribute will be treated as `SameSite=Lax`. According to the docs https://www.chromium.org/updates/same-site and https://tools.ietf.org/html/draft-west-cookie-incrementalism-00 the default without `SameSite` attribute will act at `SameSite=Lax` NOT `SameSite=None`
