### PR TITLE
Add await to PBS examples

### DIFF
--- a/src/site/content/en/blog/periodic-background-sync/index.md
+++ b/src/site/content/en/blog/periodic-background-sync/index.md
@@ -240,7 +240,7 @@ so that multiple syncs can be registered. In the example below, the tag name is
 const registration = await navigator.serviceWorker.ready;
 if ('periodicSync' in registration) {
   try {
-    registration.periodicSync.register('content-sync', {
+    await registration.periodicSync.register('content-sync', {
       // An interval of one day.
       minInterval: 24 * 60 * 60 * 1000,
     });
@@ -301,7 +301,7 @@ sync you want to unregister.
 ```js
 const registration = await navigator.serviceWorker.ready;
 if ('periodicSync' in registration) {
-  registration.periodicSync.unregister('content-sync');
+  await registration.periodicSync.unregister('content-sync');
 }
 ```
 


### PR DESCRIPTION
As @jakearchibald pointed out, `periodicSync.register()` and `periodicSync.unregister()` return `Promise<void>` as per the [proposed spec](https://github.com/WICG/BackgroundSync/blob/9dd088910ed9ebf162a2acf67495f6daa8da65be/explainers/periodicsync-WebIDL.md#definition-of-the-interface), so adding in the `await` is necessary to ensure the `catch` is triggered.

It's not 100% needed in the `unregister()` example, but it does make it clearer that it's also returning a promise.

(The original at https://developers.google.com/web/updates/2019/08/periodic-background-sync has this issue too, but I'm assuming that will eventually just redirect here?)