### PR TITLE
wrap localStorage to deal with Firefox issues

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -1,6 +1,7 @@
 import {store} from './store';
 import {saveUserUrl} from './fb';
 import {runLighthouse, fetchReports} from './lighthouse-service';
+import {localStorage} from './utils/storage';
 
 export const clearSignedInState = store.action(() => {
   const {isSignedIn} = store.getState();
@@ -160,7 +161,7 @@ export const checkIfUserAcceptsCookies = store.action(
       return;
     }
 
-    if (localStorage.getItem('web-accepts-cookies')) {
+    if (localStorage['web-accepts-cookies']) {
       return {
         userAcceptsCookies: true,
       };
@@ -171,7 +172,7 @@ export const checkIfUserAcceptsCookies = store.action(
 );
 
 export const setUserAcceptsCookies = store.action(() => {
-  localStorage.setItem('web-accepts-cookies', 1);
+  localStorage['web-accepts-cookies'] = 1;
   return {
     userAcceptsCookies: true,
     showingSnackbar: false,

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -2,6 +2,7 @@ import config from 'webdev_config';
 import {store} from './store';
 import {clearSignedInState} from './actions';
 import firestoreLoader from './firestore-loader';
+import {localStorage} from './utils/storage';
 
 /* eslint-disable require-jsdoc */
 
@@ -24,7 +25,7 @@ firebase.auth().onAuthStateChanged((user) => {
 
   // Cache whether the user was signed in, to help prevent FOUC in future, as
   // this can be read synchronosly and Firebase's auth takes ~ms to come back.
-  window.localStorage['webdev_isSignedIn'] = user ? 'probably' : '';
+  localStorage['webdev_isSignedIn'] = user ? 'probably' : '';
 
   if (!user) {
     clearSignedInState();

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -2,6 +2,7 @@ import createStore from 'unistore';
 import devtools from 'unistore/devtools';
 import getMeta from './utils/meta';
 import config from 'webdev_config';
+import {localStorage} from './utils/storage';
 
 /* eslint-disable require-jsdoc */
 
@@ -13,7 +14,7 @@ const initialState = {
   checkingSignedInState: true,
 
   // The user has successfully signed in; default to cached value to help prevent FOUC
-  isSignedIn: Boolean(window.localStorage['webdev_isSignedIn']),
+  isSignedIn: Boolean(localStorage['webdev_isSignedIn']),
   user: null,
 
   // The most recent URL measured and the Date when it was first analyzed by the user.

--- a/src/lib/utils/storage.js
+++ b/src/lib/utils/storage.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Wraps access to `window.localStorage`, as Firefox throws a
+ * SecurityError (or it is null) when it is not available.
+ */
+
+/**
+ * @return {!Object<string, string>}
+ */
+function getLocalStorage() {
+  let cand;
+  try {
+    cand = window.localStorage;
+  } catch (e) {
+    // ignore
+  }
+  return cand || {};
+}
+
+/**
+ * Exports a safe version of localStorage.
+ *
+ * @type {!Object<string, string>}
+ */
+export const localStorage = getLocalStorage();


### PR DESCRIPTION
Wraps access to `window.localStorage`. This works around Firefox throwing a `SecurityException` in its private mode when you access this object.