### PR TITLE
Default images to center alignment

### DIFF
--- a/src/site/_drafts/intrinsic-layout-overview/index.md
+++ b/src/site/_drafts/intrinsic-layout-overview/index.md
@@ -101,7 +101,7 @@ The example below demonstrates the flexibility your site gains when it uses an
 intrinsic layout. While the content might change—sometimes dramatically—the layout
 is able to accommodate these changes in a way that preserves the site's design.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video class="w-screenshot" autoplay loop muted playsinline aria-label="Large amounts of text are added to a three column layout. The layout flows the text correctly so it preserves its three column appearance.">
     <source src="https://storage.googleapis.com/web-dev-assets/intrinsic-layout-overview/intrinsic-layout-overview_intrinsic-chaos-overview.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/intrinsic-layout-overview/intrinsic-layout-overview_intrinsic-chaos-overview.mp4" type="video/mp4; codecs=h264">
@@ -156,7 +156,7 @@ If you don't have the basics of grid or flexbox down, have no fear! **You'll
 pick up the basics along the way** and I'll do my best to provide links that
 explain certain topics in-depth. 👍
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video autoplay loop muted playsinline aria-label="A man and a woman quickly running in place.">
     <source src="https://storage.googleapis.com/web-dev-assets/intrinsic-layout-overview/intrinsic-layout-overview_get-started.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/intrinsic-layout-overview/intrinsic-layout-overview_get-started.mp4" type="video/mp4; codecs=h264">

--- a/src/site/content/en/accessible/labels-and-text-alternatives/index.md
+++ b/src/site/content/en/accessible/labels-and-text-alternatives/index.md
@@ -296,7 +296,7 @@ This is especially helpful for screen readers that offer shortcuts to list all
 of the links on the page. If links are full of repetitive filler text, these
 shortcuts become much less useful:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./vo.jpg" alt="VoiceOver's links menu filled with the word 'here'.">
   <figcaption class="w-figcaption">
     Example of VoiceOver, a screen reader for macOS, showing the navigate by
@@ -330,7 +330,7 @@ When the checkbox has been labeled correctly, the screen reader can report that
 the element has a role of checkbox, is in a checked state, and is named "Receive
 promotional offers?" like in the VoiceOver example below:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./promo-offers.png"
   alt="VoiceOver text output showing 'Receive promotional offers?'">
 </figure>

--- a/src/site/content/en/accessible/semantics-and-screen-readers/index.md
+++ b/src/site/content/en/accessible/semantics-and-screen-readers/index.md
@@ -22,7 +22,7 @@ Before diving into semantics, it's helpful to understand another term:
 **affordances**. An affordance is any object that offers, or affords, its user
 the opportunity to perform an action. A classic example is the teapot:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./teapot.png" alt="" style="max-width: 400px;">
   <figcaption class="w-figcaption">
     A teapot's handle is a natural affordance.

