### PR TITLE
Set origin trial URL for Web NFC

### DIFF
--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -10,6 +10,8 @@ thumbnail: thumbnail.jpg
 alt: A photo of NFC tags
 description: |
   Reading and writing to NFC tags is now possible on Chrome for Android.
+origin_trial:
+  url: https://developers.chrome.com/origintrials/#/view_trial/236438980436951041
 tags:
   - post # post is a required tag for the article to show up in the blog.
   - capabilities


### PR DESCRIPTION
The OT URL was missing somehow.