### PR TITLE
Add ci workflow.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,32 @@
+name: Continuous integration
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
+    - cron: '0 15 * * 1-4'
+
+jobs:
+  ci:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup node and build
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+        env:
+          ELEVENTY_ENV: prod
+      - run: npm ci && npm run build && node index-algolia.js
+
+      - name: Deploy
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '270.0.0'
+          service_account_email: ${{ secrets.GCLOUD_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_KEY }}
+      - run: gcloud app deploy --project web-dev-production-1


### PR DESCRIPTION
Changes proposed in this pull request:

- Build and deploy the site anytime a commit lands on master. The commit can either be from a push or merging a PR.
- Build and deploy the site on a regular schedule (Mon-Thur, 15:00 UTC / 7:00am PST). Our peak traffic seems to be around 6-7am PST. Doing it at 7 seems to be a good balance because it hopefully captures the most users, and also ensures that our team will be oncall soon in case something goes wrong.
