### PR TITLE
don't include SW on bad hostnames, redirect from appengine-test

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,9 +46,11 @@ const notFoundHandler = (req, res, next) => {
     .sendFile("404/index.html", options, (err) => err && next(err));
 };
 
-// Disallow www.web.dev, and remove any active Service Worker too.
-const noWwwHandler = (req, res, next) => {
-  if (req.hostname === "www.web.dev") {
+// Disallow invalid hostnames, and remove any active Service Worker too (users
+// may have loaded this and otherwise they'll be stuck forever).
+const invalidHostnames = ["www.web.dev", "appengine-test.web.dev"];
+const invalidHostnameHandler = (req, res, next) => {
+  if (invalidHostnames.includes(req.hostname)) {
     if (!req.url.endsWith(".js")) {
       return res.redirect(301, "https://web.dev" + req.url);
     }
@@ -58,7 +60,7 @@ const noWwwHandler = (req, res, next) => {
 };
 
 const handlers = [
-  noWwwHandler,
+  invalidHostnameHandler,
   localeHandler,
   express.static("dist"),
   express.static("dist/en"),

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -35,5 +35,22 @@ WebComponents.waitFor(async () => {
 });
 
 if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/sw.js");
+  const allowedHostnames = ["www.web.dev", "localhost"];
+  if (allowedHostnames.indexOf(window.location.hostname) !== -1) {
+    navigator.serviceWorker.register("/sw.js");
+  } else {
+    console.warn(
+      "skipping SW, unsupported hostname:",
+      window.location.hostname,
+    );
+
+    // Remove previous Service Worker instances from this hostname. This should never normally
+    // happen but is here for safety.
+    navigator.serviceWorker.getRegistrations().then(async (all) => {
+      await all.map((reg) => reg.unregister());
+      if (all.length) {
+        window.location.reload();
+      }
+    });
+  }
 }

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -35,7 +35,7 @@ WebComponents.waitFor(async () => {
 });
 
 if ("serviceWorker" in navigator) {
-  const allowedHostnames = ["www.web.dev", "localhost"];
+  const allowedHostnames = ["web.dev", "localhost"];
   if (allowedHostnames.indexOf(window.location.hostname) !== -1) {
     navigator.serviceWorker.register("/sw.js");
   } else {


### PR DESCRIPTION
Fixes #2024 

Also attempts to prevent more major failures in future by actively not including the Service Worker on unsupported domains.

We need the `server.js` change in this for two reasons:
* the literal 301 redirect for Google/search
* some poor user might have installed the Service Worker on "appengine-test.web.dev", and unless we nuke it, they'll never get an update (but the client-side change will hopefully help prevent things like this in future).