### PR TITLE
Add redirect for /pwa/ to PWA content

### DIFF
--- a/src/site/content/en/_redirects.yaml
+++ b/src/site/content/en/_redirects.yaml
@@ -168,6 +168,9 @@ redirects:
 - from: /pwa
   to: /progressive-web-apps/
 
+- from: /pwa/
+  to: /progressive-web-apps/
+
 - from: /installable/
   to: /progressive-web-apps/#installable
 


### PR DESCRIPTION
Fixes #2337 

Changes proposed in this pull request:
- Adds redirect from `/pwa/` to `/progressive-web-apps/`

We already redirect from `/pwa`, this just ensures that whether you include the trailing slash, we redirect you to the right place.