### PR TITLE
Add try/catch blocks for better cross-browser support

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -251,13 +251,19 @@ how to create a
 that listens for `layout-shift` entries and logs them to the console:
 
 ```js
-const observer = new PerformanceObserver((list) => {
- for (const entry of list.getEntries()) {
-   console.log(entry);
- }
-});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  const observer = new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    console.log(entry);
+  }
+  });
 
-observer.observe({type: 'layout-shift', buffered: true});
+  observer.observe({type: 'layout-shift', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 To calculate the cumulative layout shift score for your pages, declare a
@@ -271,34 +277,40 @@ state](https://developers.google.com/web/updates/2018/07/page-lifecycle-api)
 changes to hidden:
 
 ```js
-// Stores the current layout shift score for the page.
-let cumulativeLayoutShiftScore = 0;
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Store the current layout shift score for the page.
+  let cumulativeLayoutShiftScore = 0;
 
-// Detects new layout shift occurrences and updates the
-// `cumulativeLayoutShiftScore` variable.
-const observer = new PerformanceObserver((list) => {
- for (const entry of list.getEntries()) {
-   // Only count layout shifts without recent user input.
-   if (!entry.hadRecentInput) {
-     cumulativeLayoutShiftScore += entry.value;
-   }
- }
-});
+  // Detect new layout shift occurrences and updates the
+  // `cumulativeLayoutShiftScore` variable.
+  const observer = new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    // Only count layout shifts without recent user input.
+    if (!entry.hadRecentInput) {
+      cumulativeLayoutShiftScore += entry.value;
+    }
+  }
+  });
 
-observer.observe({type: 'layout-shift', buffered: true});
+  observer.observe({type: 'layout-shift', buffered: true});
 
-// Sends the final score to your analytics back end once
-// the page's lifecycle state becomes hidden.
-document.addEventListener('visibilitychange', () => {
- if (document.visibilityState === 'hidden') {
-   // Force any pending records to be dispatched.
-   observer.takeRecords();
-   observer.disconnect();
+  // Send the final score to your analytics back end once
+  // the page's lifecycle state becomes hidden.
+  document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    // Force any pending records to be dispatched.
+    observer.takeRecords();
+    observer.disconnect();
 
-   // Log the final score to the console.
-   console.log('CLS:', cumulativeLayoutShiftScore);
- }
-});
+    // Log the final score to the console.
+    console.log('CLS:', cumulativeLayoutShiftScore);
+  }
+  });
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 {% Aside %}

--- a/src/site/content/en/metrics/custom-metrics/index.md
+++ b/src/site/content/en/metrics/custom-metrics/index.md
@@ -70,14 +70,20 @@ entries to listen for via the
 method:
 
 ```js
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // Log the entry and all associated details.
-    console.log(entry.toJSON());
-  }
-});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Log the entry and all associated details.
+      console.log(entry.toJSON());
+    }
+  });
 
-po.observe({type: 'some-entry-type'});
+  po.observe({type: 'some-entry-type'});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 The sections below list all the various entry types available for observing, but
@@ -166,15 +172,21 @@ To report User Timing measurements, you can use
 type `measure`:
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // Log the entry and all associated details.
-    console.log(entry.toJSON());
-  }
-});
-// Start listening for `measure` entries to be dispatched.
-po.observe({type: 'measure', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Log the entry and all associated details.
+      console.log(entry.toJSON());
+    }
+  });
+  // Start listening for `measure` entries to be dispatched.
+  po.observe({type: 'measure', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 ### Long Tasks API
@@ -195,20 +207,26 @@ To determine when long tasks happen, you can use
 and register to observe entries of type `longtask`:
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // Log the entry and all associated details.
-    console.log(entry.toJSON());
-  }
-});
-// Start listening for `longtask` entries to be dispatched.
-po.observe({type: 'longtask', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Log the entry and all associated details.
+      console.log(entry.toJSON());
+    }
+  });
+  // Start listening for `longtask` entries to be dispatched.
+  po.observe({type: 'longtask', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 {% Aside 'caution' %}
   The `buffered` flag does not currently work for Long Tasks (though
-  support is currently being added). In the meantime, you can track Long Tasks
+  support is being added). In the meantime, you can track Long Tasks
   by registering the `PerformanceObserver` in the `<head>` of your pages, before
   loading any other scripts.
 {% endAside %}
@@ -232,15 +250,21 @@ registering a PerformanceObserver to observe the element entry type.
 <p elementtiming="important-paragraph">This is text I care about.</p>
 ...
 <script>
-// Create the performance observer.
-const observer = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // Log the entry and all associated details.
-    console.log(entry.toJSON());
-  }
-});
-// Start listening for `element` entries to be dispatched.
-observer.observe({type: 'element', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Log the entry and all associated details.
+      console.log(entry.toJSON());
+    }
+  });
+  // Start listening for `element` entries to be dispatched.
+  observer.observe({type: 'element', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 </script>
 ```
 
