### PR TITLE
reorder caching so images are cached after 1st load

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -10,6 +10,11 @@ import {matchPrecache, precacheAndRoute} from "workbox-precaching";
 import {cacheNames} from "workbox-core";
 import {matchSameOriginRegExp} from "./utils/sw-match.js";
 
+/**
+ * Configure default cache for standard web.dev files: the offline page, various images etc.
+ */
+precacheAndRoute(manifest);
+
 // Architecture revision of the Service Worker. If the previously saved revision doesn't match,
 // then this will cause clients to be aggressively claimed and reloaded on install/activate.
 // Used when the design of the SW changes dramatically.
@@ -94,9 +99,6 @@ workboxRouting.registerRoute(
     ],
   }),
 );
-
-// Configure default cache for standard web.dev files: the offline page, various images etc.
-precacheAndRoute(manifest);
 
 /**
  * This is a special handler for requests without a trailing "/". These requests _should_ go to

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -11,7 +11,7 @@ import {cacheNames} from "workbox-core";
 import {matchSameOriginRegExp} from "./utils/sw-match.js";
 
 /**
- * Configure default cache for standard web.dev files: the offline page, various images etc.
+ * Configure default cache for standard web.dev files: the offline page, various images, etc.
  *
  * This must occur first, as we cache images that are also matched by runtime handlers below. See
  * this workbox issue for updates: https://github.com/GoogleChrome/workbox/issues/2402

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -12,6 +12,9 @@ import {matchSameOriginRegExp} from "./utils/sw-match.js";
 
 /**
  * Configure default cache for standard web.dev files: the offline page, various images etc.
+ *
+ * This must occur first, as we cache images that are also matched by runtime handlers below. See
+ * this workbox issue for updates: https://github.com/GoogleChrome/workbox/issues/2402
  */
 precacheAndRoute(manifest);
 


### PR DESCRIPTION
This works around the issue raised [over in Workbox](https://github.com/GoogleChrome/workbox/issues/2402).

This isn't specifically tracked but I noticed it while working on JS issues. Images that we aggressively precache (anything in /images/*) weren't be served while offline, because the runtime handler was winning and claiming nothing was found.

As per the other bug:

- images live under /images/ and include both core site images as well as profile pictures etc
- we only want to precache the things that appear on the home page
- but we want to runtime cache any extended images that the user happens to load.