### PR TITLE
Only run Percy if .js, .njk, or .scss files change.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Percy Test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-        run: npm run test:snapshots
+        run: "./tools/percy/run-percy.sh"

--- a/tools/percy/run-percy.sh
+++ b/tools/percy/run-percy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Get the name of the current branch.
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "Comparing master to $BRANCH to see if it needs screenshot testing..."
+
+# Check if js, njk, or scss files were touched in the PR.
+# If so, run Percy. Otherwise exit early.
+# Note, grep will just exit if it doesn't find anything.
+MATCHED_FILES=$(git --no-pager diff --name-only master...HEAD | egrep '^.*\.(js|njk|scss)$')
+echo "The following files triggered screenshot testing:"
+echo "$MATCHED_FILES"
+npm run test:snapshots


### PR DESCRIPTION
Fixes #2166

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:

- Adds a bash script to the Percy workflow which checks if `.js`, `.njk`, or `.scss` files were touched in the PR and only runs Percy if they were.