### PR TITLE
Fix hero images on staging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lhci": "./tools/lhci/run-lighthouse-ci.sh",
     "build": "ELEVENTY_ENV=prod npm-run-all --serial lint clean build:sass build:eleventy build:gulp build:rollup",
     "dev": "npm-run-all clean build:rollup build:sass --parallel --race watch:rollup watch:sass watch:eleventy watch:gulp start",
-    "stage": "ELEVENTY_ENV=prod npm run build && gcloud app deploy --project web-dev-staging --quiet",
+    "stage": "npm run build && gcloud app deploy --project web-dev-staging --quiet",
     "stage:personal": "ELEVENTY_ENV=prod npm run build && gcloud app deploy --project web-dev-staging --quiet --no-promote",
     "deploy": "ELEVENTY_ENV=prod npm run build && node index-algolia.js && gcloud app deploy --project web-dev-production-1 --quiet"
   },

--- a/src/site/content/en/react/react.11tydata.js
+++ b/src/site/content/en/react/react.11tydata.js
@@ -16,10 +16,10 @@ module.exports = {
       {
         title: "Next.js",
         pathItems: [
-          'performance-as-a-default-with-nextjs',
-          'nextjs-route-prefetching',
-          'nextjs-dynamic-imports',
-          'how-amp-can-guarantee-fastness-in-your-nextjs-app',
+          "performance-as-a-default-with-nextjs",
+          "nextjs-route-prefetching",
+          "nextjs-dynamic-imports",
+          "how-amp-can-guarantee-fastness-in-your-nextjs-app",
         ],
       },
       {


### PR DESCRIPTION
Fixes #1837

Changes proposed in this pull request:

- Don't use the image CDN for staging.

The way imgix (our image CDN) works is it acts as a proxy to images on web.dev. This means when you request an image from imgix, _it must already be live on the web.dev server_.

When we stage a post, the image has not been deployed to web.dev yet, so imgix doesn't find it, so it returns a 404. This change just uses the relative reference to the image for staging purposes (essentially the same as local dev).