### PR TITLE
Add GH Action to lint yaml and verify updated field.

### DIFF
--- a/.github/actions/lint-front-matter/README.md
+++ b/.github/actions/lint-front-matter/README.md
@@ -1,0 +1,18 @@
+# lint-front-matter
+
+A hopefully extensible system for adding custom YAML front matter checks.
+This action will do separate linter passes for:
+- All files
+- Added files
+- Modified files
+
+## Adding a new rule
+
+1. Write a function in the `./rules` directory that accepts:
+  - The path to the file being linted.
+  - The yaml front matter from the file.
+  - An array of failures.
+2. If your rule fails, push a new failure message into the failures array.
+3. The `./linters` directory contains functions which lint all files, or only
+   added or modified files. Add your new rule to the linter pass(es) that make
+   sense.

--- a/.github/actions/lint-front-matter/action.yml
+++ b/.github/actions/lint-front-matter/action.yml
@@ -1,0 +1,13 @@
+name: 'Lint front matter'
+description: 'Lints yaml front matter from markdown files.'
+author: 'Rob Dodson <robdodson@google.com>'
+runs:
+  using: 'node12'
+  main: 'main.js'
+inputs:
+  added:
+    description: Space separated list of added files
+    required: true
+  modified:
+    description: Space separated list of modified files
+    required: true

--- a/.github/actions/lint-front-matter/linters/added-files.js
+++ b/.github/actions/lint-front-matter/linters/added-files.js
@@ -1,0 +1,19 @@
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
+const checkUpdatedIsCurrent = require('../rules/updated-is-current.js.js');
+
+/**
+ * @param {Array<string>} files Files that should be linted.
+ * @return {Array<string>} Error messages from failed lint rules.
+ */
+module.exports = async (files) => {
+  const failures = [];
+  for (file of files) {
+    // The `updated` field is optional on newly added files
+    // but if one is present, verify that it's current.
+    const frontMatter = await getYamlFrontMatter(file);
+    if (frontMatter.updated) {
+      checkUpdatedIsCurrent(file, frontMatter, failures);
+    }
+  }
+  return failures;
+}

--- a/.github/actions/lint-front-matter/linters/added-files.js
+++ b/.github/actions/lint-front-matter/linters/added-files.js
@@ -1,5 +1,5 @@
-const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
-const checkUpdatedIsCurrent = require('../rules/updated-is-current.js.js');
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter');
+const checkUpdatedIsCurrent = require('../rules/updated-is-current');
 
 /**
  * @param {Array<string>} files Files that should be linted.

--- a/.github/actions/lint-front-matter/linters/all-files.js
+++ b/.github/actions/lint-front-matter/linters/all-files.js
@@ -1,5 +1,5 @@
-const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
-const checkHasProperty = require('../rules/has-property.js/index.js.js');
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter');
+const checkHasProperty = require('../rules/has-property.js/index');
 
 /**
  * @param {Array<string>} files Files that should be linted.

--- a/.github/actions/lint-front-matter/linters/all-files.js
+++ b/.github/actions/lint-front-matter/linters/all-files.js
@@ -1,0 +1,15 @@
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
+const checkHasProperty = require('../rules/has-property.js/index.js.js');
+
+/**
+ * @param {Array<string>} files Files that should be linted.
+ * @return {Array<string>} Error messages from failed lint rules.
+ */
+module.exports = async (files) => {
+  const failures = [];
+  for (file of files) {
+    const frontMatter = await getYamlFrontMatter(file)
+    checkHasProperty(file, frontMatter, 'date', failures);
+  }
+  return failures;
+};

--- a/.github/actions/lint-front-matter/linters/modified-files.js
+++ b/.github/actions/lint-front-matter/linters/modified-files.js
@@ -1,0 +1,17 @@
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
+const checkHasProperty = require('../rules/has-updated.js.js');
+const checkUpdatedIsCurrent = require('../rules/updated-is-current.js.js');
+
+/**
+ * @param {Array<string>} files Files that should be linted.
+ * @return {Array<string>} Error messages from failed lint rules.
+ */
+module.exports = async (files) => {
+  const failures = [];
+  for (file of files) {
+    const frontMatter = await getYamlFrontMatter(file);
+    checkHasProperty(file, frontMatter, 'updated', failures);
+    checkUpdatedIsCurrent(file, frontMatter, failures);
+  }
+  return failures;
+}

