### PR TITLE
Update page description when we load new content.

### DIFF
--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -140,10 +140,8 @@ export async function swapContent(url, isFirstRun) {
   document.title = page.title;
   // Update the page description
   const description = page.querySelector("meta[name=description]");
-  if (description && description.content) {
-    document.querySelector("meta[name=description]").content =
-      description.content;
-  }
+  const updatedContent = description ? description.content : "";
+  document.querySelector("meta[name=description]").content = updatedContent;
 
   // Focus on the first title (or fallback to content itself)
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -138,6 +138,10 @@ export async function swapContent(url, isFirstRun) {
 
   // Update the page title
   document.title = page.title;
+  // Update the page description
+  document.querySelector("meta[name=description]").content = page.querySelector(
+    "meta[name=description]",
+  ).content;
 
   // Focus on the first title (or fallback to content itself)
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -139,9 +139,11 @@ export async function swapContent(url, isFirstRun) {
   // Update the page title
   document.title = page.title;
   // Update the page description
-  document.querySelector("meta[name=description]").content = page.querySelector(
-    "meta[name=description]",
-  ).content;
+  const description = page.querySelector("meta[name=description]");
+  if (description && description.content) {
+    document.querySelector("meta[name=description]").content =
+      description.content;
+  }
 
   // Focus on the first title (or fallback to content itself)
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -106,8 +106,8 @@ module.exports = (locale, page, collections) => {
 
   // prettier-ignore
   return html`
-    <title>${pageData.title}</title>
-    <meta name="description" content="${pageData.description}" />
+    <title>${pageData.title || pageData.path.title}</title>
+    <meta name="description" content="${pageData.description || pageData.path.description}" />
 
     ${renderGoogleMeta()}
     ${renderFacebookMeta()}


### PR DESCRIPTION
Changes proposed in this pull request:

- A quick fix to update page descriptions juuuuuuuust in case googlebot is running JS on our site and navigating it as if it's a SPA. Ultimately we should replace this with merging all of the meta tags from the new document, but I wanted to throw this in real quick as a bandaid.