### PR TITLE
remove noisy warning

### DIFF
--- a/src/site/_filters/html-date-string.js
+++ b/src/site/_filters/html-date-string.js
@@ -7,9 +7,8 @@ const {DateTime} = require("luxon");
  */
 module.exports = (date) => {
   if (!date) {
-    /* eslint-disable-next-line */
-    console.warn('Date passed to htmlDateString filter was undefined or null.');
-    return;
+    // This occurs on pages like offline, 404, etc.
+    return "";
   }
   return DateTime.fromISO(date.toISOString(), {zone: "utc"}).toFormat(
     "yyyy-LL-dd",


### PR DESCRIPTION
Removes noisy warning about missing date strings.

The warning doesn't help me fix any underlying issues, doesn't provide context, so I am removing it.