### PR TITLE
Get us a 100 accessibility score on the homepage.

### DIFF
--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -154,7 +154,7 @@ module.exports = ({post, featured = false}) => {
   }
 
   return html`
-    <div class="w-card">
+    <div class="w-card" role="listitem">
       <article class="w-post-card ${featured ? "w-post-card--featured" : ""}">
         <div
           class="w-post-card__cover ${thumbnail &&

--- a/src/site/content/en/blog/preload-optional-fonts/index.md
+++ b/src/site/content/en/blog/preload-optional-fonts/index.md
@@ -5,6 +5,7 @@ authors:
   - houssein
 date: 2020-03-18
 hero: hero.jpg
+alt: A large letter A from a type set sitting on a white table.
 description: | 
   By optimizing rendering cycles, Chrome 82 eliminates layout shifting when
   preloading optional fonts. Combining <link rel="preload"> with font-display: optional is the


### PR DESCRIPTION
Changes proposed in this pull request:

- Add missing `listitem` role to `PostCard`. We need this because the `PostCard` appears inside of a grid which has `role=list`.
- Add missing `alt` text for hero image on one of our posts. We should enforce alt as part of our (upcoming) yaml linting.