### PR TITLE
Fix sticky hover and focus styles

### DIFF
--- a/src/lib/components/CopyCode/styles.scss
+++ b/src/lib/components/CopyCode/styles.scss
@@ -35,10 +35,10 @@
   &:focus {
     box-shadow: 0 0 0 1px $FOCUS_COLOR;
   }
+}
 
-  &:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
-    box-shadow: none;
-  }
+.js-focus-visible .web-copy-code__button:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
+  box-shadow: none;
 }
 
 web-copy-code {

--- a/src/lib/components/CopyCode/styles.scss
+++ b/src/lib/components/CopyCode/styles.scss
@@ -2,6 +2,7 @@
 @import '../../../styles/settings/global';
 
 .web-copy-code__button {
+  -webkit-tap-highlight-color: transparent;
   background: none;
   background-image: url("../../../images/icons/file_copy.svg");
   background-position: center;
@@ -12,22 +13,31 @@
   height: 48px;
   margin: 8px;
   opacity: 0;
+  outline: none;
   padding: 0;
   position: absolute;
   right: 0;
   transition: background-color .5s ease;
   width: 48px;
 
-  &:active {
-    background-color: rgba($WEB_SECONDARY_COLOR, 0.4);
-    opacity: 1;
-  }
-
   &:focus,
   &:hover {
     background-color: rgba($WEB_SECONDARY_COLOR, 0.2);
     opacity: 1;
     transition: background-color .2s ease;
+  }
+
+  &:active {
+    background-color: rgba($WEB_SECONDARY_COLOR, 0.4);
+    opacity: 1;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 1px $FOCUS_COLOR;
+  }
+
+  &:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
+    box-shadow: none;
   }
 }
 

--- a/src/lib/components/Tabs/_styles.scss
+++ b/src/lib/components/Tabs/_styles.scss
@@ -48,10 +48,6 @@ web-tabs {
     outline: 0;
   }
 
