### PR TITLE
Fix the updated date

### DIFF
--- a/src/site/content/en/feed.njk
+++ b/src/site/content/en/feed.njk
@@ -19,7 +19,7 @@ noindex: true
   <subtitle>{{ metadata.feed.subtitle }}</subtitle>
   <link href="{{ metadata.feed.url }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
-  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
+  <updated>{{ collections.posts | reverse | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.feed.id }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>


### PR DESCRIPTION
Fixes #2064

Changes proposed in this pull request:

- This fixes the global update date to use the latest post's date, not the earliest's.