### PR TITLE
Redirect focus on incorrect question submit

### DIFF
--- a/src/lib/components/AssessmentQuestion/index.js
+++ b/src/lib/components/AssessmentQuestion/index.js
@@ -120,6 +120,9 @@ class AssessmentQuestion extends BaseElement {
         this.updateResponseComponents();
         this.state = "unanswered";
         this.ctaLabel = "Recheck";
+
+        const tabs = this.closest("web-tabs");
+        tabs.focusTab(tabs.activeTab);
         break;
       case "completed":
         const nextQuestion = this.checkNextQuestion();

--- a/src/lib/components/AssessmentQuestion/index.js
+++ b/src/lib/components/AssessmentQuestion/index.js
@@ -122,7 +122,14 @@ class AssessmentQuestion extends BaseElement {
         this.ctaLabel = "Recheck";
 
         const tabs = this.closest("web-tabs");
-        tabs.focusTab(tabs.activeTab);
+        const assessment = this.closest("web-assessment");
+        if (tabs) {
+          // Focus currently active tab since submit button disables
+          tabs.focusTab(tabs.activeTab);
+        } else if (assessment) {
+          // For singleton questions, focus the parent assessment component
+          assessment.focus();
+        }
         break;
       case "completed":
         const nextQuestion = this.checkNextQuestion();


### PR DESCRIPTION
Changes proposed in this pull request:

- Currently, when a user submits an incorrect response to a self-assessment question, focus remains on the **Check** button even though it becomes disabled. To improve UX for keyboard users, this redirects focus to the currently active tab