### PR TITLE
Add "Label" web.dev component

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,6 +39,7 @@ const Details = require(`./${componentsDir}/Details`);
 const DetailsSummary = require(`./${componentsDir}/DetailsSummary`);
 const Hero = require(`./${componentsDir}/Hero`);
 const Instruction = require(`./${componentsDir}/Instruction`);
+const Label = require(`./${componentsDir}/Label`);
 const Meta = require(`./${componentsDir}/Meta`);
 const PathCard = require(`./${componentsDir}/PathCard`);
 const PostCard = require(`./${componentsDir}/PostCard`);
@@ -200,6 +201,7 @@ module.exports = function(config) {
   config.addPairedShortcode('DetailsSummary', DetailsSummary);
   config.addShortcode('Hero', Hero);
   config.addShortcode('Instruction', Instruction);
+  config.addPairedShortcode('Label', Label);
   config.addShortcode('Meta', Meta);
   config.addPairedShortcode('Partial', buildPartial());
   config.addShortcode('PathCard', PathCard);

--- a/src/site/_includes/components/Label.js
+++ b/src/site/_includes/components/Label.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {html} = require("common-tags");
+const md = require("markdown-it")();
+
+module.exports = (content) => {
+  return html`
+    <p class="w-label">${md.renderInline(content)}</p>
+  `;
+};

--- a/src/site/content/en/blog/module-workers/index.md
+++ b/src/site/content/en/blog/module-workers/index.md
@@ -17,13 +17,6 @@ tags:
   - modules
 ---
 
-<style>
-  .wm-filename {
-    margin-bottom: 0;
-    opacity: 0.7;
-  }
-</style>
-
 JavaScript is single-threaded, which means it can only perform one operation at a time. This is
 intuitive and works well for lots of cases on the web, but can become problematic when we need to
 do heavy lifting tasks like data processing, parsing, computation, or analysis. As more and more
@@ -41,7 +34,7 @@ expensive operations on one or more background threads.
 Here's a typical example of worker usage, where a worker script listens for messages from the main
 thread and responds by sending back messages of its own:
 
-<p class="wm-filename">page.js:</p>
+{% Label %}page.js:{% endLabel %}
 
 ```js
 const worker = new Worker('worker.js');
@@ -51,7 +44,7 @@ worker.addEventListener(e => {
 worker.postMessage('hello');
 ```
 
-<p class="wm-filename">worker.js:</p>
+{% Label %}worker.js:{% endLabel %}
 
 ```js
 addEventListener('message', e => {
@@ -85,7 +78,7 @@ pauses execution of the worker in order to fetch and evaluate each script. It al
 in the global scope like a classic `<script>` tag, meaning the variables in one script can be
 overwritten by the variables in another.
 
-<p class="wm-filename">worker.js:</p>
+{% Label %}worker.js:{% endLabel %}
 
 ```js
 importScripts('greet.js');
@@ -95,7 +88,7 @@ addEventListener('message', e => {
 });
 ```
 
-<p class="wm-filename">greet.js:</p>
+{% Label %}greet.js:{% endLabel %}
 
 ```js
 // global to the whole worker
@@ -138,7 +131,7 @@ import](https://v8.dev/features/dynamic-import) for lazy-loading code without bl
 the worker. Dynamic import is much more explicit than using `importScripts()` to load dependencies,
 since the imported module's exports are returned rather than relying on global variables.
 
-<p class="wm-filename">worker.js:</p>
+{% Label %}worker.js:{% endLabel %}
 
 ```js
 import { sayHello } from './greet.js';
@@ -147,7 +140,7 @@ addEventListener('message', e => {
 });
 ```
 
-<p class="wm-filename">greet.js:</p>
+{% Label %}greet.js:{% endLabel %}
 
 ```js
 import greetings from './data.js';

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -27,6 +27,7 @@ guidance about how to use them effectively.
 1. [Glitches](#glitches)
 1. [Images](#images)
 1. [Instructions](#instructions)
+1. [Labels](#labels)
 1. [Lists](#lists)
 1. [Stats](#stats)
 1. [Tables](#tables)
@@ -828,6 +829,24 @@ by using the `audit-auditName` argument in the Instruction shortcode.
 For example, here are the instructions for the **Performance** audit:
 
 {% Instruction 'audit-performance', 'ol' %}
+
+## Labels
+
+Labels can be used to display a filename associated with a [code](/handbook/markup-code) snippet.
+
+````text
+{% raw %}{% Label %}filename.js:{% endLabel %}{% endraw %}
+
+```js
+console.log('hello');
+```
+````
+
+{% Label %}filename.js:{% endLabel %}
+
+```js
+console.log('hello');
+```
 
 ## Lists
 See the [Lists section of the Grammar, mechanics, and usage post](/handbook/grammar/#lists)

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -19,6 +19,7 @@
 @import 'icon-list';
 @import 'images';
 @import 'layouts';
+@import 'label';
 @import 'mastheads';
 @import 'numbered-header';
 @import 'page-header';

--- a/src/styles/components/_label.scss
+++ b/src/styles/components/_label.scss
@@ -1,0 +1,10 @@
+// =============================================================================
+// LABEL OVERVIEW
+//
+// Labels can be used to display a filename associated with a code snippet.
+// =============================================================================
+
+.w-label {
+  margin-bottom: -28px;
+  opacity: .7;
+}


### PR DESCRIPTION
This PR adds a new "Label" web.dev component that authors can use when they want to show a filename associated with a code snippet:
- new `{% Label %}` web.dev component
- updates the module-workers article to use it
- adds it to the handbook web.dev components page

Live preview: 
- https://deploy-preview-2387--web-dev-staging.netlify.com/module-workers/
- https://deploy-preview-2387--web-dev-staging.netlify.com/handbook/web-dev-components/#labels

Fixes #2058

<img src=https://user-images.githubusercontent.com/634478/77053030-fd790380-69cd-11ea-9933-e3e1af683c4a.png width=49%> <img src=https://user-images.githubusercontent.com/634478/77053060-0964c580-69ce-11ea-9436-2257a0263f10.png width=49%>
old vs. new
