### PR TITLE
Add blockquote shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,6 +28,7 @@ const Aside = require(`./${componentsDir}/Aside`);
 const Author = require(`./${componentsDir}/Author`);
 const AuthorInfo = require(`./${componentsDir}/AuthorInfo`);
 const Banner = require(`./${componentsDir}/Banner`);
+const Blockquote = require(`./${componentsDir}/Blockquote`);
 const Breadcrumbs = require(`./${componentsDir}/Breadcrumbs`);
 const CodelabsCallout = require(`./${componentsDir}/CodelabsCallout`);
 const Compare = require(`./${componentsDir}/Compare`);
@@ -146,6 +147,7 @@ module.exports = function(config) {
   config.addShortcode('Author', Author);
   config.addShortcode('AuthorInfo', AuthorInfo);
   config.addPairedShortcode('Banner', Banner);
+  config.addPairedShortcode('Blockquote', Blockquote);
   config.addShortcode('Breadcrumbs', Breadcrumbs);
   config.addShortcode('CodelabsCallout', CodelabsCallout);
   config.addPairedShortcode('Compare', Compare);

--- a/src/site/_includes/components/Blockquote.js
+++ b/src/site/_includes/components/Blockquote.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {html} = require("common-tags");
+const md = require("markdown-it")();
+
+module.exports = (content, source) => {
+  if (!source) {
+    /* eslint-disable max-len */
+    throw new Error(
+      `Can't create Blockquote component without a source. Did you forget to pass the source as a string?`,
+    );
+    /* eslint-enable max-len */
+  }
+
+  return html`
+    <blockquote>
+      ${content}
+      <cite>
+        ${md.renderInline(source)}
+      </cite>
+    </blockquote>
+  `;
+};

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -17,7 +17,7 @@ guidance about how to use them effectively.
 
 1. [Asides](#asides)
 1. [Banner](#banner)
-1. [Block quotes](#blockquotes)
+1. [Block quotes](#block-quotes)
 1. [Buttons](#buttons)
 1. [Columns](#columns)
 1. [Code](#code)
@@ -175,15 +175,17 @@ Use the codelab aside to link to an associated codelab.
 
 ## Block quotes
 
-<blockquote>
-  <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum
-    a massa sit amet ullamcorper.
-  </p>
-  <cite>
-    by Jon Doe
-  </cite>
-</blockquote>
+```html
+{% raw %}{% Blockquote 'Jon Doe' %}
+[Lorem ipsum](#) dolor sit amet, consectetur adipiscing elit. Proin dictum
+a massa sit amet ullamcorper.
+{% endBlockquote %}{% endraw %}
+```
+
+{% Blockquote 'Jon Doe' %}
+[Lorem ipsum](#) dolor sit amet, consectetur adipiscing elit. Proin dictum
+a massa sit amet ullamcorper.
+{% endBlockquote %}
 
 ## Buttons
 

--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -85,9 +85,10 @@ h6 code {
   white-space: nowrap;
 }
 
-// Figcaptions are smaller than body text,
+// Figcaptions and citations are smaller than body text,
 // so code should be based on their font size.
-figcaption code {
+figcaption code,
+cite code {
   font-size: .9em;
 }
 


### PR DESCRIPTION
- Add a shortcode for blockquotes.
- Adjust code font size in `<cite>` elements so it's proportional.
