### PR TITLE
Clarify that NFC is only available on Chrome for Android

### DIFF
--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -1,6 +1,6 @@
 ---
-title: Interact with NFC devices on the web
-subhead: Reading and writing to NFC tags is now possible on the mobile web.
+title: Interact with NFC devices on Chrome for Android
+subhead: Reading and writing to NFC tags is now possible
 authors:
   - beaufortfrancois
 date: 2020-02-12
@@ -8,12 +8,11 @@ hero: hero.jpg
 thumbnail: thumbnail.jpg
 alt: A photo of NFC tags
 description: |
-  Reading and writing to NFC tags is now possible on the mobile web.
+  Reading and writing to NFC tags is now possible on Chrome for Android.
 tags:
   - post # post is a required tag for the article to show up in the blog.
   - capabilities
   - fugu
-draft: true
 ---
 
 {% Aside %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes title from "Interact with NFC devices on the web" to "Interact with NDV devices on Chrome for Android"
- Removes draft status so that the page is visible on the blog again
