### PR TITLE
Fix v2 layout bugs

### DIFF
--- a/src/lib/components/Header/_styles.scss
+++ b/src/lib/components/Header/_styles.scss
@@ -93,6 +93,7 @@ web-header {
     display: none;
     flex: 1;
     height: 100%;
+    line-height: 20px;
     padding-left: 48px;
     min-width: 50%;
 

--- a/src/lib/components/SigninButton/_styles.scss
+++ b/src/lib/components/SigninButton/_styles.scss
@@ -1,0 +1,3 @@
+.lh-signin-button {
+  margin-top: 16px;
+}

--- a/src/lib/components/_all.scss
+++ b/src/lib/components/_all.scss
@@ -8,6 +8,7 @@
 @import './ProfileSwitcher/styles';
 @import './ProgressBar/styles';
 @import './Search/styles';
+@import './SigninButton/styles';
 @import './Snackbar/styles';
 @import './SnackbarContainer/styles';
 @import './SideNav/styles';

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -61,17 +61,20 @@ module.exports = (type, listStyle = "ul") => {
       instruction = `${bullet}Click **Remix to Edit** to make the project editable.`;
       break;
 
+    // prettier-ignore
     case "console":
       instruction = html`
-        ${bullet}Click **Tools**. ${bullet}Click **Logs**. ${bullet}Click
-        **Console**.
+        ${bullet}Click **Tools**.
+        ${bullet}Click **Logs**.
+        ${bullet}Click **Console**.
       `;
       break;
 
+    // prettier-ignore
     case "create":
       instruction = html`
-        ${bullet}Click **New File** and give it a name. ${bullet}Click **Add
-        This File**.
+        ${bullet}Click **New File** and give it a name.
+        ${bullet}Click **Add This File**.
       `;
       break;
 
@@ -148,8 +151,10 @@ module.exports = (type, listStyle = "ul") => {
       `;
       substitution = type.substring("devtools-".length);
       if (substitution) {
+        // prettier-ignore
         instruction = html`
-          ${instruction} ${bullet}Click the **${capitalize(substitution)}** tab.
+          ${instruction}
+          ${bullet}Click the **${capitalize(substitution)}** tab.
         `;
       }
       break;
@@ -172,9 +177,12 @@ module.exports = (type, listStyle = "ul") => {
         // only capitalizes "Best practices"
         substitution = capitalize(substitution);
       }
+      // prettier-ignore
       instruction = html`
-        ${shared.devtools} ${bullet}Click the **Audits** tab. ${bullet}Select
-        the **${substitution}** checkbox. ${bullet}Click **Run audits**.
+        ${shared.devtools}
+        ${bullet}Click the **Audits** tab.
+        ${bullet}Select the **${substitution}** checkbox.
+        ${bullet}Click **Run audits**.
       `;
       break;
 

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -117,6 +117,22 @@
           </a>
         </li>
       </ul>
+      <div class="w-footer__license">
+        <p>
+          Except as otherwise noted, the content of this page is licensed
+          under the
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            >Creative Commons Attribution 4.0 License</a
+          >, and code samples are licensed under the
+          <a href="https://www.apache.org/licenses/LICENSE-2.0"
+            >Apache 2.0 License</a
+          >. For details, see the
+          <a href="https://developers.google.com/site-policies"
+            >Google Developers Site Policies</a
+          >. Java is a registered trademark of Oracle and/or its
+          affiliates.
+        </p>
+      </div>
     </nav>
   </div>
 </footer>

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -121,16 +121,13 @@
         <p>
           Except as otherwise noted, the content of this page is licensed
           under the
-          <a href="https://creativecommons.org/licenses/by/4.0/"
-            >Creative Commons Attribution 4.0 License</a
-          >, and code samples are licensed under the
-          <a href="https://www.apache.org/licenses/LICENSE-2.0"
-            >Apache 2.0 License</a
-          >. For details, see the
-          <a href="https://developers.google.com/site-policies"
-            >Google Developers Site Policies</a
-          >. Java is a registered trademark of Oracle and/or its
-          affiliates.
+          <a href="https://creativecommons.org/licenses/by/4.0/">
+          Creative Commons Attribution 4.0 License
+          </a>, and code samples are licensed under the
+          <a href="https://www.apache.org/licenses/LICENSE-2.0">
+          Apache 2.0 License</a>. For details, see the
+          <a href="https://developers.google.com/site-policies">
+          Google Developers Site Policies</a>.
         </p>
       </div>
     </nav>

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -584,12 +584,14 @@ iste culpa. Recusandae sit atque magni aspernatur dolorem vel omnis.
    sit amet ullamcorper.
 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
    sit amet ullamcorper.
-  <figure class="w-figure">
-    <img class="w-screenshot w-screenshot--filled" src="./image-screenshot.png" alt="">
-    <figcaption class="w-figcaption">
-      Filled screenshot.
-    </figcaption>
-  </figure>
+
+   <figure class="w-figure">
+     <img class="w-screenshot w-screenshot--filled" src="./image-screenshot.png" alt="">
+     <figcaption class="w-figcaption">
+       Filled screenshot.
+     </figcaption>
+   </figure>
+
 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
    sit amet ullamcorper.
 

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -37,6 +37,7 @@
   text-decoration: none;
   text-transform: uppercase;
   transition: background-color $TRANSITION_SPEED, box-shadow $TRANSITION_SPEED;
+  vertical-align: middle;
   white-space: nowrap;
   @include font_smoothing(
     $FONT_SMOOTHING_MOZ,

--- a/src/styles/components/_compare.scss
+++ b/src/styles/components/_compare.scss
@@ -26,7 +26,7 @@
 }
 
 .w-compare__label {
-  font-size: 1em;
+  font-size: 1.125em;
   font-weight: $FONT_WEIGHT_MEDIUM;
   padding-bottom: .5em;
 }

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -6,6 +6,17 @@
   border-top: 1px solid $GREY_300;
 }
 
+.w-footer__license {
+  padding-top: 32px;
+  width: 100%;
+}
+
+.w-footer__license p {
+  font-size: .75rem;
+  margin: 0;
+  max-width: 960px;
+}
+
 .w-footer__linkboxes {
   background: $WHITE;
   display: block;
@@ -78,6 +89,7 @@
   @include bp(md) {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     margin: 0 24px;
   }
 }

--- a/src/styles/generic/_blockquote.scss
+++ b/src/styles/generic/_blockquote.scss
@@ -18,7 +18,7 @@ blockquote {
 
   p {
     font: inherit;
-    margin-bottom: 18px;
+    margin: 0 0 18px;
   }
 
   cite {
@@ -35,4 +35,5 @@ blockquote::before {
   content: 'format_quote';
   float: left;
   margin: 4px 0 0 -48px;
+  transform: scaleX(-1);
 }

--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -25,8 +25,6 @@ $CODE_COLORS: (
 );
 
 code {
-  font-size: 1rem;
-  font-weight: 400; // DevSite override
   margin: 0 .25em;
   padding: .125em .25em;
 }
@@ -35,6 +33,8 @@ code,
 pre {
   background: map-get($CODE_COLORS, light-gray);
   border: 1px solid $GREY_300;
+  color: map-get($CODE_COLORS, black);
+  font: 1rem / 1.5em $CODE_FONT;
   hyphens: none;
   tab-size: 2;
   text-align: left;
@@ -49,7 +49,6 @@ pre {
 // Code block
 pre,
 pre[class*='language-'] {
-  font: 1rem / 1.5em $CODE_FONT;
   margin: 32px 0;
   overflow: auto;
   padding: 16px;
@@ -61,6 +60,7 @@ pre[class*='language-'] code {
   font-size: 1em;
   line-height: 1.5em;
   margin: 0;
+  padding: 0;
 }
 
 pre code {
@@ -83,6 +83,12 @@ h6 code {
   margin: 0;
   padding: 0;
   white-space: nowrap;
+}
+
+// Figcaptions are smaller than body text,
+// so code should be based on their font size.
+figcaption code {
+  font-size: .9em;
 }
 
 // Github-like theme for Prism.js

--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -73,6 +73,21 @@ ul:not([class]) > li::before {
   width: 8px;
 }
 
+ul:not([class]) > li > p,
+ol:not([class]) > li > p {
+  margin: 8px 0;
+}
+
+ul:not([class]) > li > p:first-child,
+ol:not([class]) > li > p:first-child {
+  margin-top: 0;
+}
+
+ul:not([class]) > li > p:last-child,
+ol:not([class]) > li > p:last-child {
+  margin-bottom: 0;
+}
+
 .w-unstyled-list {
   list-style: none;
 }

--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -42,6 +42,7 @@ th {
   font-family: $HEADLINE_FONT;
   font-size: .875em;
   font-weight: 500;
+  line-height: 24px;
   padding-right: 24px;
 }
 
@@ -68,6 +69,7 @@ table code {
   font-weight: 400; // DevSite override
   line-height: 1.7em; // DevSite override
   margin: 0;
+  padding: 0;
 }
 
 table ul:not([class]),
@@ -93,4 +95,8 @@ table ul:not([class]) li::before {
 
 table ol:not([class]) li::before {
   margin: 2px 0 0;
+}
+
+td > :last-child > li:last-child {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Fixes layout bugs introduced by migration off devsite.

Changes made by visually comparing pre- and post-migration versions of:
- `handbook/web-dev-components`
- `handbook/markup-media`
- `handbook/markup-code`

**Note:** UI element states _not_ tested.

Changes proposed in this pull request:

- Correct line-height of header tabs.
- Reinstate top margin on **Measure** sign-in button.
- Vertically align inline buttons.
- Revert font-size changes in Compare widget.
- Fix top margin for block quotes.
- Horizontally flip block quote icon so it's an open quote, not a close quote. (Bug predated devsite migration.)
- Fix margins for paragraphs nested in list items.
- Revert minor table layout changes.
- Fix color, font-size, and padding for code font.
- Fix broken line breaks in Instruction widget.
- Reinstate license info footer.
- Fix broken image nested in the ordered list example on `/web-dev-components`.
