### PR TITLE
Add aria-label for CopyCode button

### DIFF
--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -21,6 +21,7 @@ class CopyCode extends BaseElement {
 
     if (!this.copyButton) {
       this.copyButton = document.createElement("button");
+      this.copyButton.setAttribute("aria-label", "Copy code");
       this.copyButton.className = "web-copy-code__button";
       this.copyButton.addEventListener("click", this.onCopy);
       this.prepend(this.copyButton);


### PR DESCRIPTION
This PR adds a missing `aria-label` to the CopyCode button as suggested by Audits "Accessiblity" section.

![image](https://user-images.githubusercontent.com/634478/75956298-e4456280-5eb7-11ea-9177-c054878ef25a.png)