--- a/.github/actions/lint-front-matter/linters/modified-files.js
+++ b/.github/actions/lint-front-matter/linters/modified-files.js
@@ -1,6 +1,6 @@
-const getYamlFrontMatter = require('../utils/get-yaml-front-matter.js.js');
-const checkHasProperty = require('../rules/has-updated.js.js');
-const checkUpdatedIsCurrent = require('../rules/updated-is-current.js.js');
+const getYamlFrontMatter = require('../utils/get-yaml-front-matter');
+const checkHasProperty = require('../rules/has-updated');
+const checkUpdatedIsCurrent = require('../rules/updated-is-current');
 
 /**
  * @param {Array<string>} files Files that should be linted.

--- a/.github/actions/lint-front-matter/main.js
+++ b/.github/actions/lint-front-matter/main.js
@@ -1,8 +1,8 @@
 const core = require('@actions/core');
-const getMarkdownFiles = require('./utils/get-markdown-files.js.js');
-const lintAllFiles = require('./linters/all-files.js.js');
-const lintAddedFiles = require('./linters/added-files.js.js');
-const lintModifiedFiles = require('./linters/modified-files.js.js');
+const getMarkdownFiles = require('./utils/get-markdown-files');
+const lintAllFiles = require('./linters/all-files');
+const lintAddedFiles = require('./linters/added-files');
+const lintModifiedFiles = require('./linters/modified-files');
 
 try {
   const added = getMarkdownFiles(core.getInput('added'));

--- a/.github/actions/lint-front-matter/main.js
+++ b/.github/actions/lint-front-matter/main.js
@@ -1,0 +1,21 @@
+const core = require('@actions/core');
+const getMarkdownFiles = require('./utils/get-markdown-files.js.js');
+const lintAllFiles = require('./linters/all-files.js.js');
+const lintAddedFiles = require('./linters/added-files.js.js');
+const lintModifiedFiles = require('./linters/modified-files.js.js');
+
+try {
+  const added = getMarkdownFiles(core.getInput('added'));
+  const modified = getMarkdownFiles(core.getInput('modified'));
+  const all = [...added, ...modified];
+
+  (async () => {
+    [
+      ...(await lintAllFiles(all)),
+      ...(await lintAddedFiles(added)),
+      ...(await lintModifiedFiles(modified))
+    ].forEach((failure) => core.setFailed(failure));
+  })();
+} catch(err) {
+  core.setFailed(err);
+}

--- a/.github/actions/lint-front-matter/package.json
+++ b/.github/actions/lint-front-matter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lint-front-matter",
+  "version": "1.0.0",
+  "main": "main.js",
+  "dependencies": {
+    "@actions/core": "^1.2.0",
+    "yaml-front-matter": "^4.1.0"
+  }
+}

--- a/.github/actions/lint-front-matter/rules/has-property.js
+++ b/.github/actions/lint-front-matter/rules/has-property.js
@@ -1,0 +1,11 @@
+/**
+ * @param {string} file Filename of the file being linted.
+ * @param {Object} yaml The yaml front matter from the file.
+ * @param {string} property The name of the property to check for.
+ * @param {Array<string>} failures Error messages from failed lint checks.
+ */
+module.exports = (file, yaml, property, failures) => {
+  if (!(property in yaml)) {
+    failures.push(`${file} is missing its ${property} field.`);
+  }
+}

--- a/.github/actions/lint-front-matter/rules/updated-is-current.js
+++ b/.github/actions/lint-front-matter/rules/updated-is-current.js
@@ -1,0 +1,20 @@
+/**
+ * @param {string} file Filename of the file being linted.
+ * @param {Object} yaml The yaml front matter from the file.
+ * @param {?string} yaml.updated The updated property in the yaml front matter.
+ * @param {Array<string>} failures Error messages from failed lint checks.
+ */
+module.exports = (file, {updated}, failures) => {
+  // If updated is undefined, just return early.
+  // Rather than error here, let another lint rule that explicitly checks for
+  // the presence of the updated property handle it.
+  if (!updated) {
+    return;
+  }
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  if (today.getTime() > new Date(updated).getTime()) {
+    failures.push(`${file} updated field is out of date. It must be at least ${today.toISOString().split('T')[0]}.`);
+  }
+}

