### PR TITLE
fix(table): tables written in markdown are automatically wrapped by `<div class="w-table-wrapper">`, fixes #1917

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,13 +102,19 @@ module.exports = function(config) {
     .use(markdownItAnchor, markdownItAnchorOptions)
     .use(markdownItAttrs, markdownItAttrsOpts);
 
-  // custom renderer for fences
+  // custom renderer rules
   const fence = mdLib.renderer.rules.fence;
-  mdLib.renderer.rules.fence = function (tokens, idx, options, env, slf) {
-    const fenced = fence(tokens, idx, options, env, slf)
-    const token = tokens[idx];
-    return  `<web-copy-code>${fenced}</web-copy-code>`
+
+  const rules = {
+    fence: (tokens, idx, options, env, slf) => {
+      const fenced = fence(tokens, idx, options, env, slf);
+      return `<web-copy-code>${fenced}</web-copy-code>`;
+    },
+    table_close: () => '</table>\n</div>',
+    table_open: () => '<div class="w-table-wrapper">\n<table>\n',
   }
+
+  mdLib.renderer.rules = {...mdLib.renderer.rules, ...rules};
 
   config.setLibrary(
     'md',


### PR DESCRIPTION
Fixes #1917

Changes proposed in this pull request:
Add some rendered rules in order to wrap table elements with a `<div class="w-table-wrapper">`. This does not work with an HTML table, as from what I understand HTML doesn't go through the custom element renderers (I think it's just passed through?).

So possibly we could implement a rule for HTML and modify it, but I think that would be ugly... Maybe something like jsdom to pull out tables and add the div? (Something like this...)

```JavaScript
const jsdom = require("jsdom");

const htmlRule = (html) => {
   const dom = new JSDOM(html);

   dom.window.document.querySelectorAll("table").forEach((table) => {
    const parent = table.parentNode;
    if (!(parent instanceof HTMLDivElement && parent.classList.contains("w-table-wrapper"))) {
      const newParent = dom.window.document.createElement("div");
      newParent.classList.add("w-table-wrapper");
      parent.insertBefore(newParent, table);
      newParent.appendChild(table);
     }
  });
}
```