### PR TITLE
Fix : TypeError: axe is not a function

### DIFF
--- a/src/site/content/en/react/accessibility-auditing-react/index.md
+++ b/src/site/content/en/react/accessibility-auditing-react/index.md
@@ -121,7 +121,7 @@ You now only need to initialize the module in `index.js`:
 ```js
 if (process.env.NODE_ENV !== 'production') {
   import('react-axe').then(axe => {
-    axe(React, ReactDOM, 1000);
+    axe.default(React, ReactDOM, 1000);
     ReactDOM.render(<App />, document.getElementById('root'));
   });
 } else {


### PR DESCRIPTION
corrected as axe.default() instead of axe() - whichi is working for me

Fixes #SOME_ISSUE_NUMBER.

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:

- 
- 
- 