--- a/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
+++ b/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
@@ -79,13 +79,13 @@ You can customize any of these properties by changing the relevant value in `man
 
 A PWA references its manifest file with a `link` element in `index.html`. Once the browser finds the reference, it'll show the **Add to Home screen** prompt:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="home.png" alt="A progressive web app install prompt">
 </figure>
 
 Since the `ng-add` schematics add everything needed to make your app [installable](/discover-installable/), they generate some shortcut icons that are shown once the user adds the app to their desktop:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="icon.png" alt="A progressive web app shortcut icon">
 </figure>
 

--- a/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
+++ b/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
@@ -267,7 +267,7 @@ First, ensure that you have a sensible focus target for each component.
 For example, a complex component like a menu may be one focus target within a page
 but should then manage focus within itself so that the active menu item always takes focus.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./manage-focus.png" alt="A screenshot of a menu and submenu that requires focus management.">
   <figcaption class="w-figcaption">
     Managing focus within a complex element.
@@ -335,7 +335,7 @@ to automate running keyboard accessibility tests for toggling UI states.
 [WalkMe Engineering](https://medium.com/walkme-engineering/web-accessibility-testing-d499a7f7a032)
 has a great guide on this I recommend reading.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./aria-expanded.gif" alt="WalkMe state toggle test.">
 </figure>
 
@@ -404,7 +404,7 @@ By binding these attributes to the relevant properties on your custom component,
 you can allow users of assistive technology to interact with the element,
 change its value, and even cause the element's visual presentation to change accordingly.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./slider.png" class="w-screenshot" alt="A screenshot of a slider.">
   <figcaption class="w-figcaption">
     A range slider component.
@@ -425,7 +425,7 @@ provide labels and values for each slice
 so users who have visual impairments can understand the information
 even if they can't tell where the slices begin and end:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./pie-chart.png" alt="A pie chart with labels and values to ensure accessibility.">
   <figcaption class="w-figcaption">An accessible pie chart. (From the <a href="https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/Informational_Graphic_Contrast_(Minimum)" rel="noopener">W3C Web Accessibility Initiative</a>.)</figcaption>
 </figure>

--- a/src/site/content/en/blog/adaptive-loading-cds-2019/index.md
+++ b/src/site/content/en/blog/adaptive-loading-cds-2019/index.md
@@ -173,7 +173,7 @@ and limit loading the next image in the carousel to loading images one at a time
 as users swipe. After implementing these optimizations, they've seen significant
 improvements in average swipe count in countries such as Indonesia. 
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="tinder.png" style="max-width: 75%"
        alt="A screenshot of two versions of Tinder chat: with autoplaying video and 
             with a video with play button overlay. A screenshot of a Tinder profile with 

--- a/src/site/content/en/blog/ads-case-study-stale-while-revalidate/index.md
+++ b/src/site/content/en/blog/ads-case-study-stale-while-revalidate/index.md
@@ -67,7 +67,7 @@ Chrome rolled out `stale-while-revalidate` in version 75 to 99% of all traffic, 
 - 2% increase in early ad script loads (<500ms from the start of page load).
 - 1.1% increase in successful ad script loads overall.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./change-in-number-of-ad-script-loads-vs-ad-script-load-time.svg" alt="Percentage point change in number of ad script loads vs. Time from page load start to ad script load (ms)">
   <figcaption class="w-figcaption">
     Source: Google Internal Data, June to July 2019.

--- a/src/site/content/en/blog/advancing-framework-ecosystem-cds-2019/index.md
+++ b/src/site/content/en/blog/advancing-framework-ecosystem-cds-2019/index.md
@@ -75,7 +75,7 @@ The Angular team has shipped a number of improvements to version 8 of the framew
 +   [Differential loading](https://angular.io/guide/deployment#differential-builds) by
     default to minimize unneeded polyfills for newer browsers.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="differential-loading-angular.png" class="w-screenshot" alt="Graph showing bundle size reduction of angular.io with and without differential builds">
   <figcaption class="w-figcaption">
     Bundle size reduction for angular.io with differential builds (from <a href="https://blog.angular.io/version-8-of-angular-smaller-bundles-cli-apis-and-alignment-with-the-ecosystem-af0261112a27">Version 8 of Angular</a>)
@@ -123,7 +123,7 @@ for comments (RFCs) and pull requests (PRs):
 3.  Improved performance metric tracking which utilizes the User Timing API
     ([PR](https://github.com/zeit/next.js/pull/8069)).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="barnebys.png" class="w-screenshot-filled" alt="Homepage of Barnebys.com">
   <figcaption class="w-figcaption">
     <a href="https://www.barnebys.com/">Barnebys.com</a>, a large search engine for antiques and collectibles, saw a 23% reduction in total JavaScript after enabling granular chunking
@@ -137,7 +137,7 @@ Next.js, such as:
 +   A webpack based conformance system that analyzes all source files and generated assets to
     surface better errors and warnings ([RFC](https://github.com/zeit/next.js/issues/9310)).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="conformance.png" class="w-screenshot-filled" alt="Example of a conformance build error in Next.js">
   <figcaption class="w-figcaption">
     An example of a conformance build error in Next.js (prototype)

--- a/src/site/content/en/blog/backdrop-filter/index.md
+++ b/src/site/content/en/blog/backdrop-filter/index.md
@@ -19,7 +19,7 @@ tags:
 ---
 Translucence, blurring, and other effects are useful ways of creating depth while keeping the context of the background content. They support a host of use cases such as frosted glass, video overlays, translucent navigation headers, inappropriate image censoring, image loading, and so on. You may recognize these effects from two popular operating systems: [Windows 10](https://i.kinja-img.com/gawker-media/image/upload/s--9RLXARU4--/c_scale,dpr_2.0,f_auto,fl_progressive,q_80,w_800/trgz8yivyyqrpcnwscu5.png) and [iOS](https://static.businessinsider.com/image/51fd2822eab8eae16e00000b-750.jpg).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="weather_app.jpg" alt="An example of a frosted glass effect.">
   <figcaption class="w-figcaption">
     An example of a frosted glass effect. <a href="https://dribbble.com/shots/733714-Weather-App?list=tags&tag=android" target="_blank" rel="noopener noreferrer">Source</a>.

--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -28,7 +28,7 @@ origin_trial:
 
 ## What is the Badging API? {: #what }
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img  src="badges-on-windows.jpg" class="w-screenshot"
         alt="Example of Twitter with eight notifications and another app showing a flag type badge.">
   <figcaption class="w-figcaption">

--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -272,7 +272,7 @@ interface with a **Delete** menu item, giving people a chance to indicate that
 they're done viewing previously indexed content. This is how the deletion
 interface looks in Chrome 80:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="delete-menu.png" alt="The delete menu item." width="550">
 </figure>
 

--- a/src/site/content/en/blog/fast-ads-matter/index.md
+++ b/src/site/content/en/blog/fast-ads-matter/index.md
@@ -85,7 +85,7 @@ rate.
 With 1&nbsp;s of added delay, impressions decreased by 1.1% for mobile traffic
 and 1.9% for desktop traffic:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./ad-latency-injected-vs-impressions-change.svg" alt="Chart showing latency injected vs. impressions change">
   <figcaption class="w-figcaption">
     Source: Google Internal Data, December 2016 to January 2017.
@@ -95,7 +95,7 @@ and 1.9% for desktop traffic:
 With 1&nbsp;s of added delay, viewability rate decreased by 3.6% for mobile
 traffic and 2.9% for desktop traffic:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./ad-latency-injected-vs-viewability-rate-change.svg" alt="Chart showing latency injected vs. viewability rate change">
   <figcaption class="w-figcaption">
     Source: Google Internal Data, December 2016 to January 2017.

--- a/src/site/content/en/blog/five-ways-airshift-improved-their-react-app/index.md
+++ b/src/site/content/en/blog/five-ways-airshift-improved-their-react-app/index.md
@@ -134,7 +134,7 @@ which you can visualize from the
 of Chrome DevTools. AirSHIFT used the Timings section to find
 unnecessary logic running in React lifecycle events.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="user_timing.png" style="max-width: 75%;"
        alt="The Timings section of the Performance panel of Chrome DevTools.">
   <figcaption class="w-figcaption">

--- a/src/site/content/en/blog/image-policies/index.md
+++ b/src/site/content/en/blog/image-policies/index.md
@@ -64,7 +64,7 @@ for information on optimizing your images.
 
 A few examples illustrate this. The following shows the default behavior when cutting an image's display size in half.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./default-100x100.png" alt="The default resizing behavior" style="max-width: 326px;">
   <figcaption class="w-figcaption">
     The default resizing behavior.
@@ -75,7 +75,7 @@ If I apply the following feature policy, I get a placeholder image instead.
 
 `Feature-Policy: oversized-images *(2);`
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./resize-both-dimensions.png" alt="When the image is too large for the container" style="max-width: 326px;">
   <figcaption class="w-figcaption">
     When the image is too large for the container.
@@ -84,7 +84,7 @@ If I apply the following feature policy, I get a placeholder image instead.
 
 I get similar results if I lower only the width or the height.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./resize-width.png" alt="Resized width" style="max-width: 326px;">
   <img src="./resize-height.png" alt="Resized height" style="max-width: 326px;">
   <figcaption class="w-figcaption">
@@ -155,7 +155,7 @@ optimizing your images.
 
 The following shows the default browser behavior. Without the feature policy an unoptimized lossy image can be displayed just the same as an optimized image.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./unoptimized-lossy.png" alt="Comparing an optimized image with an unoptimized image" style="max-width: 326px;">
   <figcaption class="w-figcaption">
     Comparing an optimized image with an unoptimized image.
@@ -166,7 +166,7 @@ If I apply the following feature policy, I get a placeholder image instead.
 
 `Feature-Policy: unoptimized-lossy-images *(0.5);`
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./lossy-image-excluded.png" alt="When the image is not optimized" style="max-width: 326px;">
   <figcaption class="w-figcaption">
     When the image is not optimized.

--- a/src/site/content/en/blog/install-thumbor/index.md
+++ b/src/site/content/en/blog/install-thumbor/index.md
@@ -172,6 +172,6 @@ systemctl status thumbor.service
 
 If you've successfully set up thumbor.service to use `systemd`, the [status](https://www.freedesktop.org/software/systemd/man/systemctl.html#status%20PATTERN%E2%80%A6%7CPID%E2%80%A6%5D) should show that it is enabled and active.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./systemd.jpg" alt="Systemctl displaying the status of Thumbor" class="w-screenshot">
 </figure>

--- a/src/site/content/en/blog/javascript-and-google-search-io-2019/index.md
+++ b/src/site/content/en/blog/javascript-and-google-search-io-2019/index.md
@@ -40,7 +40,7 @@ In this post we'll focus on best practices for making JavaScript web apps discov
 
 This year we announced the much-awaited [new evergreen Googlebot](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="evergreen-googlebot.png" alt="Googlebot holding the Chrome logo" style="max-width: 400px;">
   <figcaption class="w-figcaption">
     Googlebot is now running a modern Chromium rendering engine.
@@ -53,7 +53,7 @@ Googlebot now uses a modern Chromium engine to render websites for Google Search
 
 Googlebot is a pipeline with several components. Let's take a look to understand how Googlebot indexes pages for Google Search.
 
-<figure class="w-figure w-figure--center w-figure--fullbleed">
+<figure class="w-figure w-figure--fullbleed">
   <img src="googlebot-process.png" alt="A diagram showing a URL moving from a crawling queue to a processing step that extracts linked URLs and adds them to the crawling queue, a rendering queue that feeds into a renderer which produces HTML. The processor uses this HTML to extract linked URLs again and index the content.">
   <figcaption class="w-figcaption w-figcaption--fullbleed">
     Googlebot's pipeline for crawling, rendering, and indexing a page.

--- a/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
+++ b/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
@@ -31,7 +31,7 @@ server for visual diffing and basic category score history. Existing
 seamlessly alongside the new expressive syntax for asserting *any* Lighthouse
 audit or category result.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./lighthouse-ci.png" alt="Lighthouse CI report."
        width="400">
 </figure>
@@ -54,7 +54,7 @@ blended](/performance-scoring/#weightings) to form the 0-100 Performance score:
 Paint](/first-meaningful-paint/), [Time to Interactive](/interactive/), and
 [First CPU Idle](/first-cpu-idle/).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./lighthouse-performance-score.png" alt="Comparison of Lighthouse performance score formulas in versions 5 and 6.">
 </figure>
 
@@ -101,7 +101,7 @@ Packs](https://github.com/GoogleChrome/lighthouse-stack-packs) add customized
 recommendations, curated by community experts (like you!), on top of Lighthouse
 report core audits.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./lighthouse-stack-packs.png" 
        alt="Lighthouse report recommendation for deferring offscreen images in React applications.">
 </figure>
@@ -113,7 +113,7 @@ or [contact the Lighthouse team](https://github.com/GoogleChrome/lighthouse-stac
 
 ## Coming soon: Lighthouse plugins as Chrome Extensions
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./lighthouse-plugin-icon.png" alt="Lighthouse plugin icon." width="250">
 </figure>
 
@@ -130,7 +130,7 @@ only work in [Lighthouse
 CLI](https://developers.google.com/web/tools/lighthouse#cli), but the goal is to
 enable running them in the DevTools **Audits** panel too.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./lighthouse-plugin-devtools.png" alt="Chrome DevTools Audits panel with options for running Lighthouse plugins for Google Publisher Ads and User Experience." width="400">
   <figcaption class="w-figcaption">Community Plugins in DevTools Audits panel (beta)</figcaption>
 </figure>

--- a/src/site/content/en/blog/load-faster-like-proxx/index.md
+++ b/src/site/content/en/blog/load-faster-like-proxx/index.md
@@ -26,7 +26,7 @@ At Google I/O 2019 Mariko, Jake, and I shipped [PROXX], a modern Minesweeper-clo
 
 But they run a modern browser and are very affordable. For this reason, feature phones are making a resurgence in emerging markets. Their price point allows a whole new audience, who previously couldn't afford it, to come online and make use of the modern web. **[For 2019 it is projected that around 400 million feature phones will be sold in India alone][400mil]**, so users on feature phones might become a significant portion of your audience. In addition to that, connection speeds akin to 2G are the norm in emerging markets. How did we manage to make PROXX work well under feature phone conditions?
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls loop muted
     preload="metadata"
     class="w-screenshot"
@@ -55,7 +55,7 @@ Testing your loading performance on a _real_ device is critical. If you don't ha
 
 That being said, we're going to focus on 2G in this article because PROXX is explicitly targeting feature phones and emerging markets in its target audience. Once WebPageTest has run its test, you get a waterfall (similar to what you see in DevTools) as well as a filmstrip at the top. The film strip shows what your user sees while your app is loading. On 2G, the loading experience of the unoptimized version of PROXX is pretty bad:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted
     preload="metadata"
     class="w-screenshot"
@@ -70,7 +70,7 @@ That being said, we're going to focus on 2G in this article because PROXX is exp
 
 When loaded over 3G, the user sees 4 seconds of white nothingness. **Over 2G the user sees absolutely nothing for over 8 seconds.** If you read [why performance matters] you know that we have now lost a good portion of our potential users due to impatience. The user needs to download all of the 62 KB of JavaScript for anything to appear on screen. The silver lining in this scenario is that the second anything appears on screen it is also interactive. Or is it?
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <picture>
     <source srcset="proxx-first-render.webp" type="image/webp">
     <img src="proxx-first-render.jpg">
@@ -91,7 +91,7 @@ Now that we know _what_ the user sees, we need to figure out the _why_. For this
 1. There are multiple, multi-colored thin lines.
 2. JavaScript files form a chain. For example, the second resource only starts loading once the first resource is finished, and the third resource only starts when the second resource is finished.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <picture>
     <img src="waterfall_opt.png">
   </picture>
@@ -125,7 +125,7 @@ Looking at the waterfall, we can see that once the first JavaScript file is done
 
 Let's take a look at what our changes have achieved. It's important to not change any other variables in our test setup that could skew the results, so we will be using [WebPageTest's simple setup][wpt simple] for the rest of this article and look at the filmstrip:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted
     preload="metadata"
     class="w-screenshot"
@@ -158,7 +158,7 @@ There are many ways to implement a prerenderer. In PROXX we chose to use [Puppet
 
 With this in place, we can expect an improvement for our FMP. We still need to load and execute the same amount of JavaScript as before, so we shouldn't expect TTI to change much. If anything, our `index.html` has gotten bigger and might push back our TTI a bit. There's only one way to find out: running WebPageTest.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted
     preload="metadata"
     class="w-screenshot"
@@ -177,7 +177,7 @@ With this in place, we can expect an improvement for our FMP. We still need to l
 
 Another metric that both DevTools and WebPageTest give us is [Time To First Byte (TTFB)][ttfb]. This is the time it takes from the first byte of the request being sent to the first byte of the response being received. This time is also often called a Round Trip Time (RTT), although technically there is a difference between these two numbers: RTT does not include the processing time of the request on the server side. [DevTools](https://developers.google.com/web/tools/chrome-devtools/network/reference#timing-preview) and WebPageTest visualize TTFB with a light color within the request/response block.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <picture>
     <img src="ttfb.svg">
   </picture>
@@ -196,7 +196,7 @@ Our critical CSS is already inlined thanks to CSS Modules and our Puppeteer-base
   **Note:** In this step we also subset our font files to contain only the glyphs that we need for our landing page. I am not going to go into detail on this step as it is not easily abstracted and sometimes not even practical. We still load the full font files lazily, but they are not needed for the initial render.
 {% endAside %}
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted
     preload="metadata"
     class="w-screenshot"
@@ -215,7 +215,7 @@ This shaved 1 second off our TTI. We have now reached the point where our `index
 
 Yes, our `index.html` contains everything that is needed to become interactive. But on closer inspection it turns out it also contains everything else. Our `index.html` is around 43 KB. Let's put that in relation to what the user can interact with at the start: We have a form to configure the game containing a couple of components, a start button and probably some code to persist and load user settings. That's pretty much it. 43 KB seems like a lot.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <picture>
     <source srcset="proxx-loaded.webp" type="image/webp">
     <img src="proxx-loaded.jpg">
