### PR TITLE
Add self-assessments batch 1

### DIFF
--- a/src/lib/components/Tabs/_styles.scss
+++ b/src/lib/components/Tabs/_styles.scss
@@ -23,6 +23,7 @@ web-tabs {
     border-bottom: 1px solid $GREY_300;
     display: flex;
     margin: 0 -24px;
+    overflow-x: auto;
     width: calc(100% + 48px);
   }
 

--- a/src/site/_includes/components/AssessmentHint.js
+++ b/src/site/_includes/components/AssessmentHint.js
@@ -30,7 +30,7 @@ module.exports = (content, summary, state) => {
   // prettier-ignore
   return html`
     <details class="w-self-assessment-hint" ${stateOverride}>
-      <summary class="w-self-assessment-hint__summary">${summary}</summary>
+      <summary class="w-self-assessment-hint__summary">${md.renderInline(summary)}</summary>
       <div class="w-self-assessment-hint__panel">${md.render(content)}</div>
     </details>
   `;

--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -142,6 +142,114 @@ You can learn more about them in our guide on
 [screen reader basics](/semantics-and-screen-readers).
 {% endAside %}
 
+{% AssessmentCallout 'Use the drop-down below each code sample to check your understanding of tab order.' %}
+{% Tabs 'Samples for knowledge self check' %}
+{% Tab 'sample' %}
+
+This HTML renders a modal dialog:
+```html
+<div role="dialog" aria-labelledby="dialog-header">
+  <button aria-label="Close"></button>
+  <h2 id="dialog-header">
+    Do you want to allow notifications from this website?
+  </h2>
+  <button>No</button>
+  <button>Yes</button>
+</div>
+```
+
+{% AssessmentHint 'Which elements from the sample are included in the tab order?' %}
+Only the `<button>` elements are included in the tab order
+because they're the only native HTML form elements.
+
+To insert other elements into the tab order, you would add a `tabindex` attribute.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+<section tabindex="-1">
+  <h2>Cat facts</h2>
+  <ul>
+    <li>A group of cats is called a <a href="https://m-w.com/dictionary/clowder">clowder</a>.</li>
+    <li>Most cats are <a href="https://www.catfacts.org/catnip.html"> unaffected by catnip</a>.</li>
+  </ul>
+</section>
+```
+
+{% AssessmentHint 'Which elements from the sample are included in the tab order?' %}
+Only the `<a>` elements are included in the tab order.
+
+The `<section>` element is not in the tab order
+because it has a negative `tabindex` value.
+(It can, however, be focused using the `focus()` method.)
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+<form action="./cat-info.json">
+  <p>Where did you get your cat?</p>
+  <label>
+    <input type="radio" name="source" value="shelter">
+    An animal shelter
+  </label>
+  <label>
+    <input type="radio" name="source" value="petshop">
+    A pet shop
+  </label>
+  <label>
+    <input type="radio" name="source" value="breeder">
+    A breeder
+  </label>
+  <p>Describe your cat:</p>
+  <input type="text">
+  <button type="submit">Submit</button>
+</form>
+```
+
+{% AssessmentHint 'How many tab stops does the sample include?' %}
+The sample includes **three** tab stops:
+- One for the radio group
+- One for the text input
+- One for the **Submit** button
+
+Radio groups have a
+[roving tabindex](#create-accessible-components-with-"roving-tabindex")
+by default, so the entire group has only one tab stop.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This HTML renders a popup menu followed by a search input:
+
+```html
+<div role="menu" tabindex="0">
+  <a role="menuitem" href="/learn/" tabindex="-1">Learn</a>
+  <a role="menuitem" href="/measure/" tabindex="-1">Measure</a>
+  <a role="menuitem" href="/blog/" tabindex="-1">Blog</a>
+  <a role="menuitem" href="/about/" tabindex="-1">About</a>
+</div>
+<input tabindex="1" type="text" role="search" aria-label="Search" placeholder="Search">
+```
+
+{% AssessmentHint 'Which element in the sample comes first in the tab order?' %}
+The **Search** text input comes first in the tab order.
+Because it has a `tabindex` greater than 1, it jumps to the front of the tab order.
+
+(This behavior is likely to cause confusion
+  if the menu is positioned on the page before the search input.
+  This is an example of why `tabindex>0` is considered an anti-pattern.)
+
+{% endAssessmentHint %}
+
+{% endTab %}
+{% endTabs %}
+{% endAssessmentCallout %}
+
 ## Keyboard access recipes
 
 If you're unsure what level of keyboard support your custom components might

--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -169,27 +169,6 @@ To insert other elements into the tab order, you would add a `tabindex` attribut
 {% Tab 'sample' %}
 
 ```html
-<section tabindex="-1">
-  <h2>Cat facts</h2>
-  <ul>
-    <li>A group of cats is called a <a href="https://m-w.com/dictionary/clowder">clowder</a>.</li>
-    <li>Most cats are <a href="https://www.catfacts.org/catnip.html"> unaffected by catnip</a>.</li>
-  </ul>
-</section>
-```
-
-{% AssessmentHint 'Which elements from the sample are included in the tab order?' %}
-Only the `<a>` elements are included in the tab order.
-
-The `<section>` element is not in the tab order
-because it has a negative `tabindex` value.
-(It can, however, be focused using the `focus()` method.)
-{% endAssessmentHint %}
-
-{% endTab %}
-{% Tab 'sample' %}
-
-```html
 <form action="./cat-info.json">
   <p>Where did you get your cat?</p>
   <label>
@@ -224,6 +203,27 @@ by default, so the entire group has only one tab stop.
 {% endTab %}
 {% Tab 'sample' %}
 
+```html
+<section tabindex="-1">
+  <h2>Cat facts</h2>
+  <ul>
+    <li>A group of cats is called a <a href="https://m-w.com/dictionary/clowder">clowder</a>.</li>
+    <li>Most cats are <a href="https://www.catfacts.org/catnip.html"> unaffected by catnip</a>.</li>
+  </ul>
+</section>
+```
+
+{% AssessmentHint 'Which elements from the sample are included in the tab order?' %}
+Only the `<a>` elements are included in the tab order.
+
+The `<section>` element is not in the tab order
+because it has a negative `tabindex` value.
+(It can, however, be focused using the `focus()` method.)
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
 This HTML renders a popup menu followed by a search input:
 
 ```html
@@ -241,8 +241,9 @@ The **Search** text input comes first in the tab order.
 Because it has a `tabindex` greater than 1, it jumps to the front of the tab order.
 
 (This behavior is likely to cause confusion
-  if the menu is positioned on the page before the search input.
-  This is an example of why `tabindex>0` is considered an anti-pattern.)
+if the menu is positioned on the page before the search input.
+This is an example of why having a `tabindex` value greater than zero
+is considered an anti-pattern.)
 
 {% endAssessmentHint %}
 

--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -158,46 +158,14 @@ This HTML renders a modal dialog:
 </div>
 ```
 
-{% AssessmentHint 'Which elements from the sample are included in the tab order?' %}
+{% AssessmentHint 'What is the tab order for the elements in the sample?' %}
+1. The **Close** button
+1. The **No** button
+1. The **Yes** button
+
 Only the `<button>` elements are included in the tab order
 because they're the only native HTML form elements.
-
 To insert other elements into the tab order, you would add a `tabindex` attribute.
-{% endAssessmentHint %}
-
-{% endTab %}
-{% Tab 'sample' %}
-
-```html
-<form action="./cat-info.json">
-  <p>Where did you get your cat?</p>
-  <label>
-    <input type="radio" name="source" value="shelter">
-    An animal shelter
-  </label>
-  <label>
-    <input type="radio" name="source" value="petshop">
-    A pet shop
-  </label>
-  <label>
-    <input type="radio" name="source" value="breeder">
-    A breeder
-  </label>
-  <p>Describe your cat:</p>
-  <input type="text">
-  <button type="submit">Submit</button>
-</form>
-```
-
-{% AssessmentHint 'How many tab stops does the sample include?' %}
-The sample includes **three** tab stops:
-- One for the radio group
-- One for the text input
-- One for the **Submit** button
-
-Radio groups have a
-[roving tabindex](#create-accessible-components-with-"roving-tabindex")
-by default, so the entire group has only one tab stop.
 {% endAssessmentHint %}
 
 {% endTab %}
@@ -245,6 +213,36 @@ if the menu is positioned on the page before the search input.
 This is an example of why having a `tabindex` value greater than zero
 is considered an anti-pattern.)
 
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This HTML renders a custom radio group:
+
+```html
+<div role="radiogroup" aria-labelledby="breed-header">
+  <h3 id="breed-header">Your cat's breed</h3>
+  <div role="radio" aria-checked="false" tabindex="0">Persian</div>
+  <div role="radio" aria-checked="false" tabindex="-1">Bengal</div>
+  <div role="radio" aria-checked="false" tabindex="-1">Maine Coon</div>
+</div>
+```
+
+To keep things simpler, ignore the
+[`aria-*` and `role` attributes](/semantics-and-screen-readers) for now.
+
+{% AssessmentHint 'For a roving `tabindex`, what logic should run when a user presses the `Right` arrow key while a radio element is focused?' %}
+- Change the `tabindex` values for all radio elements in the group to -1.
+- If there's a radio element after the one that's focused,
+  set its `tabindex` value to 0.
+- If there's no radio element after the one that's focused,
+  set the `tabindex` value of the first radio element in the group to 0.
+- Focus the radio element that now has a `tabindex` of 0.
+
+That's a lot—and it doesn't even include ARIA attributes!
+This is an example of why it's easier to use native elements
+with built-in keyboard behavior whenever you can.
 {% endAssessmentHint %}
 
 {% endTab %}

--- a/src/site/content/en/accessible/labels-and-text-alternatives/index.md
+++ b/src/site/content/en/accessible/labels-and-text-alternatives/index.md
@@ -334,3 +334,105 @@ promotional offers?" like in the VoiceOver example below:
   <img class="w-screenshot" src="./promo-offers.png"
   alt="VoiceOver text output showing 'Receive promotional offers?'">
 </figure>
+
+{% AssessmentCallout 'Use the drop-down below each code sample to check whether the HTML element in the sample has an accessible name.' %}
+{% Tabs 'Samples for knowledge self check' %}
+{% Tab 'sample' %}
+
+```html
+<img src="temp.svg" alt="temp">
+```
+
+{% AssessmentHint 'Does this image have an accessible name?' %}
+**Yes**. Give an image an accessible name by adding an `alt` attribute.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+<object type="application/pdf" data="/report.pdf" alt="Annual report"></object>
+```
+
+{% AssessmentHint 'Does this object have an accessible name?' %}
+**No**. Give an `<object>` element a name by providing text content.
+(An `alt` attribute on an object will not be read by assistive technologies.)
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This sample renders an icon button:
+
+```html
+<button>
+  <svg class="icon">
+    <use xlink:href="#icon-1" />
+  </svg>
+</button>
+```
+
+{% AssessmentHint 'Does this button have an accessible name?' %}
+**No**. Give a button an accessible name by providing text content,
+an `aria-label` attribute, or an `aria-labelledby` attribute.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This sample renders an icon button with a tooltip that appears on hover and focus:
+
+```html
+<button>
+  <svg class="icon">
+    <use xlink:href="#icon-1" />
+  </svg>
+  <span class="tooltip hidden">Open menu</span>
+</button>
+```
+
+{% AssessmentHint 'Does this button have an accessible name?' %}
+**Yes**. Even if the button's tooltip is visually hidden using CSS,
+assistive technologies can still read its text content.
+
+**Caution:** When visually hiding button text,
+use CSS rather than the `hidden` attribute.
+The `hidden` attribute removes the element from the accessibility tree.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+<label>
+  <input type="checkbox" value="subscribe"></input>
+  Subscribe to the newsletter?
+</label>
+```
+
+{% AssessmentHint 'Does this checkbox have an accessible name?' %}
+**Yes**. The label is associated with the checkbox
+because the label is the checkbox's parent.
+So, assistive technologies treat the label's text content as the input's name.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+<input type="checkbox" value="subscribe"></input>
+<label for="subscribe">Subscribe to the newsletter?</label>
+```
+
+{% AssessmentHint 'Does this checkbox have an accessible name?' %}
+**No**. The checkbox's `value` attribute indicates
+what text will be saved when the form is submitted,
+but assistive technologies don't read it.
+To provide an accessible name,
+add an `id` attribute with the value `subscribe`
+to associate the checkbox with the label.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% endTabs %}
+{% endAssessmentCallout %}

