### PR TITLE
Add CDS playlist to front page of site and deeplink id.

### DIFF
--- a/src/site/content/en/index.njk
+++ b/src/site/content/en/index.njk
@@ -110,13 +110,21 @@ date: 2018-11-05
     </a>
   </section> #}
 
-  <section class="w-cds-promo">
+  <section class="w-cds-promo" id="cds">
     <div class="w-cds-promo__grid">
       <div>
-        <img
-          src="/images/modules/cds19-lockup-stack.svg"
-          alt="chrome dev summit 2019"
-        >
+        <div class="w-cds-promo__video">
+          <div class="w-youtube">
+            <iframe
+              class="w-youtube__embed"
+              src="https://www.youtube.com/embed/videoseries?list=PLNYkxOF6rcIDA1uGhqy45bqlul0VcvKMr"
+              frameborder="0"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+              loading="lazy"
+            ></iframe>
+          </div>
+        </div>
       </div>
       <div>
         <p>


### PR DESCRIPTION
This was a request from @harleenkbatra08.

We'd like to run an ad campaign to direct folks to the embed on the frontpage so I've added an id as well.

Also had to switch away from the YouTube component because it doesn't support playlist embedding. This PR needs to go out today 😅 