### PR TITLE
use explicit path.join rather than passing slash to fs.readFile

### DIFF
--- a/build.js
+++ b/build.js
@@ -134,7 +134,7 @@ async function build() {
   const noticeDev = isProd ? "" : "// Not generated in dev";
 
   const layoutTemplate = await fs.readFile(
-    "dist/sw-partial-layout.partial",
+    path.join("dist", "sw-partial-layout.partial"),
     "utf-8",
   );
 


### PR DESCRIPTION
@mfriesenhahn can you try this on your Windows machine? And either way, can you upload a log of what the `npm run build` command spits out?

Attempts to solve #2331.