### PR TITLE
add Firestore backup workflow

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci && npm run build && node index-algolia.js
 
       - name: Deploy
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.1
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/snapshot-firestore.yml
+++ b/.github/workflows/snapshot-firestore.yml
@@ -1,0 +1,21 @@
+name: Snapshot firestore
+on:
+  schedule:
+    # At 19:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
+    - cron: '0 19 * * 1-4'
+
+jobs:
+  ci:
+    name: Run gcloud to snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Snapshot
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '270.0.0'
+          service_account_email: ${{ secrets.GCLOUD_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_KEY }}
+
+      # nb. gcloud uses a new timestamp'ed dir only when pointing at a top-level bucket. Thus, we
+      # can't naïvely target a subfolder (it will fail with "Path already exists").
+      - run: gcloud firestore export gs://web-dev-production-1.appspot.com

--- a/.github/workflows/snapshot-firestore.yml
+++ b/.github/workflows/snapshot-firestore.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Snapshot
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.1
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/snapshot-firestore.yml
+++ b/.github/workflows/snapshot-firestore.yml
@@ -1,8 +1,8 @@
 name: Snapshot firestore
 on:
   schedule:
-    # At 19:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
-    - cron: '0 19 * * 1-4'
+    # At 19:00 UTC / 7:00 PST on every Monday.
+    - cron: '0 19 * * 1'
 
 jobs:
   ci:
@@ -18,4 +18,6 @@ jobs:
 
       # nb. gcloud uses a new timestamp'ed dir only when pointing at a top-level bucket. Thus, we
       # can't naïvely target a subfolder (it will fail with "Path already exists").
-      - run: gcloud firestore export gs://web-dev-production-1.appspot.com
+      # This is a secondary bucket, not the default Firebase project. Its lifecycle config is set
+      # to delete objects that are >=90 days old.
+      - run: gcloud firestore export gs://web-dev-production-firestore-archive


### PR DESCRIPTION
We could target e.g. /backups/YYYY-MM-DD, but it would be a more complex workflow (have to set an env var with `date "+%Y-%m-%d"`, then pass it to the gcloud command, ...).

This will work for now.