### PR TITLE
disable scroll restoration for async loader

### DIFF
--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -1,6 +1,11 @@
 let globalHandler;
 let recentActiveUrl; // current URL not including hash
 
+// Disable automatic scroll restoration. This is helpful as back/forward behavior is technically
+// async, and most browsers will move the scroll position automatically for us, even on old content.
+// Instead, we call `scrollOnFrame` when the async load helper is done.
+window.history.scrollRestoration = "manual";
+
 /**
  * @return {string} URL pathname plus optional search part
  */


### PR DESCRIPTION
Fixes #1868.

This was surprisingly simple.

To be fair, back/forward probably shouldn't be async operations, but this lets us share code between loading _new_ pages and navigating back to old ones.