### PR TITLE
feat(CopyCode): add custom element to allow code blocks to be copied, fixes #1871

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -107,7 +107,7 @@ module.exports = function(config) {
   mdLib.renderer.rules.fence = function (tokens, idx, options, env, slf) {
     const fenced = fence(tokens, idx, options, env, slf)
     const token = tokens[idx];
-    return  `<copy-code code="${encodeURIComponent(token.content)}">${fenced}</copy-code>`
+    return  `<web-copy-code>${fenced}</web-copy-code>`
   }
 
   config.setLibrary(

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -97,11 +97,22 @@ module.exports = function(config) {
     rightDelimiter: '}',
     allowedAttributes: ['id', 'class', /^data\-.*$/],
   };
+
+  const mdLib = markdownIt(markdownItOptions)
+    .use(markdownItAnchor, markdownItAnchorOptions)
+    .use(markdownItAttrs, markdownItAttrsOpts);
+
+  // custom renderer for fences
+  const fence = mdLib.renderer.rules.fence;
+  mdLib.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    const fenced = fence(tokens, idx, options, env, slf)
+    const token = tokens[idx];
+    return  `<copy-code code="${encodeURIComponent(token.content)}">${fenced}</copy-code>`
+  }
+
   config.setLibrary(
     'md',
-    markdownIt(markdownItOptions)
-      .use(markdownItAnchor, markdownItAnchorOptions)
-      .use(markdownItAttrs, markdownItAttrsOpts)
+    mdLib
   );
 
   //----------------------------------------------------------------------------

--- a/src/images/icons/file_copy.svg
+++ b/src/images/icons/file_copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"/></svg>

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -3,6 +3,7 @@ import "./components/Header";
 import "./components/SideNav";
 import "./components/SnackbarContainer";
 import "./components/Search";
+import "./components/CopyCode";
 import {store} from "./store";
 import "focus-visible";
 import "./analytics";

--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -11,47 +11,39 @@ import {BaseElement} from "../BaseElement";
  * @final
  */
 class CopyCode extends BaseElement {
-  static get properties() {
-    return {
-      code: {type: String},
-    };
-  }
-
   constructor() {
     super();
+    this.copyCode = this.copyCode.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute("tabindex", "0");
 
-    if (this.firstChild) {
-      const copyButton = document.createElement("input");
-      copyButton.setAttribute("type", "button");
-      copyButton.setAttribute("tabindex", "0");
-      copyButton.className = "w-copy-code-button";
+    this.copyButton = document.createElement("button");
+    this.copyButton.className = "web-copy-code__button";
+    this.copyButton.addEventListener("click", this.copyCode);
 
-      this.firstChild.prepend(copyButton);
+    const copyContainer = document.createElement("div");
+    copyContainer.className = "web-copy-code__container";
+    copyContainer.append(this.copyButton);
 
-      this.addEventListener("click", (e) => {
-        if (e.target === copyButton) {
-          e.preventDefault();
-          this.copyCode();
-        }
-      });
-    }
+    this.prepend(copyContainer);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this.copyButton.removeEventListener("click", this.copyCode);
   }
 
   copyCode() {
-    const textarea = document.createElement("textarea");
-    textarea.value = decodeURIComponent(this.code);
-    textarea.setAttribute("readonly", "");
-    textarea.style.cssText = "position: fixed; bottom: -80px; height: 80px;";
-    document.body.appendChild(textarea);
-    textarea.select();
+    window.getSelection().removeAllRanges();
+    const range = document.createRange();
+    range.selectNode(this.querySelector("code"));
+    window.getSelection().addRange(range);
     document.execCommand("copy");
-    document.body.removeChild(textarea);
+    window.getSelection().removeAllRanges();
   }
 }
 
-customElements.define("copy-code", CopyCode);
+customElements.define("web-copy-code", CopyCode);

--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -13,7 +13,7 @@ import {BaseElement} from "../BaseElement";
 class CopyCode extends BaseElement {
   constructor() {
     super();
-    this.copyCode = this.copyCode.bind(this);
+    this.onCopy = this.onCopy.bind(this);
   }
 
   connectedCallback() {
@@ -21,7 +21,7 @@ class CopyCode extends BaseElement {
 
     this.copyButton = document.createElement("button");
     this.copyButton.className = "web-copy-code__button";
-    this.copyButton.addEventListener("click", this.copyCode);
+    this.copyButton.addEventListener("click", this.onCopy);
 
     const copyContainer = document.createElement("div");
     copyContainer.className = "web-copy-code__container";
@@ -33,10 +33,10 @@ class CopyCode extends BaseElement {
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    this.copyButton.removeEventListener("click", this.copyCode);
+    this.copyButton.removeEventListener("click", this.onCopy);
   }
 
-  copyCode() {
+  onCopy() {
     window.getSelection().removeAllRanges();
     const range = document.createRange();
     range.selectNode(this.querySelector("code"));

--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Element that renders copyable code.
+ */
+
+import {BaseElement} from "../BaseElement";
+
+/**
+ * Renders code block that can easily be copied.
+ *
+ * @extends {BaseElement}
+ * @final
+ */
+class CopyCode extends BaseElement {
+  static get properties() {
+    return {
+      code: {type: String},
+    };
+  }
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("tabindex", "0");
+
+    if (this.firstChild) {
+      const copyButton = document.createElement("input");
+      copyButton.setAttribute("type", "button");
+      copyButton.setAttribute("tabindex", "0");
+      copyButton.className = "w-copy-code-button";
+
+      this.firstChild.prepend(copyButton);
+
+      this.addEventListener("click", (e) => {
+        if (e.target === copyButton) {
+          e.preventDefault();
+          this.copyCode();
+        }
+      });
+    }
+  }
+
+  copyCode() {
+    const textarea = document.createElement("textarea");
+    textarea.value = decodeURIComponent(this.code);
+    textarea.setAttribute("readonly", "");
+    textarea.style.cssText = "position: fixed; bottom: -80px; height: 80px;";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+}
+
+customElements.define("copy-code", CopyCode);

--- a/src/lib/components/CopyCode/styles.scss
+++ b/src/lib/components/CopyCode/styles.scss
@@ -1,37 +1,46 @@
 @import "../../../styles/settings/colors";
 @import '../../../styles/settings/global';
 
-.w-copy-code-button {
+.web-copy-code__button {
   background: none;
   background-image: url("../../../images/icons/file_copy.svg");
   background-position: center;
   background-repeat: no-repeat;
   border: none;
   border-radius: $GLOBAL_ROUNDED;
-  float: right;
+  cursor: pointer;
   height: 48px;
-  padding: 0;
-  width: 48px;
-  z-index: 100;
+  margin: 8px;
   opacity: 0;
+  padding: 0;
+  transition: background-color .5s ease;
+  width: 48px;
 
-  &:hover,
-  &:focus {
-    background-color: rgba($WHITE, 0.5);
+  &:active {
+    background-color: rgba($WEB_SECONDARY_COLOR, 0.4);
     opacity: 1;
   }
 
-  &:active {
-    background-color: rgba($WHITE, 0.9);
+  &:focus,
+  &:hover {
+    background-color: rgba($WEB_SECONDARY_COLOR, 0.2);
     opacity: 1;
+    transition: background-color .2s ease;
   }
 }
 
-copy-code {
-  &:hover,
+.web-copy-code__container {
+  display: flex;
+  flex-direction: row-reverse;
+  height: 0;
+  margin-bottom: -32px;
+  position: relative;
+}
+web-copy-code {
+  &:active,
   &:focus,
-  &:active {
-    .w-copy-code-button {
+  &:hover {
+    .web-copy-code__button {
       opacity: 1;
     }
   }

--- a/src/lib/components/CopyCode/styles.scss
+++ b/src/lib/components/CopyCode/styles.scss
@@ -1,0 +1,38 @@
+@import "../../../styles/settings/colors";
+@import '../../../styles/settings/global';
+
+.w-copy-code-button {
+  background: none;
+  background-image: url("../../../images/icons/file_copy.svg");
+  background-position: center;
+  background-repeat: no-repeat;
+  border: none;
+  border-radius: $GLOBAL_ROUNDED;
+  float: right;
+  height: 48px;
+  padding: 0;
+  width: 48px;
+  z-index: 100;
+  opacity: 0;
+
+  &:hover,
+  &:focus {
+    background-color: rgba($WHITE, 0.5);
+    opacity: 1;
+  }
+
+  &:active {
+    background-color: rgba($WHITE, 0.9);
+    opacity: 1;
+  }
+}
+
+copy-code {
+  &:hover,
+  &:focus,
+  &:active {
+    .w-copy-code-button {
+      opacity: 1;
+    }
+  }
+}

--- a/src/lib/components/_all.scss
+++ b/src/lib/components/_all.scss
@@ -1,4 +1,5 @@
 @import './Codelab/styles';
+@import './CopyCode/styles';
 @import './Header/styles';
 @import './LighthouseGauge/styles';
 @import './LighthouseScoresAudits/styles';


### PR DESCRIPTION
Fixes #1871

Add custom element that wraps fenced code blocks and gives them a button to copy the code. I would love @kaycebasques thoughts on how it looks though.