### PR TITLE
fixes title generation issues re: Service Worker and partials

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -227,7 +227,7 @@ workboxRouting.registerRoute(
     const meta = partial.offline ? `<meta name="offline" value="true" />` : "";
     const output = layoutTemplate.replace(
       "%_CONTENT_REPLACE_%",
-      meta + `<title>${partial.title}</title>` + partial.raw,
+      meta + `<title>${partial.title || ""}</title>` + partial.raw,
     );
     const headers = new Headers();
     headers.append("Content-Type", "text/html");

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -222,10 +222,12 @@ workboxRouting.registerRoute(
 
     // Our target browsers all don't mind if we just place <title> in the middle of the document.
     // This is far simpler than trying to find the right place in <head>.
+    // Titles are not escaped, with the assumption that reviewier won't allow article to be named
+    // e.g., "</title><script>alert(1);".
     const meta = partial.offline ? `<meta name="offline" value="true" />` : "";
     const output = layoutTemplate.replace(
       "%_CONTENT_REPLACE_%",
-      meta + `<title>${escape(partial.title)}</title>` + partial.raw,
+      meta + `<title>${partial.title}</title>` + partial.raw,
     );
     const headers = new Headers();
     headers.append("Content-Type", "text/html");

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -222,8 +222,6 @@ workboxRouting.registerRoute(
 
     // Our target browsers all don't mind if we just place <title> in the middle of the document.
     // This is far simpler than trying to find the right place in <head>.
-    // Titles are not escaped, with the assumption that reviewier won't allow article to be named
-    // e.g., "</title><script>alert(1);".
     const meta = partial.offline ? `<meta name="offline" value="true" />` : "";
     const output = layoutTemplate.replace(
       "%_CONTENT_REPLACE_%",

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -109,7 +109,7 @@ module.exports = (locale, page, collections, renderData = {}) => {
 
   // prettier-ignore
   return html`
-    <title>${pageData.title || pageData.path.title}</title>
+    <title>${pageData.title || pageData.path.title || "web.dev"}</title>
     <meta name="description" content="${pageData.description || pageData.path.description}" />
 
     ${renderGoogleMeta()}

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -150,7 +150,7 @@
     <main>
       {% include 'partials/banner.njk' %}
       <div id="content">
-        {% Partial page, lang, title, offline %}{{ content | safe }}{% endPartial %}
+        {% Partial page, path, lang, title, offline %}{{ content | safe }}{% endPartial %}
       </div>
     </main>
     {% include 'partials/footer.njk' %}

--- a/src/site/_utils/build-partial.js
+++ b/src/site/_utils/build-partial.js
@@ -46,7 +46,7 @@ module.exports = function buildPartial() {
     const partial = {
       raw: content,
       lang,
-      title: title || (pageData && pathData.title) || "web.dev",
+      title: title || (pathData && pathData.title) || "web.dev",
       offline: offline || undefined,
     };
 

--- a/src/site/_utils/build-partial.js
+++ b/src/site/_utils/build-partial.js
@@ -46,7 +46,7 @@ module.exports = function buildPartial() {
     const partial = {
       raw: content,
       lang,
-      title: title || pathData.title || undefined,
+      title: title || (pageData && pathData.title) || "web.dev",
       offline: offline || undefined,
     };
 

--- a/src/site/_utils/build-partial.js
+++ b/src/site/_utils/build-partial.js
@@ -34,7 +34,7 @@ const writePartial = async (to, raw) => {
 module.exports = function buildPartial() {
   const work = [];
 
-  return function(content, page, lang, title, offline) {
+  return function(content, page, pathData, lang, title, offline) {
     if (!page.outputPath.endsWith("/index.html")) {
       return content; // unexpected output format
     }
@@ -46,7 +46,7 @@ module.exports = function buildPartial() {
     const partial = {
       raw: content,
       lang,
-      title,
+      title: title || pathData.title || undefined,
       offline: offline || undefined,
     };
 


### PR DESCRIPTION
* We were escaping titles, so pages with spaces loaded as partials were having space show up as %20

* Use the path's title as a fallback to article title (matches Meta)

* Default to a blank string if there's no title (we were stringifying "undefined")