### PR TITLE
Page responds to user input in 50 milliseconds not 5 seconds

### DIFF
--- a/src/site/content/en/lighthouse-performance/interactive/index.md
+++ b/src/site/content/en/lighthouse-performance/interactive/index.md
@@ -34,7 +34,7 @@ A page is considered fully interactive when:
 - The page displays useful content, which is measured by the
 [First Contentful Paint](/first-contentful-paint),
 - Event handlers are registered for most visible page elements, and
-- The page responds to user interactions within 50&nbsp; milliseconds.
+- The page responds to user interactions within 50&nbsp;milliseconds.
 
 {% Aside %}
 Both [First CPU Idle](/first-cpu-idle) and TTI

--- a/src/site/content/en/lighthouse-performance/interactive/index.md
+++ b/src/site/content/en/lighthouse-performance/interactive/index.md
@@ -34,7 +34,7 @@ A page is considered fully interactive when:
 - The page displays useful content, which is measured by the
 [First Contentful Paint](/first-contentful-paint),
 - Event handlers are registered for most visible page elements, and
-- The page responds to user interactions within 5&nbsp;seconds.
+- The page responds to user interactions within 50&nbsp; milliseconds.
 
 {% Aside %}
 Both [First CPU Idle](/first-cpu-idle) and TTI


### PR DESCRIPTION
Google developers states 50 milliseconds and web.dev states 5 seconds. I think this might be a typo?

Google Developers - https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive
wed.dev - https://web.dev/interactive/
