### PR TITLE
fix SW redirect and normalizing URLs

### DIFF
--- a/src/lib/components/LighthouseGauge/test.js
+++ b/src/lib/components/LighthouseGauge/test.js
@@ -18,7 +18,7 @@
 import {assert} from "../../test/assert";
 import "./index";
 
-suite("web-lighthouse-gauge", async () => {
+suite("element: web-lighthouse-gauge", async () => {
   await customElements.whenDefined("web-lighthouse-gauge");
 
   test("basic", async () => {

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -6,6 +6,7 @@
  */
 
 import {store} from "./store";
+import {normalizeUrl} from "./urls";
 import "./utils/underscore-import-polyfill";
 
 /**
@@ -45,21 +46,6 @@ export async function getPartial(url, signal) {
     }
     throw e;
   }
-}
-
-function normalizeUrl(url) {
-  const u = new URL(url, window.location);
-  let pathname = u.pathname;
-
-  if (pathname.endsWith("/index.html")) {
-    // If an internal link refers to "/foo/index.html", strip "index.html" and load.
-    pathname = pathname.slice(0, -"index.html".length);
-  } else if (!pathname.endsWith("/")) {
-    // All web.dev pages end with "/".
-    pathname = `${url}/`;
-  }
-
-  return pathname + u.search;
 }
 
 /**
@@ -102,9 +88,12 @@ function updateDom(partial) {
   content.innerHTML = partial.raw;
 
   // Close any open self-assessment modals.
-  // TODO (mfriesenhahn): Replace this logic with a store subscriber that allows
+  // TODO(samthor): Replace this logic with a store subscriber that allows
   // all components to clean up after themselves when the page changes.
-  document.querySelector("web-assessment[open]").remove();
+  const assessmentsOpen = document.querySelectorAll("web-assessment[open]");
+  for (const assessment of assessmentsOpen) {
+    assessment.remove();
+  }
 
   // Update the page title.
   document.title = partial.title || "";

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -131,7 +131,7 @@ workboxRouting.registerRoute(
 
     // Either way, redirect to the updated Location.
     const headers = new Headers();
-    headers.append("Location", event.request.url + "/");
+    headers.append("Location", `${pathname}/${url.search}`);
     const redirectResponse = new Response("", {
       status: 301,
       headers,

--- a/src/lib/test/index.js
+++ b/src/lib/test/index.js
@@ -1,2 +1,3 @@
 import "../components/ProgressBar/test";
 import "../components/LighthouseGauge/test";
+import "../urls_test";

--- a/src/lib/test/index.js
+++ b/src/lib/test/index.js
@@ -1,3 +1,3 @@
 import "../components/ProgressBar/test";
 import "../components/LighthouseGauge/test";
-import "../urls_test";
+import "../urls-test";

--- a/src/lib/urls-test.js
+++ b/src/lib/urls-test.js
@@ -3,9 +3,10 @@ import {normalizeUrl} from "./urls";
 
 suite("urls", () => {
   test("normalizeUrl", () => {
+    assert(normalizeUrl("/foo?") == "/foo/", "search should be ignored");
     assert(
       normalizeUrl("/foo?bar/index.html") == "/foo/?bar/index.html",
-      "search should be ignored",
+      "search should be ignored if it has index.html",
     );
     assert(normalizeUrl("/foo") == "/foo/", "requries trailing slash");
     assert(

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,0 +1,20 @@
+/**
+ * @param {string} url containing pathname and search only
+ * @return {string} normalized URL
+ */
+export function normalizeUrl(url) {
+  const u = new URL(url, window.location);
+  let pathname = u.pathname;
+
+  if (pathname.endsWith("/index.html")) {
+    // If an internal link refers to "/foo/index.html", strip "index.html" and load.
+    pathname = pathname.slice(0, -"index.html".length);
+  } else if (pathname.indexOf(".") !== -1) {
+    // Do nothing, cannot handle any link with a loose dot.
+  } else if (!pathname.endsWith("/")) {
+    // All web.dev pages end with "/".
+    pathname = `${pathname}/`;
+  }
+
+  return pathname + u.search;
+}

--- a/src/lib/urls_test.js
+++ b/src/lib/urls_test.js
@@ -1,0 +1,20 @@
+import {assert} from "./test/assert";
+import {normalizeUrl} from "./urls";
+
+suite("urls", () => {
+  test("normalizeUrl", () => {
+    assert(
+      normalizeUrl("/foo?bar/index.html") == "/foo/?bar/index.html",
+      "search should be ignored",
+    );
+    assert(normalizeUrl("/foo") == "/foo/", "requries trailing slash");
+    assert(
+      normalizeUrl("/zing/test/index.html") == "/zing/test/",
+      "removes index.html",
+    );
+    assert(
+      normalizeUrl("/test/hello.html") == "/test/hello.html",
+      "ignores non-index.html HTML pages",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2422

Loads to pages like "/foo?bar" (i.e., with no trailing slash on "/foo" but including a search param) resulted in redirects forever. This was a problem in both the SW and foreground pages.

This also fixes a couple of other issues:

* adds a test for normalizing
* fixes a likely `null` in the modal assessment cleanup code