### PR TITLE
Fix dup focus rings on icon buttons

### DIFF
--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -176,6 +176,7 @@
 // This replaces the default focus outline so the outline matches the shape of the button.
 .w-button--icon:focus {
   box-shadow: 0 0 0 1px $FOCUS_COLOR;
+  outline: none;
 }
 
 .js-focus-visible .w-button--icon:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format


### PR DESCRIPTION
Changes proposed in this pull request:

- Icon buttons use a box shadow for the focus ring, but an outline was also showing. This removes the outline.
