### PR TITLE
Auto-update updated field on commits.

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,7 @@
 {
   "//": "Use git push --no-verify to bypass",
   "hooks": {
+    "pre-commit": "npm run precommit",
     "pre-push": "npm run lint"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12626,6 +12626,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "stage:personal": "ELEVENTY_ENV=dev npm run build && gcloud app deploy --project web-dev-staging --quiet --no-promote",
     "deploy": "ELEVENTY_ENV=prod npm run build && node index-algolia.js && gcloud app deploy --project web-dev-production-1 --quiet",
     "snapshots": "percy exec -- node tools/percy/snapshots.js",
-    "test:snapshots": "ELEVENTY_ENV=test npm-run-all --serial build --parallel --race start snapshots"
+    "test:snapshots": "ELEVENTY_ENV=test npm-run-all --serial build --parallel --race start snapshots",
+    "precommit": "node ./tools/update-updated/index.js"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -91,6 +92,7 @@
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-attrs": "^3.0.0",
     "mocha": "^6.2.0",
+    "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.27",

--- a/tools/update-updated/index.js
+++ b/tools/update-updated/index.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Task for updating `updated` YAML field.
+ *
+ * @author Matt Gaunt & Rob Dodson 💕
+ */
+
+// This task only runs against files in this directory.
+const contentDir = "src/site/content";
+
+const chalk = require("chalk");
+const fs = require("fs").promises;
+const moment = require("moment");
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+const RE_UPDATED = /^updated:\s?(.*?)\n/m;
+const MSG_UPDATE = `Updated ${chalk.bold("updated")} in`;
+
+/**
+ * Gets the list of modified and renamed files that have been staged.
+ * This will ignore files that were added or deleted.
+ * @return {Promise<Array<string>>} Returns array of changed files.
+ */
+async function getChangedFiles() {
+  const cmd = `git diff --cached --name-only --diff-filter=MR`;
+  try {
+    const {stdout} = await exec(cmd, ".");
+    return stdout.split("\n");
+  } catch (err) {
+    throw err;
+  }
+}
+
+const run = async () => {
+  // List of all files that have changed
+  const changedFiles = await getChangedFiles();
+
+  for (const changedFile of changedFiles) {
+    if (changedFile.indexOf(contentDir) === -1) {
+      // File isn't a content file, skip it.
+      continue;
+    }
+
+    if (!changedFile.endsWith(".md")) {
+      // File isn't a Markdown file, skip it.
+      continue;
+    }
+
+    const fileContents = (await fs.readFile(changedFile)).toString();
+    const matched = RE_UPDATED.exec(fileContents);
+    if (!matched) {
+      // Updated YAML property is not in the file - nothing to do.
+      console.log(
+        `${chalk.black.bgYellow(
+          `Warning:`,
+        )} Could not find updated field in ${changedFile}.`,
+      );
+      continue;
+    }
+
+    const originalUpdated = matched[0];
+    const originalTimestamp = matched[1];
+    const momentNow = moment();
+
+    if (momentNow.isSameOrBefore(originalTimestamp)) {
+      // Updated date is today or in the future.
+      continue;
+    }
+
+    const newUpdated = originalUpdated.replace(
+      originalTimestamp,
+      momentNow.format(`YYYY-MM-DD`),
+    );
+    const newContents = fileContents.replace(originalUpdated, newUpdated);
+    await fs.writeFile(changedFile, newContents);
+    // Add the file to the current commit.
+    await exec(`git add ${changedFile}`);
+    console.log(`${MSG_UPDATE} ${chalk.cyan(changedFile)}`);
+  }
+};
+
+run();

--- a/tools/update-updated/index.js
+++ b/tools/update-updated/index.js
@@ -35,7 +35,7 @@ const run = async () => {
   const changedFiles = await getChangedFiles();
 
   for (const changedFile of changedFiles) {
-    if (changedFile.indexOf(contentDir) === -1) {
+    if (!changedFile.startsWith(contentDir)) {
       // File isn't a content file, skip it.
       continue;
     }
@@ -45,7 +45,7 @@ const run = async () => {
       continue;
     }
 
-    const fileContents = (await fs.readFile(changedFile)).toString();
+    const fileContents = await fs.readFile(changedFile, "utf-8");
     const matched = RE_UPDATED.exec(fileContents);
     if (!matched) {
       // Updated YAML property is not in the file - nothing to do.


### PR DESCRIPTION
Related to https://github.com/GoogleChrome/web.dev/issues/1959

Changes proposed in this pull request:

- Adds a precommit script that will rev the `updated` field on modified posts. If a post does not have an `updated` field it will log a warning to the console but it won't block the commit.

I'm separately working on a linter that will run as a GH Action when someone does a PR. That linter will also flag the `updated` field if it hasn't been updated. That way the reviewer can decide if it's worth updating it or not (e.g. maybe deciding not to update it for small typo fixes).
