### PR TITLE
Revert "Link actual Web Share Target demo"

### DIFF
--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -251,8 +251,8 @@ the `text` field, or occasionally in the `title` field.
 <div class="w-clearfix"></div>
 
 [spec]: https://wicg.github.io/web-share-target/
-[demo]: https://hn-share.now.sh/
-[demo-source]: https://github.com/PaulKinlan/hn-share-target
+[demo]: https://web-share.glitch.me/
+[demo-source]: https://glitch.com/edit/#!/web-share?path=index.html
 [cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=668389
 [cr-status]: https://www.chromestatus.com/features/5662315307335680
 [explainer]: https://github.com/WICG/web-share-target/blob/master/docs/explainer.md


### PR DESCRIPTION
Reverts GoogleChrome/web.dev#2431

Let's keep the web share demo where it was and fix the demo if there's an issue.