### PR TITLE
Revert "upgrade to Algolia SDK 4+ (#2348)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -310,121 +310,6 @@
         "prismjs": "^1.17.1"
       }
     },
-    "@algolia/cache-browser-local-storage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.1.0.tgz",
-      "integrity": "sha512-r8BOgqZXVt+JPgP19PQNzZ+lYP+MP6eZKNQqfRYofFEx+K9oyfdtGCqmoWJsBUi3nNOzhbOcg2jfP2GJzJBZ5g==",
-      "requires": {
-        "@algolia/cache-common": "4.1.0"
-      }
-    },
-    "@algolia/cache-common": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.1.0.tgz",
-      "integrity": "sha512-ZvvK40bs1BWLErchleZL4ctHT2uH56uLMnpZPCuIk+H2PKddeiIQc/z2JDu2BHr68u513XIAAoQ+C+LgKNugmw=="
-    },
-    "@algolia/cache-in-memory": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.1.0.tgz",
-      "integrity": "sha512-2382OXYFDeoPLA5vP9KP58ad15ows24ML5/io/T1N0xsZ0eVXDkT52qgaJw/esUfEkWScZ2R8kpesUa+qEP+kw==",
-      "requires": {
-        "@algolia/cache-common": "4.1.0"
-      }
-    },
-    "@algolia/client-account": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.1.0.tgz",
-      "integrity": "sha512-GFINlsxAHM/GEeDBjoTx8+J1ra9SINQCuXi2C9QSLFClPKug2lzApm8niJJGXckhyZ2aDLb7drJ1qJ8bTspApw==",
-      "requires": {
-        "@algolia/client-common": "4.1.0",
-        "@algolia/client-search": "4.1.0",
-        "@algolia/transporter": "4.1.0"
-      }
-    },
-    "@algolia/client-analytics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.1.0.tgz",
-      "integrity": "sha512-JMyZ9vXGbTJWiO66fWEu9uJ7GSYfouUyaq8W/6esADPtBbelf+Nc0NRlicOwHHJGwiJvWdvELafxrhkR1+KR8A==",
-      "requires": {
-        "@algolia/client-common": "4.1.0",
-        "@algolia/client-search": "4.1.0",
-        "@algolia/requester-common": "4.1.0",
-        "@algolia/transporter": "4.1.0"
-      }
-    },
-    "@algolia/client-common": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.1.0.tgz",
-      "integrity": "sha512-fjSMKeG54vAyQAhf+uz039/birTiLun8nDuCNx4CUbzGl97M0g96Q8jpsiZa0cjSNgh0VakMzn2GnHbS55W9/Q==",
-      "requires": {
-        "@algolia/requester-common": "4.1.0",
-        "@algolia/transporter": "4.1.0"
-      }
-    },
-    "@algolia/client-recommendation": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.1.0.tgz",
-      "integrity": "sha512-UEN/QgQwVtVH++yAs2uTuyZZQQ1p5Xs/7/FKT4Kh9/8NAyqDD49zuyq/giw8PRNhWc3C/9jiO7X4RKE8QrVWGw==",
-      "requires": {
-        "@algolia/client-common": "4.1.0",
-        "@algolia/requester-common": "4.1.0",
-        "@algolia/transporter": "4.1.0"
-      }
-    },
-    "@algolia/client-search": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.1.0.tgz",
-      "integrity": "sha512-bpCYMEXUdyiopEBSHHwnrRhNEwOLstIeb0Djz+/pVuTXEr3Xg3JUoAZ8xFsCVldcXaZQpbi1/T0y3ky6xUVzfw==",
-      "requires": {
-        "@algolia/client-common": "4.1.0",
-        "@algolia/requester-common": "4.1.0",
-        "@algolia/transporter": "4.1.0"
-      }
-    },
-    "@algolia/logger-common": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.1.0.tgz",
-      "integrity": "sha512-QrE4Srf1LB7ekLzl68bFqlTrv7Wk7+GpsaGfB4xFZ9Pfv89My9p7qTVqdLlA44hEFY3fZ9csJp1/PFVucgNB4w=="
-    },
-    "@algolia/logger-console": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.1.0.tgz",
-      "integrity": "sha512-sKELkiKIrj/tPRAdhOPNI0UxhK2uiIUXnGs/3ztAif6QX7vyE3lY19sj5pIVJctRvl8LW2UlzpBFGlcCDkho9Q==",
-      "requires": {
-        "@algolia/logger-common": "4.1.0"
-      }
-    },
-    "@algolia/requester-browser-xhr": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.1.0.tgz",
-      "integrity": "sha512-bLMfIAkOLs1/vGA09yxU0N5+bE0fSSvEH2ySqVssfWLMP+KRAvby2Goxm8BgI9xLkOvLbhazfQ4Ov2448VvA1g==",
-      "requires": {
-        "@algolia/requester-common": "4.1.0"
-      }
-    },
-    "@algolia/requester-common": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.1.0.tgz",
-      "integrity": "sha512-Cy0ciOv5uIm6wF+uLc9DHhxgPJtYQuy1f//hwJcW5mlPX/prPgxWwLXzWyyA+Ca7uU3q+0Y3cIFvEWM5pDxMEg=="
-    },
-    "@algolia/requester-node-http": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.1.0.tgz",
-      "integrity": "sha512-tXp6Pjx9dFgM5ccW6YfEN6v2Zqq8uGwhS1pyq03/aRYRBK60LptjG5jo++vrOytrQDOnIjcZtQzBQch2GjCVmw==",
-      "requires": {
-        "@algolia/requester-common": "4.1.0"
-      }
-    },
-    "@algolia/transporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.1.0.tgz",
-      "integrity": "sha512-Z7PjHazSC+KFLDuCFOjvRNgLfh7XOE4tXi0a9O3gBRup4Sk3VQCfTw4ygCF3rRx6uYbq192efLu0nL1E9azxLA==",
-      "requires": {
-        "@algolia/cache-common": "4.1.0",
-        "@algolia/logger-common": "4.1.0",
-        "@algolia/requester-common": "4.1.0"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -3428,6 +3313,11 @@
       "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -3446,24 +3336,35 @@
       "dev": true
     },
     "algoliasearch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.1.0.tgz",
