### PR TITLE
Force percy to scroll page to load lazy images.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -468,9 +468,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-      "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",
@@ -15048,6 +15048,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "scroll-to-bottomjs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-to-bottomjs/-/scroll-to-bottomjs-1.1.0.tgz",
+      "integrity": "sha512-+e7MRrUwY7M1V93ebqxIyPwIC8rPkvcmmmdSrOnNnCpbDP2Fpva3B6RadoRQ+ubZoYdYxye3Cculgbzb/CZiGw==",
       "dev": true
     },
     "scss-tokenizer": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "sass": "^1.22.7",
     "sass-lint": "^1.12.1",
+    "scroll-to-bottomjs": "^1.1.0",
     "slugify": "^1.3.4",
     "unified-lint-rule": "^1.0.4",
     "unist-util-map": "^1.0.5",

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -1,4 +1,5 @@
 const PercyScript = require("@percy/script");
+const scrollToBottom = require("scroll-to-bottomjs");
 const pagesToTest = [
   {
     url: "",
@@ -22,16 +23,13 @@ const pagesToTest = [
   },
 ];
 
-const sleep = (ms) => {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};
-
 // A script to navigate our app and take snapshots with Percy.
 PercyScript.run(
   async (browser, percySnapshot) => {
     for (page of pagesToTest) {
       await browser.goto(`http://localhost:8080/${page.url}`);
-      await sleep(2000);
+      await browser.evaluate(scrollToBottom);
+      await browser.waitFor(2000);
       await percySnapshot(`${page.title}`);
     }
   },


### PR DESCRIPTION
Percy [recommends using scroll-to-bottomjs](https://docs.percy.io/docs/capturing-lazy-loading-images) to force `loading=lazy` images to trigger before doing a snapshot.

Changes proposed in this pull request:

- Add scrolling to our snapshot script.
- Remove our sleep function as [PercyScript already provides one](https://docs.percy.io/docs/percyscript#section-waiting-for-elements).
