### PR TITLE
Add icon to external links (replaces #1611)

### DIFF
--- a/src/images/icons/launch.svg
+++ b/src/images/icons/launch.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#3740ff" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -57,7 +57,9 @@ use it to self-review their content and fix problems rather than waiting for rev
 ## Links
 1. Do all links work?
 1. Are all links to web.dev pages and assets [relative](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Examples_of_relative_URLs)?
-   This is important because if we need to move content around, relative paths are less likely to break.
+   (Relative links are less likely to break if content is reorganized.)
+1. Do all links to external sites use the markup shown in the
+  [web.dev components post](/handbook/web-dev-components/#links-(external))?
 1. When referencing a web platform API, does the page link out to the canonical MDN API reference?
 
 ## Mechanics

--- a/src/site/content/en/handbook/markup-post-codelab/index.md
+++ b/src/site/content/en/handbook/markup-post-codelab/index.md
@@ -71,5 +71,8 @@ Use relative URLs to link to assets for the post or codelab.
 `./image.png`
 {% endCompare %}
 
+For external links, use the markup specified on the
+[web.dev components post](/handbook/web-dev-components/#links-(external)).
+
 ## Preview your content
 Use the `npm run dev` command to start a local web server and watch for changes.

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -834,7 +834,7 @@ For example, here are the instructions for the **Performance** audit:
 
 ```html
 Lorem ipsum dolor sit amet,
-<a href="example.com" rel="noopener">consectetur adipiscing elit</a>.
+<a href="example.com" class="w-link--external" rel="noopener">consectetur adipiscing elit</a>.
 Proin dictum a massa sit amet ullamcorper.
 ```
 

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -839,7 +839,7 @@ Proin dictum a massa sit amet ullamcorper.
 ```
 
 Lorem ipsum dolor sit amet,
-<a href="example.com" rel="noopener">consectetur adipiscing elit</a>.
+<a href="example.com" class="w-link--external" rel="noopener">consectetur adipiscing elit</a>.
 Proin dictum a massa sit amet ullamcorper.
 
 ## Lists

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -27,6 +27,7 @@ guidance about how to use them effectively.
 1. [Glitches](#glitches)
 1. [Images](#images)
 1. [Instructions](#instructions)
+1. [Links (external)](#links-(external))
 1. [Lists](#lists)
 1. [Stats](#stats)
 1. [Tables](#tables)
@@ -828,6 +829,18 @@ by using the `audit-auditName` argument in the Instruction shortcode.
 For example, here are the instructions for the **Performance** audit:
 
 {% Instruction 'audit-performance', 'ol' %}
+
+## Links (external)
+
+```html
+Lorem ipsum dolor sit amet,
+<a href="example.com" rel="noopener">consectetur adipiscing elit</a>.
+Proin dictum a massa sit amet ullamcorper.
+```
+
+Lorem ipsum dolor sit amet,
+<a href="example.com" rel="noopener">consectetur adipiscing elit</a>.
+Proin dictum a massa sit amet ullamcorper.
 
 ## Lists
 See the [Lists section of the Grammar, mechanics, and usage post](/handbook/grammar/#lists)

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -85,7 +85,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 .w-author__link-listitem::after {
   content: '·';
   display: inline-block;
-  margin: 0 4px;
+  margin: 0 7px 0 4px;
 }
 
 .w-author__link-listitem:last-of-type::after {
@@ -97,7 +97,6 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   box-shadow: inset 0px 0px 0px 1px $FOCUS_COLOR;
   outline: none;
 }
-
 
 .w-authors__card {
   display: flex;

--- a/src/styles/generic/_links.scss
+++ b/src/styles/generic/_links.scss
@@ -53,6 +53,17 @@ p :visited:active {
   background-color: rgba($FOCUS_COLOR, .16);
 }
 
+// Add a launch icon to external links
+// Authors shouldn't use the target attribute, but styling it just in case.
+[rel='noopener']::after,
+[target='_blank']::after {
+  @include font-material-icon();
+  content: 'launch';
+  display: inline-block;
+  margin: 0 0 2px 2px;
+  vertical-align: middle;
+}
+
 // DevSite override
 a code,
 td a code {

--- a/src/styles/generic/_links.scss
+++ b/src/styles/generic/_links.scss
@@ -60,7 +60,7 @@ p :visited:active {
   background: url('images/icons/launch.svg') no-repeat center / contain;
   content: '';
   margin-left: 2px;
-  padding-right: 22px; // sizing
+  padding-right: 1.222em; // sizing
 }
 
 // DevSite override

--- a/src/styles/generic/_links.scss
+++ b/src/styles/generic/_links.scss
@@ -55,6 +55,7 @@ p :visited:active {
 
 // Add a launch icon to external links
 // Authors shouldn't use the target attribute, but styling it just in case.
+[href*='//']:not([href*='web.dev']),
 [rel='noopener']::after,
 [target='_blank']::after {
   @include font-material-icon();

--- a/src/styles/generic/_links.scss
+++ b/src/styles/generic/_links.scss
@@ -54,15 +54,13 @@ p :visited:active {
 }
 
 // Add a launch icon to external links
-// Authors shouldn't use the target attribute, but styling it just in case.
-[href*='//']:not([href*='web.dev']),
-[rel='noopener']::after,
-[target='_blank']::after {
-  @include font-material-icon();
-  content: 'launch';
-  display: inline-block;
-  margin: 0 0 2px 2px;
-  vertical-align: middle;
+// TODO: remove rel=noopener rule once Markdown parsing is done
+.w-link--external::after,
+[rel='noopener']::after {
+  background: url('images/icons/launch.svg') no-repeat center / contain;
+  content: '';
+  margin-left: 2px;
+  padding-right: 22px; // sizing
 }
 
 // DevSite override


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `launch` icon to external links using a `w-link--external` class.
- Add guidance to handbook to help ensure correct markup is used for external links until Markdown parsing is implemented.
- Fix spacing between links in the author lockup.

Notes:
- In #1611, @kaycebasques proposed using a selector that matches all absolute URLs. That proved very challenging to scope. (For example, I couldn't find a straightforward way to not match the links in the author lockup without referring to their class, which would create an inter-component dependency.)
- So, instead, I went with using a class, which is what /web does. The goal would be to have the Markdown parser add that class and `rel=noopener` to all absolute links.
- We should also add a rule to remark that disallows `//web.dev` to enforce relative internal links.
- Rather than a pseudo-element using the Material icon font, I went with an SVG background image for the link element. Here's why:
  - When the pseudo is set to `display: inline`, it inherits the anchor's `text-decoration`, which produces a thick, ugly underline beneath the icon.
  - Using `display: inline-block` fixes that problem but allows line wrapping between the last word of the link text and the icon.
  - Using `display:inline` and `border-bottom` instead of `text-decoration:underline` solves the wrapping and underline problems, but the border collides with code font styling.
- The downside of the background image approach is that we'll have to load different SVGs if we ever implement theming (e.g., with `prefers-color-scheme`). So, if anybody has a better idea, please share!

cc: @robdodson, @MichaelSolati 