### PR TITLE
Update lazysizes version to 5.1.2 (latest stable)

### DIFF
--- a/src/site/content/en/blog/native-lazy-loading/index.md
+++ b/src/site/content/en/blog/native-lazy-loading/index.md
@@ -232,7 +232,7 @@ library only when `loading` isn't supported. This works as follows:
     // Dynamically import the LazySizes library
     const script = document.createElement('script');
     script.src =
-      'https://cdnjs.cloudflare.com/ajax/libs/lazysizes/4.1.8/lazysizes.min.js';
+      'https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.1.2/lazysizes.min.js';
     document.body.appendChild(script);
   }
 </script>


### PR DESCRIPTION
There was a quite [noticable bug](https://github.com/aFarkas/lazysizes/blob/gh-pages/CHANGELOG.md#512) that was fixed in [5.1.2](https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.1.2/lazysizes.min.js), which is the latest stable release so changing the example code to that.