### PR TITLE
Make fugu-status live

### DIFF
--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -2,12 +2,11 @@
 title: New capabilities status
 subhead: Web apps should be able to do anything native apps can. Google wants to make it possible for you to build and deliver apps on the open web that have never been possible before.
 date: 2018-11-12
-updated: 2020-02-19
+updated: 2020-02-24
 tags:
   - post
   - capabilities
   - fugu
-draft: true
 ---
 
 {% Aside %}


### PR DESCRIPTION
Changes proposed in this pull request:
- removes `draft: true` from fugu-status page