@@ -282,15 +306,21 @@ The following example logs all resources requested by the page and indicates
 whether or not each resource was fulfilled via the cache.
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // If transferSize is 0, the resource was fulfilled via the cache.
-    console.log(entry.name, entry.transferSize === 0);
-  }
-});
-// Start listening for `resource` entries to be dispatched.
-po.observe({type: 'resource', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // If transferSize is 0, the resource was fulfilled via the cache.
+      console.log(entry.name, entry.transferSize === 0);
+    }
+  });
+  // Start listening for `resource` entries to be dispatched.
+  po.observe({type: 'resource', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 ### Navigation Timing API
@@ -309,15 +339,21 @@ First Byte](https://en.wikipedia.org/wiki/Time_to_first_byte)) is available via
 the Navigation Timing API—specifically it's entry's `responseStart` timestamp.
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // If transferSize is 0, the resource was fulfilled via the cache.
-    console.log('Time to first byte', entry.responseStart);
-  }
-});
-// Start listening for `navigation` entries to be dispatched.
-po.observe({type: 'navigation', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // If transferSize is 0, the resource was fulfilled via the cache.
+      console.log('Time to first byte', entry.responseStart);
+    }
+  });
+  // Start listening for `navigation` entries to be dispatched.
+  po.observe({type: 'navigation', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 Another metric developers who user service worker may care about is the service
@@ -329,15 +365,21 @@ The service worker startup time for a particular navigation request can be
 determined from the delta between `entry.responseStart` and `entry.workerStart`.
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    console.log('Service Worker startup time:',
-        entry.responseStart - entry.workerStart);
-  }
-});
-// Start listening for `navigation` entries to be dispatched.
-po.observe({type: 'navigation', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      console.log('Service Worker startup time:',
+          entry.responseStart - entry.workerStart);
+    }
+  });
+  // Start listening for `navigation` entries to be dispatched.
+  po.observe({type: 'navigation', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 ### Server Timing API
@@ -365,15 +407,21 @@ Then, from your pages, you can read this data on both `resource` or `navigation`
 entries from the Resource Timing and Navigation Timing APIs.
 
 ```js
-// Create the performance observer.
-const po = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    // Logs all server timing data for this response
-    console.log('Server Timing', entry.serverTiming);
-  }
-});
-// Start listening for `navigation` entries to be dispatched.
-po.observe({type: 'navigation', buffered: true});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the performance observer.
+  const po = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Logs all server timing data for this response
+      console.log('Server Timing', entry.serverTiming);
+    }
+  });
+  // Start listening for `navigation` entries to be dispatched.
+  po.observe({type: 'navigation', buffered: true});
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 [devtools]: https://developers.google.com/web/updates/2018/04/devtools#tabs

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -72,20 +72,26 @@ that listens for paint timing entries and logs the start time of the
 `first-contentful-paint` entry to the console:
 
 ```js
-// Create the Performance Observer instance.
-const observer = new PerformanceObserver((list) => {
-  for (const entry of list.getEntriesByName('first-contentful-paint')) {
-    // Log the value of FCP to the console.
-    console.log('FCP:', entry.startTime);
-    observer.disconnect();
-  }
-});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the Performance Observer instance.
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntriesByName('first-contentful-paint')) {
+      // Log the value of FCP to the console.
+      console.log('FCP:', entry.startTime);
+      observer.disconnect();
+    }
+  });
 
