### PR TITLE
feat: add support for `subtopics` inside of site content `topics`, fixes #1137

### DIFF
--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -28,15 +28,13 @@ const md = require("markdown-it")();
  * @return {Array} An array of pathItem slugs.
  */
 function getPathItemsFromTopics(topics) {
-  const temp = topics.reduce((reduced, topic) => {
+  return topics.reduce((reduced, topic) => {
     const subPathItems = (topic.subTopics || []).reduce((accumulator, subTopic) => {
       return ([...accumulator, ...(subTopic.pathItems)]);
     }, []);
     topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
     return reduced.concat(topic.pathItems);
   }, []);
-
-  return temp;
 }
 
 /**

--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -28,10 +28,15 @@ const md = require("markdown-it")();
  * @return {Array} An array of pathItem slugs.
  */
 function getPathItemsFromTopics(topics) {
-  return topics.reduce(
-    (pathItems, topic) => pathItems.concat(topic.pathItems),
-    [],
-  );
+  const temp = topics.reduce((reduced, topic) => {
+    const subPathItems = (topic.subTopics || []).reduce((accumulator, subTopic) => {
+      return ([...accumulator, ...(subTopic.pathItems)]);
+    }, []);
+    topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
+    return reduced.concat(topic.pathItems);
+  }, []);
+
+  return temp;
 }
 
 /**

--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -29,8 +29,8 @@ const md = require("markdown-it")();
  */
 function getPathItemsFromTopics(topics) {
   return topics.reduce((reduced, topic) => {
-    const subPathItems = (topic.subTopics || []).reduce((accumulator, subTopic) => {
-      return ([...accumulator, ...(subTopic.pathItems)]);
+    const subPathItems = (topic.subtopics || []).reduce((accumulator, subtopic) => {
+      return ([...accumulator, ...(subtopic.pathItems)]);
     }, []);
     topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
     return reduced.concat(topic.pathItems);

--- a/src/site/_includes/components/ArticleNavigation.js
+++ b/src/site/_includes/components/ArticleNavigation.js
@@ -29,10 +29,13 @@ const md = require("markdown-it")();
  */
 function getPathItemsFromTopics(topics) {
   return topics.reduce((reduced, topic) => {
-    const subPathItems = (topic.subtopics || []).reduce((accumulator, subtopic) => {
-      return ([...accumulator, ...(subtopic.pathItems)]);
-    }, []);
-    topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
+    const subPathItems = (topic.subtopics || []).reduce(
+      (accumulator, subtopic) => {
+        return [...accumulator, ...subtopic.pathItems];
+      },
+      [],
+    );
+    topic.pathItems = [...(topic.pathItems || []), ...subPathItems];
     return reduced.concat(topic.pathItems);
   }, []);
 }

--- a/src/site/_includes/components/PathCard.js
+++ b/src/site/_includes/components/PathCard.js
@@ -29,6 +29,16 @@ function getPostCount(learningPath) {
   // in path.njk. Ideally we should do this in the learningPath .11ty.js files
   // but eleventy hasn't parsed all of the collections when those files get
   // initialized so we can't look up posts by slug.
+
+  // Merge subTopic pathItems
+  learningPath.topics = (learningPath.topics).map((topic) => {
+    const subPathItems = (topic.subTopics || []).reduce((accumulator, subTopic) => {
+      return ([...accumulator, ...(subTopic.pathItems)]);
+    }, []);
+    topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
+    return topic;
+  });
+
   const topics = removeDrafts(learningPath.topics);
   const count = topics.reduce((pathItemsCount, topic) => {
     return pathItemsCount + topic.pathItems.length;

--- a/src/site/_includes/components/PathCard.js
+++ b/src/site/_includes/components/PathCard.js
@@ -31,15 +31,20 @@ function getPostCount(learningPath) {
   // initialized so we can't look up posts by slug.
 
   // Merge subtopic pathItems
-  learningPath.topics = (learningPath.topics).map((topic) => {
-    const subPathItems = (topic.subtopics || []).reduce((accumulator, subtopic) => {
-      return ([...accumulator, ...(subtopic.pathItems)]);
-    }, []);
-    topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
-    return topic;
+  const flattenedTopics = learningPath.topics.map((topic) => {
+    const subPathItems = (topic.subtopics || []).reduce(
+      (accumulator, subtopic) => {
+        return [...accumulator, ...subtopic.pathItems];
+      },
+      [],
+    );
+    return {
+      ...topic,
+      pathItems: [...(topic.pathItems || []), ...subPathItems],
+    };
   });
 
-  const topics = removeDrafts(learningPath.topics);
+  const topics = removeDrafts(flattenedTopics);
   const count = topics.reduce((pathItemsCount, topic) => {
     return pathItemsCount + topic.pathItems.length;
   }, 0);

--- a/src/site/_includes/components/PathCard.js
+++ b/src/site/_includes/components/PathCard.js
@@ -30,10 +30,10 @@ function getPostCount(learningPath) {
   // but eleventy hasn't parsed all of the collections when those files get
   // initialized so we can't look up posts by slug.
 
-  // Merge subTopic pathItems
+  // Merge subtopic pathItems
   learningPath.topics = (learningPath.topics).map((topic) => {
-    const subPathItems = (topic.subTopics || []).reduce((accumulator, subTopic) => {
-      return ([...accumulator, ...(subTopic.pathItems)]);
+    const subPathItems = (topic.subtopics || []).reduce((accumulator, subtopic) => {
+      return ([...accumulator, ...(subtopic.pathItems)]);
     }, []);
     topic.pathItems = [...subPathItems, ...(topic.pathItems || [])];
     return topic;

--- a/src/site/_includes/partials/item.njk
+++ b/src/site/_includes/partials/item.njk
@@ -1,0 +1,15 @@
+{% for slug in section.pathItems %}
+  {% set item = slug | findBySlug %}
+  {% if item.data.draft %}
+    {# noop #}
+  {% else %}
+    <li class="w-path-listitem">
+      <a
+        class="w-path-link"
+        href="{{ item.url | stripLanguage }}"
+      >
+        {{ item.data.title | md | safe }}
+      </a>
+    </li>
+  {% endif %}
+{% endfor %}

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -3,19 +3,12 @@
   <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
 </h2>
 <ul class="w-path-list">
-  {% for slug in topic.pathItems %}
-    {% set item = slug | findBySlug %}
-    {% if item.data.draft %}
-      {# noop #}
-    {% else %}
-      <li class="w-path-listitem">
-        <a
-          class="w-path-link"
-          href="{{ item.url | stripLanguage }}"
-        >
-          {{ item.data.title | md | safe }}
-        </a>
-      </li>
-    {% endif %}
-  {% endfor %}
+  {% if topic.subTopics %}
+    {% for section in topic.subTopics %}
+      {% include 'partials/item.njk' %}
+    {% endfor %}
+  {% elif topic.pathItems %}
+    {% set section = topic %}
+    {% include 'partials/item.njk' %}
+  {% endif %}
 </ul>

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -1,14 +1,20 @@
-<h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-numbered-header w-numbered-header--horizontal">
-  {{ topic.title }}
-  <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
-</h2>
-<ul class="w-path-list">
-  {% if topic.subTopics %}
-    {% for section in topic.subTopics %}
+<div class="w-topic">
+  <h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-topic-header">
+    {{ topic.title }}
+    <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
+  </h2>
+  <ul class="w-path-list">
+    {% if topic.subTopics %}
+      {% for section in topic.subTopics %}
+        <h3 id="{{ section.title | slug }}" class="no-link w-headline--four w-subtopic-header">
+          {{ section.title }}
+          <a class="w-headline-link" href="#{{ section.title | slug }}" aria-hidden="true">#</a>
+        </h3>
+        {% include 'partials/item.njk' %}
+      {% endfor %}
+    {% elif topic.pathItems %}
+      {% set section = topic %}
       {% include 'partials/item.njk' %}
-    {% endfor %}
-  {% elif topic.pathItems %}
-    {% set section = topic %}
-    {% include 'partials/item.njk' %}
-  {% endif %}
-</ul>
+    {% endif %}
+  </ul>
+</div>

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -4,6 +4,10 @@
     <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
   </h2>
   <ul class="w-path-list">
+    {% if topic.pathItems %}
+      {% set section = topic %}
+      {% include 'partials/item.njk' %}
+    {% endif %}
     {% if topic.subtopics %}
       {% for section in topic.subtopics %}
         <h3 id="{{ section.title | slug }}" class="no-link w-headline--four w-subtopic-header">
@@ -12,9 +16,6 @@
         </h3>
         {% include 'partials/item.njk' %}
       {% endfor %}
-    {% elif topic.pathItems %}
-      {% set section = topic %}
-      {% include 'partials/item.njk' %}
     {% endif %}
   </ul>
 </div>

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -4,8 +4,8 @@
     <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
   </h2>
   <ul class="w-path-list">
-    {% if topic.subTopics %}
-      {% for section in topic.subTopics %}
+    {% if topic.subtopics %}
+      {% for section in topic.subtopics %}
         <h3 id="{{ section.title | slug }}" class="no-link w-headline--four w-subtopic-header">
           {{ section.title }}
           <a class="w-headline-link" href="#{{ section.title | slug }}" aria-hidden="true">#</a>

--- a/src/site/_includes/partials/topic.njk
+++ b/src/site/_includes/partials/topic.njk
@@ -1,5 +1,5 @@
 <div class="w-topic">
-  <h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-topic-header">
+  <h2 id="{{ topic.title | slug }}" class="no-link w-headline--three w-topic__header">
     {{ topic.title }}
     <a class="w-headline-link" href="#{{ topic.title | slug }}" aria-hidden="true">#</a>
   </h2>
@@ -8,14 +8,16 @@
       {% set section = topic %}
       {% include 'partials/item.njk' %}
     {% endif %}
-    {% if topic.subtopics %}
-      {% for section in topic.subtopics %}
-        <h3 id="{{ section.title | slug }}" class="no-link w-headline--four w-subtopic-header">
-          {{ section.title }}
-          <a class="w-headline-link" href="#{{ section.title | slug }}" aria-hidden="true">#</a>
-        </h3>
-        {% include 'partials/item.njk' %}
-      {% endfor %}
-    {% endif %}
   </ul>
+  {% if topic.subtopics %}
+    {% for section in topic.subtopics %}
+      <h3 id="{{ section.title | slug }}" class="no-link w-headline--four w-topic__subtopic-header">
+        {{ section.title }}
+        <a class="w-headline-link" href="#{{ section.title | slug }}" aria-hidden="true">#</a>
+      </h3>
+      <ul class="w-path-list">
+        {% include 'partials/item.njk' %}
+      </ul>
+    {% endfor %}
+  {% endif %}
 </div>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -60,10 +60,8 @@ layout: layout
   </section> #}
 
   <section class="w-layout-container">
-    <div class="w-topics">
-      {% for topic in topics %}
-        {% include 'partials/topic.njk' %}
-      {% endfor %}
-    </div>
+    {% for topic in topics %}
+      {% include 'partials/topic.njk' %}
+    {% endfor %}
   </section>
 </div>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -60,7 +60,7 @@ layout: layout
   </section> #}
 
   <section class="w-layout-container">
-    <div class="w-numbered-headers">
+    <div class="w-topics">
       {% for topic in topics %}
         {% include 'partials/topic.njk' %}
       {% endfor %}

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -25,5 +25,6 @@
 @import 'post-card';
 @import 'progress';
 @import 'stats';
+@import 'topic';
 @import 'type';
 @import 'youtube';

--- a/src/styles/components/_topic.scss
+++ b/src/styles/components/_topic.scss
@@ -1,0 +1,43 @@
+@import '../tools/breakpoints';
+@import '../tools/mixins';
+@import '../settings/colors';
+
+// =============================================================================
+// TOPIC OVERVIEW
+//
+// Topics are the sections of a collection and can be broken into subtopics.
+//
+// =============================================================================
+
+$TOPIC_SPACING_SIZE_EXTRA_LARGE: 48px;
+$TOPIC_SPACING_SIZE_LARGE: 40px;
+$TOPIC_SPACING_SIZE_MEDIUM: 32px;
+$TOPIC_SPACING_SIZE_SMALL: 24px;
+
+.w-topics {
+  .w-topic {
+    border-bottom: 2px solid $WEB_PRIMARY_COLOR;
+    .w-topic-header {
+      align-items: center;
+      display: flex;
+      overflow: visible;
+      margin-left: $TOPIC_SPACING_SIZE_MEDIUM;
+      color: $WEB_PRIMARY_COLOR;
+
+      @include bp(sm) {
+        margin-left: $TOPIC_SPACING_SIZE_EXTRA_LARGE;
+      }
+    }
+
+    .w-subtopic-header {
+      align-items: center;
+      display: flex;
+      overflow: visible;
+      margin-left: -$TOPIC_SPACING_SIZE_SMALL;
+
+      @include bp(sm) {
+        margin-left: -$TOPIC_SPACING_SIZE_LARGE;
+      }
+    }
+  }
+}

--- a/src/styles/components/_topic.scss
+++ b/src/styles/components/_topic.scss
@@ -13,46 +13,44 @@ $TOPIC_SPACING_SIZE_LARGE: 48px;
 $TOPIC_SPACING_SIZE_MEDIUM: 40px;
 $TOPIC_SPACING_SIZE_SMALL: 32px;
 
-.w-topics {
-  .w-topic {
-    border-bottom: 1px solid $WEB_PRIMARY_COLOR;
+.w-topic {
+  border-bottom: 1px solid $WEB_PRIMARY_COLOR;
+}
 
-    .w-topic-header {
-      align-items: center;
+.w-topic__header {
+  align-items: center;
+  color: $WEB_PRIMARY_COLOR;
+  display: flex;
+  margin-left: $TOPIC_SPACING_SIZE_SMALL;
+  overflow: visible;
+
+  @include bp(sm) {
+    margin-left: $TOPIC_SPACING_SIZE_LARGE;
+  }
+
+  &:focus,
+  &:hover {
+    a {
       color: $WEB_PRIMARY_COLOR;
-      display: flex;
-      margin-left: $TOPIC_SPACING_SIZE_SMALL;
-      overflow: visible;
-
-      @include bp(sm) {
-        margin-left: $TOPIC_SPACING_SIZE_LARGE;
-      }
-
-      &:focus,
-      &:hover {
-        a {
-          color: $WEB_PRIMARY_COLOR;
-        }
-      }
     }
+  }
+}
 
-    .w-subtopic-header {
-      align-items: center;
+.w-topic > .w-topic__subtopic-header {
+  align-items: center;
+  color: $PRIMARY_TEXT_COLOR;
+  display: flex;
+  margin-left: $TOPIC_SPACING_SIZE_SMALL;
+  overflow: visible;
+
+  @include bp(sm) {
+    margin-left: $TOPIC_SPACING_SIZE_LARGE;
+  }
+
+  &:focus,
+  &:hover {
+    a {
       color: $PRIMARY_TEXT_COLOR;
-      display: flex;
-      margin-left: calc(#{$TOPIC_SPACING_SIZE_SMALL} - 82px);
-      overflow: visible;
-
-      @include bp(sm) {
-        margin-left: calc(#{$TOPIC_SPACING_SIZE_LARGE} - 99px);
-      }
-
-      &:focus,
-      &:hover {
-        a {
-          color: $PRIMARY_TEXT_COLOR;
-        }
-      }
     }
   }
 }

--- a/src/styles/components/_topic.scss
+++ b/src/styles/components/_topic.scss
@@ -9,34 +9,49 @@
 //
 // =============================================================================
 
-$TOPIC_SPACING_SIZE_EXTRA_LARGE: 48px;
-$TOPIC_SPACING_SIZE_LARGE: 40px;
-$TOPIC_SPACING_SIZE_MEDIUM: 32px;
-$TOPIC_SPACING_SIZE_SMALL: 24px;
+$TOPIC_SPACING_SIZE_LARGE: 48px;
+$TOPIC_SPACING_SIZE_MEDIUM: 40px;
+$TOPIC_SPACING_SIZE_SMALL: 32px;
 
 .w-topics {
   .w-topic {
-    border-bottom: 2px solid $WEB_PRIMARY_COLOR;
+    border-bottom: 1px solid $WEB_PRIMARY_COLOR;
+
     .w-topic-header {
       align-items: center;
-      display: flex;
-      overflow: visible;
-      margin-left: $TOPIC_SPACING_SIZE_MEDIUM;
       color: $WEB_PRIMARY_COLOR;
+      display: flex;
+      margin-left: $TOPIC_SPACING_SIZE_SMALL;
+      overflow: visible;
 
       @include bp(sm) {
-        margin-left: $TOPIC_SPACING_SIZE_EXTRA_LARGE;
+        margin-left: $TOPIC_SPACING_SIZE_LARGE;
+      }
+
+      &:focus,
+      &:hover {
+        a {
+          color: $WEB_PRIMARY_COLOR;
+        }
       }
     }
 
     .w-subtopic-header {
       align-items: center;
+      color: $PRIMARY_TEXT_COLOR;
       display: flex;
+      margin-left: calc(#{$TOPIC_SPACING_SIZE_SMALL} - 82px);
       overflow: visible;
-      margin-left: -$TOPIC_SPACING_SIZE_SMALL;
 
       @include bp(sm) {
-        margin-left: -$TOPIC_SPACING_SIZE_LARGE;
+        margin-left: calc(#{$TOPIC_SPACING_SIZE_LARGE} - 99px);
+      }
+
+      &:focus,
+      &:hover {
+        a {
+          color: $PRIMARY_TEXT_COLOR;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #1137.

Changes proposed in this pull request:

Inside of a collection topics can support subtopics (embedded collections?)

Here's what it would look like _if_ we had subtopics in the Angular collection:

<img width="953" alt="Screen Shot 2019-11-20 at 2 08 24 PM" src="https://user-images.githubusercontent.com/11811422/69282677-aa1db280-0b9f-11ea-9656-daa888e6a311.png">

No where currently uses subtopics, but effectively topic objects in the topics array of a post (like [`angular.11tydata.js`](https://github.com/GoogleChrome/web.dev/blob/4ec23419bbdac156ea5fb6410821db2306304bd4/src/site/content/en/angular/angular.11tydata.js#L15)) now support a `subtopics` field, which is just an array of objects of the below data structure:

```TypeScript
type SubTopic = {
     title: string;
     pathItems: string[];
}
```