### PR TITLE
Add linter for wiki MDN links

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -40,10 +40,10 @@ exports.plugins = [
   require('remark-lint-no-duplicate-headings-in-section'),
 
   // Custom plugins.
+  require('./tools/linting/bad-urls.js'),
   require('./tools/linting/fenced-code-flag.js'),
   require('./tools/linting/no-dash-spaces.js'),
   require('./tools/linting/no-repeat-punctuation.js'),
   require('./tools/linting/no-smart-quotes.js'),
-  require('./tools/linting/no-wiki-mdn-urls.js'),
   require('./tools/linting/no-unescaped-template-tags.js'),
 ];

--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -44,5 +44,6 @@ exports.plugins = [
   require('./tools/linting/no-dash-spaces.js'),
   require('./tools/linting/no-repeat-punctuation.js'),
   require('./tools/linting/no-smart-quotes.js'),
+  require('./tools/linting/no-wiki-mdn-urls.js'),
   require('./tools/linting/no-unescaped-template-tags.js'),
 ];

--- a/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
@@ -23,7 +23,7 @@ tags:
 Recently, I published [Virtual reality comes to the
 web](https://web.dev/vr-comes-to-the-web/), an article that introduced basic
 concepts behind the [WebXR Device
-API](https://wiki.developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API). I
+API](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API). I
 also provided instructions for requesting, entering, and ending an XR session.
 
 This article describes the frame loop, which is a user-agent controlled
@@ -157,7 +157,7 @@ Because steps 1 and 2a were covered in the previous article, I'll start at step
 It probably goes without saying. To draw anything in AR or VR, I need to know
 where the viewer is and where they're looking. The viewer's position and
 orientation are provided by an [XRViewerPose
-object](https://wiki.developer.mozilla.org/en-US/docs/Web/API/XRViewerPose). I
+object](https://developer.mozilla.org/en-US/docs/Web/API/XRViewerPose). I
 get the viewer's pose by calling `XRFrame.getViewerPose()` on the current
 animation frame. I pass it the reference space I acquired when I set up the
 session. The values returned by this object are always relative to the reference

--- a/src/site/content/en/blog/web-ar/index.md
+++ b/src/site/content/en/blog/web-ar/index.md
@@ -190,7 +190,7 @@ right, up, and backward, respectively.
 
 The coordinates returned by `XRFrame.getViewerPose()` depend on the requested
 [reference space
-type](https://wiki.developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpace#Reference_space_types).
+type](https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpace#Reference_space_types).
 More about that when we get to the frame loop. Right now we need to select a
 reference type that's appropriate for augmented reality. Again, this uses my
 convenience property.

--- a/tools/linting/bad-urls.js
+++ b/tools/linting/bad-urls.js
@@ -18,13 +18,10 @@ const rule = require("unified-lint-rule");
 const url = require("url");
 const visit = require("unist-util-visit");
 
-module.exports = rule("remark-lint:no-wiki-mdn-urls", checkURL);
-
-const reason = 'Change URL hostname to "developer.mozilla.org".';
+module.exports = rule("remark-lint:bad-urls", checkURL);
 
 /**
- * Walk the AST for the markdown file, find any link to
- * "wiki.developer.mozilla.org" and warn to change to "developer.mozilla.org".
+ * Walk the AST for the markdown file and find any bad URLs.
  * @param {*} tree An AST of the markdown file.
  * @param {*} file The markdown file.
  */
@@ -39,7 +36,10 @@ function checkURL(tree, file) {
     }
     const parsed = url.parse(nodeUrl);
 
+    // If URL hostname is "wiki.developer.mozilla.org", warn to change to
+    // "developer.mozilla.org".
     if (parsed.hostname == "wiki.developer.mozilla.org") {
+      const reason = 'Change URL hostname to "developer.mozilla.org".';
       file.message(reason, node);
     }
   }

--- a/tools/linting/no-wiki-mdn-urls.js
+++ b/tools/linting/no-wiki-mdn-urls.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const rule = require("unified-lint-rule");
+const url = require("url");
+const visit = require("unist-util-visit");
+
+module.exports = rule("remark-lint:no-wiki-mdn-urls", checkURL);
+
+const reason = 'Change URL hostname to "developer.mozilla.org".';
+
+/**
+ * Walk the AST for the markdown file, find any link to
+ * "wiki.developer.mozilla.org" and warn to change to "developer.mozilla.org".
+ * @param {*} tree An AST of the markdown file.
+ * @param {*} file The markdown file.
+ */
+function checkURL(tree, file) {
+  visit(tree, "link", visitor);
+
+  /* eslint-disable require-jsdoc */
+  function visitor(node) {
+    const nodeUrl = node.url;
+    if (!nodeUrl) {
+      return;
+    }
+    const parsed = url.parse(nodeUrl);
+
+    if (parsed.hostname == "wiki.developer.mozilla.org") {
+      file.message(reason, node);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a linter that checks for links to "wiki.developer.mozilla.org" and warn to change to "developer.mozilla.org". 

It also updates some articles that are not compliant with this rule.

Fixes #2142
