### PR TITLE
adds paragraph on loading images with picture tag

### DIFF
--- a/src/site/content/en/blog/native-lazy-loading/index.md
+++ b/src/site/content/en/blog/native-lazy-loading/index.md
@@ -126,6 +126,18 @@ browser reflow](https://www.youtube.com/watch?v=4-d_SoCHeWE).
   Take a look at this [demo](https://mathiasbynens.be/demo/img-loading-lazy) to see how the `loading` attribute works with 100 pictures.
 {% endAside %}
 
+Images that are defined using the `<picture>` element can also be lazy-loaded:
+
+```html
+<picture>
+  <source media="(min-width: 800px)" srcset="large.jpg 1x, larger.jpg 2x">
+  <img src="photo.jpg" loading="lazy">
+</picture>
+```
+
+Although a browser will decide which image to load from any of the `<source>` elements, the `loading`
+attribute only needs to be included to the fallback `<img>` element.
+
 ### iframe loading
 
 The `loading` attribute affects iframes differently than images, depending on whether the iframe is


### PR DESCRIPTION
Fixes #1448.

Changes proposed in this pull request:

- Adds paragraph on lazy loading images within `<picture>` 
