### PR TITLE
simplify var

### DIFF
--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -98,9 +98,8 @@ function forceFocus(el) {
  * @param {!Object} partial
  */
 function updateDom(partial) {
-  const main = document.querySelector("main");
-  const content = main.querySelector("#content");
-  main.querySelector("#content").innerHTML = partial.raw;
+  const content = document.querySelector("main #content");
+  content.innerHTML = partial.raw;
 
   // Update the page title.
   document.title = partial.title || "";
@@ -165,7 +164,8 @@ export async function swapContent({firstRun, url, signal, ready, state}) {
   const isOffline = Boolean(partial.offline);
   store.setState({currentUrl: url, isOffline});
 
-  // Inform the router that we're ready early (even though the JS isn't done).
+  // Inform the router that we're ready early (even though the JS isn't done). This updates the URL,
+  // which must happen before DOM changes and ga event.
   ready(url, {partial});
 
   ga("set", "page", window.location.pathname);


### PR DESCRIPTION
Updates use of `content` var, since otherwise we're doing a `querySelector` multiple times.

Also clarifies how `ready` is used.