### PR TITLE
Add fallback size to hero so it doesn't shift.

### DIFF
--- a/src/site/_includes/components/Hero.js
+++ b/src/site/_includes/components/Hero.js
@@ -28,6 +28,8 @@ module.exports = ({page, hero, alt, heroPosition, heroFit = "cover"}) => {
   return html`
     <img
       class="w-hero w-hero--${heroFit} ${heroPosition ? `w-hero--${heroPosition}` : ""}"
+      width="1600"
+      height="480"
       sizes="100vw"
       srcset="${srcsetRange.map((width) => html`
         ${imagePath}?auto=format&fit=max&w=${width} ${width}w,


### PR DESCRIPTION
I noticed most blog posts shift a lot as they load their hero image. I believe giving them `width` and `height` fallback attributes is the approved way to define their intrinsic size ([thread](https://github.com/WICG/intrinsicsize-attribute/issues/16#issuecomment-503245998)) and seems to help mitigate a lot of the shifting.

Related [css-tricks post](https://css-tricks.com/what-if-we-got-aspect-ratio-sized-images-by-doing-almost-nothing/).

Changes proposed in this pull request:

- Add `width` and `height` fallback attributes to hero image to prevent layout shift.