### PR TITLE
Update Contact Picker article for Chrome 80.

### DIFF
--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -68,7 +68,7 @@ which friends have already joined.
 | 2. Create initial draft of specification   | [Complete][spec]             |
 | 3. Gather feedback & iterate on design     | [Complete][spec]             |
 | 4. Origin trial                            | Complete                     |
-| **5. Launch**                              | Chrome 80                    |
+| **5. Launch**                              | **Chrome 80**                |
 
 </div>
 

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -5,13 +5,14 @@ authors:
   - petelepage
 description: Access to the user's contacts has been a feature of native apps since (almost) the dawn of time. The Contact Picker API is an on-demand API  that allows users to select an entry or entries from their contact list and share limited details of the selected contact(s) with a website. It allows users to share only what they want, when they want, and makes it easier for users to reach and connect with their friends and family.
 date: 2019-08-07
-updated: 2019-10-10
+updated: 2019-12-18
 tags:
   - post
   - capabilities
   - fugu
   - contacts
   - chrome77
+  - chrome80
   - origin-trial
 hero: hero.jpg
 alt: Telephone on yellow background.
@@ -76,8 +77,8 @@ which friends have already joined.
 | 1. Create explainer                        | [Complete][explainer]        |
 | 2. Create initial draft of specification   | [In Progress][spec]          |
 | 3. Gather feedback & iterate on design     | [In progress][spec]          |
-| **4. Origin trial**                        | **Started in Chrome 77** <br> Expected to run through Chrome 80. |
-| 5. Launch                                  | Not started                  |
+| **4. Origin trial**                        | [In progress][ot]<br> Expected to run through Chrome 80. |
+| **5. Launch**                              | Chrome 80                    |
 
 </div>
 
