### PR TITLE
Add "prefers-color-scheme" to title

### DIFF
--- a/src/site/content/en/blog/prefers-color-scheme/index.md
+++ b/src/site/content/en/blog/prefers-color-scheme/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hello darkness, my old friend
+title: "prefers-color-scheme: Hello darkness, my old friend"
 subhead: Overhyped or necessity? Learn everything about dark mode and how to support it to the benefit of your users!
 authors:
   - thomassteiner


### PR DESCRIPTION
@tomayac this article is currently #2 for `prefers-color-scheme` Search query:

![image](https://user-images.githubusercontent.com/4713486/70199066-97d66500-16c5-11ea-8f57-215b6991e371.png)

Title keywords seem to have a big impact on documentation rankings in Search. I'm curious to see if this nudges the article up to number 1. Any reason on your side why the title can't change?