### PR TITLE
fix(w-card): set fixed height of `.w-card` when on breakpoints smaller than smart phones, fixes #1653

### DIFF
--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -13,13 +13,13 @@
 .w-card {
   border-radius: 8px;
   display: block;
-  height: 462px;
+  min-height: 462px;
   overflow: hidden;
   position: relative;
   transition: box-shadow $TRANSITION_SPEED;
 
   @include bp(md) {
-    height: auto;
+    min-height: auto;
   }
 }
 

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -13,9 +13,14 @@
 .w-card {
   border-radius: 8px;
   display: block;
+  height: 462px;
   overflow: hidden;
   position: relative;
   transition: box-shadow $TRANSITION_SPEED;
+
+  @include bp(md) {
+    height: auto;
+  }
 }
 
 .w-card:hover,


### PR DESCRIPTION
Fixes #1653.

Changes proposed in this pull request:

In order to keep the cards in the blog view the same height, regardless of if in mobile view (single card per row) or in desktop view (multiple cards per row) I've given the cards a set height (which is the height of a thumbnail card when the bp is less than md). When md or larger it'll default to auto where cards without a thumbnail will match the height of the other cards (with a thumbnail).