### PR TITLE
Update the Lighthouse CI url

### DIFF
--- a/src/site/content/en/fast/performance-budgets-101/index.md
+++ b/src/site/content/en/fast/performance-budgets-101/index.md
@@ -80,7 +80,7 @@ Choosing a tool for this will depend a lot on the scale of your project and reso
 
 * [Webpack performance features](https://webpack.js.org/configuration/performance/)
 * [bundlesize](https://github.com/siddharthkp/bundlesize)
-* [Lighthouse CI](https://github.com/ebidel/lighthouse-ci)
+* [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci)
 
 If something goes over a defined threshold, you can either:
 


### PR DESCRIPTION
The previous one was redirecting to the "old" Lighthouse Bot

Fixes #1889

Changes proposed in this pull request:

- update the link to Lighthouse CI tool
