### PR TITLE
fix(measure): disable report downloads, fixes #1224

### DIFF
--- a/src/lib/components/LighthouseScoresMeta/index.js
+++ b/src/lib/components/LighthouseScoresMeta/index.js
@@ -61,17 +61,6 @@ class LighthouseScoresMeta extends BaseElement {
               rel="noopener"
               >View Report</a
             >
-            |
-            <a
-              href="${LH_HOST}/lh/html?url=${encodedUrl}&download"
-              download
-              class="downloadreport lh-report-link gc-analytics-event"
-              data-category="web.dev"
-              data-label="download lighthouse report"
-              data-action="click"
-              title="Download latest Lighthouse report"
-              >Download Report</a
-            >
           </span>
         </span>
         <span class="lh-error-msg">${this.errorMessage}</span>


### PR DESCRIPTION
Fixes #1224

Seems like downloading HTML pages on Chrome for Android is an issue with chromium => https://bugs.chromium.org/p/chromium/issues/detail?id=1041209 . So for now we will remove the button until there's a proper fix in Chrome.