### PR TITLE
Auto-size table if device is small

### DIFF
--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -1,5 +1,5 @@
 @import '../settings/type';
-
+@import '../tools/breakpoints';
 // =============================================================================
 // TABLES OVERVIEW
 //
@@ -21,6 +21,9 @@ table {
   margin: 0;
   min-width: 512px;
   width: 100%;
+  @include bp(sm) {
+    min-width:auto;
+  }
 }
 
 tr {

--- a/src/styles/pages/_post.scss
+++ b/src/styles/pages/_post.scss
@@ -20,6 +20,9 @@
 
   @include bp(sm) {
     margin-bottom: 160px;
+    table{
+      min-width:auto;
+    }
   }
 }
 


### PR DESCRIPTION
The table will overflow and have hidden content if the device width is smaller than 512px. 
See here for an example: [https://web.dev/periodic-background-sync/#current-status](https://web.dev/periodic-background-sync/#current-status)

Couldn't find any issue related to this. I just noticed it on my phone earlier and it annoyed me. 

Changes proposed in this pull request:

- Change style of table to have `min-width:auto` on sm-breakpoint
- 
- 
