### PR TITLE
Address issues in 1st self-assessment sets

### DIFF
--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -11,14 +11,14 @@ description: |
 ---
 
 Native HTML elements such as `<button>` or `<input>` have keyboard accessibility
-built-in for free. If you're building _custom_ interactive components, use the
-`tabindex` attribute to ensure that they're keyboard accessible.
+built in for free. If you're building _custom_ interactive components, however,
+use the `tabindex` attribute to ensure that they're keyboard accessible.
 
 {% Aside %}
 Whenever possible, use a native HTML element rather than building your
 own custom version. `<button>`, for example, is very easy to style and
 already has full keyboard support. This will save you from needing to manage
-`tabindex` or to add semantics with ARIA.
+`tabindex` or add semantics with ARIA.
 {% endAside %}
 
 ## Check if your controls are keyboard accessible
@@ -26,8 +26,8 @@ already has full keyboard support. This will save you from needing to manage
 A tool like Lighthouse is great at detecting certain accessibility issues, but
 some things can only be tested by a human.
 
-Try pressing the `TAB` key to navigate through your site. Are you able to reach
-all of the interactive controls on the page? If not, you may need to use
+Try pressing the `Tab` key to navigate through your site. Are you able to reach
+all the interactive controls on the page? If not, you may need to use
 [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
 to improve the focusability of those controls.
 
@@ -46,7 +46,7 @@ Insert an element into the natural tab order using `tabindex="0"`. For example:
 <div tabindex="0">Focus me with the TAB key</div>
 ```
 
-To focus an element, press the `TAB` key or call the element's `focus()` method.
+To focus an element, press the `Tab` key or call the element's `focus()` method.
 
 <div class="glitch-embed-wrap" style="height: 346px; width: 100%;">
   <iframe
@@ -74,6 +74,19 @@ focused by calling its `focus()` method.
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>
+
+Note that applying `tabindex="-1"` to an element doesn't affect its children;
+if they're in the tab order naturally or because of a `tabindex` value,
+they'll remain in the tab order.
+To remove an element and all its children from the tab order, consider using
+[the WICG's `inert` polyfill](https://github.com/WICG/inert).
+The polyfill emulates the behavior of a proposed `inert` attribute,
+which prevents elements from being selected or read by assistive technologies.
+
+{% Aside 'caution' %}
+The `inert` polyfill is experimental and may not work as expected in all cases.
+Test carefully before using in production.
+{% endAside %}
 
 ## Avoid `tabindex > 0`
 
@@ -187,6 +200,7 @@ Only the `<a>` elements are included in the tab order.
 The `<section>` element is not in the tab order
 because it has a negative `tabindex` value.
 (It can, however, be focused using the `focus()` method.)
+The `tabindex` value for the `<section>` element doesn't affect its children.
 {% endAssessmentHint %}
 
 {% endTab %}
@@ -218,7 +232,10 @@ is considered an anti-pattern.)
 {% endTab %}
 {% Tab 'sample' %}
 
-This HTML renders a custom radio group:
+This HTML renders a custom radio group, which should have a
+[roving `tabindex`](#create-accessible-components-with-"roving-tabindex").
+(To keep things simpler, ignore the
+[`aria-*` attributes](/semantics-and-screen-readers) for now.)
 
 ```html
 <div role="radiogroup" aria-labelledby="breed-header">
@@ -229,10 +246,7 @@ This HTML renders a custom radio group:
 </div>
 ```
 
-To keep things simpler, ignore the
-[`aria-*` and `role` attributes](/semantics-and-screen-readers) for now.
-
-{% AssessmentHint 'For a roving `tabindex`, what logic should run when a user presses the `Right` arrow key while a radio element is focused?' %}
+{% AssessmentHint 'When a `role="radio"` element is focused, what should happen when a user presses the `Right` arrow key ?' %}
 - Change the `tabindex` values for all radio elements in the group to -1.
 - If there's a radio element after the one that's focused,
   set its `tabindex` value to 0.

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -4,6 +4,7 @@
 @import '../tools/mixins';
 
 $CHEVRON_SIZE: 24px;
+$CHEVRON_MARGIN: 12px;
 $BORDER_COLOR: $GREY_300;
 
 .w-details {
@@ -58,7 +59,7 @@ $BORDER_COLOR: $GREY_300;
 .w-details__header {
   color: $LIGHT_BLUE_600;
   margin: 0;
-  padding: .75rem #{$CHEVRON_SIZE + 2px + 12px} .75rem 0;
+  padding: .75rem #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 4px} .75rem 0;
   position: relative;
 
   &::after {
@@ -79,7 +80,7 @@ $BORDER_COLOR: $GREY_300;
 
   @include bp(xsm) {
     & {
-      padding: 1.125em #{$CHEVRON_SIZE + 12px + 12px} 1.125em 0;
+      padding: 1.125em #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 12px} 1.125em 0;
     }
 
     &::after {
@@ -99,12 +100,12 @@ $BORDER_COLOR: $GREY_300;
 
 .w-details__header:only-child {
   line-height: 1.5rem;
-  padding: .375rem #{$CHEVRON_SIZE + 8px} .375rem 0;
+  padding: .375rem #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 4px} .375rem 0;
 }
 
 h2.w-details__header:only-child {
   line-height: 1.3333em;
-  padding: .75rem #{$CHEVRON_SIZE + 8px} .75rem 0;
+  padding: .75rem #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 4px} .75rem 0;
 }
 
 .w-details > p:first-of-type {

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -58,7 +58,7 @@ $BORDER_COLOR: $GREY_300;
 .w-details__header {
   color: $LIGHT_BLUE_600;
   margin: 0;
-  padding: .75rem #{$CHEVRON_SIZE + 12px} .75rem 0;
+  padding: .75rem #{$CHEVRON_SIZE + 2px + 12px} .75rem 0;
   position: relative;
 
   &::after {
@@ -78,6 +78,10 @@ $BORDER_COLOR: $GREY_300;
   }
 
   @include bp(xsm) {
+    & {
+      padding: 1.125em #{$CHEVRON_SIZE + 12px + 12px} 1.125em 0;
+    }
+
     &::after {
       padding: .25em;
     }

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -4,6 +4,7 @@
 @import '../tools/mixins';
 
 $CHEVRON_SIZE: 24px;
+$CHEVRON_MARGIN: 12px;
 $BORDER_COLOR: $GREY_300;
 
 .w-self-assessment-hint {
@@ -21,7 +22,7 @@ $BORDER_COLOR: $GREY_300;
   font: inherit;
   font-weight: 500;
   list-style: none;
-  padding: 1.125em #{$CHEVRON_SIZE + 2px + 12px} 1.125em 0;
+  padding: 1.125em #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 4px} 1.125em 0;
   position: relative;
 
   // scss-lint thinks this is a pseudo class instead of a psuedo element
@@ -54,7 +55,7 @@ $BORDER_COLOR: $GREY_300;
 
   @include bp(xsm) {
     & {
-      padding: 1.125em #{$CHEVRON_SIZE + 12px + 12px} 1.125em 0;
+      padding: 1.125em #{$CHEVRON_SIZE + $CHEVRON_MARGIN + 12px} 1.125em 0;
     }
 
     &::after {

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -21,7 +21,7 @@ $BORDER_COLOR: $GREY_300;
   font: inherit;
   font-weight: 500;
   list-style: none;
-  padding: 1.125em #{$CHEVRON_SIZE + 12px} 1.125em 0;
+  padding: 1.125em #{$CHEVRON_SIZE + 2px + 12px} 1.125em 0;
   position: relative;
 
   // scss-lint thinks this is a pseudo class instead of a psuedo element
@@ -53,6 +53,10 @@ $BORDER_COLOR: $GREY_300;
   }
 
   @include bp(xsm) {
+    & {
+      padding: 1.125em #{$CHEVRON_SIZE + 12px + 12px} 1.125em 0;
+    }
+
     &::after {
       padding: .25em;
     }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes collisions between `<summary>` text and the chevron hover state in Details and AssessmentHint widgets.
- Addresses feedback from @kaycebasques on PR #2052:
  - Added a paragraph to `control-focus-with-tabindex` to make explicit that adding a `tabindex` value to an element doesn't affect its children.
  - Reframed item 4 in the `control-focus-with-tabindex` set to hopefully (!) clarify the task.
