### PR TITLE
Add hero image notice.

### DIFF
--- a/src/site/_drafts/_template-case-study/index.md
+++ b/src/site/_drafts/_template-case-study/index.md
@@ -2,6 +2,9 @@
 title: TODO           # Title should mention the type of change that was made and the improvement.
 subhead: TODO         # Subhead can elaborate on the title, if needed.
 date: YYYY-MM-DD
+# !!! IMPORTANT: If your post does not contain a hero image it will not appear
+# on the homepage.
+hero: hero.jpg
 authors:
   - TODO
 description: |

--- a/src/site/_drafts/_template-post/index.md
+++ b/src/site/_drafts/_template-post/index.md
@@ -12,6 +12,8 @@ date: 2019-10-31
 # Add an updated date to your post if you edit in the future.
 # updated: 2019-11-01
 
+# !!! IMPORTANT: If your post does not contain a hero image it will not appear
+# on the homepage.
 hero: hero.jpg
 # You can adjust the fit of your hero image with this property.
 # Values: contain | cover (default)

--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -2,7 +2,7 @@
 layout: handbook
 title: Images and video
 date: 2019-06-26
-updated: 2020-03-25
+updated: 2020-04-01
 description: |
   Learn how to create the Markdown for images and video for web.dev.
 ---
@@ -26,6 +26,10 @@ alt: A description of the hero. # Also used by the thumbnail (when applicable).
 …
 ---
 ```
+
+{% Aside 'warning' %}
+If your post does not contain a hero image it will not be displayed on the homepage.
+{% endAside %}
 
 Hero images should be 3200 px x 960 px.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- See https://github.com/GoogleChrome/web.dev/pull/2139 for context
- Add notice that posts without a hero will not appear on the homepage.
