### PR TITLE
fix typo

### DIFF
--- a/src/site/content/en/angular/precaching-with-the-angular-service-worker/index.md
+++ b/src/site/content/en/angular/precaching-with-the-angular-service-worker/index.md
@@ -97,4 +97,4 @@ Specifying other assets to be precached is just as straightforward: update the p
 Using a service worker for precaching can improve the performance of your apps by saving assets to a local cache, which makes them more reliable on poor networks. To use precaching with Angular and the Angular CLI:
 
 1. Add the `@angular/pwa` package to your project.
-2. Control what the service worker caches by editing `ngsw-config.js`.
+2. Control what the service worker caches by editing `ngsw-config.json`.


### PR DESCRIPTION
Conclusion section has wrong reference to filename

Fixes #SOME_ISSUE_NUMBER.

Note: If this is written content for the site please include the issue number from your [content proposal](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+label%3A%22content+proposal%22).

Changes proposed in this pull request:
- Set correct filename extension of ngsw config
