### PR TITLE
Set dimensions on footer lazyloaded image

### DIFF
--- a/src/site/_includes/devsite/devsite-footer.njk
+++ b/src/site/_includes/devsite/devsite-footer.njk
@@ -133,7 +133,7 @@
         data-label="Footer Google Developers Link"
       >
         <img
-          loading="lazy"
+          loading="lazy" width="185" height="33"
           class="devsite-footer-sites-logo"
           src="https://web.dev/_static/images/lockup-color.png"
           alt="Google Developers"

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -77,7 +77,7 @@
     <nav class="w-footer__utility-nav">
       <a href="https://developers.google.com/" class="w-footer__utility-logo-link"
         data-category="Site-Wide Custom Events" data-label="Footer Google Developers Link">
-        <img loading="lazy" class="w-footer__utility-logo" src="/images/lockup-color.png"
+        <img loading="lazy" width="185" height="33" class="w-footer__utility-logo" src="/images/lockup-color.png"
           alt="Google Developers" />
       </a>
       <ul class="w-footer__utility-list">


### PR DESCRIPTION
Fixes #https://github.com/GoogleChrome/web.dev/issues/2364

Changes proposed in this pull request:

- Adds dimensions on footer lazyloaded image as suggested by chrome `[Intervention]`
