### PR TITLE
chore: rev lighthouse-keeper version.

### DIFF
--- a/src/lib/lighthouse-service.js
+++ b/src/lib/lighthouse-service.js
@@ -1,6 +1,5 @@
 // export const LH_HOST = "https://lighthouse-dot-webdotdevsite.appspot.com";
-export const LH_HOST =
-  "https://20191018t150919-dot-lighthouse-dot-webdotdevsite.appspot.com/";
+export const LH_HOST = "https://lighthouse-dot-webdotdevsite.appspot.com/";
 
 /**
  * Fetches recent median values for various Lighthouse categories. This is used as a baseline for


### PR DESCRIPTION
Changes proposed in this pull request:

- While we were transitioning off of devsite I created a named version of the lighthouse-keeper service. Today I migrated all traffic to this version. This updates the source to also use the default name instead of the specific version number.