--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -113,24 +113,6 @@ outcome to expect.
 {% Tabs 'Samples for knowledge self check' %}
 {% Tab 'sample' %}
 
-When selected, this element opens a modal dialog:
-
-```html
-<a href="#" onclick="openDialog()">
-```
-
-{% AssessmentHint 'Should this sample use a button or a link?' %}
-This sample should use a **button**. The sample is **incorrect**.
-
-When selected,
-the element runs a function that opens a modal dialog on the same page;
-since the element isn't navigating the user to a separate page,
-a button is semantic.
-{% endAssessmentHint %}
-
-{% endTab %}
-{% Tab 'sample' %}
-
 ```html
 See <a href="https://webaim.org/intro/" rel="noopener">WebAIM's Introduction to Web Accessibility</a> for more information.
 ```
@@ -157,25 +139,19 @@ When selected, the element navigates the user to a different page on the same do
 {% endTab %}
 {% Tab 'sample' %}
 
-This code renders a horizontal navigation menu at the top of a website:
+When selected, this element opens a modal dialog:
 
 ```html
-<nav>
-  <button>About</button>
-  <button>Services</button>
-  <button>Work</button>
-  <button>Contact</button>
-</nav>
+<a href="#" onclick="openDialog()">
 ```
 
 {% AssessmentHint 'Should this sample use a button or a link?' %}
