### PR TITLE
Update content issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-new-content.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-content.md
@@ -1,28 +1,14 @@
 ---
-name: Propose new content or update existing content
-about: Use this ticket for anything related to adding/updating/removing web.dev content
+name: Propose new content
+about: Use this template to propose new web.dev content
 title: 'content: TODO'
 labels: content
 assignees: 'kaycebasques'
 ---
 
-* Use this template to update existing content or propose new content.
+* Use this template to propose new content.
 * Delete any fields that aren't relevant to your issue. 
 * Update the title of this issue with a brief summary of the work to be done.
-
-## Update existing content
-
-### What page(s) need to be updated?
-
-Provide a list of URLs.
-
-### Why is this update needed?
-
-### What's the deadline?
-
-#### Is it a hard deadline?
-
-If yes, please explain why.
 
 ## Propose new content
 

--- a/.github/ISSUE_TEMPLATE/propose-new-content.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-content.md
@@ -10,8 +10,6 @@ assignees: 'kaycebasques'
 * Delete any fields that aren't relevant to your issue. 
 * Update the title of this issue with a brief summary of the work to be done.
 
-## Propose new content
-
 ### Workflow for Googlers
 
 Fill out the web.dev content proposal form: https://docs.google.com/forms/d/e/1FAIpQLSdYePZbDZ9Idi4MKL0cbqTuUHfPU7ZZJNnV9hDzjc0e1c2UXw/viewform?fbzx=7994504531518856644

--- a/.github/ISSUE_TEMPLATE/update-existing-content.md
+++ b/.github/ISSUE_TEMPLATE/update-existing-content.md
@@ -1,0 +1,23 @@
+---
+name: Update existing content
+about: Use this template for anything related to updating existing web.dev content
+title: 'content: TODO'
+labels: content
+assignees: 'kaycebasques'
+---
+
+* Use this template to request updates to existing content.
+* Delete any fields that aren't relevant to your issue. 
+* Update the title of this issue with a brief summary of the work to be done.
+
+### What page(s) need to be updated?
+
+Provide a list of URLs.
+
+### Why is this update needed?
+
+### What's the deadline?
+
+#### Is it a hard deadline?
+
+If yes, please explain why.


### PR DESCRIPTION
Changes proposed in this pull request:

- Splits the content issue template into two templates: one for proposing new content, another one for updating existing content
