### PR TITLE
Add a workflow to catch the DO NOT MERGE label.

### DIFF
--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   do_not_merge:
+    name: Do not merge
     runs-on: ubuntu-latest
     steps:
-      - name: Do not merge
-        run: echo "::error ::PR can't be merged with the DO NOT MERGE label."
+      - run: echo "::error ::PR can't be merged with the DO NOT MERGE label."; exit 1
         if: contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE')

--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -1,0 +1,12 @@
+name: Required checks
+
+on:
+  pull_request
+
+jobs:
+  do_not_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do not merge
+        run: echo "::error ::PR can't be merged with the DO NOT MERGE label."
+        if: contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE')

--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -2,7 +2,7 @@ name: Required checks
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [labeled]
 
 jobs:
   do_not_merge:

--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -2,7 +2,7 @@ name: Required checks
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   do_not_merge:

--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -1,7 +1,8 @@
 name: Required checks
 
 on:
-  pull_request
+  pull_request:
+    types: [labeled, unlabeled]
 
 jobs:
   do_not_merge:


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a GitHub Action to catch the DO NOT MERGE label. Should be set as a required check for branch protection in repo settings.