### PR TITLE
Terser rollup comment and dev/production

### DIFF
--- a/build.js
+++ b/build.js
@@ -124,11 +124,12 @@ async function build() {
   const swBundle = await rollup.rollup({
     input: "src/lib/sw.js",
     plugins: [
-      // Workbox uses a variable known to be undefined (!) and forces this plugin to be used.
-      // TODO(samthor): This generates statements like "if (1 !== 1)", which are NOT removed from
-      // the final bundle code. Terser/Rollup don't strip them.
+      // This variable is defined by Webpack (and some other tooling), but not by Rollup. Set it to
+      // "production" if we're in prod, which will hide all of Workbox's log messages.
+      // Note that Terser below will actually remove the conditionals (this replace will generate
+      // lots of `if ("production" !== "production")` statements).
       rollupPluginReplace({
-        "process.env.NODE_ENV": JSON.stringify("production"),
+        "process.env.NODE_ENV": isProd ? JSON.stringify("production") : "",
       }),
       rollupPluginVirtual({
         "cache-manifest": `export default ${JSON.stringify(

--- a/build.js
+++ b/build.js
@@ -129,7 +129,7 @@ async function build() {
       // Note that Terser below will actually remove the conditionals (this replace will generate
       // lots of `if ("production" !== "production")` statements).
       rollupPluginReplace({
-        "process.env.NODE_ENV": isProd ? JSON.stringify("production") : "",
+        "process.env.NODE_ENV": JSON.stringify(isProd ? "production" : ""),
       }),
       rollupPluginVirtual({
         "cache-manifest": `export default ${JSON.stringify(

--- a/package-lock.json
+++ b/package-lock.json
@@ -18553,9 +18553,9 @@
       }
     },
     "terser": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
-      "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
+      "integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lit-element": "^2.2.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-virtual": "^1.0.1",
-    "terser": "^4.3.9",
+    "terser": "^4.6.4",
     "unistore": "^3.4.1",
     "wicg-inert": "^3.0.1",
     "workbox-build": "^5.0.0",


### PR DESCRIPTION
Follow-on from #2246.

Generates Workbox logs in dev, removes in prod. Updates comment to explain how it works.