### PR TITLE
feat(SnackbarContainer): only allow PWA install prompt if cookies accepted, fixes #1771

### DIFF
--- a/src/lib/components/SnackbarContainer/index.js
+++ b/src/lib/components/SnackbarContainer/index.js
@@ -77,7 +77,7 @@ class SnackbarContainer extends BaseElement {
 
     if (this.acceptedCookies && this.installPrompt) {
       this.installPrompt.prompt();
-      this.installPrompt.userChoice.then(() => (this.installPrompt = false));
+      this.installPrompt.userChoice.then(() => (this.installPrompt = null));
     }
   }
 

--- a/src/lib/components/SnackbarContainer/index.js
+++ b/src/lib/components/SnackbarContainer/index.js
@@ -41,6 +41,11 @@ class SnackbarContainer extends BaseElement {
     super.connectedCallback();
     store.subscribe(this.onStateChanged);
     this.onStateChanged();
+
+    window.addEventListener("beforeinstallprompt", (e) => {
+      e.preventDefault();
+      this.installPrompt = e;
+    });
   }
 
   disconnectedCallback() {
@@ -52,6 +57,11 @@ class SnackbarContainer extends BaseElement {
     const state = store.getState();
     this.open = state.showingSnackbar;
     this.type = state.snackbarType;
+
+    if (state.userAcceptsCookies && this.installPrompt) {
+      this.installPrompt.prompt();
+      this.installPrompt.userChoice.then(() => (this.installPrompt = false));
+    }
   }
 
   render() {


### PR DESCRIPTION
Fixes #1771

Changes proposed in this pull request:
On connection of the component add an event listener for before the PWA install prompt appears. Stop it and save it until the user has accepted cookies.