### PR TITLE
Add "Web NFC" to "New capabilities status" page

### DIFF
--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -162,6 +162,11 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
         <td>
           Web NFC provides sites the ability to read and write to NFC tags when
           they are in close proximity to the user's device.
+          For example, museums and art galleries could display additional
+          information about a display when the user touches their device to an
+          NFC card near the exhibit; or an inventory management web app could
+          read or write data to sn NFC tag on a container to update information
+          on its contents.
         </td>
       </tr>
     </tbody>

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -155,6 +155,15 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
           running.
         </td>
       </tr>
+      <tr>
+        <td>
+          <a href="/nfc/">Web NFC</a>
+        </td>
+        <td>
+          Web NFC provides sites the ability to read and write to NFC tags when
+          they are in close proximity to the user's device.
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -165,7 +165,7 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
           For example, museums and art galleries could display additional
           information about a display when the user touches their device to an
           NFC card near the exhibit; or an inventory management web app could
-          read or write data to sn NFC tag on a container to update information
+          read or write data to an NFC tag on a container to update information
           on its contents.
         </td>
       </tr>

--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -17,10 +17,9 @@ tags:
 
 {% Aside %}
 Web apps should be able to do anything native apps can. The [Capabilities
-project](https://developers.google.com/web/updates/capabilities), of which Web
-NFC is only a part, aims to do just that. To learn about other capabilities and
-to keep up with their progress, follow [Unlocking new capabilities for the
-web](/fugu-status/).
+project](/fugu-status/), of which Web NFC is only a part, aims to do just that.
+To learn about other capabilities and to keep up with their progress, follow
+[Unlocking new capabilities for the web](/fugu-status/).
 {% endAside %}
 
 ## What is Web NFC? {: #what }

--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -20,7 +20,7 @@ Web apps should be able to do anything native apps can. The [Capabilities
 project](https://developers.google.com/web/updates/capabilities), of which Web
 NFC is only a part, aims to do just that. To learn about other capabilities and
 to keep up with their progress, follow [Unlocking new capabilities for the
-web](https://developers.google.com/web/updates/capabilities).
+web](/fugu-status/).
 {% endAside %}
 
 ## What is Web NFC? {: #what }


### PR DESCRIPTION
This PR simply adds "Web NFC" to the new "New capabilities status" page and updates the Web NFC article to link back to it. 