### PR TITLE
Fix code samples in RSS feed

### DIFF
--- a/src/site/content/en/feed.njk
+++ b/src/site/content/en/feed.njk
@@ -31,7 +31,7 @@ noindex: true
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
     {% for entry in post.data.authors %}
     {%- set author =  contributors[entry] -%}
     <author>


### PR DESCRIPTION
Fixes #2039

Changes proposed in this pull request:

- Code samples didn't show up in the RSS feed since they were wrapped in `<web-copy-code>`. This PR wraps them in a `<div>` instead.