### PR TITLE
Add missing meta theme-color

### DIFF
--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -5,6 +5,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#fff"/>
     {% if noindex or draft -%}
       <meta name="robots" content="noindex">
     {%- endif %}


### PR DESCRIPTION
This PR adds missing meta theme-color element as suggested in Audits "Progressive Web App" section.

The value is the same as the one found in the web manifest.

![image](https://user-images.githubusercontent.com/634478/75778979-15f3e780-5d59-11ea-8dd6-4efbdbd87d15.png)
