### PR TITLE
Synchronize tags in fugu posts.

### DIFF
--- a/src/site/content/en/blog/maskable-icon/index.md
+++ b/src/site/content/en/blog/maskable-icon/index.md
@@ -13,6 +13,7 @@ alt: Icons contained inside white circles compared to icons covering its entire 
 tags:
   - post
   - capabilities
+  - fugu
   - progressive-web-apps
 ---
 

--- a/src/site/content/en/blog/periodic-background-sync/index.md
+++ b/src/site/content/en/blog/periodic-background-sync/index.md
@@ -17,6 +17,7 @@ description: |
   of a native app.
 tags:
   - capabilities
+  - fugu
   - post
   - progressive-web-apps
   - service-worker

--- a/src/site/content/en/blog/sms-receiver-api-announcement/index.md
+++ b/src/site/content/en/blog/sms-receiver-api-announcement/index.md
@@ -17,6 +17,7 @@ tags:
   - post # post is a required tag for the article to show up in the blog.
   - identity
   - sms
+  - capabilities
   - fugu
 ---
 
@@ -278,10 +279,10 @@ Chrome Stable
 
 ### Demos
 
-Try various messages with the demo:  
+Try various messages with the demo:
 [https://sms-receiver-demo.glitch.me](https://sms-receiver-demo.glitch.me)
 
-You may also fork it and create your version:  
+You may also fork it and create your version:
 [https://glitch.com/edit/#!/sms-receiver-demo](https://glitch.com/edit/#!/sms-receiver-demo).
 
 ### Enabling support during the origin trial
@@ -302,10 +303,10 @@ To participate in an origin trial:
    for your origin.
 1. Add the token to your pages, there are two ways to provide this token on any
    page in your origin:
-    * Add an `origin-trial <meta>` tag to the head of any page:  
+    * Add an `origin-trial <meta>` tag to the head of any page:
       `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
     * If you can configure your server, you can also provide the token on pages
-      using an `Origin-Trial` HTTP header:  
+      using an `Origin-Trial` HTTP header:
       `Origin-Trial: TOKEN_GOES_HERE`
 
 ## Feedback

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -14,6 +14,7 @@ description: |
 tags:
   - post
   - capabilities
+  - fugu
 ---
 
 On a mobile device, sharing should be as simple as clicking the **Share** button,

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -14,6 +14,7 @@ description: |
 tags:
   - post
   - capabilities
+  - fugu
 ---
 
 With the Web Share API, web apps are able to use the same system-provided share

--- a/src/site/content/en/blog/workbox-share-targets/index.md
+++ b/src/site/content/en/blog/workbox-share-targets/index.md
@@ -14,12 +14,13 @@ alt: Two pairs of hands holding a cup of tomatoes.
 tags:
   - post
   - capabilities
+  - fugu
   - workbox
 ---
 
 The [Web Share Target API](https://web.dev/web-share-target/) lets you display
-your [Progressive Web App](https://developers.google.com/web/progressive-web-apps/checklist) in a 
-user's native share [sheet] after it's been installed. While it works great if you have a server 
+your [Progressive Web App](https://developers.google.com/web/progressive-web-apps/checklist) in a
+user's native share [sheet] after it's been installed. While it works great if you have a server
 available to receive the request, it's much harder to get working if you don't.
 
 In this article we'll use


### PR DESCRIPTION
Makes the tags for fugu/capabilities consistent across the blog.