### PR TITLE
misc: update lhci to 0.3.x

### DIFF
--- a/tools/lhci/.lighthouserc
+++ b/tools/lhci/.lighthouserc
@@ -10,6 +10,7 @@
       ]
     },
     "upload": {
+      "token": "d96145f6-c3d2-4b22-9e53-6913cdd2df03",
       "serverBaseUrl": "https://lhci-canary.herokuapp.com/"
     }
   }

--- a/tools/lhci/.lighthouserc
+++ b/tools/lhci/.lighthouserc
@@ -2,6 +2,7 @@
   "ci": {
     "collect": {
       "numberOfRuns": 3,
+      "startServerCommand": "npm start",
       "url": [
         "http://localhost:8080/",
         "http://localhost:8080/interactive",

--- a/tools/lhci/run-lighthouse-ci.sh
+++ b/tools/lhci/run-lighthouse-ci.sh
@@ -5,4 +5,5 @@ set -eox pipefail
 # Install latest LHCI
 npm install -g @lhci/cli@0.3.x
 
+# Run healthcheck, collect, and upload
 lhci autorun --config=./tools/lhci/.lighthouserc

--- a/tools/lhci/run-lighthouse-ci.sh
+++ b/tools/lhci/run-lighthouse-ci.sh
@@ -5,4 +5,4 @@ set -eox pipefail
 # Install latest LHCI
 npm install -g @lhci/cli@0.3.x
 
-lhci autorun --config=./tools/lhci/.lighthouserc --upload.token=d96145f6-c3d2-4b22-9e53-6913cdd2df03
+lhci autorun --config=./tools/lhci/.lighthouserc

--- a/tools/lhci/run-lighthouse-ci.sh
+++ b/tools/lhci/run-lighthouse-ci.sh
@@ -2,18 +2,7 @@
 
 set -eox pipefail
 
-export LHCI_TOKEN=d96145f6-c3d2-4b22-9e53-6913cdd2df03
-export LHCI_RC_FILE=./tools/lhci/.lighthouserc
-
 # Install latest LHCI
-npm install -g @lhci/cli@next
+npm install -g @lhci/cli@0.3.x
 
-# Start up a local webserver and wait for it to get going
-npm start &
-sleep 2
-
-lhci collect
-lhci upload
-
-# Kill the webserver process
-kill $!
+lhci autorun --config=./tools/lhci/.lighthouserc --upload.token=d96145f6-c3d2-4b22-9e53-6913cdd2df03


### PR DESCRIPTION
Changes proposed in this pull request:

- Moves the script to the safer, non-breaking change `0.3.x` tag
- Cleans up the script to take advantage of `startServerCommand`

~~WIP: looks like LHCI was already failing with the commiter timestamp change, so wait for that to be fixed before merging~~ should be fixed in 0.3.1 :)
