### PR TITLE
feat(canonical): add support for canonical tags on pages, fixes #1035, fixes #2204

### DIFF
--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -108,11 +108,12 @@ module.exports = (locale, page, collections, renderData = {}) => {
   }
 
   function renderCanonicalMeta() {
-    if (pageData.canonical) {
-      return html`
-        <link rel="canonical" href="${pageData.canonical}" />
-      `;
-    }
+    return html`
+      <link
+        rel="canonical"
+        href="${pageData.canonical ? pageData.canonical : site.url + pageUrl}"
+      />
+    `;
   }
 
   // prettier-ignore

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -107,11 +107,20 @@ module.exports = (locale, page, collections, renderData = {}) => {
     `;
   }
 
+  function renderCanonicalMeta() {
+    if (pageData.canonical) {
+      return html`
+        <link rel="canonical" href="${pageData.canonical}" />
+      `;
+    }
+  }
+
   // prettier-ignore
   return html`
     <title>${pageData.title || pageData.path.title}</title>
     <meta name="description" content="${pageData.description || pageData.path.description}" />
 
+    ${renderCanonicalMeta()}
     ${renderGoogleMeta()}
     ${renderFacebookMeta()}
     ${renderTwitterMeta()}


### PR DESCRIPTION
Fixes #1035 #2204

By adding a `canonical` field to the head of a file will add a `rel=canonical` to the head of the HTML.

@devnook @samthor PTAL, it's a small feature