### PR TITLE
fix(Snackbar): set max-width to only on sizes larger than smart phones, fixes #1930

### DIFF
--- a/src/lib/components/Snackbar/_styles.scss
+++ b/src/lib/components/Snackbar/_styles.scss
@@ -6,22 +6,25 @@ web-snackbar {
   align-items: center;
   display: flex;
   visibility: hidden;
-  
+
   .web-snackbar__surface {
     align-items: center;
     background-color: $GREY_900;
     display: flex;
     justify-content: flex-start;
-    max-width: 400px;
     min-width: 344px;
     opacity: 0;
     transform: scale(.8);
-    
+
     @include bp(sm) {
       border-radius: $GLOBAL_RADIUS;
       box-shadow: 0 3px 5px -1px rgba(0, 0, 0, .2),
                   0 6px 10px 0 rgba(0, 0, 0, .14),
                   0 1px 18px 0 rgba(0, 0, 0, .12);
+    }
+
+    @include bp(md) {
+      max-width: 400px;
     }
   }
 


### PR DESCRIPTION
Fixes #1930.

Changes proposed in this pull request:

Only apply `max-width` on sizes larger than smart phones so that the cookies snackbar takes up the full width of larger smart phones.