### PR TITLE
Make sure ids are unique in custom elements

### DIFF
--- a/src/lib/components/BaseElement/index.js
+++ b/src/lib/components/BaseElement/index.js
@@ -6,6 +6,22 @@ export class BaseElement extends LitElement {
     super();
   }
 
+  /**
+   * Generates a random string that can be used to ensure uniqueness of
+   * the elements id on a page.
+   * @param {string} idPrefix An id prefix to be followed by the generated salt.
+   *     Used to check the uniqueness of the outcome id (prefix + salt).
+   * @return {string} Id salt.
+   */
+  static generateIdSalt(idPrefix) {
+    const salt = Math.random()
+      .toString(36)
+      .substr(2, 9);
+    return document.getElementById(idPrefix + salt)
+      ? BaseElement.generateIdSalt(idPrefix)
+      : salt;
+  }
+
   createRenderRoot() {
     // Disable shadow DOM.
     // Instead templates will be rendered in the light DOM.

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -10,6 +10,7 @@ class Tabs extends BaseElement {
 
   constructor() {
     super();
+    this.idSalt = BaseElement.generateIdSalt("web-tab-");
 
     this.prerenderedChildren = null;
     this.tabs = null;
@@ -31,8 +32,8 @@ class Tabs extends BaseElement {
       for (const child of this.children) {
         // Set id and aria-labelledby attributes for each panel for a11y
         // and remove hidden attribute on first tab.
-        child.id = "web-tab-" + i + "-panel";
-        child.setAttribute("aria-labelledby", "web-tab-" + i);
+        child.id = `web-tab-${this.idSalt}-${i}-panel`;
+        child.setAttribute("aria-labelledby", `web-tab-${this.idSalt}-${i}`);
         if (i === 1) {
           child.removeAttribute("hidden");
         }
@@ -81,8 +82,8 @@ class Tabs extends BaseElement {
         class="web-tabs__tab"
         role="tab"
         aria-selected="${isActive}"
-        id="web-tab-${i}"
-        aria-controls="web-tab-${i}-panel"
+        id="web-tab-${this.idSalt}-${i}"
+        aria-controls="web-tab-${this.idSalt}-${i}-panel"
         tabindex=${tabIndex}
       >
         <span class="web-tabs__text-label">${tabLabel}</span>


### PR DESCRIPTION
Make sure ids are unique when Tabs custom element is used multiple times on a page. 

I added a salt generator utility to BaseElement to generate unique ids - let me know if there is a better place for it!