@@ -92,16 +93,11 @@ that specifies the types of contact information you want.
   [source](https://glitch.com/edit/#!/contact-picker?path=demo.js:20:0).
 {% endAside %}
 
-### Enabling via chrome://flags
-
-To experiment with the Contact Picker API locally, without an origin
-trial token, enable the `#enable-experimental-web-platform-features` flag
-in `chrome://flags`.
-
 ### Enabling support during the origin trial phase {: #origin-trial }
 
-Starting in Chrome 77, the Contact Picker API is available as an origin
-trial on Chrome for Android.
+Since Chrome 77, the Contact Picker API is available as an origin trial on
+Chrome for Android. The origin trial is ending soon, but is still open because
+we're still taking feedback, even as the feature is enabled by default.
 
 {% include 'content/origin-trials.njk' %}
 
@@ -147,10 +143,11 @@ user gesture.
 
 ### Handling the results
 
-The Contact Picker API returns an array of contacts, and each contact
-includes an array of the requested properties. If a contact doesn't have
-data for the requested property, or the user chooses to opt-out of sharing
-a particular property, it returns an empty array.
+The Contact Picker API returns an array of contacts, and each contact includes
+an array of the requested properties. If a contact doesn't have data for the
+requested property, or the user chooses to opt-out of sharing a particular
+property, it returns an empty array. (I describe how the user chooses properties
+later.)
 
 For example, if a site requests `name`, `email`, and `tel`, and a user
 selects a single contact that has data in the name field, provides two
@@ -271,7 +268,7 @@ different from the spec?
 * File a bug at [https://new.crbug.com][new-bug]. Be sure to include as much
   detail as you can, provide simple instructions for reproducing the bug, and
   set *Components* to `Blink>Contacts`. [Glitch](https://glitch.com) works great
-  for sharing quick and easy repros.
+  for sharing quick and easy problem reproductions.
 
 ### Planning to use the API?
 
@@ -287,7 +284,7 @@ critical it is to support them.
 
 * [Public explainer][explainer]
 * [Contact Picker Specification][spec]
-* [Contact Picker API Demo][demo] & [Contact Picker API demo source][demo-source]
+* [Contact Picker API Demo][demo] and [Contact Picker API demo source][demo-source]
 * [Tracking bug][cr-bug]
 * [ChromeStatus.com entry][cr-status]
 * Request an [origin trial token]({{origin_trial.url}})
@@ -313,6 +310,7 @@ PS: The 'names' in my contact picker, are characters from Alice in Wonderland.
 [explainer]: https://github.com/WICG/contact-api/
 [wicg-discourse]: https://discourse.wicg.io/t/proposal-contact-picker-api/3507
 [new-bug]: https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3EContacts
+[ot]: https://developers.chrome.com/origintrials/#/view_trial/85568392920039425
 [ot-what-is]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/README.md
 [ot-dev-guide]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
 [ot-use]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -13,18 +13,9 @@ tags:
   - contacts
   - chrome77
   - chrome80
-  - origin-trial
 hero: hero.jpg
 alt: Telephone on yellow background.
-origin_trial:
-  url: https://developers.chrome.com/origintrials/#/view_trial/85568392920039425
 ---
-
-{% Aside %}
-  The Contact Picker API begins an origin trial in Chrome 77
-  (stable in September) as part of our capabilities project. We'll keep this
-  post updated as the implementation progresses.
-{% endAside %}
 
 ## What is the Contact Picker API? {: #what }
 
@@ -50,11 +41,11 @@ Access to the user's contacts has been a feature of native apps since
 I hear from web developers, and is often the key reason they build a native
 app.
 
-The [Contact Picker API][spec] is an on-demand API that allows users to
-select entries from their contact list and share limited details of the
-selected entries with a website. It allows users to share only what they
-want, when they want, and makes it easier for users to reach and connect
-with their friends and family.
+Available by default in Chrome 80, the [Contact Picker API][spec] is an
+on-demand API that allows users to select entries from their contact list and
+share limited details of the selected entries with a website. It allows users to
+share only what they want, when they want, and makes it easier for users to
+reach and connect with their friends and family.
 
 For example, a web-based email client could use the Contact Picker API to
 select the recipient(s) of an email. A voice-over-IP app could look up
@@ -77,7 +68,7 @@ which friends have already joined.
 | 1. Create explainer                        | [Complete][explainer]        |
 | 2. Create initial draft of specification   | [In Progress][spec]          |
 | 3. Gather feedback & iterate on design     | [In progress][spec]          |
-| **4. Origin trial**                        | [In progress][ot]<br> Expected to run through Chrome 80. |
+| 4. Origin trial                            | Complete                     |
 | **5. Launch**                              | Chrome 80                    |
 
 </div>
@@ -92,16 +83,6 @@ that specifies the types of contact information you want.
   and view the
   [source](https://glitch.com/edit/#!/contact-picker?path=demo.js:20:0).
 {% endAside %}
-
-### Enabling support during the origin trial phase {: #origin-trial }
-
-Since Chrome 77, the Contact Picker API is available as an origin trial on
-Chrome for Android. The origin trial is ending soon, but is still open because
-we're still taking feedback, even as the feature is enabled by default.
-
-{% include 'content/origin-trials.njk' %}
-
-{% include 'content/origin-trial-register.njk' %}
 
 ### Feature detection
 
@@ -287,7 +268,6 @@ critical it is to support them.
 * [Contact Picker API Demo][demo] and [Contact Picker API demo source][demo-source]
 * [Tracking bug][cr-bug]
 * [ChromeStatus.com entry][cr-status]
-* Request an [origin trial token]({{origin_trial.url}})
 * Blink Component: `Blink>Contacts`
 
 ### Thanks
@@ -310,11 +290,6 @@ PS: The 'names' in my contact picker, are characters from Alice in Wonderland.
 [explainer]: https://github.com/WICG/contact-api/
 [wicg-discourse]: https://discourse.wicg.io/t/proposal-contact-picker-api/3507
 [new-bug]: https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3EContacts
-[ot]: https://developers.chrome.com/origintrials/#/view_trial/85568392920039425
-[ot-what-is]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/README.md
-[ot-dev-guide]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
-[ot-use]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin
 [powerful-apis]: https://chromium.googlesource.com/chromium/src/+/lkgr/docs/security/permissions-for-powerful-web-platform-features.md
 [secure-contexts]: https://w3c.github.io/webappsec-secure-contexts/
 [cr-dev-twitter]: https://twitter.com/chromiumdev
-[ot-guide]: https://googlechrome.github.io/OriginTrials/developer-guide.html

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -11,7 +11,6 @@ tags:
   - capabilities
   - fugu
   - contacts
-  - chrome77
   - chrome80
 hero: hero.jpg
 alt: Telephone on yellow background.
@@ -66,8 +65,8 @@ which friends have already joined.
 | Step                                       | Status                       |
 | ------------------------------------------ | ---------------------------- |
 | 1. Create explainer                        | [Complete][explainer]        |
-| 2. Create initial draft of specification   | [In Progress][spec]          |
-| 3. Gather feedback & iterate on design     | [In progress][spec]          |
+| 2. Create initial draft of specification   | [Complete][spec]             |
+| 3. Gather feedback & iterate on design     | [Complete][spec]             |
 | 4. Origin trial                            | Complete                     |
 | **5. Launch**                              | Chrome 80                    |
 
@@ -128,7 +127,7 @@ The Contact Picker API returns an array of contacts, and each contact includes
 an array of the requested properties. If a contact doesn't have data for the
 requested property, or the user chooses to opt-out of sharing a particular
 property, it returns an empty array. (I describe how the user chooses properties
-later.)
+in the [User control](#security-control) section.)
 
 For example, if a site requests `name`, `email`, and `tel`, and a user
 selects a single contact that has data in the name field, provides two
@@ -230,16 +229,8 @@ with the site.
 
 ## Feedback {: #feedback }
 
-The Web Platform Incubator Group and the Chrome team want to hear about your
-experiences with the Contact Picker API.
-
-### Tell us about the API design
-
-Is there something about the API that doesn't work as expected? Or
-are there missing methods or properties that you need to implement your idea?
-
-* File a spec issue on the [WICG Contact Picker API GitHub repo][issues],
-  or add your thoughts to an existing issue.
+The Chrome team wants to hear about your experiences with the Contact Picker
+API.
 
 ### Problem with the implementation?
 
@@ -282,7 +273,6 @@ PS: The 'names' in my contact picker, are characters from Alice in Wonderland.
 [spec]: https://wicg.github.io/contact-api/spec/
 [spec-select]: https://wicg.github.io/contact-api/spec/#contacts-manager-select
 [spec-security]: https://wicg.github.io/contact-api/spec/#privacy
-[issues]: https://github.com/WICG/contact-api/issues
 [demo]: https://contact-picker.glitch.me
 [demo-source]: https://glitch.com/edit/#!/contact-picker?path=demo.js:20:0
 [cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=860467

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -126,7 +126,7 @@ user gesture.
 The Contact Picker API returns an array of contacts, and each contact includes
 an array of the requested properties. If a contact doesn't have data for the
 requested property, or the user chooses to opt-out of sharing a particular
-property, it returns an empty array. (I describe how the user chooses properties
+property, the API returns an empty array. (I describe how the user chooses properties
 in the [User control](#security-control) section.)
 
 For example, if a site requests `name`, `email`, and `tel`, and a user


### PR DESCRIPTION
Fixes #1907  

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:

- Removes origin trial information from article because the feature is shipping.
