### PR TITLE
Lazy load Google Developers footer image

### DIFF
--- a/src/site/_includes/devsite/devsite-footer.njk
+++ b/src/site/_includes/devsite/devsite-footer.njk
@@ -133,6 +133,7 @@
         data-label="Footer Google Developers Link"
       >
         <img
+          loading="lazy"
           class="devsite-footer-sites-logo"
           src="https://web.dev/_static/images/lockup-color.png"
           alt="Google Developers"

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -77,7 +77,7 @@
     <nav class="w-footer__utility-nav">
       <a href="https://developers.google.com/" class="w-footer__utility-logo-link"
         data-category="Site-Wide Custom Events" data-label="Footer Google Developers Link">
-        <img class="w-footer__utility-logo" src="/images/lockup-color.png"
+        <img loading="lazy" class="w-footer__utility-logo" src="/images/lockup-color.png"
           alt="Google Developers" />
       </a>
       <ul class="w-footer__utility-list">


### PR DESCRIPTION
Instead of unconditionally loading the footer image for "Google Developers" below that users usually don't get to see, this PR loads it lazily thanks to `loading=lazy` as described in https://web.dev/native-lazy-loading/

![image](https://user-images.githubusercontent.com/634478/76509664-aebcee00-6450-11ea-9eca-9dfd9d825e4c.png)

This will hopefully save one HTTP request on first load.