### PR TITLE
Register analytics event for elements with gc-analytics-event class

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -31,16 +31,18 @@ function trackEvent({category, action, label, value}) {
 }
 
 /**
- * Configure tracking events for any clicks on `<a href="...">`, searching for (requiring at least)
- * `data-category`, but also allowing `data-action`, `data-label` and `data-value`.
+ * Configure tracking events for any clicks on a link (`<a href="...">`)
+ * or another trackable element (class="gc-analytics-event"), searching
+ * for (requiring at least `data-category`, but also allowing
+ * `data-action`, `data-label` and `data-value`.
  */
 document.addEventListener("click", (e) => {
-  const link = e.target.closest("a[href]");
-  if (!link) {
+  const clickableEl = e.target.closest("a[href], .gc-analytics-event");
+  if (!clickableEl) {
     return;
   }
 
-  const data = getAnalyticsDataFromElement(link);
+  const data = getAnalyticsDataFromElement(clickableEl);
   if (!data.category) {
     return; // category is required
   }

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -78,12 +78,14 @@ class Tabs extends BaseElement {
       <button
         @click="${this.onClick}"
         @keydown="${this.onKeydown}"
-        class="web-tabs__tab"
+        class="web-tabs__tab gc-analytics-event"
         role="tab"
         aria-selected="${isActive}"
         id="web-tab-${i}"
         aria-controls="web-tab-${i}-panel"
         tabindex=${tabIndex}
+        data-category="Site-Wide Custom Events"
+        data-label="tab, ${tabLabel}"
       >
         <span class="web-tabs__text-label">${tabLabel}</span>
       </button>


### PR DESCRIPTION
As mentioned in the comment (https://github.com/GoogleChrome/web.dev/pull/1595#pullrequestreview-320230019), we should be bale to track events for other elements than links.

I'm using existing gc-analytics-event class to do that, while keeping tracking of all a#href clicks too. If we agree on this approach, I'll add the class to other trackable custom elements too. 

- 
- 
- 
