### PR TITLE
Style fixes

### DIFF
--- a/src/lib/components/ProfileSwitcher/index.js
+++ b/src/lib/components/ProfileSwitcher/index.js
@@ -66,7 +66,7 @@ class ProfileSwitcher extends BaseElement {
       image.onload = () => resolve(image);
 
       // Ignore errors and don't display a photo at all.
-      image.onerror = () => reject(emptyFrag);
+      image.onerror = () => resolve(emptyFrag);
     });
     return true;
   }

--- a/src/lib/components/SigninButton/index.js
+++ b/src/lib/components/SigninButton/index.js
@@ -14,7 +14,8 @@ class SigninButton extends BaseStateElement {
 
   render() {
     if (this.isSignedIn) {
-      return "";
+      // lit-element ignores "" (prior to 2.2.2), so return an empty template.
+      return html``;
     }
 
     // We don't set "disabled" attribute on the <button> based on this, because

--- a/src/lib/components/Snackbar/_styles.scss
+++ b/src/lib/components/Snackbar/_styles.scss
@@ -12,15 +12,16 @@ web-snackbar {
     background-color: $GREY_900;
     display: flex;
     justify-content: flex-start;
-    min-width: 344px;
     opacity: 0;
     transform: scale(.8);
+    width: 100vw;
 
     @include bp(sm) {
       border-radius: $GLOBAL_RADIUS;
       box-shadow: 0 3px 5px -1px rgba(0, 0, 0, .2),
                   0 6px 10px 0 rgba(0, 0, 0, .14),
                   0 1px 18px 0 rgba(0, 0, 0, .12);
+      min-width: 344px;
     }
 
     @include bp(md) {

--- a/src/site/content/en/measure/index.njk
+++ b/src/site/content/en/measure/index.njk
@@ -22,8 +22,9 @@ to remove them as part of the v1 migration. #}
       </p>
       <web-signin-button></web-signin-button>
       <p class="w-page-header__copy w-unsupported-notice">
-        Sorry, the measure tool does not work with legacy browsers. Please try
-        again using the latest Firefox, Safari, or Chrome.
+        Sorry, the measure tool does not work with legacy browsers or with
+        JavaScript disabled. Please try again using an up-to-date version of
+        Edge, Firefox, Safari, or Chrome.
       </p>
     </header>
   </div>


### PR DESCRIPTION
Fixes #2272 and a few other small things.

* makes the Measure sign-in button hidden after you sign-in
* prevents a failure when a user's profile image 403's (we were calling `reject` which didn't exist)
* updates text on Measure page for unsupported browsers
* makes snackbar not extend past page size on very small devices (e.g. iPhone at 320px)