### PR TITLE
Auto-overflow tables in blog-posts on small devices

### DIFF
--- a/src/styles/pages/_post.scss
+++ b/src/styles/pages/_post.scss
@@ -20,6 +20,23 @@
 
   @include bp(sm) {
     margin-bottom: 160px;
+
+    table > tbody {
+      display:table;
+    }
+  }
+
+  table {
+    display:block;
+    max-width:100%;
+    min-width:initial;
+    overflow-x:auto;
+  }
+
+  tbody {
+    display: inline-block;
+    min-width: 512px;
+    width:100%;
   }
 }
 


### PR DESCRIPTION
When table-elements are placed inline in markdown for blogs it doens't scroll on small devices. Example: [https://web.dev/periodic-background-sync/](https://web.dev/periodic-background-sync/) and [https://web.dev/sms-receiver-api-announcement/](https://web.dev/sms-receiver-api-announcement/#current-status)

Changes proposed in this pull request:
-  Let table overflow-scroll on small devices in blogposts
- 
- 
