### PR TITLE
Fix search widget accessibility issues

### DIFF
--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -86,7 +86,7 @@ class Search extends BaseElement {
         <input
           class="web-search__input"
           type="text"
-          role="search"
+          role="searchbox"
           autocomplete="off"
           aria-autocomplete="list"
           aria-controls="web-search-popout__list"
@@ -110,7 +110,13 @@ class Search extends BaseElement {
   /* eslint-disable indent */
   get hitsTemplate() {
     if (!this.showHits) {
-      return "";
+      return html`
+        <div
+          id="web-search-popout__list"
+          role="listbox"
+          aria-hidden="true"
+        ></div>
+      `;
     }
 
     if (!this.hits.length) {


### PR DESCRIPTION
This PR fixes some accessibility issues in the search widget discovered in the Audits accessibility section:
- Search input role needs to be ["searchbox"](https://www.w3.org/TR/wai-aria-1.1/#searchbox) instead of "search" to be compliant
- The search input wrapper aria-owns values was invalid because the `id` didn't exist in the page when search was not triggered. This is now fixed.

This change allows web.dev to reach the Accessibility score of 100.

![image](https://user-images.githubusercontent.com/634478/76500982-c771d780-6441-11ea-92f5-d03c41aa40d9.png)
