### PR TITLE
feat(PostCard): display author(s) and date of post in a card, fixes #1330

### DIFF
--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -15,6 +15,7 @@
  */
 
 const {html} = require("common-tags");
+const prettyDate = require("../../_filters/pretty-date");
 const stripLanguage = require("../../_filters/strip-language");
 const md = require("../../_filters/md");
 const getImagePath = require("../../_utils/get-image-path");
@@ -60,20 +61,64 @@ module.exports = ({post}) => {
     `;
   }
 
-  // function renderAuthors(authors) {
-  //   return html`
-  //     <div class="w-authors">
-  //       ${authors.map((author) => {
-  //         return `${Author({
-  //           post,
-  //           author: contributors[author],
-  //           avatar: author,
-  //           small: true,
-  //         })}`;
-  //       })}
-  //     </div>
-  //   `;
-  // }
+  function renderAuthorImages(authors) {
+    if (!Array.isArray(authors)) return;
+
+    return html`
+      <div class="w-author__image--row">
+        ${authors
+          .slice(0, 2)
+          .reverse()
+          .map((authorId) => {
+            const author = data.contributors[authorId];
+            const fullName = `${author.name.given} ${author.name.family}`;
+            return html`
+              <div class="w-author__image--row-item">
+                <img
+                  class="w-author__image w-author__image--small"
+                  src="/images/authors/${authorId}.jpg"
+                  alt="${fullName}"
+                />
+              </div>
+            `;
+          })}
+      </div>
+    `;
+  }
+
+  function renderAuthorNames(authors) {
+    if (!Array.isArray(authors)) return;
+
+    return html`
+      <span class="w-author__name">
+        ${authors
+          .map((authorId) => {
+            const author = data.contributors[authorId];
+            const fullName = `${author.name.given} ${author.name.family}`;
+            return html`
+              ${fullName}
+            `;
+          })
+          .join(", ")}
+      </span>
+    `;
+  }
+
+  function renderAuthorsAndDate(post) {
+    const authors = post.data.authors;
+
+    return html`
+      <div class="w-authors__card">
+        ${renderAuthorImages(authors)}
+        <div>
+          ${renderAuthorNames(authors)}
+          <div class="w-author__published">
+            <time>${prettyDate(post.date)}</time>
+          </div>
+        </div>
+      </div>
+    `;
+  }
 
   return html`
     <a href="${url}" class="w-card">
@@ -91,6 +136,7 @@ module.exports = ({post}) => {
             ${md(data.title)}
           </h2>
         </div>
+        ${renderAuthorsAndDate(post)}
         <div class="w-post-card__desc">
           <p class="w-post-card__subhead">
             ${md(data.subhead)}

--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -62,13 +62,11 @@ module.exports = ({post}) => {
   }
 
   function renderAuthorImages(authors) {
-    if (!Array.isArray(authors)) return;
+    if (!Array.isArray(authors) || authors.length > 2) return;
 
     return html`
       <div class="w-author__image--row">
         ${authors
-          .slice(0, 2)
-          .reverse()
           .map((authorId) => {
             const author = data.contributors[authorId];
             const fullName = `${author.name.given} ${author.name.family}`;
@@ -81,7 +79,8 @@ module.exports = ({post}) => {
                 />
               </div>
             `;
-          })}
+          })
+          .reverse()}
       </div>
     `;
   }

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -127,3 +127,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   position: relative;
   width: $AUTHOR_IMAGE_SIZE_SMALL;
 }
+
+.w-author__image--row-item > .w-author__image {
+  border: solid white 2px;
+}

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -10,6 +10,8 @@
 //
 // =============================================================================
 
+$AUTHOR_IMAGE_SIZE_SMALL: 40px;
+
 .w-authors {
   display: grid;
   grid-column-gap: 16px;
@@ -42,8 +44,8 @@
 }
 
 .w-author__image--small {
-  height: 40px;
-  width: 40px;
+  height: $AUTHOR_IMAGE_SIZE_SMALL;
+  width: $AUTHOR_IMAGE_SIZE_SMALL;
 }
 
 .w-author__name,
@@ -94,4 +96,34 @@
 .w-author__link:focus {
   box-shadow: inset 0px 0px 0px 1px $FOCUS_COLOR;
   outline: none;
+}
+
+
+.w-authors__card {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 12px;
+
+  @include bp(sm) {
+    grid-template-columns: 256px 256px;
+  }
+
+  @include bp(md) {
+    grid-template-columns: 256px 256px 256px;
+  }
+}
+
+.w-author__image--row {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  margin: 0px calc(#{$AUTHOR_IMAGE_SIZE_SMALL} / 4) 0px calc(#{$AUTHOR_IMAGE_SIZE_SMALL} / 2);
+}
+
+.w-author__image--row-item {
+  border-radius: 50%;
+  height: $AUTHOR_IMAGE_SIZE_SMALL;
+  margin-left: calc(-#{$AUTHOR_IMAGE_SIZE_SMALL} / 2);
+  overflow: hidden;
+  position: relative;
+  width: $AUTHOR_IMAGE_SIZE_SMALL;
 }

--- a/src/styles/components/_post-card.scss
+++ b/src/styles/components/_post-card.scss
@@ -22,11 +22,11 @@
 
 .w-post-card__cover {
   display: block;
-  margin: 32px 0 24px;
+  margin: 32px 0 12px;
 }
 
 .w-post-card__cover--with-image {
-  margin: 32px 0 24px;
+  margin: 32px 0 12px;
 
   @include bp(md) {
     margin-top: -1px;


### PR DESCRIPTION
Fixes #1330

Changes proposed in this pull request:

Display author(s) and date of post in a card, it'd look like this:

<img width="1311" alt="Screen Shot 2019-12-04 at 4 15 01 PM" src="https://user-images.githubusercontent.com/11811422/70192652-48863980-16b1-11ea-92ad-30eda4e32910.png">

2+ Authors => We don't show any images.
2 Authors => Display images, there's a white border radius to separate authors.
1 Author => Display image, there's a white border radius as when there are 2 authors, however you don't really notice it so it doesn't matter.
0 Authors => Just show the date.