-This sample should use **links**. The sample is **incorrect**.
+This sample should use a **button**. The sample is **incorrect**.
 
-The elements in the `<nav>` menu navigate the user to other pages.
-Those pages may be separate resources in a static site,
-or they may be views in a
-[single-page application](https://developers.google.com/web/fundamentals/architecture/app-shell).
-Either way, since the user is navigating somewhere else, links are semantic.
+When selected,
+the element runs a function that opens a modal dialog on the same page;
+since the element isn't navigating the user to a separate page,
+a button is semantic.
 {% endAssessmentHint %}
 
 {% endTab %}
@@ -192,17 +168,36 @@ This sample should use a **button**. The sample is **incorrect**.
 
 When selected,
 the element runs a function that opens a navigation menu on the same page.
-_Opening_ the menu is an action, so a button is semantic.
-(Selecting an item _in_ the menu, however, would be a navigation.)
+Opening the menu is an action, so a button is semantic.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This code renders a horizontal navigation menu at the top of a website:
+
+```html
+<nav>
+  <button>About</button>
+  <button>Services</button>
+  <button>Work</button>
+  <button>Contact</button>
+</nav>
+```
+
+{% AssessmentHint 'Should this sample use buttons or links?' %}
+This sample should use **links**. The sample is **incorrect**.
+
+The elements in the `<nav>` menu navigate the user to other pages.
+Those pages may be separate resources in a static site,
+or they may be views in a
+[single-page application](https://developers.google.com/web/fundamentals/architecture/app-shell).
+Either way, since the user is navigating somewhere else, links are semantic.
 {% endAssessmentHint %}
 
 {% endTab %}
 {% endTabs %}
 {% endAssessmentCallout %}
-
-<object type="application/pdf" data="/report.pdf">
-Annual report.
-</object>
 
 ## Styling
 

--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -33,7 +33,7 @@ attribute are sometimes used for freeform text entry.
 It's easy to overlook the built-in keyboard support that these elements offer.
 Below are some example elements to explore. Instead of using your
 mouse, try using your keyboard to operate them. You can use `TAB` (or `SHIFT +
-TAB`) to move between controls, and you can use the arrow keys and keys like 
+TAB`) to move between controls, and you can use the arrow keys and keys like
 `ENTER` and `SPACE` to manipulate their values.
 
 <div class="glitch-embed-wrap" style="height: 450px; width: 100%;">
@@ -72,7 +72,7 @@ that the keycode is `ENTER` or `SPACE`, and then run your click handler. Ouch!
 That's a lot of extra work!
 
 Compare the difference in this example. `TAB` to either control, and use `ENTER`
-and `SPACE` to attempt to click on them. 
+and `SPACE` to attempt to click on them.
 
 <div class="glitch-embed-wrap" style="height: 346px; width: 100%;">
   <iframe
@@ -108,6 +108,101 @@ should you choose?
 The reason for this is that buttons and links are announced differently by
 screen readers. Using the correct element helps screen reader users know which
 outcome to expect.
+
+{% AssessmentCallout 'Use the drop-down below each code sample to check whether the sample should use buttons or links.' %}
+{% Tabs 'Samples for knowledge self check' %}
+{% Tab 'sample' %}
+
+When selected, this element opens a modal dialog:
+
+```html
+<a href="#" onclick="openDialog()">
+```
+
+{% AssessmentHint 'Should this sample use a button or a link?' %}
+This sample should use a **button**. The sample is **incorrect**.
+
+When selected,
+the element runs a function that opens a modal dialog on the same page;
+since the element isn't navigating the user to a separate page,
+a button is semantic.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+See <a href="https://webaim.org/intro/" rel="noopener">WebAIM's Introduction to Web Accessibility</a> for more information.
+```
+
+{% AssessmentHint 'Should this sample use a button or a link?' %}
+This sample should use a **link**. The sample is **correct**.
+
+When selected, the element navigates the user to another page on a different domain, so a link is semantic.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+```html
+See the <a href="/semantics-and-screen-readers">Semantics and screen readers page</a> for more information.
+```
+
+{% AssessmentHint 'Should this sample use a button or a link?' %}
+This sample should use a **link**. The sample is **correct**.
+
+When selected, the element navigates the user to a different page on the same domain. No matter where a resource is located, use a link to semantically indicate navigation.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+This code renders a horizontal navigation menu at the top of a website:
+
+```html
+<nav>
+  <button>About</button>
+  <button>Services</button>
+  <button>Work</button>
+  <button>Contact</button>
+</nav>
+```
+
+{% AssessmentHint 'Should this sample use a button or a link?' %}
+This sample should use **links**. The sample is **incorrect**.
+
+The elements in the `<nav>` menu navigate the user to other pages.
+Those pages may be separate resources in a static site,
+or they may be views in a
+[single-page application](https://developers.google.com/web/fundamentals/architecture/app-shell).
+Either way, since the user is navigating somewhere else, links are semantic.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+When selected, this element opens a navigation menu:
+
+```html
+<a href="#" onclick="openNavMenu()">
+```
+
+{% AssessmentHint 'Should this sample use a button or a link?' %}
+This sample should use a **button**. The sample is **incorrect**.
+
+When selected,
+the element runs a function that opens a navigation menu on the same page.
+_Opening_ the menu is an action, so a button is semantic.
+(Selecting an item _in_ the menu, however, would be a navigation.)
+{% endAssessmentHint %}
+
+{% endTab %}
+{% endTabs %}
+{% endAssessmentCallout %}
+
+<object type="application/pdf" data="/report.pdf">
+Annual report.
+</object>
 
 ## Styling
 

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -52,7 +52,7 @@ the opportunity **Eliminate render-blocking resources**, pointing to the
 {% Aside %}
 The CSS we are using for this demo site is quite small. If you were requesting
 larger CSS files (which are not uncommon in production scenarios), and if
-Lighthouse detects that a page has, at least, 2048 bytes of CSS rules that
+Lighthouse detects that a page has at least 2048&nbsp;bytes of CSS rules that
 weren't used while rendering the **above the fold** content, you'll
 also receive a suggestion called **Remove Unused CSS**.
 {% endAside %}
@@ -60,7 +60,7 @@ also receive a suggestion called **Remove Unused CSS**.
 To visualize how this CSS blocks rendering:
 
 1. Open [the page](https://defer-css-unoptimized.glitch.me/) in Chrome.
-{% Instruction 'devtools-performance' %}
+{% Instruction 'devtools-performance', 'ol' %}
 1. In the Performance panel, click **Reload**.
 
 In the resulting trace, you'll see that the **FCP** marker is placed immediately

--- a/src/site/content/en/reliable/codelab-explore-network-panel/index.md
+++ b/src/site/content/en/reliable/codelab-explore-network-panel/index.md
@@ -12,9 +12,9 @@ related_post: identify-resources-via-network-panel
 ---
 
 This codelab walks you through the process of interpreting all of the network
-traffic for a more complex sample application. At the end of the exercise,
-you'll have the skills you need to figure out _what_ your own web application's
-loading, and _when_ each of the requests are being made.
+traffic for a somewhat complex sample application. At the end of the exercise,
+you'll have the skills you need to figure out _what_ your own web application is
+loading and _when_ it's making each request.
 
 {% Aside %}
 The screenshots and instructions in this codelab assume that you're using
@@ -32,18 +32,15 @@ application.
 {% Instruction 'devtools-network', 'ol' %}
 1. Reload the page to see the network traffic.
 
-You should see the DevTools interface open up, in either a new window or as a
-sidebar in your existing window. In the DevTools, select the Network
-tab to open the Network panel.
-The Network panel shows all the assets loaded as a result of your initial
+The Network panel shows all the assets loaded because of your initial
 navigation:
 
 <img class="screenshot" src="./initial-navigation.png" alt="Chrome DevTools' network panel.">
 
 {% Aside %}
 The actual columns you see in the Network panel may be different; the
-screenshot shows a simplified view with everything but the Name, Type, and
-Waterfall columns hidden.
+screenshot shows a simplified view with everything but the **Name**, **Type**, and
+**Waterfall** columns hidden.
 {% endAside %}
 
 ## How to interpret the entries
@@ -52,7 +49,7 @@ Each row of recorded network traffic represents a single request and response
 pair.
 
 The first row, with type `document`, is the initial navigation request for the
-web app's HTML. This is the "source" for the waterfall; each of the subsequent
+web app's HTML. This is the source for the waterfall; each of the subsequent
 requests for additional assets (known as subresources of the main document) flow
 from this original source.
 
@@ -63,28 +60,29 @@ Looking at _when_ those requests are made, the waterfall diagram shows that
 they're not started until very late in the process of responding to the
 navigation request.
 
-Taken together, the requests for the HTML document along with some CSS and
-JavaScript are the set of requests needed to display the full page during the
+Taken together, the requests for the HTML document, CSS, and
+JavaScript are needed to display the full page during the
 initial navigation.
 
 ## Create some additional runtime requests
 
-With the Network panel still open and recording, it's time to simulate something
+With the **Network** panel still open and recording, it's time to simulate something
 common for a lot of web apps: additional API requests used to add more data to
 the page after the initial navigation is complete.
 
-Trigger these additional requests by clicking the **Find Me** button, and then
-**Allow**ing the site to access your current location:
+Trigger these additional requests by clicking **Find Me** in the app and then
+**Allow** in the popup that appears.
+This will allow the site to access your current location:
 
 <img src="./allow-location.png" alt="The allow location permission prompt.">
 
 {% Aside %}
-You could also deny Geolocation permission, in which case the web app
+You could also deny geolocation permission, in which case the web app
 will fall back to a default location.
 {% endAside %}
 
-Once the web app has a location to work with, clicking on the **Find Nearby
-Wikipedia Entries** button results in several additional Network requests. You
+Once the web app has a location to work with, clicking **Find Nearby
+Wikipedia Entries** results in several additional network requests. You
 should see something like this:
 
 ![image](./network-requests.png)

--- a/src/site/content/en/secure/same-origin-policy/index.md
+++ b/src/site/content/en/secure/same-origin-policy/index.md
@@ -106,7 +106,7 @@ cross-origin resource is blocked.
 A webpage on the web.dev domain includes this iframe:
 
 ```html
-<iframe src="https://example.com/some-page.html" alt="Sample iframe"></iframe>
+<iframe id="iframe" src="https://example.com/some-page.html" alt="Sample iframe"></iframe>
 ```
 
 The webpage's JavaScript includes this code to get the text content from an element in the embedded page:

--- a/src/site/content/en/secure/same-origin-policy/index.md
+++ b/src/site/content/en/secure/same-origin-policy/index.md
@@ -14,32 +14,34 @@ codelabs:
   - codelab-same-origin-iframe
 ---
 
-The same-origin policy is a browser security feature that restricts cross-origin
-interactions by documents and scripts.
+The same-origin policy is a browser security feature that restricts how
+documents and scripts on one origin can interact with resources
+on another origin.
 
-A browser can load and display resources from multiple sites. You might have
+A browser can load and display resources from multiple sites at once. You might have
 multiple tabs open at the same time, or a site could embed multiple iframes from
-different sites. If there is no restriction on interactions between those
-resources, and if a script is compromised by an attacker, the script could
-expose everything on a user's browser.
+different sites. If there is no restriction on interactions between these
+resources, and a script is compromised by an attacker, the script could
+expose everything in a user's browser.
 
 The same-origin policy prevents this from happening by blocking read access to
-resources loaded from a different origin. "But wait", you say. "I load images
+resources loaded from a different origin. "But wait," you say, "I load images
 and scripts from other origins _all the time_." Browsers allow a few tags to
-embed resources from different origin. This is mostly historical artifacts and
-could expose your site to vulnerabilities such as [clickjacking using
-iframes](#how-to-prevent-clickjacking). You can restrict the origins for these
-tags using a [Content Security
+embed resources from a different origin. This policy is mostly a historical
+artifact and can expose your site to vulnerabilities such as [clickjacking using
+iframes](#how-to-prevent-clickjacking). You can restrict cross-origin reading
+of these tags using a [Content Security
 Policy](https://developers.google.com/web/fundamentals/security/csp/).
 
-## What is considered "same-origin"?
+## What's considered same-origin?
 
 An origin is defined by the scheme (also known as the  protocol, for example
 HTTP or HTTPS), port (if it is specified), and host. When all three are the same
-for two URLs, it is considered same-origin. For example.
-`http://www.example.com/foo` is the same-origin as `http://www.example.com/bar`
-but not <code><strong>https</strong>://www.example.com/baz</code> (the scheme is
-different).
+for two URLs, they are considered same-origin. For example,
+`http://www.example.com/foo` is the same origin as
+<code><strong>http</strong>://www.example.com/bar</code>
+but not <code><strong>https</strong>://www.example.com/bar</code>
+because the scheme is different.
 
 {% Aside 'codelab' %}
 [See how the same-origin policy works when fetching resources](/codelab-same-origin-fetch).
@@ -54,39 +56,39 @@ cross-origin resource is blocked.
   <table>
     <tbody>
     <tr>
-      <td>iframe </td>
+      <td>iframes</td>
       <td>
-        Cross-origin embed is permitted (if <code>X-Frame-Options</code> permits) but cross-origin read, such as using JavaScript to access a document in an iframe, is not permitted.
+        Cross-origin embedding is usually permitted (depending on the <code><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options" rel="noopener">X-Frame-Options</a></code> directive), but cross-origin reading (such as using JavaScript to access a document in an iframe) isn't.
       </td>
     </tr>
     <tr>
-      <td>css</td>
+      <td>CSS</td>
       <td>
-        Cross-origin CSS can be embedded using a <code>link</code> tag, or <code>@import</code> in a CSS file. The correct <code>Content-Type</code> header may be required.
+        Cross-origin CSS can be embedded using a <code>&lt;link&gt;</code> element or an <code>@import</code> in a CSS file. The correct <code>Content-Type</code> header may be required.
       </td>
     </tr>
     <tr>
-      <td>form</td>
+      <td>forms</td>
       <td>
-        Cross-origin URL can be used as the <code>action</code> attribute value of a form element. A web application can write form data to a cross-origin destination.
+        Cross-origin URLs can be used as the <code>action</code> attribute value of form elements. A web application can write form data to a cross-origin destination.
       </td>
     </tr>
     <tr>
-      <td>img</td>
+      <td>images</td>
       <td>
-        Embedding cross-origin images is permitted. However, reading cross-origin images is blocked (such as loading a cross-origin image into a <code>canvas</code> element using JavaScript).
+        Embedding cross-origin images is permitted. However, reading cross-origin images (such as loading a cross-origin image into a <code>canvas</code> element using JavaScript) is blocked.
       </td>
     </tr>
     <tr>
-      <td>media</td>
+      <td>multimedia</td>
       <td>
-        Cross-origin video and audio can be embedded using <code>video</code> and <code>audio</code> elements.
+        Cross-origin video and audio can be embedded using <code>&lt;video&gt;</code> and <code>&lt;audio&gt;</code> elements.
       </td>
     </tr>
     <tr>
       <td>script</td>
       <td>
-        Cross-origin script can be embedded; however, access to certain APIs might be blocked, such as cross-origin fetch requests.
+        Cross-origin scripts can be embedded; however, access to certain APIs (such as cross-origin fetch requests) might be blocked.
       </td>
     </tr>
     </tbody>
@@ -94,8 +96,96 @@ cross-origin resource is blocked.
 </div>
 
 {% Aside 'codelab' %}
-[See how the same-origin policy works works when accessing data inside an iframe](/codelab-same-origin-iframe).
+[See how the same-origin policy works when accessing data inside an iframe](/codelab-same-origin-iframe).
 {% endAside %}
+
+{% AssessmentCallout 'Use the drop-down below each cross-origin resource to check whether the specified action is allowed.' %}
+{% Tabs 'Samples for knowledge self check' %}
+{% Tab 'sample' %}
+
+A webpage on the web.dev domain includes this iframe:
+
+```html
+<iframe src="https://example.com/some-page.html" alt="Sample iframe"></iframe>
+```
+
+The webpage's JavaScript includes this code to get the text content from an element in the embedded page:
+
+```html
+const iframe = document.getElementById('iframe');
+const message = iframe.contentDocument.getElementById('message').innerText;
+```
+
+{% AssessmentHint 'Is this JavaScript allowed?' %}
+**No**. Since the iframe is not on the same origin as the host webpage,
+the browser doesn't allow reading of the embedded page.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+A webpage on the web.dev domain includes this form:
+
+```html
+<form action="https://example.com/results.json">
+  <label for="email">Enter your email: </label>
+  <input type="email" name="email" id="email" required>
+  <button type="submit">Subscribe</button>
+</form>
+```
+
+{% AssessmentHint 'Can this form be submitted?' %}
+**Yes**. Form data can be written to a cross-origin URL specified
+in the `action` attribute of the `<form>` element.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+A webpage on the web.dev domain includes this iframe:
+
+```html
+<iframe src="https://example.com/some-page.html" alt="Sample iframe"></iframe>
+```
+
+{% AssessmentHint 'Is this iframe embed allowed?' %}
+**Usually**. Cross-origin iframe embeds are allowed
+as long as the origin owner hasn't set the
+[`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
+HTTP header to `deny` or `sameorigin`.
+{% endAssessmentHint %}
+
+{% endTab %}
+{% Tab 'sample' %}
+
+A webpage on the web.dev domain includes this canvas:
+
+```html
+<canvas id="bargraph"></canvas>
+```
+
+The webpage's JavaScript includes this code to draw an image on the canvas:
+
+```js
+var context = document.getElementById('bargraph').getContext('2d');
+var img = new Image();
+img.onload = function() {
+  context.drawImage(img, 0, 0);
+};
+img.src = 'https://example.com/graph-axes.svg';
+```
+
+{% AssessmentHint 'Can this image be drawn on the canvas?' %}
+**It depends!** 😅 The image is on a different origin.
+If the origin's owner gave the image the appropriate
+[CORS header](/cross-origin-resource-sharing),
+the image can be safely drawn. If not, the image will
+[cause an error](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#What_is_a_.22tainted.22_canvas.3F).
+{% endAssessmentHint %}
+
+{% endTab %}
+{% endTabs %}
+{% endAssessmentCallout %}
 
 ### How to prevent Clickjacking
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add first four self-assessment sets in:
  - `control-focus-with-tabindex`
  - `use-semantic-html`
  - `labels-and-text-alternatives`
  - `same-origin-policy`
- Add horizontal scrolling when tabs overflow viewport. (Matches behavior of Material tabs, except scrollbar is visible to improve discoverability and usability for mouse users.)
- Add Markdown parsing to AssessmentHint `<summary>` element.
- Tidy editorial issues in `same-origin-policy` post.
- Tidy editorial issues in `codelab-explore-network-panel` post. (Was going to add a set to this post but decided against it after tidying.)
- Fix instruction list formatting in `defer-non-critical-css`. (Same as above.)
