### PR TITLE
Add rel="noreferrer" to twitter share button

### DIFF
--- a/src/lib/components/Actions/index.js
+++ b/src/lib/components/Actions/index.js
@@ -90,6 +90,7 @@ class Actions extends BaseElement {
         data-action="click"
         href="${url}"
         target="_blank"
+        rel="noreferrer"
         @click=${this.onTwitterShare}
       >
         <span>Share</span>


### PR DESCRIPTION
This PR adds `rel="noreferrer"` to twitter share button as suggested in Audits "Best Practises".

`rel="noopener"` prevents the new page from being able to access the `window.opener` property and ensures it runs in a separate process.
`rel="noreferrer"` has the same effect but also prevents the `Referer` header from being sent to the new page.

![image](https://user-images.githubusercontent.com/634478/75778200-aaf5e100-5d57-11ea-8813-888dc359c21a.png)

