### PR TITLE
adaptive-service-based-on-network-quality url 404

### DIFF
--- a/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
+++ b/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
@@ -48,4 +48,4 @@ There are many possible causes of slow server responses, and therefore many poss
 ## Resources
 
 - [Source code for **Reduce server response times (TTFB)** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/time-to-first-byte.js)
-- [Adaptive Serving with Network Information API](/adaptive-service-based-on-network-quality)
+- [Adaptive Serving with Network Information API](/adaptive-serving-based-on-network-quality)


### PR DESCRIPTION
Hi, 
I have noticed current "Adaptive Serving with Network Information API" URL "adaptive-service-based-on-network-quality" is going to 404 and the correct URL should be https://web.dev/adaptive-serving-based-on-network-quality/

*serving instead of *service

Thanks
Manjeet

Fixes #SOME_ISSUE_NUMBER.

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:

- 
- 
- 
![adaptive-service-based-on-network-quality](https://user-images.githubusercontent.com/6074872/68244832-fac8d380-0015-11ea-92e4-95990f6586e3.png)

