### PR TITLE
Bug/fix broken images

### DIFF
--- a/src/site/_drafts/_template-post/index.md
+++ b/src/site/_drafts/_template-post/index.md
@@ -97,7 +97,7 @@ ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
 quam sem.
 
 <figure class="w-figure">
-  <img src="image-small.png" alt="" style="max-width: 400px;">
+  <img src="image-small.png" alt="" width="400">
   <figcaption class="w-figcaption">
     Small image.
   </figcaption>
@@ -122,7 +122,7 @@ quam sem.
 ## Image, Inline
 
 <figure class="w-figure w-figure--inline-right">
-  <img class="w-screenshot" src="image-inline.png" alt="" style="max-width: 200px;">
+  <img class="w-screenshot" src="image-inline.png" alt="" width="200">
   <figcaption class="w-figcaption">
     Inline right, outlined image.
   </figcaption>
@@ -143,7 +143,7 @@ aliquet urna ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet
 velit. Morbi at quam sem.
 
 <figure class="w-figure w-figure--inline-left">
-  <img class="w-screenshot" src="image-inline.png" alt="" style="max-width: 200px;">
+  <img class="w-screenshot" src="image-inline.png" alt="" width="200">
   <figcaption class="w-figcaption">
     Inline left, outlined image.
   </figcaption>

--- a/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
+++ b/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
@@ -33,7 +33,7 @@ audit or category result.
 
 <figure class="w-figure w-figure--center">
   <img class="w-screenshot" src="./lighthouse-ci.png" alt="Lighthouse CI report."
-       style="max-width: 50%">
+       width="50%">
 </figure>
 
 Lighthouse CI supports [Travis CI](https://travis-ci.com/), [Circle
@@ -114,7 +114,7 @@ or [contact the Lighthouse team](https://github.com/GoogleChrome/lighthouse-stac
 ## Coming soon: Lighthouse plugins as Chrome Extensions
 
 <figure class="w-figure w-figure--center">
-  <img src="./lighthouse-plugin-icon.png" alt="Lighthouse plugin icon." style="max-width: 250px;">
+  <img src="./lighthouse-plugin-icon.png" alt="Lighthouse plugin icon." width="250">
 </figure>
 
 [Lighthouse
@@ -131,7 +131,7 @@ CLI](https://developers.google.com/web/tools/lighthouse#cli), but the goal is to
 enable running them in the DevTools **Audits** panel too.
 
 <figure class="w-figure w-figure--center">
-  <img class="w-screenshot" src="./lighthouse-plugin-devtools.png" alt="Chrome DevTools Audits panel with options for running Lighthouse plugins for Google Publisher Ads and User Experience." style="max-width: 400px;">
+  <img class="w-screenshot" src="./lighthouse-plugin-devtools.png" alt="Chrome DevTools Audits panel with options for running Lighthouse plugins for Google Publisher Ads and User Experience." width="400">
   <figcaption>Community Plugins in DevTools Audits panel (beta)</figcaption>
 </figure>
 

--- a/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
+++ b/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
@@ -33,7 +33,7 @@ audit or category result.
 
 <figure class="w-figure w-figure--center">
   <img class="w-screenshot" src="./lighthouse-ci.png" alt="Lighthouse CI report."
-       width="50%">
+       width="400">
 </figure>
 
 Lighthouse CI supports [Travis CI](https://travis-ci.com/), [Circle
@@ -132,7 +132,7 @@ enable running them in the DevTools **Audits** panel too.
 
 <figure class="w-figure w-figure--center">
   <img class="w-screenshot" src="./lighthouse-plugin-devtools.png" alt="Chrome DevTools Audits panel with options for running Lighthouse plugins for Google Publisher Ads and User Experience." width="400">
-  <figcaption>Community Plugins in DevTools Audits panel (beta)</figcaption>
+  <figcaption class="w-figcaption">Community Plugins in DevTools Audits panel (beta)</figcaption>
 </figure>
 
 When users install Lighthouse plugin extensions from the [Chrome Web

--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -92,10 +92,10 @@ To make an image extend slightly beyond the width of the content column (for emp
   </figcaption>
 </figure>
 
-To keep an image from growing beyond a specified size, add the `w-figure--center` class to the `figure` element and add an inline `max-width` style to the `img` element:
+To keep an image from growing beyond a specified size, add the `w-figure--center` class to the `figure` element and add a `width` attribute to the `img` element. For example, `width="400"`. All images will have a `max-width` of `100%` on mobile:
 
 <figure class="w-figure w-figure--center">
-  <img src="./image-small.png" alt="A screenshot of a section of the Chrome DevTools user interface." style="max-width: 400px;">
+  <img src="./image-small.png" alt="A screenshot of a section of the Chrome DevTools user interface." width="400">
   <figcaption class="w-figcaption">
     A small, centered image.
     </figcaption>
@@ -104,7 +104,7 @@ To keep an image from growing beyond a specified size, add the `w-figure--center
 To place an image inline with text, add the `w-figure--inline-left` or `w-figure--inline-right` class to the `figure` element, depending on what alignment you want:
 
 <figure class="w-figure w-figure--inline-left">
-  <img class="w-screenshot" src="./image-inline.png" alt="A diagram of the interactions between a client, a service worker, and the server." style="max-width: 200px;">
+  <img class="w-screenshot" src="./image-inline.png" alt="A diagram of the interactions between a client, a service worker, and the server." width="200">
   <figcaption class="w-figcaption">
     A left-aligned inline image.
   </figcaption>


### PR DESCRIPTION
I noticed some images looked a little off on mobile so I made some changes. Maybe we should  enact these as image policies?

- If an author wants a specific width for an image, they should use the `width` attribute and ideally set it in a pixel value instead of a percentage. They *should not* use `style="max-width: ..."` because images are set to be max-width 100% by default and by overriding that value with something like max-width: 400px it causes the images to break out of the container.