### PR TITLE
Rev service worker version to force it to update.

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -1,7 +1,7 @@
 // Architecture revision of the Service Worker. If the previously saved revision doesn't match,
 // then this will cause clients to be aggressively claimed and reloaded on install/activate.
 // Used when the design of the SW changes dramatically, e.g. from DevSite to v2.
-const serviceWorkerArchitecture = "v2";
+const serviceWorkerArchitecture = "v3";
 
 const normalizeIndexCacheKeyPlugin = {
   cacheKeyWillBeUsed({request, mode}) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Force sw to claim clients. I think the change I landed in https://github.com/GoogleChrome/web.dev/pull/2074 may have broken something but I don't know caching well enough to explain it. For web.dev/subscribe we do a server-side redirect to https://services.google.com/fb/forms/web-dev-subscribe/. After #2074 went live, that page started showing up as offline for folks ¯\_(ツ)_/¯ but worked again after they refreshed.