### PR TITLE
fix router not setting correct URL on failure

### DIFF
--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -136,7 +136,7 @@ export function listen(handler) {
           window.location.href = url;  // always use the updated URL
           throw err;
         }
-        console.warn("err loading (preempted)", url, err);
+        console.warn("err loading", url, err);
         return true;
       });
   };

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -133,7 +133,7 @@ export function listen(handler) {
       .catch((err) => {
         // Only throw errors if not preempted and not the first load.
         if (!controller.signal.aborted && !firstRun) {
-          window.location.href = window.location.href;
+          window.location.href = url;  // always use the updated URL
           throw err;
         }
         console.warn("err loading (preempted)", url, err);


### PR DESCRIPTION
If the routing code failed before we called `ready()` to signify that the URL should change, we weren't setting the new URL correctly (instead just taking the old one).

I may force-submit this as this is relatively dangerous not to have out, it could prevent navigation.