--- a/.github/actions/lint-front-matter/utils/get-markdown-files.js
+++ b/.github/actions/lint-front-matter/utils/get-markdown-files.js
@@ -1,0 +1,9 @@
+const isMarkdownFile = new RegExp(/^.*\.(md|markdown)$/);
+
+/**
+ * @param {string} files A space separated list of file names.
+ * @return {Array<string>} An array of markdown file names.
+ */
+module.exports = (files="") => {
+  return files.split(' ').filter((file) => isMarkdownFile.test(file));
+}

--- a/.github/actions/lint-front-matter/utils/get-yaml-front-matter.js
+++ b/.github/actions/lint-front-matter/utils/get-yaml-front-matter.js
@@ -1,0 +1,11 @@
+const fs = require('fs').promises;
+const yaml = require('yaml-front-matter');
+
+/**
+ * @param {string} file A path to a file.
+ * @return {Object} The parsed YAML front matter from the file.
+ */
+module.exports = async (file) => {
+  const content = await fs.readFile(file, 'utf-8');
+  return yaml.loadFront(content);
+};

--- a/.github/workflows/lint-front-matter-workflow.yml
+++ b/.github/workflows/lint-front-matter-workflow.yml
@@ -1,0 +1,40 @@
+name: Lint front matter
+on:
+# By default, runs when a pull_request's activity type is opened, synchronize,
+# or reopened
+  pull_request:
+    paths:
+      - 'src/site/content/**.md'
+      - 'src/site/content/**.markdown'
+
+jobs:
+  linter:
+    name: Linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      
+      - name: Install
+        run: npm ci
+      
+      - name: Git diff
+        id: git_diff
+        uses: futuratrepadeira/changed-files@v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint yaml front matter
+        uses: ./.github/actions/lint-yaml
+        with:
+          added: ${{ steps.git_diff.outputs.files_created }}
+          modified: ${{ steps.git_diff.outputs.files_updated }}
+        # Only run the linter if the previous step indicated that files were
+        # added or modified in the pull request.
+        if: steps.git_diff.outputs.files_created || steps.git_diff.outputs.files_updated
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -310,6 +310,12 @@
         "prismjs": "^1.17.1"
       }
     },
+    "@actions/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -17895,21 +17901,13 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml-front-matter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yaml-front-matter/-/yaml-front-matter-4.0.0.tgz",
-      "integrity": "sha1-EcN4xU6sMGGoLLr2k6abTkxE9IQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/yaml-front-matter/-/yaml-front-matter-4.1.0.tgz",
+      "integrity": "sha512-E2NKXUe8Amsf3kyLDK48c2gvnfom0Yj3m7455iVVg+G5UbX66V5iqFSpEUkQ+A3iJCKIz+mvAbkN7BQ+N0wiLA==",
       "dev": true,
       "requires": {
-        "commander": "1.0.0",
+        "commander": "^2.14.1",
         "js-yaml": "^3.10.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
-          "integrity": "sha1-XmqI5wcP9ZCINurRkWlUjDD5C80=",
-          "dev": true
-        }
       }
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@11ty/eleventy": "^0.10.0",
     "@11ty/eleventy-plugin-rss": "^1.0.7",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
+    "@actions/core": "^1.2.2",
     "@percy/script": "^1.0.3",
     "ansi-colors": "^3.2.4",
     "autoprefixer": "^9.6.1",
@@ -107,7 +108,7 @@
     "unist-util-map": "^1.0.5",
     "unist-util-to-list-of-char": "^0.1.2",
     "unist-util-visit": "^1.4.1",
-    "yaml-front-matter": "^4.0.0"
+    "yaml-front-matter": "^4.1.0"
   },
   "optionalDependencies": {
     "node-sass": "^4.12.0"


### PR DESCRIPTION
Fixes #1959 

Changes proposed in this pull request:

- Adds a new GitHub Actions workflow that runs against pull requests which contain markdown files in `src/site/content/**`.
- Adds a GitHub Action that lints yaml front matter. Currently checks for `date` field, and verifies the `updated` field has been added to modified files and that it's current.
- See the README in the `.github/actions/lint-front-matter` directory which explains how to add your own custom rules.

cc @petele @kaycebasques @mfriesenhahn @jpmedley 
