### PR TITLE
Correct window to navigator in supporting section

### DIFF
--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -173,7 +173,7 @@ function setBadge(...args) {
   if (navigator.setExperimentalAppBadge) {
     navigator.setExperimentalAppBadge(...args);
   } else {
-    window.setAppBadge(...args);
+    navigator.setAppBadge(...args);
   }
 }
 
@@ -181,7 +181,7 @@ function clearBadge() {
   if (navigator.clearExperimentalAppBadge) {
     navigator.clearExperimentalAppBadge();
   } else {
-    window.clearAppBadge(...args);
+    navigator.clearAppBadge(...args);
   }
 }
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

- fixes the invalid call of `setAppBadge` and `clearAppBadge` - they are available within `Navigator`, as the article itself informs.