### PR TITLE
Deeplinks

### DIFF
--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -22,21 +22,29 @@ async function loadEntrypoint(url) {
 }
 
 /**
- * Gets the partial content of the target normalized URL.
+ * Gets the partial content of the target normalized URL. Returns null if aborted.
  *
  * @param {string} url of the page to fetch.
- * @return {{raw: string, title: string, offline: (boolean|undefined)}}
+ * @param {!AbortSignal=} signal
+ * @return {?{raw: string, title: string, offline: (boolean|undefined)}}
  */
-export async function getPartial(url) {
+export async function getPartial(url, signal) {
   if (!url.endsWith("/")) {
     throw new Error(`partial unsupported for non-folder: ${url}`);
   }
 
-  const res = await fetch(url + "index.json");
-  if (!res.ok && res.status !== 404) {
-    throw res.status;
+  try {
+    const res = await fetch(url + "index.json", {signal});
+    if (!res.ok && res.status !== 404) {
+      throw res.status;
+    }
+    return await res.json();
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      return null;
+    }
+    throw e;
   }
-  return await res.json();
 }
 
 function normalizeUrl(url) {
@@ -85,82 +93,12 @@ function forceFocus(el) {
 }
 
 /**
- * Swap the current page for a new one. Assumes the current URL is the target.
+ * Replaces the current #content element with new partial content.
  *
- * If this is the first run, then the correct HTML will already be in place (from server or Service
- * Worker). Otherwise, async load the partial and replace previous content.
- *
- * Either way, ensure that the correct JS entrypoint is available.
- *
- * @param {boolean} isFirstRun whether this is the first run
- * @param {function(): boolean} isAborted call to determine if load is aborted
- * @return {!Promise<void>}
+ * @param {!Object} partial
  */
-export async function swapContent(isFirstRun, isAborted) {
-  let url = window.location.pathname + window.location.search;
-
-  // If we disagree with the URL we're loaded at, then replace it inline.
-  const normalized = normalizeUrl(url);
-  if (normalized) {
-    const update = normalized + window.location.hash;
-    window.history.replaceState(window.history.state, null, update);
-    url = window.location.pathname + window.location.search;
-  }
-
-  // Ensure that the correct JS entrypoint is available.
-  const entrypointPromise = loadEntrypoint(url);
-
-  // When the router boots it will always try to run a handler for the current route. We don't need
-  // this for the HTML of the initial page load so we return early, but always wait for the page's
-  // JS to load.
-  if (isFirstRun) {
-    return entrypointPromise;
-  }
-
-  store.setState({isPageLoading: true});
-
+function updateDom(partial) {
   const main = document.querySelector("main");
-
-  // If the partial is found in the current state, this means that this was a back/forward browser
-  // nav: just use it as a cache (which is basically how real pages operate). By doing this before
-  // any frames occur, the scroll position doesn't "jump" around unexpectedly.
-  // It's still possible to see invalid scroll positions, as the router won't preempt currently
-  // active page loads (e.g., I load a new page on a very bad network connection and then go back
-  // and forward a bunch).
-  const {state} = window.history;
-  const partialFromHistory = (state && state.partial) || null;
-
-  // Use the network if we don't have the partial (because this is a new navigation or it failed
-  // previously).
-  const partial = partialFromHistory || (await getPartial(url));
-  if (isAborted()) {
-    return null; // a further navigation prevented partial from loading
-  }
-  if (!partialFromHistory) {
-    window.history.replaceState({partial}, null, null);
-  }
-
-  // Throwing here will cause the router to just do a real page load.
-  if (typeof partial !== "object") {
-    // This will occur in the Netlify staging environment as we don't serve the 404 JSON.
-    throw new Error(`invalid partial for: ${url}`);
-  }
-
-  // We set the currentUrl in global state _after_ the partial has loaded. This is different than
-  // the History API itself which transitions immediately (like a real web browser).
-  store.setState({
-    isPageLoading: false,
-    currentUrl: url,
-
-    // bootstrap.js uses this to trigger a reload if we see an "online" event. Only returned via
-    // the Service Worker if we failed to fetch a 'real' page.
-    isOffline: Boolean(partial.offline),
-  });
-
-  ga("set", "page", window.location.pathname);
-  ga("send", "pageview");
-
-  // Replace the current #content element with the new partial content.
   main.querySelector("#content").innerHTML = partial.raw;
 
   // Update the page title.
@@ -168,8 +106,76 @@ export async function swapContent(isFirstRun, isAborted) {
 
   // Focus on the first title (or fallback to content itself).
   forceFocus(content.querySelector("h1, h2, h3, h4, h5, h6") || content);
+}
+
+/**
+ * Swap the current page for a new one. Accepts an incoming URL.
+ *
+ * @param {{
+ *   firstRun: boolean,
+ *   url: string,
+ *   signal: !AbortSignal,
+ *   ready: function(string, ?Object): void,
+ *   state: ?Object,
+ * }} object
+ */
+export async function swapContent({firstRun, url, signal, ready, state}) {
+  url = normalizeUrl(url);
+
+  // Kick off loading the correct JS entrypoint.
+  const entrypointPromise = loadEntrypoint(url);
+
+  // If this is the first run, bail out early. We generate an inferred partial for back/forward nav,
+  // as we only have the initial prerendered HTML.
+  if (firstRun) {
+    const content = document.querySelector("main #content");
+    const inferredPartial = {
+      raw: content.innerHTML,
+      title: document.title,
+    };
+    if (store.getState().isOffline) {
+      inferredPartial.offline = true;
+    }
+    ready(url, {partial: inferredPartial});
+    return entrypointPromise;
+  }
+
+  // Either use a partial from the previous state (user has hit back/forward) if it's not offline,
+  // or fetch it anew from the network.
+  let partial;
+  if (state && state.partial && !state.partial.offline) {
+    partial = state.partial;
+  } else {
+    store.setState({isPageLoading: true});
+    partial = await getPartial(url, signal);
+    if (signal.aborted) {
+      return null;
+    }
+  }
+
+  // If the partial was bad, force a real page load. This will occur in Netlify or other simple
+  // staging environments on 404, where we don't serve real JSON.
+  if (!partial || typeof partial !== "object") {
+    throw new Error(`invalid partial for: ${url}`);
+  }
+
+  // The bootstrap code uses this to trigger a reload if we see an "online" event. Only returned via
+  // the Service Worker if we failed to fetch a 'real' page.
+  const isOffline = Boolean(partial.offline);
+  store.setState({currentUrl: url, isOffline});
+
+  ga("set", "page", window.location.pathname);
+  ga("send", "pageview");
+  updateDom(partial);
+
+  // Inform the router that we're ready early (even though the JS isn't done).
+  ready(url, {partial});
 
   // Finally, just await for the entrypoint JS. It this fails we'll throw an exception and force a
   // complete reload.
-  return entrypointPromise;
+  await entrypointPromise;
+
+  if (!signal.aborted) {
+    store.setState({isPageLoading: false});
+  }
 }

--- a/src/lib/utils/abort-controller-polyfill.js
+++ b/src/lib/utils/abort-controller-polyfill.js
@@ -1,0 +1,31 @@
+/**
+ * An incredibly simple AbortController polyfill. Does not actually abort in-flight fetch()
+ * requests.
+ */
+class AbortControllerPolyfill {
+  constructor() {
+    let aborted = false;
+    const handlers = [];
+
+    this.abort = () => {
+      aborted = true;
+
+      const event = new CustomEvent("AbortEvent");
+      handlers.forEach((fn) => fn(event));
+      handlers.splice(0, handlers.length);
+    };
+
+    this.signal = Object.freeze({
+      get aborted() {
+        return aborted;
+      },
+      addEventListener(name, fn) {
+        if (!aborted && name === "abort") {
+          handlers.push(fn);
+        }
+      },
+    });
+  }
+}
+
+window.AbortController = window.AbortController || AbortControllerPolyfill;

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -115,7 +115,7 @@ export function listen(handler) {
       } else {
         window.history.replaceState(state, null, update);
       }
-      recentActiveUrl = update;
+      recentActiveUrl = url;
     };
 
     const arg = {
@@ -179,8 +179,7 @@ export function route(url) {
     // element (if any) and scroll to it.
     const target = document.getElementById(u.hash.substr(1)) || null;
     if (target) {
-      // nb. this avoids collision with top menubars etc
-      target.scrollIntoView({block: "center"});
+      target.scrollIntoView();
     } else {
       document.documentElement.scrollTop = 0;
     }

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -1,35 +1,11 @@
 let globalHandler;
 let recentActiveUrl; // current URL not including hash
 
-// Disable automatic scroll restoration. This is helpful as back/forward behavior is technically
-// async, and most browsers will move the scroll position automatically for us, even on old content.
-// Instead, we call `scrollOnFrame` when the async load helper is done.
-window.history.scrollRestoration = "manual";
-window.addEventListener("pagehide", (e) => {
-  // ... but re-enable when the page is unloaded, which happens if a user refreshes the page using
-  // their browser. This prevents this type of reload from jumping back to the top of the viewport.
-  window.history.scrollRestoration = "auto";
-});
-
 /**
  * @return {string} URL pathname plus optional search part
  */
 function getUrl() {
   return window.location.pathname + window.location.search;
-}
-
-/**
- * Brings the target element, or top scroll position, into view.
- *
- * @param {!Element|number} target
- */
-function scrollOnFrame(target) {
-  if (target instanceof Element) {
-    // nb. this avoids collision with top menubars etc
-    target.scrollIntoView({block: "center"});
-  } else {
-    document.documentElement.scrollTop = +target || 0;
-  }
 }
 
 /**
@@ -56,22 +32,7 @@ function onPopState(e) {
     return;
   }
   recentActiveUrl = updatedUrl;
-  const state = window.history.state;
-  globalHandler().then((success) => {
-    if (success) {
-      scrollOnFrame(state ? state.scrollTop : 0);
-    }
-  });
-}
-
-/**
- * Retain the current scroll position for forward/back stack changes.
- */
-function onDedupScroll() {
-  const state = {
-    scrollTop: document.documentElement.scrollTop,
-  };
-  window.history.replaceState(state, null, null);
+  globalHandler();
 }
 
 /**
@@ -121,53 +82,35 @@ export function listen(handler) {
     throw new Error("listen can only be called once");
   };
 
-  let pendingHandlerPromise = Promise.resolve();
   let requestCount = 0;
 
   // globalHandler is called for the current page URL (i.e., it reads
   // window.location rather than accepting an argument) to trigger a load via
-  // the passed handler. Only one handler can run at once.
+  // the passed handler.
   globalHandler = () => {
-    const localRequest = ++requestCount;
+    const localRequest = ++requestCount; // initial load will be 1
+    const isAborted = () => localRequest !== requestCount;
 
-    // Delay until any previous load is complete, then run handler for the
-    // now-active URL.
-    pendingHandlerPromise = pendingHandlerPromise
+    // Trigger the handler immediately, which will abort any previous fetch.
+    return Promise.resolve()
       .then(async () => {
-        if (localRequest !== requestCount) {
-          return false;
-        }
-        await handler();
-        return true;
+        await handler(false, isAborted);
+        return isAborted();
       })
       .catch((err) => {
-        window.location.href = window.location.href;
-        throw err;
+        // Only throw errors if not prseempted and not the first load.
+        if (!isAborted() && localRequest !== 1) {
+          window.location.href = window.location.href;
+          throw err;
+        }
       });
-    return pendingHandlerPromise;
   };
 
   window.addEventListener("replacestate", onReplaceState);
   window.addEventListener("popstate", onPopState);
   window.addEventListener("click", onClick);
 
-  // Write scroll value after settling.
-  let scrollTimeout = 0;
-  window.addEventListener(
-    "scroll",
-    () => {
-      window.clearTimeout(scrollTimeout);
-      scrollTimeout = window.setTimeout(onDedupScroll, 250);
-    },
-    {passive: true},
-  );
-
-  // And on initial load.
-  onDedupScroll();
-
-  // Don't catch errors for the first load.
-  recentActiveUrl = getUrl();
-  handler(true);
+  globalHandler();
 }
 
 /**
@@ -191,12 +134,19 @@ export function route(url) {
   recentActiveUrl = candidateUrl;
 
   window.history.pushState(null, null, u.toString()); // Edge needs toString
-  globalHandler().then((success) => {
-    if (success) {
-      // Since we're loading this page dynamically, look for the target hash-ed
-      // element (if any) and scroll to it.
-      const target = document.getElementById(u.hash.substr(1)) || 0;
-      return scrollOnFrame(target);
+  globalHandler().then((aborted) => {
+    if (aborted) {
+      return false;
+    }
+
+    // Since we're loading this page dynamically, look for the target hash-ed
+    // element (if any) and scroll to it.
+    const target = document.getElementById(u.hash.substr(1)) || null;
+    if (target) {
+      // nb. this avoids collision with top menubars etc
+      target.scrollIntoView({block: "center"});
+    } else {
+      document.documentElement.scrollTop = 0;
     }
   });
   return true;


### PR DESCRIPTION
I hate routing. Fixes #2336.

I've changed the way the router works and disabled manual `scrollRestoration`. Notably DevSite has the "flash" of incorrect scroll positions (which is an older issue) because they still are where we were a few PRs ago.

* Allows multiple loads to occur at once (but we abort via `AbortController`); previously, we tried to complete them in series (confusing for users rapidly hitting back/forward)
* Cache page contents for back/forward and don't go to the network unless we need to (matches what normal pages do)
* Creates a faux-partial for the first loaded page (since it's prerendered HTML)
  * we could also put this into the Cache API for caching the first load (but that's out of scope)
* Allows our loader to inform the router it's `ready()` early, swapping the URL, but still showing a loading bar for the JS payload

I might factor this out into a nicer library tonight, that's better documented.