-      "integrity": "sha512-0lzjvqQZkJYPuv7LyQauMIMCFFzJWfUf3m9KuHjmFubwbnTDa87KCMXKouMJ0kWXXt6nTLNt0+2YRREOWx2PHw==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.0.tgz",
+      "integrity": "sha512-Om4aLzkGbUi+Rc3sa8s48CRj2Qe7u5TXS7lK7Z681x2EiAa5Qx5uB/kbp8A6qY6dFDX7vstYRIYZ7t9XgdJ1dw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.1.0",
-        "@algolia/cache-common": "4.1.0",
-        "@algolia/cache-in-memory": "4.1.0",
-        "@algolia/client-account": "4.1.0",
-        "@algolia/client-analytics": "4.1.0",
-        "@algolia/client-common": "4.1.0",
-        "@algolia/client-recommendation": "4.1.0",
-        "@algolia/client-search": "4.1.0",
-        "@algolia/logger-common": "4.1.0",
-        "@algolia/logger-console": "4.1.0",
-        "@algolia/requester-browser-xhr": "4.1.0",
-        "@algolia/requester-common": "4.1.0",
-        "@algolia/requester-node-http": "4.1.0",
-        "@algolia/transporter": "4.1.0"
+        "agentkeepalive": "^2.2.0",
+        "debug": "^2.6.9",
+        "envify": "^4.0.0",
+        "es6-promise": "^4.1.0",
+        "events": "^1.1.0",
+        "foreach": "^2.0.5",
+        "global": "^4.3.2",
+        "inherits": "^2.0.1",
+        "isarray": "^2.0.1",
+        "load-script": "^1.0.0",
+        "object-keys": "^1.0.11",
+        "querystring-es3": "^0.2.1",
+        "reduce": "^1.0.1",
+        "semver": "^5.1.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "align-text": {
@@ -6746,6 +6647,11 @@
         "entities": "^1.1.1"
       }
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+    },
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -7065,6 +6971,15 @@
       "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
       "dev": true
     },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -7142,6 +7057,11 @@
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promise-pool": {
       "version": "2.5.0",
@@ -7401,6 +7321,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "exec-buffer": {
       "version": "3.2.0",
@@ -8245,6 +8170,11 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "foreachasync": {
       "version": "3.0.0",
@@ -9194,6 +9124,15 @@
             "upath": "^1.1.1"
           }
         }
+      }
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "global-modules": {
@@ -10792,8 +10731,7 @@
     "isarray": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-      "dev": true
+      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -11401,6 +11339,11 @@
           "dev": true
         }
       }
+    },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-utils": {
       "version": "0.2.17",
@@ -12058,6 +12001,14 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -14422,6 +14373,11 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -14770,6 +14726,11 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
     "queue": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz",
@@ -14962,6 +14923,14 @@
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
+      }
+    },
+    "reduce": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.2.tgz",
+      "integrity": "sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==",
+      "requires": {
+        "object-keys": "^1.1.0"
       }
     },
     "regenerate": {
@@ -18646,8 +18615,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^2.3.0",
-    "algoliasearch": "^4.1.0",
+    "algoliasearch": "^3.35.0",
     "babel-eslint": "^10.0.3",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.4",

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -7,7 +7,7 @@ import {BaseElement} from "../BaseElement";
 import {store} from "../../store";
 import * as router from "../../utils/router";
 import {debounce} from "../../utils/debounce";
-import algoliasearch from "algoliasearch/dist/algoliasearch-lite.esm.browser";
+import algoliasearch from "algoliasearch/dist/algoliasearchLite";
 import "./_styles.scss";
 
 // Create an algolia client so we can get search results.
@@ -280,7 +280,7 @@ class Search extends BaseElement {
       return;
     }
     try {
-      const {hits} = await index.search(query, {hitsPerPage: 10});
+      const {hits} = await index.search({query, hitsPerPage: 10});
       if (this.query === query) {
         this.hits = hits;
       }


### PR DESCRIPTION
This reverts commit 6586f7fd8b4f5f77ffc29762092e7c98efd601bc.

Changes proposed in this pull request:

- Undo changes in #2348. It looks like those changes were causing index-algolia.js to break so the site wasn't deploying anymore. You can see an example of the build output here: https://github.com/GoogleChrome/web.dev/runs/514705638?check_suite_focus=true

![Screen Shot 2020-03-17 at 3 34 34 PM](https://user-images.githubusercontent.com/1066253/76908195-55482b00-6865-11ea-95e2-a9474b6921e4.png)
