### PR TITLE
Clean up the "last audit" section on /measure on mobile.

### DIFF
--- a/src/lib/components/LighthouseScoresMeta/_styles.scss
+++ b/src/lib/components/LighthouseScoresMeta/_styles.scss
@@ -29,6 +29,12 @@ web-lighthouse-scores-meta {
     @include bp(sm) {
       margin-left: 8px;
     }
+
+    @include bp(md) {
+      min-width: 180px;
+      margin-right: 16px;
+      display: inline-block;
+    }
   }
 
   .lh-report-invisible {
@@ -63,25 +69,3 @@ web-lighthouse-scores-meta {
       alt: '';
     }
   }
-
-  /// @deprecated
-  @media screen and (min-width: $BREAKPOINT_VALUE_DESKTOP) {
-    .lh-report-meta {
-      margin-bottom: 32px;
-    }
-  }
-
-  /// @deprecated
-  @media screen and (min-width: $BREAKPOINT_VALUE_TABLET) {
-    .lh-report-meta {
-      display: flex;
-      align-items: center;
-    }
-
-    .lh-report-meta__lastaudit {
-      min-width: 180px;
-      margin-right: 16px;
-      display: inline-block;
-    }
-  }
-}

--- a/src/lib/components/LighthouseScoresMeta/_styles.scss
+++ b/src/lib/components/LighthouseScoresMeta/_styles.scss
@@ -69,3 +69,4 @@ web-lighthouse-scores-meta {
       alt: '';
     }
   }
+}

--- a/src/lib/components/LighthouseScoresMeta/_styles.scss
+++ b/src/lib/components/LighthouseScoresMeta/_styles.scss
@@ -1,10 +1,34 @@
 @import '../../../styles/settings/dimensions';
+@import '../../../styles/tools/breakpoints';
+
 
 web-lighthouse-scores-meta {
   .lh-report-meta {
     margin-top: 8px;
     margin-bottom: 16px;
     font-size: 14px;
+  }
+
+  .lh-report-meta__links {
+    display: flex;
+    flex-direction: column;
+
+    @include bp(sm) {
+      justify-content: space-between;
+      flex-direction: row;
+    }
+
+    @include bp(md) {
+      display: block;
+    }
+  }
+
+  .lh-report-meta__lastaudit {
+    margin-left: 8px;
+
+    @include bp(sm) {
+      margin-left: 8px;
+    }
   }
 
   .lh-report-invisible {
@@ -58,14 +82,6 @@ web-lighthouse-scores-meta {
       min-width: 180px;
       margin-right: 16px;
       display: inline-block;
-    }
-  }
-
-  /// @deprecated
-  @media screen and (max-width: $BREAKPOINT_VALUE_TABLET) {
-    .lh-report-meta__links {
-      display: flex;
-      justify-content: space-between;
     }
   }
 }

--- a/src/lib/components/LighthouseScoresMeta/index.js
+++ b/src/lib/components/LighthouseScoresMeta/index.js
@@ -46,28 +46,30 @@ class LighthouseScoresMeta extends BaseElement {
           <span class="lh-report-meta__lastaudit">
             <span>Last audit:</span> <span>${auditedOnText}</span>
           </span>
-          <a
-            href="${LH_HOST}/lh/html?url=${this.url}"
-            title="View latest Lighthouse report"
-            class="viewreport lh-report-link gc-analytics-event"
-            data-category="web.dev"
-            data-label="view lighthouse report"
-            data-action="click"
-            target="_blank"
-            rel="noopener"
-            >View Report</a
-          >
-          |
-          <a
-            href="${LH_HOST}/lh/html?url=${this.url}&download"
-            download
-            class="downloadreport lh-report-link gc-analytics-event"
-            data-category="web.dev"
-            data-label="download lighthouse report"
-            data-action="click"
-            title="Download latest Lighthouse report"
-            >Download Report</a
-          >
+          <span>
+            <a
+              href="${LH_HOST}/lh/html?url=${this.url}"
+              title="View latest Lighthouse report"
+              class="viewreport lh-report-link gc-analytics-event"
+              data-category="web.dev"
+              data-label="view lighthouse report"
+              data-action="click"
+              target="_blank"
+              rel="noopener"
+              >View Report</a
+            >
+            |
+            <a
+              href="${LH_HOST}/lh/html?url=${this.url}&download"
+              download
+              class="downloadreport lh-report-link gc-analytics-event"
+              data-category="web.dev"
+              data-label="download lighthouse report"
+              data-action="click"
+              title="Download latest Lighthouse report"
+              >Download Report</a
+            >
+          </span>
         </span>
         <span class="lh-error-msg">${this.errorMessage}</span>
       </div>


### PR DESCRIPTION
Fixes #1118 (partially)

Clean up the "last audit" section on /measure on mobile. 

Before:

<img width="397" alt="Screenshot 2020-01-09 at 16 21 35" src="https://user-images.githubusercontent.com/1914261/72080113-75ef8400-32fc-11ea-839e-974e3c8646ab.png">

After:

<img width="408" alt="Screenshot 2020-01-09 at 16 21 56" src="https://user-images.githubusercontent.com/1914261/72080125-7f78ec00-32fc-11ea-92d5-0072f9c004ef.png">

