### PR TITLE
Make deep links scroll properly.

### DIFF
--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -7,6 +7,8 @@
 //
 // =============================================================================
 
+$WEB_HEADER_HEIGHT: 65px;
+
 // Set box-sizing globally to handle padding and border widths
 *,
 *::before,
@@ -68,7 +70,8 @@ var {
 *:not([href])[id]::before {
   content: ' ';
   display: block;
-  height: 65px;
-  margin-top: -65px;
+  height: $WEB_HEADER_HEIGHT;
+  margin-top: -#{$WEB_HEADER_HEIGHT};
+  pointer-events: none;
   visibility: hidden;
 }

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -71,7 +71,7 @@ var {
   content: ' ';
   display: block;
   height: $WEB_HEADER_HEIGHT;
-  margin-top: -#{$WEB_HEADER_HEIGHT};
+  margin-top: -$WEB_HEADER_HEIGHT;
   pointer-events: none;
   visibility: hidden;
 }

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -62,3 +62,13 @@ var {
   -webkit-hyphens: none;
   hyphens: none;
 }
+
+// Ensures deep linking to headers has enough space to account for the
+// top navigation so they don't overlap.
+*:not([href])[id]::before {
+  content: ' ';
+  display: block;
+  height: 65px;
+  margin-top: -65px;
+  visibility: hidden;
+}


### PR DESCRIPTION
Fixes #1976

Changes proposed in this pull request:

- Prevent top navigation from overlapping with headers when we deep link.
