### PR TITLE
Link actual Web Share Target demo

### DIFF
--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -251,8 +251,8 @@ the `text` field, or occasionally in the `title` field.
 <div class="w-clearfix"></div>
 
 [spec]: https://wicg.github.io/web-share-target/
-[demo]: https://web-share.glitch.me/
-[demo-source]: https://glitch.com/edit/#!/web-share?path=index.html
+[demo]: https://hn-share.now.sh/
+[demo-source]: https://github.com/PaulKinlan/hn-share-target
 [cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=668389
 [cr-status]: https://www.chromestatus.com/features/5662315307335680
 [explainer]: https://github.com/WICG/web-share-target/blob/master/docs/explainer.md


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

- Web Share Target demo link led to a Web Share demo, now leads to an actual Web Share Target demo