### PR TITLE
Add a feature card class to 1st post on homepage.

### DIFF
--- a/src/site/_collections/recent-posts.js
+++ b/src/site/_collections/recent-posts.js
@@ -17,11 +17,14 @@
 const livePosts = require("../_filters/live-posts");
 
 // Return the three most recent blog posts.
+// Because these posts appear on the homepage they need to have a hero or
+// thumbnail image, otherwise the visual layout will not work.
 module.exports = (collection) => {
   const tag = process.env.ELEVENTY_ENV === "test" ? "test-post" : "post";
   return collection
     .getFilteredByTag(tag)
     .filter(livePosts)
+    .filter((item) => item.data.hero || item.data.thumbnail)
     .reverse()
     .slice(0, 3);
 };

--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -30,7 +30,7 @@ const postTags = require("../../_data/postTags");
  * @param {Object} post An eleventy collection item with post data.
  * @return {string}
  */
-module.exports = ({post}) => {
+module.exports = ({post, featured = false}) => {
   const url = stripLanguage(post.url);
   const data = post.data;
   const displayedTags = [];

--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -151,13 +151,17 @@ module.exports = ({post, featured = false}) => {
 
   return html`
     <div class="w-card">
-      <article class="w-post-card">
-        <a class="w-post-card__link" href="${url}">
-          <div
-            class="w-post-card__cover ${thumbnail &&
-              `w-post-card__cover--with-image`}"
-          >
+      <article class="w-post-card ${featured ? "w-post-card--featured" : ""}">
+        <div
+          class="w-post-card__cover ${thumbnail &&
+            `w-post-card__cover--with-image`}"
+        >
+          <a class="w-post-card__link" tabindex="-1" href="${url}">
             ${thumbnail && renderThumbnail(url, thumbnail, alt)}
+          </a>
+        </div>
+        <div class="w-post-card__blurb">
+          <a class="w-post-card__link" href="${url}">
             <h2
               class="${thumbnail
                 ? `w-post-card__headline--with-image`
@@ -165,17 +169,16 @@ module.exports = ({post, featured = false}) => {
             >
               ${md(data.title)}
             </h2>
-          </div>
-        </a>
-        ${renderAuthorsAndDate(post)}
-
-        <div class="w-post-card__desc">
-          <a class="w-post-card__link" tabindex="-1" href="${url}">
-            <p class="w-post-card__subhead">
-              ${md(data.subhead)}
-            </p>
           </a>
-          ${renderChips()}
+          ${renderAuthorsAndDate(post)}
+          <div class="w-post-card__desc">
+            <a class="w-post-card__link" tabindex="-1" href="${url}">
+              <p class="w-post-card__subhead">
+                ${md(data.subhead)}
+              </p>
+            </a>
+            ${renderChips()}
+          </div>
         </div>
       </article>
     </div>

--- a/src/site/content/en/index.njk
+++ b/src/site/content/en/index.njk
@@ -73,9 +73,13 @@ date: 2018-11-05
       </header>
     </div>
     <div class="w-grid w-pb--std">
-      <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
+      <div class="w-grid__columns w-grid__columns--featured" role="list">
         {% for post in collections.recentPosts %}
-          {% PostCard {post: post} %}
+          {% if loop.first %}
+            {% PostCard {post: post, featured: true} %}
+          {% else %}
+            {% PostCard {post: post} %}
+          {% endif %}
         {% endfor %}
       </div>
     </div>

--- a/src/styles/components/_grid.scss
+++ b/src/styles/components/_grid.scss
@@ -61,6 +61,28 @@
   }
 }
 
+.w-grid__columns--featured {
+  @include bp(md) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, minmax(min-content, max-content));
+    max-width: 960px;
+
+    *:nth-child(1) { grid-area: 1 / 1 / 2 / 3; }
+    *:nth-child(2) { grid-area: 2 / 1 / 3 / 2; }
+    *:nth-child(3) { grid-area: 2 / 2 / 3 / 3; }
+  }
+
+  @include bp(lg) {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: 1fr;
+    max-width: 1320px;
+
+    *:nth-child(1) { grid-area: auto; }
+    *:nth-child(2) { grid-area: auto; }
+    *:nth-child(3) { grid-area: auto; }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // !!! DEPRECATED !!!
 //

--- a/src/styles/components/_post-card.scss
+++ b/src/styles/components/_post-card.scss
@@ -12,6 +12,7 @@
 
 .w-post-card {
   @include w-body-text();
+  height: 100%;
   padding: 24px;
   position: relative;
 
@@ -154,4 +155,37 @@
   color: $GREY_700;
   font: inherit;
   margin: 0;
+}
+
+// This is a special variation of the PostCard component that's only used on
+// the homepage.
+// The card needs to have a different layout only when it's between breakpoints
+// otherwise it acts just like any other card.
+// Because it would be onerous to extend the block and all of its elements, we
+// just use a descendant selector.
+@media (min-width: #{$BREAKPOINT_VALUE_MEDIUM}) and (max-width: #{$BREAKPOINT_VALUE_LARGE}) {
+  .w-post-card--featured {
+    display: flex;
+
+    .w-post-card__cover,
+    .w-post-card__blurb {
+      flex: 1;
+    }
+
+    .w-post-card__cover,
+    .w-post-card__figure {
+      margin: 0;
+    }
+
+    .w-post-card__blurb {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding-left: 64px;
+    }
+
+    .w-post-card__desc::before {
+      display: none;
+    }
+  }
 }

--- a/src/styles/components/_post-card.scss
+++ b/src/styles/components/_post-card.scss
@@ -169,6 +169,8 @@
 // just use a descendant selector.
 @media (min-width: #{$BREAKPOINT_VALUE_MEDIUM}) and (max-width: #{$BREAKPOINT_VALUE_LARGE}) {
   .w-post-card--featured {
+    // 32px * 2 of padding to match the columns below + 8px gap.
+    column-gap: 72px;
     display: grid;
     grid-template-columns: 1fr 1fr;
 
@@ -186,7 +188,6 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
-      padding-left: 40px;
     }
 
     // Normally this little symbol is obscured by the hero thumbnail image

--- a/src/styles/components/_post-card.scss
+++ b/src/styles/components/_post-card.scss
@@ -147,6 +147,10 @@
   }
 }
 
+.w-post-card__link:focus {
+  outline: none;
+}
+
 .w-post-card__link:hover {
   text-decoration: none;
 }
@@ -165,25 +169,28 @@
 // just use a descendant selector.
 @media (min-width: #{$BREAKPOINT_VALUE_MEDIUM}) and (max-width: #{$BREAKPOINT_VALUE_LARGE}) {
   .w-post-card--featured {
-    display: flex;
-
-    .w-post-card__cover,
-    .w-post-card__blurb {
-      flex: 1;
-    }
+    display: grid;
+    grid-template-columns: 1fr 1fr;
 
     .w-post-card__cover,
     .w-post-card__figure {
       margin: 0;
     }
 
+    .w-post-card__cover,
+    .w-post-card__blurb {
+      grid-area: auto;
+    }
+
     .w-post-card__blurb {
       display: flex;
       flex-direction: column;
       justify-content: center;
-      padding-left: 64px;
+      padding-left: 40px;
     }
 
+    // Normally this little symbol is obscured by the hero thumbnail image
+    // but we need to hide it for the side-by-side featured layout.
     .w-post-card__desc::before {
       display: none;
     }

--- a/src/styles/tools/_breakpoints.scss
+++ b/src/styles/tools/_breakpoints.scss
@@ -8,30 +8,30 @@
 // sass-lint:disable variable-name-format
 
 // Feature phones
-$BREAKPOINT_VALUE_XXSMALL: '(min-width: 241px)';
+$BREAKPOINT_VALUE_XXSMALL: 241px;
 
 // Smart phones
-$BREAKPOINT_VALUE_XSMALL: '(min-width: 321px)';
-$BREAKPOINT_VALUE_SMALL: '(min-width: 481px)';
+$BREAKPOINT_VALUE_XSMALL: 321px;
+$BREAKPOINT_VALUE_SMALL: 481px;
 
 // Tablets
-$BREAKPOINT_VALUE_MEDIUM: '(min-width: 865px)';
+$BREAKPOINT_VALUE_MEDIUM: 865px;
 
 // Desktops
-$BREAKPOINT_VALUE_LARGE: '(min-width: 1264px)';
+$BREAKPOINT_VALUE_LARGE: 1264px;
 
 // Media breakpoint helper
 // Credit: http://css-tricks.com/conditional-media-query-mixins/
 @mixin bp($point) {
   @if $point == xxsm {
-    @media #{$BREAKPOINT_VALUE_XXSMALL} { @content; }
+    @media (min-width: #{$BREAKPOINT_VALUE_XXSMALL}) { @content; }
   } @else if $point == xsm {
-    @media #{$BREAKPOINT_VALUE_XSMALL} { @content; }
+    @media (min-width: #{$BREAKPOINT_VALUE_XSMALL}) { @content; }
   } @else if $point == sm {
-    @media #{$BREAKPOINT_VALUE_SMALL} { @content; }
+    @media (min-width: #{$BREAKPOINT_VALUE_SMALL}) { @content; }
   } @else if $point == md {
-    @media #{$BREAKPOINT_VALUE_MEDIUM} { @content; }
+    @media (min-width: #{$BREAKPOINT_VALUE_MEDIUM}) { @content; }
   } @else if $point == lg {
-    @media #{$BREAKPOINT_VALUE_LARGE} { @content; }
+    @media (min-width: #{$BREAKPOINT_VALUE_LARGE}) { @content; }
   }
 }


### PR DESCRIPTION
Fixes #2028 

On the homepage, when you resize to a smaller display, the recent posts cards wrap in a way that looks broken. This resolves the issue by changing the layout for the most recent card so it's in more of a featured position.

This is a short term fix, but really I'd like us to redesign the homepage at some point 👨‍🎨

Since a lot of work has been done on #1808, I think we should wait until that PR lands before merging this one. I can rebase against master after #1808 lands and clean things up in this PR. This PR is read for review though, so PTAL!

**Before**
![image](https://user-images.githubusercontent.com/1066253/74059447-f0afcb80-499c-11ea-8f1b-ebe24a3f1cfd.png)

**After**
![image](https://user-images.githubusercontent.com/1066253/74059539-14731180-499d-11ea-918b-2c53d8ec79e9.png)

Changes proposed in this pull request:

- Changes the `recentPosts` collection so it ensures all posts have a thumbnail
- Adds a `featured` argument to the `PostCard` shortcode so it can apply a featured modifier class.
- Adds a featured grid layout.
- Adds a featured variation to the PostCard styles.
- Changes the `breakpoints.scss` so it's easier to use the actual breakpoint values in cases where you might want to do a max-width breakpoint.
