### PR TITLE
Fix internal dead URLs

### DIFF
--- a/src/site/content/en/blog/how-to-distribute-signed-http-exchanges/index.md
+++ b/src/site/content/en/blog/how-to-distribute-signed-http-exchanges/index.md
@@ -101,7 +101,7 @@ But such cases are rare because typical websites consist of a lot of subresource
 
 ## Send feedback
 
-Chromium engineers are keen to hear your feedback on distributing SXG at [webpackage-dev@chromium.org](webpackage-dev@chromium.org).
+Chromium engineers are keen to hear your feedback on distributing SXG at [webpackage-dev@chromium.org](mailto:webpackage-dev@chromium.org).
 You can also join [the spec discussion](https://github.com/WICG/webpackage/issues), or [report a bug](https://bugs.chromium.org/p/chromium/issues/entry?status=untriaged&components=Blink%3ELoader&labels=Type-Bug,Hotlist-SignedExchange) to the team.
 Your feedback will greatly help the standardization process and also help address implementation issues.
 Thank you!

--- a/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
+++ b/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
@@ -261,7 +261,7 @@ server {
 
 ## Send feedback
 
-The Chromium engineers working on SXG are keen to hear your feedback at [webpackage-dev@chromium.org](webpackage-dev@chromium.org).
+The Chromium engineers working on SXG are keen to hear your feedback at [webpackage-dev@chromium.org](mailto:webpackage-dev@chromium.org).
 You can also join the [spec discussion](https://github.com/WICG/webpackage/issues), or [report a bug](https://bugs.chromium.org/p/chromium/issues/entry?status=untriaged&components=Blink%3ELoader&labels=Type-Bug,Hotlist-SignedExchange) to the team.
 Your feedback will greatly help the standardization process and also help address implementation issues.
 Thank you!

--- a/src/site/content/en/blog/native-file-system/index.md
+++ b/src/site/content/en/blog/native-file-system/index.md
@@ -449,5 +449,5 @@ critical it is to support them.
 [text-editor-source]: https://github.com/GoogleChromeLabs/text-editor/
 [text-editor-fs-helper]: https://github.com/GoogleChromeLabs/text-editor/blob/master/src/inline-scripts/fs-helpers.js
 [text-editor-app-js]: https://github.com/GoogleChromeLabs/text-editor/blob/master/src/inline-scripts/app.js
-[download-file]: /web/updates/2011/08/Downloading-resources-in-HTML5-a-download
+[download-file]: https://developers.google.com/web/updates/2011/08/Downloading-resources-in-HTML5-a-download
 [cr-dev-twitter]: https://twitter.com/chromiumdev

--- a/src/site/content/en/blog/next-gen-css-2019/index.md
+++ b/src/site/content/en/blog/next-gen-css-2019/index.md
@@ -69,7 +69,7 @@ This post focuses on the features you can use today,
 so be sure to watch the talk
 for a deeper discussion of upcoming features like Houdini.
 You can also find demos for all the features we discuss on our
-[CSS@CDS page](a.nerdy.dev/css-at-cds).
+[CSS@CDS page](https://a.nerdy.dev/css-at-cds).
 
 {% YouTube '-oyeaIirVC0' %}
 

--- a/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
@@ -23,7 +23,7 @@ origin's user experience.
 The CrUX Dashboard is built with a Data Studio feature called [Community
 Connectors](https://developers.google.com/datastudio/connector/).
 This connector is a pre-established link between the raw CrUX data on
-[BigQuery](./bigquery.html) and the visualizations of Data Studio. It eliminates
+[BigQuery](https://console.cloud.google.com/bigquery?p=chrome-ux-report) and the visualizations of Data Studio. It eliminates
 the need for users of the dashboard to write any queries or generate any charts.
 Everything is built for you -- all you need is to provide an origin to look up.
 The connector code is also

--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -55,7 +55,7 @@ use it to self-review their content and fix problems rather than waiting for rev
 1. Are code blocks and sample apps as simple as possible while still conveying the core concept?
 1. Is a brief description of a sample app's functionality provided before the app itself?
 1. Is [code highlighting](/handbook/markup-code/#code-highlighting) used to indicate lines that have been added or changed?
-1. Is all sample code [accessible](/inclusion-and-accessibility/#create-accessible-code-blocks)?
+1. Is all sample code [accessible](/handbook/inclusion-and-accessibility/#create-accessible-code-blocks)?
 
 ## Links
 1. Do all links work?
@@ -64,7 +64,7 @@ use it to self-review their content and fix problems rather than waiting for rev
 1. When referencing a web platform API, does the page link out to the canonical MDN API reference?
 
 ## Mechanics
-1. Is the text free of spelling and capitalization errors? (Check the [word list](/word-list).)
+1. Is the text free of spelling and capitalization errors? (Check the [word list](/handbook/word-list).)
 1. Are [dashes and hyphens](/handbook/grammar/#dashes-and-hyphens) used correctly?
 1. Are titles and headings in sentence case with no terminal period?
 1. Are [keyboard key commands](/handbook/grammar/#ui-elements-and-interaction) correctly formatted?

--- a/src/site/content/en/handbook/inclusion-and-accessibility/index.md
+++ b/src/site/content/en/handbook/inclusion-and-accessibility/index.md
@@ -58,7 +58,7 @@ If you're creating an illustration, the parts that are essential for understandi
 Avoid images that may exclude certain audience members. Just like when you _write_ about people, remember to be inclusive when you _show_ people and the things they do and make. For example, avoid stock photos that show only male developers.
 
 ## Create accessible code blocks
-Make sure code blocks are [simple](/handbook/style#keep-it-simple) and follow  accessibility best practices. At a minimum:
+Make sure code blocks are [simple](/handbook/quality/#keep-it-simple) and follow accessibility best practices. At a minimum:
 * Add [labels](/labels-and-text-alternatives/#label-form-elements) to form elements.
 * Include [alt text](/image-alt) for every image.
 

--- a/src/site/content/en/handbook/markup-sample-app/index.md
+++ b/src/site/content/en/handbook/markup-sample-app/index.md
@@ -21,7 +21,7 @@ web.dev uses [Glitch](https://glitch.com/) to embed web-based sample apps and de
 ## Authoring tips
 Make all Glitch code [accessible](/handbook/inclusion-and-accessibility#create-accessible-code-blocks).
 
-[Be mindful of the development landscape](/handbook/style#be-mindful-of-the-development-landscape) when selecting tools and frameworks.
+[Be mindful of the development landscape](/handbook/quality/#be-mindful-of-the-development-landscape) when selecting tools and frameworks.
 
 Make sure the `README` for your Glitch links back to web.dev. Here's a template you can use:
 


### PR DESCRIPTION
Similarly to https://github.com/GoogleChrome/web.dev/pull/2340, by running a custom version of [remark-lint-no-dead-urls](https://github.com/davidtheclark/remark-lint-no-dead-urls), I was able to find dead internal URLs in web.dev. This PR updates some of them to the correct ones.