### PR TITLE
Only run Percy on certain file types.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -7,10 +7,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.js'
+      - '**.njk'
+      - '**.scss'
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
   pull_request:
-
+    paths:
+      - '**.js'
+      - '**.njk'
+      - '**.scss'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #2166
Better version of #2180

Changes proposed in this pull request:

- Use GitHub Actions' [request paths syntax](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) to limit when Percy runs. Should only run if .njk, .js, or .scss files are changed.