### PR TITLE
Clean up percy.

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -18,6 +18,7 @@ const locale = require("../../../shared/locale");
 
 module.exports = {
   env: process.env.ELEVENTY_ENV || "dev",
+  percy: process.env.PERCY || false,
   title: "web.dev",
   titleVariation: "Home",
   defaultLocale: locale.defaultLocale,

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -636,6 +636,12 @@ at.
 </div>
 ```
 
+<!-- Don't attempt to load Glitch if we're screenshot testing. -->
+{% if site.percy %}
+<div style="background: aquamarine; width: 400px; height: 400px;">
+  Glitch iframe placeholder
+</div>
+{% else %}
 <div class="glitch-embed-wrap" style="height: 480px; width: 100%;">
   <iframe
     src="https://glitch.com/embed/#!/embed/tabindex-zero?path=index.html&attributionHidden=true"
@@ -643,6 +649,7 @@ at.
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>
+{% endif %}
 
 ## Images
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Disable the glitch embed when percy is running against the components page.

I think at some point we should probably rename the `site.env` variable since it's specific to eleventy at this point but I didn't want to do that in this PR for fear of breaking something unseen.
