### PR TITLE
cache partials for PWA readyness

### DIFF
--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -45,22 +45,24 @@ if ("serviceWorker" in navigator) {
 function serviceWorkerIsSupported(hostname) {
   // Allow local/prod as well as .netlify staging deploy target.
   const allowedHostnames = ["web.dev", "localhost"];
-  return allowedHostnames.includes(hostname) || hostname.endsWith(".netlify.com");
+  return (
+    allowedHostnames.includes(hostname) || hostname.endsWith(".netlify.com")
+  );
 }
 
 function ensureServiceWorker() {
-  const ensurePartialCache = (isFirstInstall=false) => {
+  const ensurePartialCache = (isFirstInstall = false) => {
     const {pathname} = window.location;
     if (isFirstInstall) {
       // We don't fetch the partial for the initial, real, HTML fetch from out HTTP server. This
       // ensures that if the user goes offline and reloads for some reason, the page still loads.
       getPartial(pathname);
     }
-    if (pathname !== '/') {
+    if (pathname !== "/") {
       // Aggressively refetch the landing page every time the site is loaded.
       // TODO(samthor): Check Workbox's cache time and fetch if needed. Additionally, cache a
       // number of recent articles.
-      getPartial('/');
+      getPartial("/");
     }
   };
 
@@ -68,7 +70,7 @@ function ensureServiceWorker() {
   if (isFirstInstall) {
     // Watch for the brand new Service Worker to be activated. We claim this foreground page
     // inside the Service Worker, so this event will fire when it is activated.
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
       ensurePartialCache(true);
     });
   } else {
@@ -77,18 +79,15 @@ function ensureServiceWorker() {
 
     // We claim active clients if the Service Worker's architecture rev changes. We can't
     // reliably force a reload via the Client interface as it's unsupported in Safari.
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
       window.location.reload();
     });
   }
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker.register("/sw.js");
 }
 
 function removeServiceWorker() {
-  console.warn(
-    "skipping SW, unsupported hostname:",
-    window.location.hostname,
-  );
+  console.warn("skipping SW, unsupported hostname:", window.location.hostname);
 
   // Remove previous Service Worker instances from this hostname. This should never normally
   // happen but is here for safety.

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -27,7 +27,7 @@ async function loadEntrypoint(url) {
  * @param {string} url of the page to fetch.
  * @return {{raw: string, title: string, offline: (boolean|undefined)}}
  */
-async function getPartial(url) {
+export async function getPartial(url) {
   if (!url.endsWith("/")) {
     throw new Error(`partial unsupported for non-folder: ${url}`);
   }

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -15,15 +15,7 @@ import {matchSameOriginRegExp} from "./utils/sw-match.js";
 // Used when the design of the SW changes dramatically, e.g. from DevSite to v2.
 const serviceWorkerArchitecture = "v3";
 
-let replacingPreviousServiceWorker = false;
-
 self.addEventListener("install", (event) => {
-  // This is non-null if there was a previous Service Worker registered. Record for "activate", so
-  // that a lack of current architecture can be seen as a reason to reload our clients.
-  if (self.registration.active) {
-    replacingPreviousServiceWorker = true;
-  }
-
   event.waitUntil(self.skipWaiting());
 });
 
@@ -43,7 +35,7 @@ self.addEventListener("activate", (event) => {
     await idb.set("arch", serviceWorkerArchitecture);
 
     // If the architecture changed (including due to an initial install), claim our clients
-    // immediately. If this is an architecture rev change, this forces a reload on the client
+    // immediately. If this is an architecture rev change, this triggers a reload on the client
     // (required as `client.navigate()` is unsupported on Safari).
     await self.clients.claim();
   });


### PR DESCRIPTION
Fixes #2311 and #1940.

I find the setup of the SW a bit fiddly, but I think the flows here make sense.

No SW => register and install, it claims clients, we "upgrade" to being intercepted by the SW. Partials are fetched. Can install as PWA almost immediately and work offline#.

Existing SW => force a refresh of partial(s), try to upgrade, if we're claimed by the SW (because of an architecture revision), do a reload ("abandon ship").