-  .web-tabs__tab:focus:not(.focus-visible) {
-    box-shadow: none;
-  }
-
   .web-tabs__tab:active {
     background: rgba($SUCCESS_COLOR, .3);
     box-shadow: none;
@@ -76,4 +72,8 @@ web-tabs {
   .web-tabs__panel[hidden] {
     display: none;
   }
+}
+
+.js-focus-visible .web-tabs__tab:focus:not(.focus-visible) {
+  box-shadow: none;
 }

--- a/src/lib/components/Tabs/_styles.scss
+++ b/src/lib/components/Tabs/_styles.scss
@@ -27,6 +27,7 @@ web-tabs {
   }
 
   .web-tabs__tab {
+    -webkit-tap-highlight-color: transparent;
     @include base-button();
     color: $BLACK;
     flex: 1 0 auto;
@@ -35,14 +36,20 @@ web-tabs {
     opacity: .6;
   }
 
-  .web-tabs__tab:hover,
-  .web-tabs__tab:focus {
-    background: rgba($SUCCESS_COLOR, .1);
+  @include hover() {
+    .web-tabs__tab:hover,
+    .web-tabs__tab:focus {
+      background: rgba($SUCCESS_COLOR, .1);
+    }
   }
 
   .web-tabs__tab:focus {
     box-shadow: inset 0 0 0 1px $FOCUS_COLOR;
     outline: 0;
+  }
+
+  .web-tabs__tab:focus:not(.focus-visible) {
+    box-shadow: none;
   }
 
   .web-tabs__tab:active {

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -15,6 +15,7 @@
 // but since we're using all: initial, we need to make things
 // initially consistent.
 .w-button {
+  -webkit-tap-highlight-color: transparent; // Prevents tap highlight on hidden tooltips
   @include base-button();
   border-radius: $GLOBAL_RADIUS;
   overflow: hidden;

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -22,6 +22,7 @@ $BORDER_COLOR: $GREY_300;
 }
 
 .w-details__summary {
+  -webkit-tap-highlight-color: transparent;
   cursor: pointer;
   flex-grow: 1;
   font: inherit;
@@ -39,13 +40,19 @@ $BORDER_COLOR: $GREY_300;
     outline: none;
   }
 
-  &:hover .w-details__header::after,
-  &:focus .w-details__header::after {
-    background: $LIGHT_BLUE_50;
+  @include hover() {
+    &:hover .w-details__header::after,
+    &:focus .w-details__header::after {
+      background: $LIGHT_BLUE_50;
+    }
   }
 
   &:focus .w-details__header::after {
     box-shadow: 0 0 0 1px $FOCUS_COLOR;
+  }
+
+  .js-focus-visible &:focus:not(.focus-visible) .w-details__header::after { // sass-lint:disable-line class-name-format
+    box-shadow: none;
   }
 
   &:active .w-details__header::after {
@@ -134,6 +141,9 @@ h2.w-details__header:only-child {
   display: none;
 }
 
-.w-details__summary:hover .w-details__preview::after {
-  color: $LINK_COLOR;
+@include hover() {
+  .w-details__summary:hover .w-details__preview::after,
+  .w-details__summary:focus .w-details__preview::after {
+    color: $LINK_COLOR;
+  }
 }

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -49,7 +49,7 @@ $BORDER_COLOR: $GREY_300;
     speak: none;
     top: 50%;
     transform: translateY(-50%);
-    transition: background $TRANSITION_SPEED, transform .3s;
+    transition: background $TRANSITION_SPEED;
     visibility: visible;
   }
 
@@ -72,6 +72,10 @@ $BORDER_COLOR: $GREY_300;
 
   .js-focus-visible &:focus:not(.focus-visible)::after { // sass-lint:disable-line class-name-format
     box-shadow: none;
+  }
+
+  &:active::after {
+    background: $GREEN_100;
   }
 }
 

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -15,6 +15,7 @@ $BORDER_COLOR: $GREY_300;
 }
 
 .w-self-assessment-hint__summary {
+  -webkit-tap-highlight-color: transparent;
   color: $SUCCESS_COLOR;
   cursor: $CURSOR_POINTER_VALUE;
   flex-grow: 1;
@@ -58,13 +59,19 @@ $BORDER_COLOR: $GREY_300;
     }
   }
 
-  &:hover::after,
-  &:focus::after {
-    background: $GREEN_50;
+  @include hover() {
+    &:hover::after,
+    &:focus::after {
+      background: $GREEN_50;
+    }
   }
 
   &:focus::after {
     box-shadow: 0 0 0 1px $FOCUS_COLOR;
+  }
+
+  .js-focus-visible &:focus:not(.focus-visible)::after { // sass-lint:disable-line class-name-format
+    box-shadow: none;
   }
 
   &:active::after {

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -73,10 +73,6 @@ $BORDER_COLOR: $GREY_300;
   .js-focus-visible &:focus:not(.focus-visible)::after { // sass-lint:disable-line class-name-format
     box-shadow: none;
   }
-
-  &:active::after {
-    background: $GREEN_100;
-  }
 }
 
 .w-self-assessment-hint[open] .w-self-assessment-hint__summary::after {

--- a/src/styles/components/_tooltips.scss
+++ b/src/styles/components/_tooltips.scss
@@ -1,3 +1,10 @@
+@mixin tooltip-visible() {
+  opacity: .77;
+  transform: scale(1) translateX(-50%);
+  transition: opacity .15s .3s, transform .15s .3s, visibility 0s;
+  visibility: visible;
+}
+
 .w-tooltip {
   background: $BLACK;
   border-radius: $GLOBAL_RADIUS;
@@ -13,6 +20,7 @@
   top: calc(100% + 3px);
   transform: scale(.85) translateX(-50%);
   transform-origin: top left;
+  transition: opacity 75ms, transform 0s 75ms, visibility 0s 75ms;
   visibility: hidden;
   white-space: nowrap;
 }
@@ -28,22 +36,34 @@
   transform-origin: top right;
 }
 
-// Need descendent combinator for focus to accommodate details widget
-:hover > .w-tooltip,
-:focus .w-tooltip {
-  opacity: .77;
-  transform: scale(1) translateX(-50%);
-  transition: opacity .15s .3s, transform .15s .3s;
-  visibility: visible;
+@include hover() {
+  :hover > .w-tooltip,
+  :focus .w-tooltip { // Need descendent combinator for focus to accommodate details widget
+    @include tooltip-visible();
+  }
+
+  :hover > .w-tooltip--left,
+  :focus .w-tooltip--left {
+    transform: scale(1);
+  }
+
+  :hover > .w-tooltip--right,
+  :focus .w-tooltip--right {
+    transform: translateX(-100%) scale(1);
+  }
 }
 
-:hover > .w-tooltip--left,
-:focus .w-tooltip--left {
+// Separate active styles so tooltip appears on long press on touch devices
+:active > .w-tooltip {
+  @include tooltip-visible();
+  transition: opacity .15s .5s, transform .15s .5s, visibility 0s;
+}
+
+:active > .w-tooltip--left {
   transform: scale(1);
 }
 
-:hover > .w-tooltip--right,
-:focus .w-tooltip--right {
+:active > .w-tooltip--right {
   transform: translateX(-100%) scale(1);
 }
 

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -96,6 +96,11 @@
   );
 }
 
+// Mixin for exposing hover styles only on devices that support hover
+@mixin hover() {
+  @media (hover: hover) { @content; }
+}
+
 // Mixin for styling typography via maps containing required integer values for
 // font-family, font-size, font-weight, and line-height; with an optional value
 // for letter-spacing.


### PR DESCRIPTION
iOS makes `:hover` styles stick while an element is focused, which was causing issues with the chevron animations in the Details and AssessmentHint components.

Changes proposed in this pull request:
- Add a `hover()` mixin that can be used when components need to show hover states only on devices that support `:hover`.
- Apply the `hover()` mixin to the AssessmentHint, Details, Tabs, and Tooltip components. 
- Hide tab highlight color on AssessmentHint, CopyCode, Button, Details, and Tabs components so it doesn't interfere with our styling.
- Hide focus outline for AssessmentHint, CopyCode, Details, and Tabs components to match behavior of rest of site.
- Show tooltips on long press on mobile devices to better align with Material specs.
- Fixes to the CopyCode component:
  - Resequence active style in stylesheet so it actually appears.
  - Make focus outline round rather than square to match button shape.

**Note:** I didn't apply `hover()` to the following components, so hover is still sticky for them. With the possible exceptions of buttons and cards (for which you can easily activate hover state while swiping through a collection page), these elements navigate the user elsewhere, so sticky hover isn't a huge problem. I can add `hover()` if folks think it'd be helpful though.
- Buttons
- Action buttons
- Article nav buttons
- Cards
- Chips
- Cross-links
- Links