### PR TITLE
Fix external dead URLs

### DIFF
--- a/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
+++ b/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
@@ -480,7 +480,7 @@ debugging the accessibility of your visual components.
   ![Screenshot of a code editor with an accessibility issue flagged by codelyzer.](./angular-a11y-testing.png)
 
 - You can examine the way that assistive technologies see web content by using
-  [Accessibility Inspector](https://developer.apple.com/library/mac/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTesting/OSXAXTestingApps.html#//apple_ref/doc/uid/TP40001078-CH210-TPXREF101) (Mac)
+  [Accessibility Inspector](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html#//apple_ref/doc/uid/TP40001078-CH210-SW1) (Mac)
   or [Windows Automation API Testing Tools](http://msdn.microsoft.com/en-us/library/windows/desktop/dd373661(v=vs.85).aspx)
   and [AccProbe](http://accessibility.linuxfoundation.org/a11yweb/util/accprobe/) (Windows).
   You can also see the full accessibility tree that Chrome creates

--- a/src/site/content/en/blog/ar-hit-test/index.md
+++ b/src/site/content/en/blog/ar-hit-test/index.md
@@ -25,7 +25,7 @@ that some of the work is finished. In Chrome 81, two new features have arrived:
 * [Hit testing](https://www.chromestatus.com/features/4755348300759040)
 
 This article covers the [WebXR Hit Test
-API](https://github.com/immersive-web/hit-test/blob/master/explainer.md), a
+API](https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md), a
 means of placing virtual objects in a real-world camera view.
 
 In this article I assume you already know how to create an augmented reality
@@ -289,7 +289,7 @@ reticle gives you a constant source of hit tests, the simplest way to place an
 object is to draw it at the location of the reticle at the last hit test. If you
 need to, say you have a legitimate reason not to show a reticle, you can call
 `requestHitTest()` in the select event [as shown in the
-sample](https://github.com/immersive-web/webxr-samples/blob/master/proposals/phone-ar-hit-test.html#L187).
+sample](https://github.com/immersive-web/webxr-samples/blob/429aeb7cd46f1009d2e529e69854418a5a0903d5/proposals/phone-ar-hit-test.html#L189).
 
 ```js
 function onSelect(event) {
@@ -304,7 +304,7 @@ function onSelect(event) {
 ## Conclusion
 
 The best way to get a handle on this is to step through the [sample
-code](https://immersive-web.github.io/webxr-samples/proposals/phone-ar.html) or
+code](https://github.com/immersive-web/webxr-samples/blob/4c0646414ebb55eb741838772ad4e80e901391a6/proposals/phone-ar.html) or
 try out the
 [codelab](https://codelabs.developers.google.com/codelabs/ar-with-webxr). I hope
 I've given you enough background to make sense of both.

--- a/src/site/content/en/blog/perception-toolkit/index.md
+++ b/src/site/content/en/blog/perception-toolkit/index.md
@@ -42,7 +42,7 @@ UI.
 I'll show you enough of this to give you a taste of how it works. For a complete
 explanation, check out the [Getting
 Started](https://perceptiontoolkit.dev/getting-started/) guide, the [toolkit
-reference](https://perceptiontoolkit.dev/documentation/), the [I/O Sandbox demo](https://io.perceptiontoolkit.dev/) and the [sample demos](https://github.com/GoogleChromeLabs/perception-toolkit/tree/restructure_demo/demo).
+reference](https://perceptiontoolkit.dev/documentation/), the [I/O Sandbox demo](https://io.perceptiontoolkit.dev/) and the [sample demos](https://github.com/GoogleChromeLabs/perception-toolkit/tree/master/demo).
 
 ## Structured data
 
@@ -227,7 +227,7 @@ Toolkit](https://github.com/GoogleChromeLabs/perception-toolkit). Hopefully it g
 you a sense of how easy it is to add visual searching to a website. Learn more
 with the [Getting Started](https://perceptiontoolkit.dev/getting-started/) guide
 and the [sample
-demos](https://github.com/GoogleChromeLabs/perception-toolkit/tree/restructure_demo/demo).
+demos](https://github.com/GoogleChromeLabs/perception-toolkit/tree/master/demo).
 Dig in to the [toolkit
 documentation](https://perceptiontoolkit.dev/documentation/) to learn what it
 can do.

--- a/src/site/content/en/blog/vr-comes-to-the-web/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web/index.md
@@ -72,8 +72,8 @@ If you're familiar with early versions of the WebXR Device API, you should
 glance over all of this material. There have been changes.
 
 The code in this article is based on the Immersive Web Working Group's barebones
-sample ([demo](https://immersive-web.github.io/webxr-samples/xr-barebones.html),
-[source](https://github.com/immersive-web/webxr-samples/blob/master/xr-barebones.html)),
+sample ([demo](https://immersive-web.github.io/webxr-samples/vr-barebones.html),
+[source](https://github.com/immersive-web/webxr-samples/blob/master/vr-barebones.html)),
 but is edited for clarity and simplicity.
 
 Part of creating the WebXR specification has been fleshing out security and

--- a/src/site/content/en/handbook/contributor-profile/index.md
+++ b/src/site/content/en/handbook/contributor-profile/index.md
@@ -7,7 +7,7 @@ description: |
 ---
 
 ## Add yourself to the contributors list
-1. Add a new object to [`contributors.json`](https://github.com/GoogleChrome/web.dev/blob/master/src/site/_data/contributors.json) with the following structure. Make sure to choose a unique contributor slug.
+1. Add a new object to [`contributors.json`](https://github.com/GoogleChrome/web.dev/blob/master/src/site/_data/contributors.js) with the following structure. Make sure to choose a unique contributor slug.
 
     ```json
     "contributorslug": {

--- a/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
+++ b/src/site/content/en/lighthouse-accessibility/audio-caption/index.md
@@ -45,5 +45,5 @@ with attribute `kind="captions"`:
 
 ## Resources
 
-- [Source code for **`<audio>` elements are missing a `<track>` element with `[kind="captions"]`** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/audit-caption.js)
+- [Source code for **`<audio>` elements are missing a `<track>` element with `[kind="captions"]`** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/audio-caption.js)
 - [`<audio> `elements must have a captions `<track>` (Deque University)](https://dequeuniversity.com/rules/axe/3.3/audio-caption)

--- a/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
+++ b/src/site/content/en/lighthouse-accessibility/duplicate-id/index.md
@@ -29,5 +29,5 @@ Lighthouse flags duplicate IDs found in a page:
 
 ## Resources
 
-- [Source code for **`[id]` attributes on the page are not unique** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/accessibility/duplicate-id.js)
+- [Source code for **`[id]` attributes on the page are not unique** audit](https://github.com/GoogleChrome/lighthouse/blob/4e11bd297010a3957a6f76a8e25abddc7ed5a716/lighthouse-core/audits/accessibility/duplicate-id.js)
 - [ID attribute values must be unique (Deque University)](https://dequeuniversity.com/rules/axe/3.3/duplicate-id)

--- a/src/site/content/en/reliable/workbox/index.md
+++ b/src/site/content/en/reliable/workbox/index.md
@@ -116,7 +116,6 @@ Workbox integration found in many popular starter kits and add-on plugins:
 +  [preact-cli](https://github.com/prateekbh/preact-cli-workbox-plugin/blob/master/README.md)
 +  [Gatsby](https://www.gatsbyjs.org/packages/gatsby-plugin-offline/)
 +  [Next.js](https://github.com/hanford/next-offline/blob/master/readme.md)
-+  [PWA Starter Kit](https://polymer.github.io/pwa-starter-kit/what's-in-the-box/)
 
 ### Add Workbox to your existing build process
 


### PR DESCRIPTION
By running a custom version of [remark-lint-no-dead-urls](https://github.com/davidtheclark/remark-lint-no-dead-urls), I was able to find dead external URLs in web.dev. This PR updates all of them to the correct ones or removes them when it doesn't exist or is not relevant anymore.