### PR TITLE
Fix warning in Firefox related to querying null

### DIFF
--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -179,10 +179,13 @@ export function route(url) {
     // element (if any) and scroll to it.
     const hash = u.hash.substr(1);
     if (hash) {
-      document.getElementById(hash).scrollIntoView();
-    } else {
-      document.documentElement.scrollTop = 0;
+      const target = document.getElementById(hash);
+      if (target) {
+        target.scrollIntoView();
+        return;
+      }
     }
+    document.documentElement.scrollTop = 0;
   });
   return true;
 }

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -177,9 +177,9 @@ export function route(url) {
 
     // Since we're loading this page dynamically, look for the target hash-ed
     // element (if any) and scroll to it.
-    const target = document.getElementById(u.hash.substr(1)) || null;
-    if (target) {
-      target.scrollIntoView();
+    const hash = u.hash.substr(1);
+    if (hash) {
+      document.getElementById(hash).scrollIntoView();
     } else {
       document.documentElement.scrollTop = 0;
     }


### PR DESCRIPTION
Changes proposed in this pull request:

- I noticed Firefox was logging a warning because when we navigate to a page without a hash in the url we still try to querySelector for one.