### PR TITLE
Make tabs selectable on mobile

### DIFF
--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -79,8 +79,9 @@ class Tabs extends BaseElement {
 
     return html`
       <button
-        @focus="${this.onFocus}"
-        @keydown="${this.onKeydown}"
+        @click=${this.onFocus}
+        @focus=${this.onFocus}
+        @keydown=${this.onKeydown}
         class="web-tabs__tab gc-analytics-event"
         role="tab"
         aria-selected="false"

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -77,6 +77,7 @@ class Tabs extends BaseElement {
         break;
     }
 
+    // Need @click so tabs work on iOS Safari
     return html`
       <button
         @click=${this.onFocus}


### PR DESCRIPTION
Changes proposed in this pull request:

- During the last refactor of the Tabs web component, we removed the click handler and only had a focus handler to streamline the code. Turns out you need the click handler for iOS Safari.