### PR TITLE
fix(SnackbarContainer): check`localStorage` before intercepting install prompt, fixes #2023

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -8,7 +8,6 @@ import "./components/CopyCode";
 import {store} from "./store";
 import "focus-visible";
 import "./analytics";
-import {checkIfUserAcceptsCookies} from "./actions";
 
 // Configures global page state
 function onGlobalStateChanged({isSignedIn, isPageLoading}) {
@@ -26,11 +25,3 @@ function onGlobalStateChanged({isSignedIn, isPageLoading}) {
 }
 store.subscribe(onGlobalStateChanged);
 onGlobalStateChanged(store.getState());
-
-// Give elements time to set up before kicking off state changes.
-// This is useful for elements with CSS animations who need to have been
-// rendered to the page at least once before they start transitioning.
-// Currently this includes the Snackbar.
-setTimeout(() => {
-  checkIfUserAcceptsCookies();
-}, 0);

--- a/src/lib/components/SnackbarContainer/index.js
+++ b/src/lib/components/SnackbarContainer/index.js
@@ -44,25 +44,22 @@ class SnackbarContainer extends BaseElement {
     store.subscribe(this.onStateChanged);
     this.onStateChanged();
 
-    if (!this.acceptedCookies) {
-      window.addEventListener(
-        "beforeinstallprompt",
-        this.onBeforeInstallPrompt,
-      );
-    }
+    window.addEventListener("beforeinstallprompt", this.onBeforeInstallPrompt);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     store.unsubscribe(this.onStateChanged);
-  }
-
-  onBeforeInstallPrompt(e) {
-    e.preventDefault();
     window.removeEventListener(
       "beforeinstallprompt",
       this.onBeforeInstallPrompt,
     );
+  }
+
+  onBeforeInstallPrompt(e) {
+    if (!this.acceptedCookies) {
+      e.preventDefault();
+    }
   }
 
   onStateChanged() {

--- a/src/lib/components/SnackbarContainer/index.js
+++ b/src/lib/components/SnackbarContainer/index.js
@@ -55,15 +55,10 @@ class SnackbarContainer extends BaseElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     store.unsubscribe(this.onStateChanged);
-    window.removeEventListener(
-      "beforeinstallprompt",
-      this.onBeforeInstallPrompt,
-    );
   }
 
   onBeforeInstallPrompt(e) {
     e.preventDefault();
-    this.installPrompt = e;
     window.removeEventListener(
       "beforeinstallprompt",
       this.onBeforeInstallPrompt,
@@ -75,11 +70,6 @@ class SnackbarContainer extends BaseElement {
     this.open = state.showingSnackbar;
     this.type = state.snackbarType;
     this.acceptedCookies = state.userAcceptsCookies;
-
-    if (this.acceptedCookies && this.installPrompt) {
-      this.installPrompt.prompt();
-      this.installPrompt.userChoice.then(() => (this.installPrompt = null));
-    }
   }
 
   render() {

--- a/src/lib/components/SnackbarContainer/index.js
+++ b/src/lib/components/SnackbarContainer/index.js
@@ -21,7 +21,7 @@
 import {html} from "lit-element";
 import {BaseElement} from "../BaseElement";
 import {store} from "../../store";
-import {setUserAcceptsCookies} from "../../actions";
+import {setUserAcceptsCookies, checkIfUserAcceptsCookies} from "../../actions";
 import "../Snackbar";
 
 class SnackbarContainer extends BaseElement {
@@ -40,6 +40,7 @@ class SnackbarContainer extends BaseElement {
 
   connectedCallback() {
     super.connectedCallback();
+    checkIfUserAcceptsCookies();
     store.subscribe(this.onStateChanged);
     this.onStateChanged();
 


### PR DESCRIPTION
Fixes #2023

The `if (!this.acceptedCookies)` would always be `true` on initial start of the app because the initial state didn't use the `localStorage` value. So we trigger a check if the user has accepted the cookies, which updates the store before we get the store's state in the component and run the check.

Now you will be greeted with the prompt after you accept cookies (which we could stop), and every subsequent visit should behave as normal. This only impacts the user until they accept cookies.

@robdodson @devnook PTAL