### PR TITLE
Disable pointer events on action button children

### DIFF
--- a/src/styles/components/_actions.scss
+++ b/src/styles/components/_actions.scss
@@ -92,6 +92,10 @@ $W_FAB_LARGE_RADIUS: 28px;
   @include w-overlay();
 }
 
+.w-actions__fab * {
+  pointer-events: none;
+}
+
 .w-actions__fab:hover::after {
   background-color: rgba($WHITE, .08);
 }


### PR DESCRIPTION
I noticed the share button wasn't working if you clicked on the span text inside of it. I think it's because it uses `e.target.href` to open the little share window.

Changes proposed in this pull request:

- Disable pointer events on action button children.
