### PR TITLE
remove mkdirp

### DIFF
--- a/compile-css.js
+++ b/compile-css.js
@@ -19,7 +19,6 @@ const isProd = process.env.ELEVENTY_ENV === "prod";
 
 const fs = require("fs");
 const path = require("path");
-const mkdirp = require("mkdirp");
 const log = require("fancy-log");
 
 const sassEngine = (function() {
@@ -38,7 +37,7 @@ const sassEngine = (function() {
  * @return {{css: !Buffer, map: !Buffer}}
  */
 function compileCSS(input, output) {
-  mkdirp.sync(path.dirname(output)); // make sure output dir exists
+  fs.mkdirSync(path.dirname(output), {recursive: true});
 
   // #1: Compile CSS with either engine.
   const compiledOptions = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12376,12 +12376,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
-      "dev": true
-    },
     "mocha": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "markdown-it": "^8.4.2",
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-attrs": "^3.0.0",
-    "mkdirp": "^1.0.3",
     "mocha": "^6.2.0",
     "node-fetch": "^2.3.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Remove explicit use of mkdirp in favor of built-in Node API.

FWIW a whole bunch of our immediate dependencies transitively depend on it still. It appears a bunch at the 2nd level.