### PR TITLE
Normalize border-radii [Self-assessments]

### DIFF
--- a/src/lib/components/LighthouseScoresAudits/_styles.scss
+++ b/src/lib/components/LighthouseScoresAudits/_styles.scss
@@ -60,7 +60,7 @@ web-lighthouse-scores-audits {
       background-color: transparentize($WEB_EXTENDED_TERTIARY_COLOR, .8);
       color: $WEB_EXTENDED_TERTIARY_COLOR;
       font-weight: $FONT_WEIGHT_MEDIUM;
-      border-radius: 20px;
+      border-radius: $GLOBAL_RADIUS_LARGE;
       height: 32px;
       flex-grow: 0;
       flex-shrink: 0;

--- a/src/lib/components/UrlChooser/_styles.scss
+++ b/src/lib/components/UrlChooser/_styles.scss
@@ -13,7 +13,6 @@ web-url-chooser {
   $INPUT_HEIGHT: 56px;
 
   display: block;
-  border-radius: 6px;
 
   &:not([switching]) .lh-enterurl--switch {
     display: none;

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -34,7 +34,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 
 .w-author__image {
   background-color: $GREY_300;
-  border-radius: 50%;
+  border-radius: $GLOBAL_ROUNDED;
   flex-shrink: 0;
   height: 64px;
   margin: 0 12px 0 0;
@@ -139,7 +139,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 }
 
 .w-author__image--row-item {
-  border-radius: 50%;
+  border-radius: $GLOBAL_ROUNDED;
   height: $AUTHOR_IMAGE_SIZE_SMALL;
   margin-left: calc(-#{$AUTHOR_IMAGE_SIZE_SMALL} / 2);
   overflow: hidden;

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -11,7 +11,7 @@
 // =============================================================================
 
 .w-card {
-  border-radius: 8px;
+  border-radius: $GLOBAL_RADIUS_MEDIUM;
   display: block;
   min-height: 506px;
   overflow: hidden;

--- a/src/styles/components/_chips.scss
+++ b/src/styles/components/_chips.scss
@@ -18,7 +18,7 @@
 .w-chip {
   background-color: rgba($GREY_900, 0);
   border: 1px solid rgba($GREY_900, .16);
-  border-radius: 20px;
+  border-radius: $GLOBAL_RADIUS_LARGE;
   box-sizing: border-box;
   color: $GREY_900;
   display: block;

--- a/src/styles/components/_cross-links.scss
+++ b/src/styles/components/_cross-links.scss
@@ -18,7 +18,7 @@
   align-items: center;
   background-color: rgba($WEB_EXTENDED_SECONDARY_COLOR, .08);
   border: 1px solid transparent;
-  border-radius: 3px;
+  border-radius: $GLOBAL_RADIUS;
   color: rgba($WEB_EXTENDED_SECONDARY_COLOR, 1);
   display: inline-flex;
   height: 32px;

--- a/src/styles/components/_numbered-header.scss
+++ b/src/styles/components/_numbered-header.scss
@@ -28,7 +28,7 @@ $NUMBERED_COUNTER_SIZE_SMALL: 32px;
 }
 
 .w-numbered-header::before {
-  border-radius: 50%;
+  border-radius: $GLOBAL_ROUNDED;
   box-shadow: 0 2px 4px $DISC_SHADOW;
   content: counter(numbered-headers);
   counter-increment: numbered-headers;

--- a/src/styles/settings/_global.scss
+++ b/src/styles/settings/_global.scss
@@ -7,6 +7,8 @@
 
 // We use these to make sure border radius matches unless we want it different.
 $GLOBAL_RADIUS: 3px;
+$GLOBAL_RADIUS_MEDIUM: 8px;
+$GLOBAL_RADIUS_LARGE: 20px;
 $GLOBAL_ROUNDED: 50%;
 
 // We use this as cursor values for enabling the option of having custom cursors


### PR DESCRIPTION
Material Design encourages a three-part component size hierarchy (small, medium, and large) to help ensure visual consistency across an app. This seems good :)

Currently, web.dev only has one component that might be considered large: the callout. However, self-assessments will introduce modals, which would also be large. To start moving toward a standardized visual treatment, this PR introduces global `border-radius` variables at three sizes and migrates all web.dev-specific components* to those variables.

*Components that inherit styling from external sources (e.g., the profile switcher) are left as-is.

Changes proposed in this pull request:

- Introduce global `border-radius` variables at three sizes.
- Migrate `LighthouseScoresAudits`, `Author`, `Card`, `Chips`, `Cross-links`, and `Numbered-header` components to global variables.
- Remove unused `border-radius` value from `URLChooser` component.
