### PR TITLE
Fix multiple broken URLs that result in 404s

### DIFF
--- a/src/site/content/en/lighthouse-accessibility/accessibility-scoring/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accessibility-scoring/index.md
@@ -20,7 +20,7 @@ but others don't, the page gets a 0 for the
 
 The following table shows the weighting for each accessibility audit.
 More heavily weighted audits have a bigger effect on your score.
-[Manual audits](http://localhost:8080/lighthouse-accessibility/#additional-items-to-manually-check)
+[Manual audits](https://web.dev/lighthouse-accessibility/#additional-items-to-manually-check)
 aren't included in the table because they don't affect your score.
 
 <div class="w-table-wrapper">

--- a/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
+++ b/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
@@ -44,7 +44,7 @@ Use the critical request chains audit results to target the resources that have 
 
 Learn more about optimizing your
 [images](/use-imagemin-to-compress-images),
-[JavaScript](/apply-instant-loading-with-prp),
+[JavaScript](/apply-instant-loading-with-prpl),
 [CSS](/defer-non-critical-css), and
 [web fonts](/avoid-invisible-text).
 

--- a/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
+++ b/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
@@ -83,4 +83,4 @@ Check their respective sites for full details:
 - [Add a web app manifest](/add-manifest/)
 - [Discover what it takes to be installable](/discover-installable)
 - [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)
-- [Does not use HTTPS](http://localhost:8080/is-on-https/)
+- [Does not use HTTPS](https://web.dev/is-on-https/)

--- a/src/site/content/en/lighthouse-pwa/load-fast-enough-for-pwa/index.md
+++ b/src/site/content/en/lighthouse-pwa/load-fast-enough-for-pwa/index.md
@@ -52,6 +52,6 @@ If the time to interactive is more than 10&nbsp;seconds, the audit fails.
 - [Baseline Progressive Web App Checklist](https://developers.google.com/web/progressive-web-apps/checklist#baseline)
 - [Critical Rendering Path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/)
 - [Get Started With Analyzing Runtime Performance](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/)
-- [Record load performance](/web/tools/chrome-devtools/evaluate-performance/reference#record-load)
+- [Record load performance](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference#record-load)
 - [Optimizing Content Efficiency](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/)
 - [Rendering Performance](https://developers.google.com/web/fundamentals/performance/rendering/)


### PR DESCRIPTION
There are multiple URLs on web.dev that 404 or no longer found. This fixes a few of them.