### PR TITLE
Small visual fixes to /measure at 360px

### DIFF
--- a/src/lib/components/LighthouseScoresAudits/_styles.scss
+++ b/src/lib/components/LighthouseScoresAudits/_styles.scss
@@ -121,12 +121,12 @@ web-lighthouse-scores-audits {
       border-bottom: 1px solid $GREY_700;
       margin-bottom: 0;
     }
-  
+
     &::after {
       @include font-material-icon();
       content: 'arrow_drop_down';
     }
-  
+
     &[data-inverted]::after {
       content: 'arrow_drop_up';
     }
@@ -139,6 +139,7 @@ web-lighthouse-scores-audits {
   .lh-audit-list-row__recommendation,
   .lh-audit-list-row__guide {
     width: 50%;
+    overflow: hidden;
   }
 
   .lh-audit-list-row__guide {

--- a/src/lib/components/LighthouseScoresMetrics/_styles.scss
+++ b/src/lib/components/LighthouseScoresMetrics/_styles.scss
@@ -39,7 +39,7 @@ web-lighthouse-scores-metrics {
     min-width: 260px;
     max-width: 300px;
     flex-basis: auto;
-    margin-right: $MARGIN;
+    margin: 0 $MARGIN;
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
Prevent audit cells to overflow, eg:

<img width="338" alt="Screenshot 2020-01-09 at 15 28 08" src="https://user-images.githubusercontent.com/1914261/72153567-a4c63280-33ae-11ea-965c-0c11aa5893d8.png">

I use 360px as the smallest screen base, as our analytics show there's not really much traffic below that value.
