### PR TITLE
Hide post card image from screen readers.

### DIFF
--- a/src/site/_includes/components/PostCard.js
+++ b/src/site/_includes/components/PostCard.js
@@ -160,7 +160,12 @@ module.exports = ({post, featured = false}) => {
           class="w-post-card__cover ${thumbnail &&
             `w-post-card__cover--with-image`}"
         >
-          <a class="w-post-card__link" tabindex="-1" href="${url}">
+          <a
+            class="w-post-card__link"
+            tabindex="-1"
+            href="${url}"
+            aria-hidden="true"
+          >
             ${thumbnail && renderThumbnail(url, thumbnail, alt)}
           </a>
         </div>


### PR DESCRIPTION
Changes proposed in this pull request:

- If an author forgets to put alt text on their hero image, then the link for the post card image will not have a name (and our a11y Lighthouse score will go down). But if someone is using a screen reader they likely don't get much from this link anyway since it's duplicative of the link used on the article title. So let's hide this link from screen readers and reduce the number of tab stops.