### PR TITLE
Add segmention rec for mobile and desktop

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -310,9 +310,9 @@ document.addEventListener('visibilitychange', () => {
 ## What is a good CLS score?
 
 To provide a good user experience, sites should strive to have a Cumulative
-Layout Shift of less than **0.1**. To ensure you're hitting this target for
-most of your users, a good threshold to measure is the **75th percentile** of
-page loads on mobile devices.
+Layout Shift of less than **0.1**. To ensure you're hitting this target for most
+of your users, a good threshold to measure is the **75th percentile** of page
+loads, segmented across mobile and desktop devices.
 
 ## How to improve CLS
 

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -96,7 +96,7 @@ sends the FCP value to your analytics service.
 To provide a good user experience, sites should strive to have First Contentful
 Paint occur within **1 second** of the page starting to load. To ensure you're
 hitting this target for most of your users, a good threshold to measure is the
-**75th percentile** of page loads on mobile devices.
+**75th percentile** of page loads, segmented across mobile and desktop devices.
 
 ## How to improve FCP
 

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -216,7 +216,7 @@ percentile of mobile users.
 To provide a good user experience, sites should strive to have a First Input
 Delay of less than **100 milliseconds**. To ensure you're hitting this target
 for most of your users, a good threshold to measure is the **75th percentile**
-of page loads on mobile devices.
+of page loads, segmented across mobile and desktop devices.
 
 ## How to improve FID
 

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -276,7 +276,8 @@ the article on [custom metrics](/custom-metrics/#element-timing-api).
 To provide a good user experience, sites should strive to have Largest
 Contentful Paint occur within the first **2.5 seconds** of the page starting to
 load. To ensure you're hitting this target for most of your users, a good
-threshold to measure is the **75th percentile** of page loads on mobile devices.
+threshold to measure is the **75th percentile** of page loads, segmented across
+mobile and desktop devices.
 
 ## How to improve LCP
 


### PR DESCRIPTION
Expands on the update in https://github.com/GoogleChrome/web.dev/pull/2271 to suggest segmentation across both mobile and desktop devices and measuring the 75th percentile of both.
