### PR TITLE
Clarify that the p75 threshold is for mobile users

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -309,7 +309,10 @@ document.addEventListener('visibilitychange', () => {
 
 ## What is a good CLS score?
 
-To provide a good user experience, sites should strive to have a Cumulative Layout Shift of less than **0.1** for at least **75% of page loads**.
+To provide a good user experience, sites should strive to have a Cumulative
+Layout Shift of less than **0.1**. To ensure you're hitting this target for
+most of your users, a good threshold to measure is the **75th percentile** of
+page loads on mobile devices.
 
 ## How to improve CLS
 

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -94,8 +94,9 @@ sends the FCP value to your analytics service.
 ## What is a good FCP score?
 
 To provide a good user experience, sites should strive to have First Contentful
-Paint occur within **1 second** of the page starting to load for at least **75%
-of page loads**.
+Paint occur within **1 second** of the page starting to load. To ensure you're
+hitting this target for most of your users, a good threshold to measure is the
+**75th percentile** of page loads on mobile devices.
 
 ## How to improve FCP
 

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -214,7 +214,9 @@ percentile of mobile users.
 ## What is a good FID score?
 
 To provide a good user experience, sites should strive to have a First Input
-Delay of less than **100 milliseconds** for at least **75% of page loads**.
+Delay of less than **100 milliseconds**. To ensure you're hitting this target
+for most of your users, a good threshold to measure is the **75th percentile**
+of page loads on mobile devices.
 
 ## How to improve FID
 

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -275,7 +275,8 @@ the article on [custom metrics](/custom-metrics/#element-timing-api).
 
 To provide a good user experience, sites should strive to have Largest
 Contentful Paint occur within the first **2.5 seconds** of the page starting to
-load for at least **75% of page loads**.
+load. To ensure you're hitting this target for most of your users, a good
+threshold to measure is the **75th percentile** of page loads on mobile devices.
 
 ## How to improve LCP
 

--- a/src/site/content/en/metrics/tbt/index.md
+++ b/src/site/content/en/metrics/tbt/index.md
@@ -126,7 +126,8 @@ TBT](/lighthouse-total-blocking-time) for usage details.
 ## What is a good TBT score?
 
 To provide a good user experience, sites should strive to have a Total Blocking
-Time of less than **300 milliseconds** when tested on average mobile hardware.
+Time of less than **300 milliseconds** when tested on **average mobile
+hardware**.
 
 For details on how your page's TBT affects your Lighthouse performance score,
 see [How Lighthouse determines your TBT

--- a/src/site/content/en/metrics/tti/index.md
+++ b/src/site/content/en/metrics/tti/index.md
@@ -87,7 +87,8 @@ TTI](/interactive/) for usage details.
 ## What is a good TTI score?
 
 To provide a good user experience, sites should strive to have a Time to
-Interactive of less than **5 seconds** when tested on average mobile hardware.
+Interactive of less than **5 seconds** when tested on **average mobile
+hardware**.
 
 For details on how your page's TTI affects your Lighthouse performance score,
 see [How Lighthouse determines your TTI


### PR DESCRIPTION
Clarifies the changes made in https://github.com/GoogleChrome/web.dev/pull/2250 to indicate that the 75th percentile recommendation refers specifically to mobile users.