### PR TITLE
fix go/bundle example for current usage

### DIFF
--- a/src/site/content/en/blog/web-bundles/index.md
+++ b/src/site/content/en/blog/web-bundles/index.md
@@ -129,7 +129,7 @@ specification built in [Go](https://golang.org/).
 2. Use the `gen-bundle` command to build a `.wbn` file.
 
     ```bash
-    gen-bundle -dir build -baseURL https://preact-todom.vc -primaryURL https://preact-todom.vc -o todomvc.wbn
+    gen-bundle -dir build -baseURL https://preact-todom.vc/ -primaryURL https://preact-todom.vc/ -o todomvc.wbn
     ```
 
 Congratulations! TodoMVC is now a Web Bundle.


### PR DESCRIPTION
Without tail `/`, `gen-bundle` command throws error.

Fixes #SOME_ISSUE_NUMBER.

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:

- 
- 
- 
