### PR TITLE
Disabled indented code blocks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -110,7 +110,8 @@ module.exports = function(config) {
 
   const mdLib = markdownIt(markdownItOptions)
     .use(markdownItAnchor, markdownItAnchorOptions)
-    .use(markdownItAttrs, markdownItAttrsOpts);
+    .use(markdownItAttrs, markdownItAttrsOpts)
+    .disable('code');
 
   // custom renderer rules
   const fence = mdLib.renderer.rules.fence;

--- a/src/site/content/en/handbook/markup-code/index.md
+++ b/src/site/content/en/handbook/markup-code/index.md
@@ -36,6 +36,11 @@ Include the [language name](https://prismjs.com/#supported-languages) after the 
 ```
 ````
 
+{% Aside 'warning' %}
+Indented code blocks won't work on web.dev,
+so make sure to use fenced code blocks as described above.
+{% endAside %}
+
 For code blocks that don't need syntax highlighting (for example, HTTP headers), set
 the language to `text`:
 


### PR DESCRIPTION
MarkDown's default behavior of converting indented text to code blocks makes writing human-readable short codes very difficult. This PR turns off indented code blocks.