### PR TITLE
Add node_modules caching to speed up Actions.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           node-version: '12.x'
 
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Build
         env:
           ELEVENTY_ENV: prod

--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -4,6 +4,14 @@ name: Percy
 # configure each event separately. You must append a colon (:) to all events,
 # including events without configuration.
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.js'
+      - '**.njk'
+      - '**.scss'
+
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
   pull_request:
@@ -11,6 +19,7 @@ on:
       - '**.js'
       - '**.njk'
       - '**.scss'
+
 jobs:
   percy:
     runs-on: ubuntu-latest

--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -4,13 +4,6 @@ name: Percy
 # configure each event separately. You must append a colon (:) to all events,
 # including events without configuration.
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '**.js'
-      - '**.njk'
-      - '**.scss'
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
   pull_request:
@@ -19,7 +12,7 @@ on:
       - '**.njk'
       - '**.scss'
 jobs:
-  build:
+  percy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,6 +21,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Install
         run: npm ci
       - name: Percy Test


### PR DESCRIPTION
Changes proposed in this pull request:

- Add cache action to speed up our build times ([see cache Action explainer](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows))
- Change percy task to only run on pull_requests. It seems duplicative to run it when we merge into master as well.
