### PR TITLE
Hide yt iframe during screenshot tests.

### DIFF
--- a/src/site/_includes/components/YouTube.js
+++ b/src/site/_includes/components/YouTube.js
@@ -29,6 +29,13 @@ module.exports = (id, startTime) => {
     throw new Error("Cannot create YouTube component if id is undefined");
   }
 
+  // Don't load YT iframe in our test environment. This specifically affects
+  // screenshot testing where the iframe can be slow or flaky to load and fail
+  // because YouTube is always fiddling with their UI.
+  if (process.env.ELEVENTY_ENV === "test") {
+    return "";
+  }
+
   let src = `https://www.youtube.com/embed/${id}`;
   if (startTime) {
     src += `?start=${startTime}`;

--- a/src/site/_includes/components/YouTube.js
+++ b/src/site/_includes/components/YouTube.js
@@ -33,11 +33,13 @@ module.exports = (id, startTime) => {
   // screenshot testing where the iframe can be slow or flaky to load and fail
   // because YouTube is always fiddling with their UI.
   // Load a placeholder to fill the space instead.
-  if (process.env.ELEVENTY_ENV === "test") {
-    return html`
-      <div class="w-youtube" style="background: grey;"></div>
-    `;
-  }
+  // if (process.env.ELEVENTY_ENV === "test") {
+  return html`
+    <div class="w-youtube" style="background: aquamarine;">
+      YouTube iframe placeholder
+    </div>
+  `;
+  // }
 
   let src = `https://www.youtube.com/embed/${id}`;
   if (startTime) {

--- a/src/site/_includes/components/YouTube.js
+++ b/src/site/_includes/components/YouTube.js
@@ -32,8 +32,11 @@ module.exports = (id, startTime) => {
   // Don't load YT iframe in our test environment. This specifically affects
   // screenshot testing where the iframe can be slow or flaky to load and fail
   // because YouTube is always fiddling with their UI.
+  // Load a placeholder to fill the space instead.
   if (process.env.ELEVENTY_ENV === "test") {
-    return "";
+    return html`
+      <div class="w-youtube" style="background: grey;"></div>
+    `;
   }
 
   let src = `https://www.youtube.com/embed/${id}`;


### PR DESCRIPTION
Changes proposed in this pull request:

- Hides the yt iframe during screenshot testing cuz it's flaky and keeps shifting the channel logo around a few pixels which breaks the tests. Returning `""` instead of a undefined return because eleventy will literally write "undefined" if we do that and it just looks ugly :P