### PR TITLE
Web share article: Correct link to web share target article

### DIFF
--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -31,7 +31,7 @@ support for files was added in Chrome 76.
 {% Aside %}
 The Web Share Target API is only half of the magic. Web apps can share data,
 files, links, or text using the Web Share API. See
-[Share like a native](/share-like-a-native) for details.
+[Share like a native](/web-share/) for details.
 {% endAside %}
 
 <figure class="w-figure w-figure--inline-right">

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -24,7 +24,7 @@ way as native apps.
 {% Aside %}
   Sharing is only half of the magic. Web apps can also be share
   targets, meaning they can receive data, links, text, and files from
-  native or web apps. See the [Receive shared data](/receive-shared-data/)
+  native or web apps. See the [Receive shared data](/web-share-target/)
   post for details on how to register your app as a share target.
 {% endAside %}
 


### PR DESCRIPTION
The link should be https://web.dev/web-share-target/

CC: @petele @jpmedley 