### PR TITLE
Load dynamically Firebase

### DIFF
--- a/src/lib/firebase-loader.js
+++ b/src/lib/firebase-loader.js
@@ -1,0 +1,29 @@
+let firebasePromise;
+
+export default function() {
+  if (firebasePromise) {
+    return firebasePromise;
+  }
+
+  const ids = ["firebase-app", "firebase-auth", "firebase-performance"];
+
+  const promises = ids.map((id) => {
+    return new Promise((resolve, reject) => {
+      const el = document.getElementById(id);
+      if (!el) {
+        return reject(`missing ${id}`);
+      }
+
+      const s = document.createElement("script");
+      s.src = el.getAttribute("value");
+
+      s.onerror = reject;
+      s.onload = resolve;
+
+      document.head.appendChild(s);
+    });
+  });
+
+  firebasePromise = Promise.all(promises);
+  return firebasePromise;
+}

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -34,9 +34,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
-    <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-app.js"></script>
-    <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js"></script>
-    <script defer src="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js"></script>
+    {# This is used by src/lib/firebase-loader.js to dynamically load Firebase #}
+    <meta id="firebase-app" value="//www.gstatic.com/firebasejs/6.6.1/firebase-app.js" />
+    <meta id="firebase-auth" value="//www.gstatic.com/firebasejs/6.6.1/firebase-auth.js" />
+    <meta id="firebase-performance" value="//www.gstatic.com/firebasejs/6.6.1/firebase-performance.js" />
     {# This is used by src/lib/firestore-loader.js to dynamically load Firestore #}
     <meta id="firebase-firestore" value="//www.gstatic.com/firebasejs/6.6.1/firebase-firestore.js" />
     <script>


### PR DESCRIPTION
This PR improves loading performance by loading dynamically Firebase after images have been requested.

Note that the diff doesn't reflect well at a first glance what actually changed in the first part of  `src/lib/fb.js`. See help below

```js

// Load dynamically Firebase
firebaseLoader()
  .then(() => {
   /* Unchanged */
  })
  .catch((err) => {
    console.warn("failed to load Firebase library");
  });
