### PR TITLE
update web-codelab and include notice on mobile

### DIFF
--- a/build.js
+++ b/build.js
@@ -37,6 +37,7 @@ process.on("unhandledRejection", (reason, p) => {
 
 const bootstrapConfig = {
   prod: isProd,
+  env: process.env.ELEVENTY_ENV || "dev",
   version:
     "v" +
     new Date()

--- a/src/lib/components/Codelab/_styles.scss
+++ b/src/lib/components/Codelab/_styles.scss
@@ -1,13 +1,28 @@
 @import '../../../styles/settings/colors';
+@import '../../../styles/generic/shared';
 @import '../../../styles/tools/breakpoints';
 
 web-codelab {
   display: flex;
-  height: 100%;
+
+  flex-flow: column;
+  @include bp(md) {
+    flex-flow: row;
+  }
 
   .w-sizer {
-    width: 100%;
-    height: 100%;
+    padding: 16px 32px;
+
+    .w-aside {
+      margin: 0;
+    }
+
+    @include bp(md) {
+      padding: 16px;
+      position: sticky;
+      top: $WEB_HEADER_HEIGHT;
+      height: calc(100vh - #{$WEB_HEADER_HEIGHT});
+    }
   }
 
   .web-codelab__headline {
@@ -19,28 +34,20 @@ web-codelab {
     padding: 32px;
 
     @include bp(md) {
-      // on desktop, scroll the instructions so the Glitch can take up the full page size
+      // on desktop, set the maximum size so the Glitch can fit to the right
       width: 600px;
-      overflow-x: hidden;
-      overflow-y: scroll;
     }
   }
   
   .web-codelab__glitch {
     flex: 1;
-    padding: 0 32px;
-    order: -100;
 
+    // on small screens, we repurpose this element for the warning notice: put
+    // the notice at the top
+    order: -1;
     @include bp(md) {
-      padding: 16px;
       order: initial;
     }
-  }
-
-  flex-flow: column;
-
-  @include bp(md) {
-    flex-flow: row;
   }
 }
 

--- a/src/lib/components/Codelab/_styles.scss
+++ b/src/lib/components/Codelab/_styles.scss
@@ -5,29 +5,42 @@ web-codelab {
   display: flex;
   height: 100%;
 
+  .w-sizer {
+    width: 100%;
+    height: 100%;
+  }
+
   .web-codelab__headline {
     margin-top: 0;
     margin-bottom: 8px;
   }
   
   .web-codelab__instructions {
-    overflow-x: hidden;
-    overflow-y: scroll;
     padding: 32px;
 
     @include bp(md) {
+      // on desktop, scroll the instructions so the Glitch can take up the full page size
       width: 600px;
+      overflow-x: hidden;
+      overflow-y: scroll;
     }
   }
   
   .web-codelab__glitch {
     flex: 1;
-    padding: 16px;
-    display: none;
+    padding: 0 32px;
+    order: -100;
 
     @include bp(md) {
-      display: block;
+      padding: 16px;
+      order: initial;
     }
+  }
+
+  flex-flow: column;
+
+  @include bp(md) {
+    flex-flow: row;
   }
 }
 

--- a/src/lib/components/Codelab/_styles.scss
+++ b/src/lib/components/Codelab/_styles.scss
@@ -17,6 +17,25 @@ web-codelab {
       margin: 0;
     }
 
+    &.w-test {
+      display: flex;
+      flex-flow: column;
+      justify-content: space-between;
+      background: #eee;
+
+      &::before,
+      &::after {
+        background: blue;
+        color: white;
+        content: 'Top of codelab';
+        display: block;
+      }
+      &::after {
+        background: red;
+        content: 'Bottom of codelab';
+      }
+    }
+
     @include bp(md) {
       padding: 16px;
       position: sticky;

--- a/src/lib/components/Codelab/_styles.scss
+++ b/src/lib/components/Codelab/_styles.scss
@@ -13,27 +13,22 @@ web-codelab {
   .w-sizer {
     padding: 16px 32px;
 
-    .w-aside {
-      margin: 0;
+    &.w-test {
+      @include bp(md) {
+        display: flex;
+        flex-flow: column;
+        justify-content: space-between;
+
+        &::after {
+          content: '';
+          background: $WARNING_COLOR;
+          height: 2px;
+        }
+      }
     }
 
-    &.w-test {
-      display: flex;
-      flex-flow: column;
-      justify-content: space-between;
-      background: #eee;
-
-      &::before,
-      &::after {
-        background: blue;
-        color: white;
-        content: 'Top of codelab';
-        display: block;
-      }
-      &::after {
-        background: red;
-        content: 'Bottom of codelab';
-      }
+    .w-aside {
+      margin: 0;
     }
 
     @include bp(md) {

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -5,7 +5,10 @@
 
 import {html} from "lit-element";
 import {BaseElement} from "../BaseElement";
+import config from "webdev_config";
 import "./_styles.scss";
+
+const {env} = config;
 
 /**
  * Render codelab instructions and Glitch
@@ -93,6 +96,14 @@ class Codelab extends BaseElement {
             </p>
           </div>
         </div>
+      `;
+    }
+
+    // Disable the Glitch in dev environments, as it takes a while to load.
+    // Used for screenshot testing.
+    if (env === "test") {
+      return html`
+        <div class="w-sizer w-test"></div>
       `;
     }
 

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -32,7 +32,8 @@ class Codelab extends BaseElement {
 
     this.glitch = "";
     this.path = "index.html";
-    this._isDesktop = false;
+    // _isDesktop has no default value as it's only correctly set between connected/disconnected
+    // callbacks via the MediaQueryList's listener.
 
     this._mql = window.matchMedia("(min-width: 865px)");
     this._toggleDesktop = () => (this._isDesktop = this._mql.matches);

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -32,9 +32,7 @@ class Codelab extends BaseElement {
     this._isMobile = true;
 
     this._mql = window.matchMedia("(min-width: 865px)");
-    this._toggleMobile = () => (
-      (this._isMobile = !this._mql.matches)
-    );
+    this._toggleMobile = () => (this._isMobile = !this._mql.matches);
   }
 
   connectedCallback() {
@@ -63,34 +61,50 @@ class Codelab extends BaseElement {
     return container;
   }
 
-  get src() {
+  glitchSrc(embed) {
     let url = `https://glitch.com/embed/?attributionHidden=true`;
 
     if (this.path) {
       url += `&path=${encodeURI(this.path)}`;
     }
 
-    url += `#!/embed/${encodeURI(this.glitch)}`;
+    if (embed) {
+      url += `#!/embed/${encodeURI(this.glitch)}`;
+    }
 
     return url;
   }
 
   render() {
     const loadGlitch = !this._isMobile && this.glitch;
-    const iframePart = loadGlitch
-      ? html`
-          <iframe
-            allow="geolocation; microphone; camera; midi; encrypted-media"
-            alt="Embedded glitch ${this.glitch}"
-            src="${this.src}"
-            style="height: 100%; width: 100%; border: 0;"
-          >
-          </iframe>
-        `
-      : "";
+    let iframePart = "";
+
+    if (loadGlitch) {
+      iframePart = html`
+        <iframe
+          allow="geolocation; microphone; camera; midi; encrypted-media"
+          alt="Embedded glitch ${this.glitch}"
+          src="${this.glitchSrc(true)}"
+          style="height: 100%; width: 100%; border: 0;"
+        >
+        </iframe>
+      `;
+    } else if (this.glitch) {
+      iframePart = html`
+        <div class="w-aside w-aside--warning">
+          <p>
+            <strong>Warning:</strong> This Glitch isn't available on small
+            screens,
+            <a target="_blank" rel="noopener" href=${this.glitchSrc(false)}>
+              open it in a new tab</a
+            >
+          </p>
+        </div>
+      `;
+    }
 
     return html`
-      <div style="height: 100%; width: 100%;">${iframePart}</div>
+      <div class="w-sizer">${iframePart}</div>
     `;
   }
 }

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -19,8 +19,8 @@ class Codelab extends BaseElement {
       glitch: {type: String},
       // The file to show when the Glitch renders.
       path: {type: String},
-      // Whether we are a mobile browser or not.
-      _isMobile: {type: Boolean},
+      // Whether we are a desktop-sized browser or not.
+      _isDesktop: {type: Boolean},
     };
   }
 
@@ -29,21 +29,21 @@ class Codelab extends BaseElement {
 
     this.glitch = "";
     this.path = "index.html";
-    this._isMobile = true;
+    this._isDesktop = false;
 
     this._mql = window.matchMedia("(min-width: 865px)");
-    this._toggleMobile = () => (this._isMobile = !this._mql.matches);
+    this._toggleDesktop = () => (this._isDesktop = this._mql.matches);
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this._mql.addListener(this._toggleMobile);
-    this._toggleMobile();
+    this._mql.addListener(this._toggleDesktop);
+    this._toggleDesktop();
   }
 
   disconnectedCallback() {
     super.connectedCallback();
-    this._mql.removeListener(this._toggleMobile);
+    this._mql.removeListener(this._toggleDesktop);
   }
 
   createRenderRoot() {
@@ -76,11 +76,28 @@ class Codelab extends BaseElement {
   }
 
   render() {
-    const loadGlitch = !this._isMobile && this.glitch;
-    let iframePart = "";
+    if (!this.glitch) {
+      return html``;
+    }
 
-    if (loadGlitch) {
-      iframePart = html`
+    if (!this._isDesktop) {
+      return html`
+        <div class="w-sizer">
+          <div class="w-aside w-aside--warning">
+            <p>
+              <strong>Warning:</strong> This Glitch isn't available on small
+              screens,
+              <a target="_blank" rel="noopener" href=${this.glitchSrc(false)}>
+                open it in a new tab.</a
+              >
+            </p>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="w-sizer">
         <iframe
           allow="geolocation; microphone; camera; midi; encrypted-media"
           alt="Embedded glitch ${this.glitch}"
@@ -88,23 +105,7 @@ class Codelab extends BaseElement {
           style="height: 100%; width: 100%; border: 0;"
         >
         </iframe>
-      `;
-    } else if (this.glitch) {
-      iframePart = html`
-        <div class="w-aside w-aside--warning">
-          <p>
-            <strong>Warning:</strong> This Glitch isn't available on small
-            screens,
-            <a target="_blank" rel="noopener" href=${this.glitchSrc(false)}>
-              open it in a new tab</a
-            >
-          </p>
-        </div>
-      `;
-    }
-
-    return html`
-      <div class="w-sizer">${iframePart}</div>
+      </div>
     `;
   }
 }

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -82,28 +82,27 @@ class Codelab extends BaseElement {
     if (!this.glitch) {
       return html``;
     }
+    const isTest = env === "test";
 
-    if (!this._isDesktop) {
+    // If this is a test, always show the warning. Percy snapshots our DOM at a
+    // low resolution before resizing it, so we can't rely on _isDesktop being
+    // different for smaller or larger tests. The `w-test` ensures we test the
+    // sticky behavior of this element.
+    if (!this._isDesktop || isTest) {
+      const message = isTest
+        ? "This Glitch isn't loaded in a test environment"
+        : "This Glitch isn't available on small screens";
       return html`
-        <div class="w-sizer">
+        <div class="w-sizer ${isTest ? "w-test" : ""}">
           <div class="w-aside w-aside--warning">
             <p>
-              <strong>Warning:</strong> This Glitch isn't available on small
-              screens,
+              <strong>Warning:</strong> ${message},
               <a target="_blank" rel="noopener" href=${this.glitchSrc(false)}>
                 open it in a new tab.</a
               >
             </p>
           </div>
         </div>
-      `;
-    }
-
-    // Disable the Glitch in dev environments, as it takes a while to load.
-    // Used for screenshot testing.
-    if (env === "test") {
-      return html`
-        <div class="w-sizer w-test"></div>
       `;
     }
 

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -4,17 +4,7 @@ permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
 ---
 
 <div class="codelab-landing-page">
-  {% if site.env === 'prod' %}
-    <style>
-      devsite-content-footer,
-      devsite-footer-promos,
-      devsite-footer-linkboxes,
-      devsite-footer-utility {
-        display: none;
-      }
-    </style>
-  {% endif %}
-  <web-codelab glitch="{{ glitch }}" {% if glitch_path %}path="{{ glitch_path }}{% endif %}">
+  <web-codelab glitch="{{ glitch }}" {% if glitch_path %}path="{{ glitch_path }}"{% endif %} {% if site.env === 'test' %}testmode{% endif %}>
     <div class="web-codelab__instructions">
       <h1 class="w-headline w-headline--two web-codelab__headline">{{ title }}</h1>
       {% if date %}

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -26,6 +26,7 @@ web-header {
   top: 0;
   width: 100%;
   z-index: 200;
+  overflow-x: hidden;
 
   .web-header__hamburger-btn {
     height: 2.75rem;

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -21,7 +21,6 @@ web-header {
   display: flex;
   font-size: 14px;
   height: 64px;
-  overflow-x: hidden;
   padding: 0 24px;
   position: fixed;
   top: 0;

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -21,12 +21,12 @@ web-header {
   display: flex;
   font-size: 14px;
   height: 64px;
+  overflow-x: hidden;
   padding: 0 24px;
   position: fixed;
   top: 0;
   width: 100%;
   z-index: 200;
-  overflow-x: hidden;
 
   .web-header__hamburger-btn {
     height: 2.75rem;

--- a/src/styles/generic/_page.scss
+++ b/src/styles/generic/_page.scss
@@ -20,7 +20,7 @@ body {
   );
   margin: 0;
   overflow-wrap: break-word;
-  overflow-x: hidden;
+  // nb. Don't set `overflow-x: hidden`, as this can break descendant sticky.
   padding: 0;
   word-wrap: break-word;
 }

--- a/src/styles/pages/_all.scss
+++ b/src/styles/pages/_all.scss
@@ -1,6 +1,5 @@
 @import 'home';
 @import 'about';
-@import 'codelab';
 @import 'learn';
 @import 'measure';
 @import 'pagination';

--- a/src/styles/pages/_codelab.scss
+++ b/src/styles/pages/_codelab.scss
@@ -1,5 +1,0 @@
-// sass-lint:disable class-name-format
-.codelab-landing-page {
-  height: calc(100vh - 64px);
-}
-// sass-lint:enable class-name-format

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -20,6 +20,10 @@ const pagesToTest = [
     url: "about",
     title: "About page",
   },
+  {
+    url: "codelab-avoid-invisible-text",
+    title: "Test codelab page",
+  },
 ];
 
 // A script to navigate our app and take snapshots with Percy.


### PR DESCRIPTION
This updates @beaufortfrancois' work, but tries to add/remove the listener as the element appears and is removed from the page.

It also (somewhat awkwardly) adds a warning notice when the screen is small. (This will be infinitely better when we switch to Shadow DOM).