### PR TITLE
Fix SXG debian package urls

### DIFF
--- a/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
+++ b/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
@@ -94,10 +94,10 @@ You can install the package in the usual Debian way, as long as the OpenSSL (`li
 
 ```bash
 sudo apt install -y libssl-dev
-wget https://github.com/google/libsxg/releases/download/v0.2/libsxg0_0.2_amd64.deb
-wget https://github.com/googl/etwlibsxg/releases/download/v0.2/libsxg-dev_0.2_amd64.deb
-sudo dpkg -i libsxg0_0.2_amd64.deb
-sudo dpkg -i libsxg-dev_0.2_amd64.deb
+wget https://github.com/google/libsxg/releases/download/v0.2/libsxg0_0.2-1_amd64.deb
+wget https://github.com/google/libsxg/releases/download/v0.2/libsxg-dev_0.2-1_amd64.deb
+sudo dpkg -i libsxg0_0.2-1_amd64.deb
+sudo dpkg -i libsxg-dev_0.2-1_amd64.deb
 ```
 
 ### Option 2: Build `libsxg` manually
@@ -184,7 +184,7 @@ http {
     }
 }
 ```
- 
+
 * `sxg_cert_url` is essential for browsers to load SXG properly because it locates the certificate chain. The certificate chain contains certificate and OCSP stapling information with cbor format. Note that you do not have to serve the `cert.cbor` file from the same origin. You can serve it via any CDNs or other static file serving services as long as it supports HTTPS.
 * `sxg_validitiy_url` is planned to serve SXG-signature-header-related information. If a page has not been modified since the last SXG, downloading the entire SXG file is not required technically. So updating signature header information alone is expected to reduce network traffic. But the details are not implemented yet.
 

--- a/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
+++ b/src/site/content/en/blog/how-to-set-up-signed-http-exchanges/index.md
@@ -123,7 +123,7 @@ The [SXG module for `nginx`](https://github.com/kumagi/nginx-sxg-module) is dist
 On Debian-based systems, you can install it as a binary package:
 
 ```bash
-sudo apt install nginx
+sudo apt install -y nginx
 wget https://github.com/google/nginx-sxg-module/releases/download/v0.1/libnginx-mod-http-sxg-filter_1.15.9-0ubuntu1.1_amd64.deb
 sudo dpkg -i libnginx-mod-http-sxg-filter_1.15.9-0ubuntu1.1_amd64.deb
 ```


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #2083 

I tried installing SXG and its nginx plugin with reading this document, and noticed some URLs are wrong to install [libsxg](https://github.com/google/libsxg/releases) from debian package.

Changes proposed in this pull request:

- Fixes 404 urls for `libsxg` debian package
- Add `-y` option for consistency