-// Start observing paint entry types.
-observer.observe({
-  type: 'paint',
-  buffered: true,
-});
+  // Start observing paint entry types.
+  observer.observe({
+    type: 'paint',
+    buffered: true,
+  });
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 Note, in your own code, you'd likely replace the `console.log()` with code that

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -182,19 +182,25 @@ that listens for
 entries, calculates FID, and logs the value to the console:
 
 ```js
-// Create the Performance Observer instance.
-const observer = new PerformanceObserver((list) => {
-  for (const entry of list.getEntries()) {
-    const fid = entry.processingStart - entry.startTime;
-    console.log('FID:', fid);
-  }
-});
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create the Performance Observer instance.
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      const fid = entry.processingStart - entry.startTime;
+      console.log('FID:', fid);
+    }
+  });
 
-// Start observing first-input entries.
-observer.observe({
-  type: 'first-input',
-  buffered: true,
-});
+  // Start observing first-input entries.
+  observer.observe({
+    type: 'first-input',
+    buffered: true,
+  });
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 ### Analyzing and reporting on FID data

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -230,33 +230,39 @@ that listens for `largest-contentful-paint` entries and logs the LCP value to
 the console:
 
 ```js
-// Create a variable to hold the latest LCP value (since it can change).
-let lcp;
+// Catch errors since some browsers throw when using the new `type` option.
+// https://bugs.webkit.org/show_bug.cgi?id=209216
+try {
+  // Create a variable to hold the latest LCP value (since it can change).
+  let lcp;
 
-// Create the PerformanceObserver instance.
-const po = new PerformanceObserver((entryList) => {
-  const entries = entryList.getEntries();
-  const lastEntry = entries[entries.length - 1];
+  // Create the PerformanceObserver instance.
+  const po = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
 
-  // Update `lcp` to the latest value, using `renderTime` if it's available,
-  // otherwise using `loadTime`. (Note: `renderTime` may not be available if
-  // the element is an image and it's loaded cross-origin without the
-  // `Timing-Allow-Origin` header.)
-  lcp = lastEntry.renderTime || lastEntry.loadTime;
-});
+    // Update `lcp` to the latest value, using `renderTime` if it's available,
+    // otherwise using `loadTime`. (Note: `renderTime` may not be available if
+    // the element is an image and it's loaded cross-origin without the
+    // `Timing-Allow-Origin` header.)
+    lcp = lastEntry.renderTime || lastEntry.loadTime;
+  });
 
-// Observe entries of type `largest-contentful-paint`, including buffered
-// entries, i.e. entries that occurred before calling `observe()`.
-po.observe({type: 'largest-contentful-paint', buffered: true});
+  // Observe entries of type `largest-contentful-paint`, including buffered
+  // entries, i.e. entries that occurred before calling `observe()`.
+  po.observe({type: 'largest-contentful-paint', buffered: true});
 
-// Send the latest LCP value to your analytics server once the user
-// leaves the tab.
-addEventListener('visibilitychange', function fn() {
-  if (lcp && document.visibilityState === 'hidden') {
-    console.log('LCP:', lcp);
-    removeEventListener('visibilitychange', fn, true);
-  }
-}, true);
+  // Send the latest LCP value to your analytics server once the user
+  // leaves the tab.
+  addEventListener('visibilitychange', function fn() {
+    if (lcp && document.visibilityState === 'hidden') {
+      console.log('LCP:', lcp);
+      removeEventListener('visibilitychange', fn, true);
+    }
+  }, true);
+} catch (e) {
+  // Do nothing if the browser doesn't support this API.
+}
 ```
 
 Note, this example waits to log LCP until the page's [lifecycle


### PR DESCRIPTION
Fixes #2078

This PR adds a try/catch block around every code example that uses `PerformanceObserver` with the `type` option to avoid errors due to [this Safari bug](https://bugs.webkit.org/show_bug.cgi?id=209216).

Note: it feels a bit excessive to add the comment and bug link to each code example, but I did so because I was concerned that, without it, developers might think they need to use a try/catch *any* time they ever use `PerformanceObserver`, which isn't true.

An alternative way would be to define a helper function that wraps the try/catch and then use that helper function in each example, but that's also awkward to define for each metric.

If anyone has any thoughts on how to do this better, please let me know.

