### PR TITLE
Update .gitlocalize.yml

### DIFF
--- a/.gitlocalize.yml
+++ b/.gitlocalize.yml
@@ -1,8 +1,18 @@
 pretranslate:
   segments:
+    ignore_frontmatter_keys:
+    - "layout"
+    - "permalink"
+    - "noindex"
+    - "date"
+    - "override"
+    - "codelabs"
+    - "tags"
+    - "authors"
+  
     ignore_patterns:
     - "Native"
-    - "{%\\s?([a-zA-Z0-9\\.\\-\\?\'\"\\s]*)\\s?%}"
+    - !ruby/regexp /{%\s?([a-zA-Z0-9\.\-\?\'\"\,\!\s]*)\s?%}/
 
   paths:
   - source: "src/site/content/en"


### PR DESCRIPTION
GitLocalize auto-pretranslate config: 
-adds a section to ignore frontmatter keys 
-fixes the regexp to ignore the {%%} tags

