### PR TITLE
flip prod auth domain

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -49,7 +49,7 @@ module.exports = {
   firebase: {
     prod: {
       apiKey: "AIzaSyCyThSjI_ZUT1NwV9aQLtqklVcNj72gvo8",
-      authDomain: "web-dev-production-1.firebaseapp.com",
+      authDomain: "auth.web.dev",
       databaseURL: "https://web-dev-production-1.firebaseio.com",
       projectId: "web-dev-production-1",
       storageBucket: "web-dev-production-1.appspot.com",


### PR DESCRIPTION
Fixes #2114.

We're now receiving a cert from Firebase Hosting for https://auth.web.dev, so we can use it for login.