### PR TITLE
clear scroll restoration before unload

### DIFF
--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -5,6 +5,11 @@ let recentActiveUrl; // current URL not including hash
 // async, and most browsers will move the scroll position automatically for us, even on old content.
 // Instead, we call `scrollOnFrame` when the async load helper is done.
 window.history.scrollRestoration = "manual";
+window.addEventListener("beforeunload", (e) => {
+  // ... but re-enable when the page is unloaded, which happens if a user refreshes the page using
+  // their browser. This prevents this type of reload from jumping back to the top of the viewport.
+  window.history.scrollRestoration = "auto";
+});
 
 /**
  * @return {string} URL pathname plus optional search part
@@ -156,6 +161,9 @@ export function listen(handler) {
     },
     {passive: true},
   );
+
+  // And on initial load.
+  onDedupScroll();
 
   // Don't catch errors for the first load.
   recentActiveUrl = getUrl();

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -5,7 +5,7 @@ let recentActiveUrl; // current URL not including hash
 // async, and most browsers will move the scroll position automatically for us, even on old content.
 // Instead, we call `scrollOnFrame` when the async load helper is done.
 window.history.scrollRestoration = "manual";
-window.addEventListener("beforeunload", (e) => {
+window.addEventListener("pagehide", (e) => {
   // ... but re-enable when the page is unloaded, which happens if a user refreshes the page using
   // their browser. This prevents this type of reload from jumping back to the top of the viewport.
   window.history.scrollRestoration = "auto";


### PR DESCRIPTION
cc @philipwalton 

### an aside

This actually isn't ideal and I played with not using scroll restoration, and instead doing something more like the polyfills for this feature do—basically when the browser does a popstate, two things happen:

1. `popstate`
2. (later, not sure how far) `scroll` (to restore position)

So you can basically retain the scroll position in the first event, immediately revert that position on the scroll, then once your async loading code is done, set the position as it was intended by `scroll`.

But the behavior seems pretty inconsistent.