@@ -227,7 +227,7 @@ Yes, our `index.html` contains everything that is needed to become interactive. 
 
 To understand where our bundle size is coming from we can use a [source map explorer] or a similar tool to break down what the bundle consists of. As predicted, our bundle contains the game logic, the rendering engine, the win screen, the lose screen and a bunch of utilities. Only a small subset of these modules are needed for the landing page. Moving everything that is not strictly required for interactivity into a lazily-loaded module will decrease TTI _significantly_.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <picture>
     <img src="sourcemap.svg">
   </picture>
@@ -281,7 +281,7 @@ return (
 
 With all of this in place, we reduced our `index.html` to a mere 20 KB, less than half of the original size. What effect does this have on FMP and TTI? WebPageTest will tell!
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted
     preload="metadata"
     class="w-screenshot"

--- a/src/site/content/en/blog/maskable-icon/index.md
+++ b/src/site/content/en/blog/maskable-icon/index.md
@@ -21,7 +21,7 @@ tags:
 
 If you've installed a Progressive Web App on a recent Android phone, you might notice the icon shows up with a white background. Android Oreo introduced adaptive icons, which display app icons in a variety of shapes across different device models. Icons that don't follow this new format are given white backgrounds.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="homescreen-any.png" alt="PWA icons in white circles on Android" style="width: 400px; max-width: 100%">
   <figcaption class="w-figcaption">
     Transparent PWA icons appear inside white circles on Android
@@ -30,7 +30,7 @@ If you've installed a Progressive Web App on a recent Android phone, you might n
 
 Maskable icons are a new icon format that give you more control and let your Progressive Web App use adaptive icons. If you supply a maskable icon, your icon can fill up the entire shape and look great on all Android devices. Firefox and Chrome have recently added support for this new format, and you can adopt it in your apps.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="homescreen-maskable.png" alt="PWA icons covering the entire circle on Android" style="width: 400px; max-width: 100%">
   <figcaption class="w-figcaption">
     Maskable icons cover the entire circle instead
@@ -55,7 +55,7 @@ Luckily, there's a well-defined and [standardized](https://w3c.github.io/manifes
 
 You can check which parts of your icons land within the safe zone with Chrome DevTools. With your Progressive Web App open, launch DevTools and navigate to the **Application** panel. In the **Icons** section, you can choose to **Show only the minimum safe area for maskable icons**. Your icons will be trimmed so that only the safe area is visible. If your logo is visible within this safe area, you're good to go.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="devtools.png" class="w-screenshot" alt="Applications panel in DevTools displaying PWA icons with edges cropped">
   <figcaption class="w-figcaption">
     The Applications panel
@@ -68,7 +68,7 @@ If you want to preview your maskable icon in other shapes it may appear in on An
 
 If you want to create a maskable icon based off your existing icon, you can use the [Maskable.app Editor](https://maskable.app/editor). Upload your icon, adjust the color and size, then export the image.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="maskable-app-editor.png" class="w-screenshot" alt="Maskable.app Editor screenshot">
   <figcaption class="w-figcaption">
     Creating icons in Maskable.app Editor

--- a/src/site/content/en/blog/next-gen-css-2019/index.md
+++ b/src/site/content/en/blog/next-gen-css-2019/index.md
@@ -172,7 +172,7 @@ One exciting implication of these media queries is that we can design for multip
 
 It's important to Adam that "prefers reduced motion" doesn't get implemented as "no motion." The user is saying they prefer less motion, not that they don't want any animation. He asserts reduced motion is not no motion. Here's an example that uses a crossfade animation when the user prefers reduced motion:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted>
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/reduced-motion.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/reduced-motion.mp4" type="video/mp4; codecs=h264">
@@ -223,7 +223,7 @@ Sticky positioning lets you create many useful effects that previously required 
 
 In this demo, all sticky elements share the same container. That means that each sticky element slides over the previous one as the user scrolls down. The sticky elements share the same stuck position.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted>
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-stack.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-stack.mp4" type="video/mp4; codecs=h264">
@@ -234,7 +234,7 @@ In this demo, all sticky elements share the same container. That means that each
 
 Here, the sticky elements are cousins. (That is, their parents are siblings.) When a sticky element hits the lower boundary of its container, it moves up with the container, creating the impression that lower sticky elements are pushing up higher ones. In other words, they appear to compete for the stuck position.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted>
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-slide.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-slide.mp4" type="video/mp4; codecs=h264">
@@ -245,7 +245,7 @@ Here, the sticky elements are cousins. (That is, their parents are siblings.) Wh
 
 Like Sticky Slide, the sticky elements in this demo are cousins. However, they've been placed in containers set to a two-column grid layout.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted>
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-desperado.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/next-gen-css-2019/sticky-desperado.mp4" type="video/mp4; codecs=h264">

--- a/src/site/content/en/blog/off-main-thread/index.md
+++ b/src/site/content/en/blog/off-main-thread/index.md
@@ -223,7 +223,7 @@ the UI is frozen for six seconds after the user interacts with it.
 There's no feedback, and the user has to wait for the full six seconds
 before being able to do something else.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted class="w-screenshot" style="max-width: 400px;">
     <source src="https://storage.googleapis.com/web-dev-assets/off-main-thread/proxx-nonomt.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/off-main-thread/proxx-nonomt.mp4" type="video/mp4; codecs=h264">
@@ -242,7 +242,7 @@ The user therefore knows that something is happening
 and can continue playing as the UI updates,
 making the game feel considerably better.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls muted class="w-screenshot" style="max-width: 400px;">
     <source src="https://storage.googleapis.com/web-dev-assets/off-main-thread/proxx-omt.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/off-main-thread/proxx-omt.mp4" type="video/mp4; codecs=h264">

--- a/src/site/content/en/blog/oyo-lite-twa/index.md
+++ b/src/site/content/en/blog/oyo-lite-twa/index.md
@@ -129,7 +129,7 @@ Here's what the OYO team did:
 * Created a custom splash screen.
 
 And here's the result:
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
     <source src="https://storage.googleapis.com/web-dev-assets/oyo-case-study/oyo-lite.webm" type="video/webm; codecs=vp8">
     <source src="https://storage.googleapis.com/web-dev-assets/oyo-case-study/oyo-lite.mp4" type="video/mp4; codecs=h264">

--- a/src/site/content/en/blog/perception-toolkit/index.md
+++ b/src/site/content/en/blog/perception-toolkit/index.md
@@ -56,7 +56,7 @@ then show and hide cards based on the information provided in the data. Try this
 for yourself using our [artifact-map
 demo](https://github.com/GoogleChromeLabs/perception-toolkit/tree/master/demo/artifact-map).
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="found-target.png"
        alt="The default interface is available by using just the linked data." class="screenshot"
        width="300">

--- a/src/site/content/en/blog/periodic-background-sync/index.md
+++ b/src/site/content/en/blog/periodic-background-sync/index.md
@@ -360,7 +360,7 @@ in the periodic background sync lifecycle: registering for sync, performing a
 background sync, and unregistering. To obtain information about these events,
 click **Start recording**.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="1-record.png" alt="The record button in DevTools" style="max-width: 75%">
   <figcaption class="w-figcaption">
     The record button in DevTools
@@ -370,7 +370,7 @@ click **Start recording**.
 While recording, entries will appear in DevTools corresponding to events, with
 context and metadata logged for each.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="2-record-result.png" alt="An example of recorded periodic background sync data"
        style="max-width: 75%">
   <figcaption class="w-figcaption">
@@ -396,7 +396,7 @@ event to use, and to trigger it as many times as you'd like.
   Manually triggering a `periodicsync` event requires Chrome 81 or later.
 {% endAside %}
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="3-sw-panel.png"
        alt="The 'Service Workers' section of the Application panel shows a 'Periodic Sync'
             text field and button." style="max-width: 90%">
@@ -407,7 +407,7 @@ event to use, and to trigger it as many times as you'd like.
 Starting in Chrome 81, you'll see a **Periodic Background Sync** section in the
 DevTools *Application* panel.
 
-   <figure class="w-figure w-figure--center">
+   <figure class="w-figure">
      <img class="w-screenshot" src="7-panel.png"
           alt="The Application panel showing the Periodic Background Sync section"
           style="max-width: 75%">

--- a/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
+++ b/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
@@ -57,14 +57,14 @@ chrome.com [improved Time To Interactive](https://twitter.com/addyosmani/status/
 
 Due to versioned dependencies, you sometimes end up in a situation where you know you'll be requesting a resource from a particular CDN, but not the exact path for it.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
 <img src="versioned-url.png" style="max-width:450px" alt="A url of a script with the version name.">
 <figcaption>An example of a versioned URL.</figcaption>
 </figure>
 
 The other common case is loading images from an [image CDN](/image-cdns), where the exact path for an image depends on media queries or runtime feature checks on the user's browser.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
 <img src="image-cdn-url.png" alt="An image CDN URL with the parameters size=300x400 and quality=auto.">
 <figcaption>An example of an image CDN URL.</figcaption>
 </figure>

--- a/src/site/content/en/blog/samesite-cookie-recipes/index.md
+++ b/src/site/content/en/blog/samesite-cookie-recipes/index.md
@@ -73,7 +73,7 @@ Cookies may be used here to, among other things, maintain session state, store
 general preferences, enable statistics, or personalize content for users with
 existing accounts.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="iframe.png"
       alt="Diagram of a browser window where the URL of embedded content does
         not match the URL of the page."
@@ -100,7 +100,7 @@ Cookies marked as `SameSite=Lax` will be sent on safe top-level navigations,
 e.g. clicking a link to go to a different site. However something like a
 `<form>` submission via POST to a different site would not include cookies.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="safe-navigation.png"
       alt="Diagram of a request moving from one page to another."
       style="max-width: 35vw;">

--- a/src/site/content/en/blog/samesite-cookies-explained/index.md
+++ b/src/site/content/en/blog/samesite-cookies-explained/index.md
@@ -51,7 +51,7 @@ this:
 Set-Cookie: promo_shown=1; Max-Age=2600000; Secure
 ```
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="set-cookie-response-header.png" alt="Three cookies being sent to a
     browser from a server in a response" style="max-width: 60vw">
   <figcaption class="w-figcaption">
@@ -67,7 +67,7 @@ will send this header in its request:
 Cookie: promo_shown=1
 ```
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="cookie-request-header.png" alt="Three cookies being sent from a
     browser to a server in a request" style="max-width: 60vw;">
   <figcaption class="w-figcaption">
@@ -93,7 +93,7 @@ context, with each cookie separated by a semicolon:
 < "promo_shown=1; color_theme=peachpuff; sidebar_loc=left"
 ```
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="document-cookie.png" alt="JavaScript accessing cookies within the
     browser" style="max-width: 35vw;">
   <figcaption class="w-figcaption">
@@ -121,7 +121,7 @@ current site are referred to as **third-party** cookies. This isn't an absolute
 label but is relative to the user's context; the same cookie can be either
 first-party or third-party depending on which site the user is on at the time.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="cross-site-set-cookie-response-header.png" alt="Three cookies being
     sent to a browser from different requests on the same page"
     style="max-width: 60vw;">
@@ -148,7 +148,7 @@ embedded player by a third-party cookie—meaning that "Watch later" button will
 just save the video in one go rather than prompting them to sign in or having to
 navigate them away from your page and back over to YouTube.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="cross-site-cookie-request-header.png" alt="The same cookie being
     sent in three different contexts" style="max-width: 60vw;">
   <figcaption class="w-figcaption">
@@ -265,7 +265,7 @@ is being made explicit by introducing a new value of `SameSite=None`. This means
 you can use `None` to clearly communicate that you intentionally want the cookie
 sent in a third-party context.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="samesite-none-lax-strict.png" alt="Three cookies labelled None,
     Lax, or Strict depending on their context" style="max-width: 60vw;">
   <figcaption class="w-figcaption">

--- a/src/site/content/en/blog/snap-after-layout/index.md
+++ b/src/site/content/en/blog/snap-after-layout/index.md
@@ -59,7 +59,7 @@ snaps.
 </figure>
 
 ### Shortcomings
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/resizing-breaks-snap-positions.webm" type="video/webm;">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/resizing-breaks-snap-positions.mp4" type="video/mp4;">
@@ -101,7 +101,7 @@ what happens when the layout changes in the following
 
 <div class="w-columns">
 {% Compare 'worse', 'Snap position lost' %}
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/snap-positions-lost.webm" type="video/webm;">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/snap-positions-lost.mp4" type="video/mp4;">
@@ -118,7 +118,7 @@ scroll snap position was lost.
 {% endCompare %}
 
 {% Compare 'better', 'Snap position preserved' %}
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/snap-positions-preserved.webm" type="video/webm;">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/snap-positions-preserved.mp4" type="video/mp4;">
@@ -157,7 +157,7 @@ lines of CSS:
 Want to learn more? See the following [demo chat
 UI](https://codepen.io/argyleink/pen/RwPWqKe) for visuals.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/scroll-snap-bottom.webm" type="video/webm;">
     <source src="https://storage.googleapis.com/web-dev-assets/snap-after-layout/scroll-snap-bottom.mp4" type="video/mp4;">

--- a/src/site/content/en/blog/speed-tooling-evolutions-cds-2019/index.md
+++ b/src/site/content/en/blog/speed-tooling-evolutions-cds-2019/index.md
@@ -61,14 +61,14 @@ A [task is considered long](/custom-metrics/#long-tasks-api) if it runs on the
 main thread for more than 50 milliseconds. Any millisecond over that is counted
 towards that task's blocking time. 
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./tbt.png" alt="A diagram representing a 150 millisecond task which has 100 miliseconds of blocking time.">
 </figure>
 
 The Total Blocking Time for a page is the sum of the blocking times of all long
 tasks that occured between FCP and TTI. 
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./tbt2.png" alt="A diagram representing a five tasks with 60 miliseconds of total blocking time out of 270 milliseconds of main thread time.">
 </figure>
 
@@ -84,7 +84,7 @@ quantifies how often users experience unexpected layout shifts. Unexpected
 movement of content can be very frustrating and this new metric helps you
 address that problem by measuring how often it's occurring for your users.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video autoplay controls loop muted
     class="w-screenshot"
     poster="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability-poster.png"
@@ -109,7 +109,7 @@ The new Lighthouse performance score formula will soon de-emphasize FMP and FCI
 and include the three new metrics—LCP, TBT, and CLS—as they better capture when
 a page feels usable. 
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./performance-metrics.png"
        alt="In Lighthouse v6 First Contentful Paint, Speed Index, and Largest
             Contentful Paint are the main load performance metrics; Time To Interactive,
@@ -133,7 +133,7 @@ use to label a website "slow", 'moderate", or "fast" in field performance.
 "slow" and "fast" is now changed to "moderate" which is more fitting since this
 middle group was not related to a statistical average. {% endAside %}
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./crux-data.png" alt="Two bar charts showing
   the distribution of slow, fast, and moderate speed for FCP and FID.">
 </figure>
@@ -175,7 +175,7 @@ PageSpeed Insights team has added a reanalyze prompt to PSI. For sites that are
 redirected to a new URL, you're prompted to rerun the report on the landing URL
 for a more complete picture of your actual performance.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./psi-reanalyze.png" alt="PSI user interface
   showing the URL redirect and the 'Reanalyze' button">
 </figure>
@@ -190,14 +190,14 @@ Speed report automatically assigns groups of similar URLs into "Fast",
 "Moderate," and "Slow" buckets, and helps prioritize performance improvements
 for specific issues.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./search-console-speed-report.png" alt="Search
   Console Speed report.">
 </figure>
 
 ## Web Almanac
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./web-almanac-at-cds-2019.png" alt="Dion Almaer
   presenting Web Almanac at CDS 2019.">
 </figure>

--- a/src/site/content/en/blog/truebil-lite/index.md
+++ b/src/site/content/en/blog/truebil-lite/index.md
@@ -175,7 +175,7 @@ For users who had interacted with the app for a while, the team used highly cont
 
 Finally, the team built in a non-intrusive banner with a notification-like design that's triggered at specific events, such as opening a listing page or after the user has spent a set amount of time spent in the app:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="notification.png" alt="A screenshot of Truebil Lite's time-based installation prompt banner.">
 </figure>
 

--- a/src/site/content/en/blog/use-srcset-to-automatically-choose-the-right-image/index.md
+++ b/src/site/content/en/blog/use-srcset-to-automatically-choose-the-right-image/index.md
@@ -26,7 +26,7 @@ According to [HTTP Archive](https://httparchive.org/reports/state-of-images), a
 typical mobile web page weighs over 2.6 MB, and more than two thirds of that
 weight is images. That's a great opportunity for optimization!
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="http-archive.svg">
   <figcaption class="w-figcaption">
     <a href="https://mobile.httparchive.org/">Average mobile page bytes by content type</a>
@@ -61,11 +61,11 @@ They appear nearly identical, but the file size of one is more than 10 times
 larger than the other.
 
 <div class="w-columns">
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img class="w-screenshot" src="kittens-1000.jpg" alt="Little Puss and Lias: two ten week old tabby kittens." width="300">
     <figcaption class="w-figcaption">Saved width 1000 px, file size 184 KB</figcaption>
   </figure>
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img class="w-screenshot" src="kittens-300.jpg" alt="Little Puss and Lias: two ten week old tabby kittens." width="300">
     <figcaption class="w-figcaption">Saved width 300 px, file size 16 KB</figcaption>
   </figure>

--- a/src/site/content/en/blog/use-thumbor/index.md
+++ b/src/site/content/en/blog/use-thumbor/index.md
@@ -32,7 +32,7 @@ If you would like to install Thumbor on your own server and then follow along wi
 
 As mentioned in [Use Image CDNs to Optimize Images](https://web.dev/image-cdns), each image CDN uses a slightly different URL format for images. Figure 1 represents Thumbor's format.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor0.jpg" alt="A Thumbor URL has the following components: origin, security key, size, filters and image." class="w-screenshot">
   <figcaption>Thumbor's URL format</figcaption>
 </figure>
@@ -56,14 +56,14 @@ Try it now:
 
 1. Click the following URL to view the image served at its original size in a new tab: <a href="http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/https://web.dev/backdrop-filter/hero.jpg</a>
 
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img src="./Use-thumbor1.jpg" alt="Image at original size" class="w-screenshot">
       <figcaption>Original image</figcaption>
     </figure>
 
 2. Resize the image to 100x100 pixels: <a href="http://34.67.235.246:8888/unsafe/100x100/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/100x100/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor2.jpg" alt="Image at 100x100 pixels" class="w-screenshot">
   <figcaption>Image resized to 100x100 pixels</figcaption>
 </figure>
@@ -77,7 +77,7 @@ Try it now:
 
 1. Apply a single filter: a Gaussian [blur](https://thumbor.readthedocs.io/en/latest/blur.html) effect with a radius of 25 pixels: <a href="http://34.67.235.246:8888/unsafe/filters:blur(25)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:blur(25)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img src="./Use-thumbor3.jpg" alt="Blurred image" class="w-screenshot">
       <figcaption>Blurred image</figcaption>
     </figure>
@@ -85,7 +85,7 @@ Try it now:
 
 2. Apply multiple filter. Convert to [grayscale](https://thumbor.readthedocs.io/en/latest/grayscale.html) and [rotate](https://thumbor.readthedocs.io/en/latest/rotate.html) the image 90 degrees: <a href="http://34.67.235.246:8888/unsafe/filters:grayscale():blur(90)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:grayscale():blur(90)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor4.jpg" alt="Grayscale image that has been rotated 90 degrees" class="w-screenshot">
   <figcaption>Grayscale, rotated image</figcaption>
 </figure>
@@ -105,14 +105,14 @@ Try it now:
 
 1. Compress the image to a quality of 1 (very bad): <a href="http://34.67.235.246:8888/unsafe/filters:quality(1)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:quality(1)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img src="./Use-thumbor5.jpg" alt="Low-quality image" class="w-screenshot">
       <figcaption>Low-quality image</figcaption>
     </figure>
 
 2. Compress the image using Thumbor's default compression settings: <a href="http://34.67.235.246:8888/unsafe/filters:quality()/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:quality()/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor6.jpg" alt="Compressed image with no noticible quality issues" class="w-screenshot">
   <figcaption>Compressed image</figcaption>
 </figure>
@@ -126,7 +126,7 @@ Try it now:
 1. Resize the image to a width of 200 pixels while maintaining original proportions: <a href="http://34.67.235.246:8888/unsafe/200x0/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/200x0/https://web.dev/backdrop-filter/hero.jpg</a>
 
     <!-- lint disable code-block-style -->
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img src="./Use-thumbor7.jpg" alt="Image that is 200 pixels wide" class="w-screenshot">
       <figcaption>Image resized to a width of 200 pixels</figcaption>
     </figure>
@@ -134,7 +134,7 @@ Try it now:
 
 2. Resize the image to a height of 500 pixels while maintaining original proportion: <a href="http://34.67.235.246:8888/unsafe/0x500/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/0x500/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor8.jpg" alt="Image that is 500 pixels tall" class="w-screenshot">
   <figcaption>Image resized to a height of 500 pixels<figcaption>
 </figure>
@@ -147,7 +147,7 @@ Try it now:
 
 1. Resize the image to 50% of the original: <a href="http://34.67.235.246:8888/unsafe/filters:proportion(.5)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:proportion(.5)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img src="./Use-thumbor9.jpg" alt="Image that is 50% the size of the original" class="w-screenshot">
       <figcaption>Image resized to 50% the size of the original</figcaption>
     </figure>
@@ -155,7 +155,7 @@ Try it now:
 
 2. Resize the image to a width of 1000 pixels, then resize the image to 10% of its current size: <a href="http://34.67.235.246:8888/unsafe/1000x/filters:proportion(.1)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/1000x/filters:proportion(.1)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor10.jpg" alt="Image that is 100 pixels wide" class="w-screenshot">
   <figcaption>Image resized to a width of 100 pixels</figcaption>
 </figure>
@@ -172,7 +172,7 @@ Try it now:
 
 1. Convert the image to WebP. If you open the **Network** panel of DevTools the document's **Content-Type response header** shows that the server returned a WebP image: <a href="http://34.67.235.246:8888/unsafe/filters:format(webp)/https://web.dev/backdrop-filter/hero.jpg" target="_blank" rel="noreferrer">http://34.67.235.246:8888/unsafe/filters:format(webp)/https://web.dev/backdrop-filter/hero.jpg</a>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./Use-thumbor11.jpg" alt="DevTools screenshot showing the content-type (WebP) of an image" class="w-screenshot">
   <figcaption>The <code>content-type</code> response header shown in DevTools</figcaption>
 </figure>

--- a/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
@@ -118,7 +118,7 @@ Notice the relationship between `XRWebGLLayer` and `WebGLRenderingContext`. One
 corresponds to the viewer's device and the other corresponds to the web page.
 `WebGLFramebuffer` and `XRViewport` are passed from the former to the latter.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./players.png" style="max-width: 100%;" alt="The relationship between XRWebGLLayer and WebGLRenderingContext"/>
   <figcaption class="w-figcaption w-figcaption--fullbleed">
     The relationship between <code>XRWebGLLayer</code> and <code>WebGLRenderingContext</code>

--- a/src/site/content/en/blog/vr-comes-to-the-web/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web/index.md
@@ -44,7 +44,7 @@ reality to completely virtual, with degrees of immersion in between. The 'X' in
 XR is intended to reflect that thinking by being a sort of algebraic variable
 that stands for anything in the spectrum of immersive experiences.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./immersive-spectrum.png" style="max-width: 100%;" alt="A graph illustrating the spectrum of visual experiences from complete reality to completely immersive."/>
   <figcaption class="w-figcaption w-figcaption--fullbleed">
     The spectrum of immersive experiences

--- a/src/site/content/en/blog/web-bundles/index.md
+++ b/src/site/content/en/blog/web-bundles/index.md
@@ -37,7 +37,7 @@ images, or stylesheets.
  are part of the [Web Packaging](https://goto.google.com/webpackaging-one-pager)
  proposal.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="webbundle.png" 
        alt="A figure demonstrating that a Web Bundle is a collection of web resources." 
        style="max-width: 75%">
@@ -153,7 +153,7 @@ To try out a Web Bundle:
 1. Open `chrome://flags/#web-bundles`.
 1. Set the **Web Bundles** flag to **Enabled**.
 
-   <figure class="w-figure  w-figure--center">
+   <figure class="w-figure">
      <img src="chromeflag.png" alt="A screenshot of chrome://flags" style="max-width: 75%">
      <figcaption class="w-figcaption">
        Enabling Web Bundles in <code>chrome://flags</code>

--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -145,7 +145,7 @@ the user needing to press **Continue**.
 
 The whole process is diagrammed in the image below.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./diagram.png" width="486" height="499" />
   <figcaption class="w-figcaption w-figcaption--fullbleed">
     Web OTP API diagram

--- a/src/site/content/en/fast/adaptive-serving-based-on-network-quality/index.md
+++ b/src/site/content/en/fast/adaptive-serving-based-on-network-quality/index.md
@@ -45,7 +45,7 @@ Netflix and most other video (or video calling) services automatically adjust
 the resolution during streaming. When Gmail is loading, it provides users with a
 link to "load basic HTML (for slow connections)".
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./loading_gmail_slow_connection.png" alt="A link to load basic HTML version of Gmail when users are on slow connections">
 </figure>
 

--- a/src/site/content/en/fast/extract-critical-css/index.md
+++ b/src/site/content/en/fast/extract-critical-css/index.md
@@ -22,7 +22,7 @@ The browser must download and parse CSS files before it can show the page, which
 Critical CSS is a technique that extracts the CSS for above-the-fold content in order to render content to the user as fast as possible.
 {% endAside %}
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="" src="./above-the-fold.png" alt="An illustration of a laptop and a mobile device with web pages overflowing the edges of screens" style="max-width: 600px; width: 100%;">
 </figure>
 
@@ -32,7 +32,7 @@ Above-the-fold is all the content a viewer sees on page load, before scrolling. 
 
 Inlining extracted styles in the `<head>` of the HTML document eliminates the need to make an additional request to fetch these styles. The remainder of the CSS can be loaded asynchronously.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
     <img class="w-screenshot" src="./inline-critical-css.png" alt="HTML file with critical CSS inlined in the head">
     <figcaption class="w-figcaption">
     Inlined critical CSS
@@ -41,7 +41,7 @@ Inlining extracted styles in the `<head>` of the HTML document eliminates the ne
 
 Improving render times can make a huge difference in [perceived performance](https://developers.google.com/web/fundamentals/performance/rail#ux), especially under poor network conditions. On mobile networks, high latency is an issue regardless of bandwidth.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./filmstrip-comparison.png" alt="Filmstrip view comparison of loading a page with render-blocking CSS (top) and the same page with inlined critical CSS (bottom) on a 3G connection. Top filmstrip shows six blank frames before finally displaying content. Bottom filmstrip displays meaningful content in the first frame.">
   <figcaption class="w-figcaption">
     Comparison of loading a page with render-blocking CSS (top) and the same page with inlined critical CSS (bottom) on a 3G connection

--- a/src/site/content/en/fast/how-can-performance-improve-conversion/index.md
+++ b/src/site/content/en/fast/how-can-performance-improve-conversion/index.md
@@ -19,7 +19,7 @@ In our other e-commerce guides you have learned about [what you should measure
 to improve performance](/what-should-you-measure-to-improve-performance/), and
 [how to measure and report metrics to build a performance culture](how-to-report-metrics/).
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="https://web.dev/what-should-you-measure-to-improve-performance/funnel.png" alt="A conversion funnel going from discover to engage to convert to re-engage." style="max-width: 600px; width: 100%;">
   <figcaption class="w-figcaption">
     A conversion funnel.
@@ -41,7 +41,7 @@ Make sure to use appropriate tools as described in [Fast Load Times](/fast) to o
 
 After getting users to your site, you need to keep them engaged with your content, which you can verify in your analytics of choice by looking at session length, time-on-page, pages-per-session and general [user flows](https://support.google.com/analytics/answer/1709395?hl=en).
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./ga_flow.png" alt="A Google Analytics dashboard shows the number of users that drop off from starting page to first and second interactions.">
   <figcaption class="w-figcaption">
     A user flow through the funnel as seen by Google Analytics.
@@ -64,7 +64,7 @@ Make sure to optimize for fast repeat loads and smooth UX flows to increase chan
 
 E-commerce sites always strive for conversions, which are at the end of a purchase funnel. Every step along the funnel needs to be optimized for website speed to minimize bounce rates and drop-offs, and for each step there are different things to optimize, different pitfalls and culprits:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="https://web.dev/what-should-you-measure-to-improve-performance/funnel.png" alt="A conversion funnel going from discover to engage to convert to re-engage." style="max-width: 600px; width: 100%;">
   <figcaption class="w-figcaption">
     An e-commerce funnel showing which metric to optimize in which step.

--- a/src/site/content/en/fast/how-to-report-metrics/index.md
+++ b/src/site/content/en/fast/how-to-report-metrics/index.md
@@ -52,7 +52,7 @@ Finding this metric can be done by using your analytics tool of choice
 to map performance metrics to user engagement, conversions and transaction values.
 For example, a custom report to do so looks like this in Google Analytics:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./speed_report.png" alt="A Google Analytics dashboard shows a number of fields being added to a custom report.">
   <figcaption class="w-figcaption w-figcaption--center">
     Fig 1: Custom report in Google Analytics to analyze the impact of speed on conversions and engagement.
@@ -166,7 +166,7 @@ Some ways to handle third party content with respect to performance:
 -   Routinely audit and clean out redundant third party scripts, trackers
     and widgets. This can easily be done via [Ghostery Extension](https://chrome.google.com/webstore/detail/ghostery-%E2%80%93-privacy-ad-blo/mlomiejdfkolichcflejclcbmpeaniij?hl=en) or tools like [WhatRuns](https://chrome.google.com/webstore/detail/whatruns/cmkdbmfndkfgebldhnkbfhlneefdaaip?hl=en):
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./ghostery.png" alt="A Ghostery report showing all loaded trackers.">
   <figcaption class="w-figcaption w-figcaption--center">
     A Ghostery report showing all loaded trackers

--- a/src/site/content/en/fast/how-to-stay-fast/index.md
+++ b/src/site/content/en/fast/how-to-stay-fast/index.md
@@ -19,7 +19,7 @@ Brands that optimize speed will often find they regress quickly. This is because
 
 Performance budgets are one way to address this. A performance budget is a set of limits on metrics that affect site performance. The concept is similar to a financial budget: you set a limit and make sure you stay within it. In general, a good performance budget combines different types of metrics; so, for example, the performance budget for a product page might look as follows:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./performance-budget-example.png" alt="Image of a performance budget example" style="max-width: 600px;">
   <figcaption class="w-figcaption">
     Example performance budget

--- a/src/site/content/en/fast/identify-slow-third-party-javascript/index.md
+++ b/src/site/content/en/fast/identify-slow-third-party-javascript/index.md
@@ -70,7 +70,9 @@ To enable third-party badges:
 1. Press `Control+Shift+P` (or `Command+Shift+P` on Mac) to bring up the **Command** menu.
 1. Enter `Show third party badges` in the box.
 
-<img class="w-figure--center" src="./badges.png" alt="Screenshot of the Chrome DevTools Command menu.">
+<figure class="w-figure">
+  <img src="./badges.png" alt="Screenshot of the Chrome DevTools Command menu.">
+</figure>
 
 Now you can see third-party badges on any site you visit. To test this, navigate to [https://developers.google.com/web/](https://developers.google.com/web/).
 

--- a/src/site/content/en/fast/image-cdns/index.md
+++ b/src/site/content/en/fast/image-cdns/index.md
@@ -22,7 +22,7 @@ Image CDNs specialize in the transformation, optimization, and delivery of image
 
 
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./image-cdn-requests.jpg" alt="Shows the request/response flow between the image CDN and the client. Parameters like size and format are used to request variations of the same image.">
   <figcaption class="w-figcaption">
     Examples of transformations image CDNs can perform based on parameters in image URLs.
@@ -39,7 +39,7 @@ Image URLs used by image CDNs convey important information about an image and th
 
 
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./image-cdn-url.jpg" alt="Image URLs typically consist of the following components: origin, image, security key, and transformations.">
 </figure>
 

--- a/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
+++ b/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
@@ -54,7 +54,7 @@ Turn on [performance hints](https://webpack.js.org/configuration/performance/) i
 
 After the build step, webpack outputs a color-coded list of assets and their sizes. Anything over budget is highlighted in yellow.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./webpack-output.png" alt="Webpack output highlighting bundle.js">
   <figcaption class="w-figcaption">
     The highlighted bundle.js is bigger than your budget
@@ -63,7 +63,7 @@ After the build step, webpack outputs a color-coded list of assets and their siz
 
 The default limit for both assets and entry-points is **250 KB**. You can set your own targets in the configuration file.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./webpack-warning.jpg" alt="Webpack bundle size warning">
   <figcaption class="w-figcaption">
     Webpack bundle size warning ⚠️
@@ -76,7 +76,7 @@ The budgets are compared against **uncompressed asset sizes**. Uncompressed [Jav
 Compressed asset sizes affect the transfer time, which is very important on slow networks.
 {% endAside %}
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./webpack-recommendation.jpg" alt="Webpack performance optimization recommendation">
   <figcaption class="w-figcaption">
     Bonus feature: webpack won’t only warn you, it will give you a recommendation on how to downsize your bundles. 💁
@@ -97,14 +97,14 @@ bundlesize -f "dist/bundle.js" -s 170kB
 
 Bundlesize outputs color-coded test results in one line.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./bundlesize-fail.png" alt="Failing bundlesize CLI test">
   <figcaption class="w-figcaption">
     Failing bundlesize CLI test ❌
   </figcaption>
 </figure>
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./bundlesize-pass.png" alt="Passing bundlesize CLI test">
   <figcaption class="w-figcaption">
     Passing bundlesize CLI test ✔️

--- a/src/site/content/en/fast/performance-budgets-101/index.md
+++ b/src/site/content/en/fast/performance-budgets-101/index.md
@@ -32,7 +32,7 @@ We've already mentioned a few things you can include in a performance budget suc
 
 However, these numbers don't tell you much about the user experience. Two pages with the same number of requests or same weight can render differently depending on the order in which resources get requested. If a [critical resource](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/) like a hero image or a stylesheet on one of the pages is loaded late in the process, the users will wait longer to see something useful and perceive the page as slower. If on the other page the most important parts load quickly, they may not even notice if the rest of the page doesn't.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./progressive-page-rendering.png" alt="Image of progressive page rendering based on the critical-path" class="w-screenshot">
 </figure>
 

--- a/src/site/content/en/fast/value-of-speed/index.md
+++ b/src/site/content/en/fast/value-of-speed/index.md
@@ -138,7 +138,7 @@ period after the speed optimization (Aug–Sept in the example). You can find
 revenue data in Google Analytics under the section **Audience > Mobile >
 Overview**.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./period-revenue.jpg" alt="Revenue data for January through September showing Rel mCvR" style="max-width: 600px; width: 100%">
 </figure>
 
@@ -147,21 +147,21 @@ improved. Do this by dividing the revenue (€1,835,962) by the current Rel
 mCvR (51%) and multiplying by the Rel mCvR for the period before the speed
 optimization (42%).
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./revenue-would-have-been.jpg" alt="Screenshot: spreadsheet cells showing formula for revenue without Rel mCvR improvements" style="max-width: 600px; width: 100%">
 </figure>
 
 **Step 9:** Subtract the revenue that the company earned from what it would have
 earned if Rel mCvR had not improved.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./extra-revenue-formula.jpg" alt="Screenshot: spreadsheet cells showing extra revenue formula" style="max-width: 600px; width: 100%">
 </figure>
 
 In this example, the company earned an additional €323,993 in eight weeks thanks
 to Rel mCvR improving—that is, thanks to the mobile site becoming faster.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./thanks-to-increased.jpg" alt="Screenshot: spreadsheet cells showing extra revenue due to Rel mCvR improvements" style="max-width: 600px; width: 100%">
 </figure>
 

--- a/src/site/content/en/fast/what-should-you-measure-to-improve-performance/index.md
+++ b/src/site/content/en/fast/what-should-you-measure-to-improve-performance/index.md
@@ -18,7 +18,7 @@ tags:
 The different steps of a purchase funnel are prone to performance issues in
 different ways, and therefore need different measurement and optimizations:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./funnel.png" alt="A conversion funnel going from discover to engage to convert to re-engage." style="max-width: 600px; width: 100%;">
   <figcaption class="w-figcaption">
     A conversion funnel.
@@ -181,7 +181,7 @@ an eye on this though, and a great lab test tool for repeat visits is
 [WebPageTest](https://www.webpagetest.org/), which has a dedicated option for a
 direct repeat visit:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./webpagetest_repeat.png" alt="The WebPageTest homepage form for auditing a site. The repeat view option is highlighted.">
   <figcaption class="w-figcaption w-figcaption--center">
     Webpagetest offers options to test first load and repeat load as well
@@ -192,7 +192,7 @@ To get a better feeling for repeat visit performance in the field use your
 analytics package of choice to segment your performance metrics by user type.
 Here is an example of such a report in Google Analytics:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./ga_speed_repeat.png" alt="A Google Analytics dashboard shows a number of fields being added to a custom report.">
   <figcaption class="w-figcaption w-figcaption--center">
     A Google Analytics custom report can be used to report speed metrics for new and returning users.

--- a/src/site/content/en/handbook/contributor-profile/index.md
+++ b/src/site/content/en/handbook/contributor-profile/index.md
@@ -32,7 +32,7 @@ description: |
     },
     ```
 
-    <figure class="w-figure  w-figure--center">
+    <figure class="w-figure">
       <img class="w-screenshot" src="./lockup.png" alt="Screenshot of a contributor lockup">
     </figure>
 

--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -92,9 +92,9 @@ To make an image extend slightly beyond the width of the content column (for emp
   </figcaption>
 </figure>
 
-To keep an image from growing beyond a specified size, add the `w-figure--center` class to the `figure` element and add a `width` attribute to the `img` element. For example, `width="400"`. All images will have a `max-width` of `100%` on mobile:
+To keep an image from growing beyond a specified size, add the `w-figure` class to the `figure` element and add a `width` attribute to the `img` element. For example, `width="400"`. All images will have a `max-width` of `100%` on mobile:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./image-small.png" alt="A screenshot of a section of the Chrome DevTools user interface." width="400">
   <figcaption class="w-figcaption">
     A small, centered image.

--- a/src/site/content/en/handbook/sandbox/images/index.njk
+++ b/src/site/content/en/handbook/sandbox/images/index.njk
@@ -35,7 +35,7 @@ tags:
   porta dolor erat, vel molestie dolor posuere in.
 </p>
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="../image-small.png" alt="" style="max-width: 400px;">
   <figcaption class="w-figcaption">
     Centered, small image.

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -394,13 +394,13 @@ by wrapping them in a `<div class="w-columns">` element:
 
 ```html
 <div class="w-columns">
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img src="./image-small.png" alt="">
     <figcaption class="w-figcaption">
       Small image.
     </figcaption>
   </figure>
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img src="./image-small.png" alt="">
     <figcaption class="w-figcaption">
       Small image.
@@ -410,13 +410,13 @@ by wrapping them in a `<div class="w-columns">` element:
 ```
 
 <div class="w-columns">
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img src="./image-small.png" alt="">
     <figcaption class="w-figcaption">
       Small image.
     </figcaption>
   </figure>
-  <figure class="w-figure w-figure--center">
+  <figure class="w-figure">
     <img src="./image-small.png" alt="">
     <figcaption class="w-figcaption">
       Small image.

--- a/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
+++ b/src/site/content/en/lighthouse-accessibility/color-contrast/index.md
@@ -70,7 +70,7 @@ The color picker tells you whether the element
 meets color contrast requirements,
 taking font size and weight into account:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="color-picker.png"
     alt="Screenshot of Chrome DevTools color picker with color contrast information highlighted">
 </figure>
@@ -80,7 +80,7 @@ until its contrast is high enough.
 It's easiest to make adjustments in the HSL color format.
 Switch to that format by clicking the toggle button on the right of the picker:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="color-format-toggle.png"
     alt="Screenshot of Chrome DevTools color picker with the color format toggle highlighted">
 </figure>
@@ -93,7 +93,7 @@ as do UI elements and images.
 For text on an image, you can use DevTools' background color picker to check
 the background that the text appears on:
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="bg-color-picker.png"
     alt="Screenshot of Chrome DevTools background color picker">
 </figure>

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -32,7 +32,7 @@ else!
 Most of the time these kinds of experiences are just annoying, but in some
 cases, they can cause real damage.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <video autoplay controls loop muted
     class="w-screenshot"
     poster="https://storage.googleapis.com/web-dev-assets/layout-instability-api/layout-instability-poster.png"

--- a/src/site/content/en/notifications/use-push-notifications-to-engage-users/index.md
+++ b/src/site/content/en/notifications/use-push-notifications-to-engage-users/index.md
@@ -18,12 +18,12 @@ Notifications present small chunks of information to a user. Web apps can use no
 
 The look-and-feel of notifications varies between platforms. For example: 
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./predicaments-android.png" alt="">
   <figcaption class="w-figcaption">A notification on an Android device.</figcaption>
 </figure>
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./predicaments-macbook.png" alt="">
   <figcaption class="w-figcaption">A notification on a MacBook.</figcaption>
 </figure>

--- a/src/site/content/en/progressive-web-apps/what-are-pwas/index.md
+++ b/src/site/content/en/progressive-web-apps/what-are-pwas/index.md
@@ -30,7 +30,7 @@ like take pictures, see playing songs listed on the home screen, or control song
 playback while in another app. Native applications feel like _part_ of the
 device they run on.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./capabilities-reach.svg" style="max-width: 100%;"
     alt="A graph illustrating the relative capabilites and reach of native apps, with high capabilities, web apps, with high reach, and progressive web apps, which have both high capabilities and high reach."/>
   <figcaption class="w-figcaption w-figcaption--fullbleed">

--- a/src/site/content/en/react/add-manifest-react/index.md
+++ b/src/site/content/en/react/add-manifest-react/index.md
@@ -22,7 +22,7 @@ Create React App (CRA) includes a web app manifest by default. Modifying this
 file will allow you to change how your application is displayed when installed
 on the user's device.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img src="./icon-home-screen.png" alt="A progressive web app icon on a mobile phone's home screen">
 </figure>
 

--- a/src/site/content/en/react/code-splitting-with-dynamic-imports-in-nextjs/index.md
+++ b/src/site/content/en/react/code-splitting-with-dynamic-imports-in-nextjs/index.md
@@ -75,14 +75,14 @@ To see how Next.js bundles the app, inspect the network trace in DevTools:
 When you load the page, all the necessary code, including the `Puppy.js`
 component, is bundled in `index.js`:
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img src="./network1.png" alt="DevTools Network tab showing showing six JavaScript files: index.js, app.js, webpack.js, main.js, 0.js and the dll (dynamic-link library) file.">
 </figure>
 
 When you press the **Click me** button, only the request for the puppy JPEG is
 added to the **Network** tab:
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img src="./network2.png" alt="DevTools Network tab after the button click, showing the same six JavaScript files and one image.">
 </figure>
 
@@ -117,14 +117,14 @@ When you first load the app, only `index.js` is downloaded. This time it's
 0.5&nbsp;KB smaller (it went down from 37.9&nbsp;KB to 37.4&nbsp;KB) because it
 doesn't include the code for the `Puppy` component:
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img src="./network3.png" alt="DevTools Network showing the same six JavaScript files, except index.js is now 0.5 KB smaller.">
 </figure>
 
 The `Puppy` component is now in a separate chunk, `1.js`, which is loaded only
 when you press the button:
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img src="./network4.png" alt="DevTools Network tab after the button click, showing the additional 1.js file and the image added to the bottom of the file list.">
 </figure>
 
@@ -169,7 +169,7 @@ DevTools:
 Now when you click the button it takes a while to load the component and the app
 displays the "Loading…" message in the meantime.
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img src="./loading.png" alt='A dark screen with the text "Loading...".'>
 </figure>
 

--- a/src/site/content/en/react/prerender-with-react-snap/index.md
+++ b/src/site/content/en/react/prerender-with-react-snap/index.md
@@ -21,7 +21,7 @@ times in your application.
 Here's a comparison of the same application with and without pre-rendering
 loaded on a simulated 3G connection and mobile device:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./compare.gif" alt="A side by side loading comparsion. The version using pre-rendering loads 4.2 seconds faster.">
 </figure>
 

--- a/src/site/content/en/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/en/react/route-prefetching-in-nextjs/index.md
@@ -18,7 +18,7 @@ In [Next.js](https://nextjs.org/), you don't need to set up routing manually.
 Next.js uses file-system-based routing, which lets you just create files and folders
 inside the `./pages/` directory:
 
-<figure class="w-figure--center">
+<figure class="w-figure">
 <img class="w-screenshot" src="./pages-directory.png" alt="Screenshot of the pages directory containting three files: index.js, margherita.js, and pineapple-pizza.js.">
 </figure>
 

--- a/src/site/content/en/react/virtualize-long-lists-react-window/index.md
+++ b/src/site/content/en/react/virtualize-long-lists-react-window/index.md
@@ -38,7 +38,7 @@ very small subset of the entire list and the "window" of visible content _moves_
 when the user continues to scroll. This improves both the rendering and
 scrolling performance of the list.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./window-diagram.jpg" alt="Window of content in a virtualized list">
   <figcaption class="w-figcaption">
     Moving "window" of content in a virtualized list
@@ -170,7 +170,7 @@ an example.
 or grids. In this context, the "window" of visible content changes as the user
 scrolls horizontally **and** vertically.
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./window-diagram-grid.jpg" alt="Moving window of content in a virtualized grid is two-dimensional">
   <figcaption class="w-figcaption">
     Moving "window" of content in a virtualized grid is two-dimensional
@@ -210,7 +210,7 @@ calculations and DOM mutations slower.
 
 The following diagram might help summarize this:
 
-<figure class="w-figure  w-figure--center">
+<figure class="w-figure">
   <img class="w-screenshot" src="./difference-in-scrolling.jpg" alt="Difference in scrolling between a regular and virtualized list">
   <figcaption class="w-figcaption">
     Difference in scrolling between a regular and virtualized list

--- a/src/site/content/en/reliable/http-cache/index.md
+++ b/src/site/content/en/reliable/http-cache/index.md
@@ -160,7 +160,7 @@ got!" There's very little data to transfer when sending this type of response,
 so it's usually much faster than having to actually send back a copy of the
 actual resource being requested.
 
-<figure class="w-figure w-figure--center">
+<figure class="w-figure">
   <img src="./http-cache.png" alt="A diagram of a client requesting a resource and the server responding with a 304 header.">
   <figcaption class="w-figcaption w-text--left">
     A request/response flow. The server uses a 304 Not Modifier header

--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -75,16 +75,13 @@
 
 .w-figure {
   margin: 32px 0;
+  text-align: center;
 }
 
 // Allow images contained within a figure to be break outside of the main
 // container in articles and be full bleed on mobile.
 .w-figure--fullbleed {
   margin: 64px -32px;
-}
-
-.w-figure--center {
-  text-align: center;
 }
 
 // Inline images are typically quite small so we'll center them on smaller


### PR DESCRIPTION
This PR defaults images to center alignment so that authors don't need to add the now removed `w-figure--center` class every time they want to center an image.

Fixes #2141