### PR TITLE
Remove Details animation

### DIFF
--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -1,11 +1,7 @@
-@import '../settings/colors';
-@import '../settings/global';
-@import '../settings/type';
 @import '../tools/mixins';
 
 $CHEVRON_SIZE: 24px;
 $CHEVRON_MARGIN: 12px;
-$BORDER_COLOR: $GREY_300;
 
 .w-details {
   border: 1px solid $BORDER_COLOR;
@@ -81,7 +77,7 @@ $BORDER_COLOR: $GREY_300;
     speak: none;
     top: 50%;
     transform: translateY(-50%);
-    transition: background .2s, transform .3s;
+    transition: background .2s;
     visibility: visible;
   }
 

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -18,6 +18,7 @@ $CHEVRON_MARGIN: 12px;
   }
 }
 
+
 .w-details__summary {
   -webkit-tap-highlight-color: transparent;
   cursor: pointer;

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -18,7 +18,6 @@ $CHEVRON_MARGIN: 12px;
   }
 }
 
-
 .w-details__summary {
   -webkit-tap-highlight-color: transparent;
   cursor: pointer;


### PR DESCRIPTION
The chevron animation in the Details component is janky in Firefox. Since the details panel doesn't animate, animating the chevron doesn't seem essential, so this PR removes it.

Changes proposed in this pull request:
- Remove Details component chevron animation.
- Remove $BORDER_COLOR variable from details stylesheet so it uses the global variable.

**Note:** Percy is grumping because it's not seeing a lazy-loaded image on the Learn page, but this PR causes no visual changes to the page on load; it just removes the chevron animation in the Details component.