### PR TITLE
Add accessible focus ring to w-button

### DIFF
--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -33,9 +33,7 @@
   border: 0;
 }
 
-.w-button:hover,
-.w-button:focus,
-.w-button:active {
+@mixin button-hover() {
   background: $WHITE; // DevSite override
   box-shadow:
   0 2px 4px -1px rgba($BLACK, .2),
@@ -43,6 +41,27 @@
   0 1px 10px 0 rgba($BLACK, .12);
   outline: none;
   text-decoration: none;
+}
+
+// Prevent hover and focus states from lingering on touch.
+@include hover() {
+  .w-button:hover,
+  .w-button:focus {
+    @include button-hover();
+  }
+}
+
+.w-button:active {
+  @include button-hover();
+}
+
+.w-button:focus {
+  outline: 1px solid rgba($WEB_PRIMARY_COLOR, .8);
+  outline-offset: -3px;
+}
+
+.js-focus-visible .w-button:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
+  outline: none;
 }
 
 .w-button[disabled] {
@@ -59,12 +78,15 @@
   @include w-overlay();
 }
 
-.w-button:hover::after {
-  background-color: rgba($WEB_PRIMARY_COLOR, .04);
-}
+// Prevent hover and focus states from lingering on touch.
+@include hover() {
+  .w-button:hover::after {
+    background-color: rgba($WEB_PRIMARY_COLOR, .04);
+  }
 
-.w-button:focus::after {
-  background-color: rgba($WEB_PRIMARY_COLOR, .12);
+  .w-button:focus::after {
+    background-color: rgba($WEB_PRIMARY_COLOR, .12);
+  }
 }
 
 .w-button:active::after {
@@ -105,16 +127,23 @@
   color: $WHITE;
 }
 
-.w-button--primary:hover::after {
-  background-color: rgba($WHITE, .08);
-}
+// Prevent hover and focus states from lingering on touch.
+@include hover() {
+  .w-button--primary:hover::after {
+    background-color: rgba($WHITE, .08);
+  }
 
-.w-button--primary:focus::after {
-  background-color: rgba($WHITE, .24);
+  .w-button--primary:focus::after {
+    background-color: rgba($WHITE, .24);
+  }
 }
 
 .w-button--primary:active::after {
   background-color: rgba($WHITE, .32);
+}
+
+.w-button--primary:focus {
+  outline: 1px solid rgba($WHITE, .8);
 }
 
 // Secondary action button.
@@ -127,14 +156,21 @@
   color: $PRIMARY_TEXT_COLOR;
 }
 
-.w-button--secondary:hover::after {
-  background-color: rgba($BLACK, .04);
-}
+// Prevent hover and focus states from lingering on touch.
+@include hover() {
+  .w-button--secondary:hover::after {
+    background-color: rgba($BLACK, .04);
+  }
 
-.w-button--secondary:focus::after {
-  background-color: rgba($BLACK, .08);
+  .w-button--secondary:focus::after {
+    background-color: rgba($BLACK, .08);
+  }
 }
 
 .w-button--secondary:active::after {
   background-color: rgba($BLACK, .1);
+}
+
+.w-button--secondary:focus {
+  outline: 1px solid rgba($PRIMARY_TEXT_COLOR, .6);
 }


### PR DESCRIPTION
The existing `.w-button` states had two issues:
- Hover and focus states were sticky on touch devices.
- The focus state wasn't conformant with [WCAG 2.1 SC 1.4.11](https://www.w3.org/TR/WCAG21/#non-text-contrast) (contrast for visual indicators of focus state was below 3:1).

Changes proposed in this pull request:
- Using `@hover()` mixin, only show hover and existing focus state on devices that support hover.
- Using `focus-visible`, add contrast conformant focus ring* that appears only on keyboard navigation.

*Note: I would have preferred the focus ring to have rounded corners, but `box-shadow` and both pseudos are already in use.