### PR TITLE
Fix focus behavior for side nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16408,9 +16408,9 @@
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "wicg-inert": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-2.1.3.tgz",
-      "integrity": "sha512-3AezUQILDlNeoVHUn6ntyHoEO6HJT32yPkNr9HJQ5Y1/cLXe4jWRelo79nO6hWzcy/cEAa3PWfdRNfU7mW3YRw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.0.1.tgz",
+      "integrity": "sha512-ge5a5cTzkESRLPx7saeKVnJsxEZCs2h8Yx9Jnl3IAuYpeL7AO06CVWem7GU2P/HP8X+s6u3OcAiMHOBYpXSNkg=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-virtual": "^1.0.1",
     "terser": "^4.3.9",
     "unistore": "^3.4.1",
-    "wicg-inert": "^2.1.3",
+    "wicg-inert": "^3.0.1",
     "workbox-build": "^4.3.1"
   },
   "devDependencies": {

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -124,8 +124,10 @@ export const expandSideNav = store.action(() => {
   document.body.classList.add("web-side-nav--expanded");
   const main = document.querySelector("main");
   const header = document.querySelector("web-header");
+  const footer = document.querySelector(".w-footer");
   main.inert = true;
   header.inert = true;
+  footer.inert = true;
   return {isSideNavExpanded: true};
 });
 
@@ -133,8 +135,10 @@ export const collapseSideNav = store.action(() => {
   document.body.classList.remove("web-side-nav--expanded");
   const main = document.querySelector("main");
   const header = document.querySelector("web-header");
+  const footer = document.querySelector(".w-footer");
   main.inert = false;
   header.inert = false;
+  footer.inert = false;
   return {isSideNavExpanded: false};
 });
 


### PR DESCRIPTION
Fixes #2102.

Changes proposed in this pull request:

- Rev `wicg-inert` to latest version (3.0.1) to ensure `<details>` children of an inert element aren't focusable.
- Add `inert` to `.w-footer` when SideNav is open. 
