### PR TITLE
fix: Remove Strong tags from code

### DIFF
--- a/src/site/content/en/fast/codelab-serve-modern-code/index.md
+++ b/src/site/content/en/fast/codelab-serve-modern-code/index.md
@@ -38,19 +38,14 @@ optimizations:
 {% Instruction 'disable-cache', 'ol' %}
 {% Instruction 'reload-app', 'ol' %}
 
-```html
 <img class="w-screenshot" src="./original-bundle-size.png" alt="Original bundle size request">
-```
 
 Over 80 KB is used for this application! Time to find out if parts of the bundle
 aren't being used:
 
 {% Instruction 'devtools-command', 'ol' %}
 <!--lint disable code-block-style-->
-
-```html
-<img class="w-screenshot" src="./show-coverage-command-menu.png" alt="Command Menu">
-```
+    <img class="w-screenshot" src="./show-coverage-command-menu.png" alt="Command Menu">
 
 1. Enter `Show Coverage` and hit `Enter` to display the **Coverage** tab.
 1. In the **Coverage** tab, click **Reload** to reload the

--- a/src/site/content/en/fast/codelab-serve-modern-code/index.md
+++ b/src/site/content/en/fast/codelab-serve-modern-code/index.md
@@ -38,14 +38,19 @@ optimizations:
 {% Instruction 'disable-cache', 'ol' %}
 {% Instruction 'reload-app', 'ol' %}
 
+```html
 <img class="w-screenshot" src="./original-bundle-size.png" alt="Original bundle size request">
+```
 
 Over 80 KB is used for this application! Time to find out if parts of the bundle
 aren't being used:
 
 {% Instruction 'devtools-command', 'ol' %}
 <!--lint disable code-block-style-->
-    <img class="w-screenshot" src="./show-coverage-command-menu.png" alt="Command Menu">
+
+```html
+<img class="w-screenshot" src="./show-coverage-command-menu.png" alt="Command Menu">
+```
 
 1. Enter `Show Coverage` and hit `Enter` to display the **Coverage** tab.
 1. In the **Coverage** tab, click **Reload** to reload the
@@ -186,7 +191,7 @@ transforms and polyfills that are included, add a `debug` field to `.babelrc:`
       "@babel/preset-env",
       {
         "targets": "last 2 versions",
-        <strong>"debug": true</strong>
+        "debug": true
       }
     ]
   ]
@@ -239,7 +244,7 @@ the target browsers, add a `useBuiltIns: 'entry'` to the configuration.
       {
         "targets": "last 2 versions",
         "debug": true
-        <strong>"useBuiltIns": "entry"</strong>
+        "useBuiltIns": "entry"
       }
     ]
   ]
@@ -292,7 +297,7 @@ The number of browser targets included is still quite large, and not many users
 use discontinued browsers such as Internet Explorer. Update the configurations
 to the following:
 
-```js/6/5
+```js/6
 {
   "presets": [
     [

--- a/src/site/content/en/fast/codelab-serve-modern-code/index.md
+++ b/src/site/content/en/fast/codelab-serve-modern-code/index.md
@@ -292,7 +292,7 @@ The number of browser targets included is still quite large, and not many users
 use discontinued browsers such as Internet Explorer. Update the configurations
 to the following:
 
-```js/6
+```js/6/5
 {
   "presets": [
     [


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove `<strong>` from code
- Add syntax highlighting to HTML snippets

#### Previews

##### Current 

![Screenshot from 2019-12-20 23-37-19](https://user-images.githubusercontent.com/13482373/71294677-e4869500-2381-11ea-913a-a326968944f4.png)
![Screenshot from 2019-12-20 23-36-58](https://user-images.githubusercontent.com/13482373/71294680-e6505880-2381-11ea-8898-77195921ae80.png)


##### Update

![Screenshot from 2019-12-20 23-39-39](https://user-images.githubusercontent.com/13482373/71294758-1e579b80-2382-11ea-8bcb-0583a839c3de.png)
![Screenshot from 2019-12-20 23-39-26](https://user-images.githubusercontent.com/13482373/71294759-1ef03200-2382-11ea-8311-232db3dbcf85.png)
