### PR TITLE
build script cleanup + virtual imports

### DIFF
--- a/build.js
+++ b/build.js
@@ -149,7 +149,7 @@ async function build() {
   // Does not hash "bootstrap.js" entrypoint, but hashes all generated chunks,
   // useful for cache busting.
   const appBundle = await rollup.rollup({
-    input: "src/lib/bootstrap.js",
+    input: 'src/lib/bootstrap.js',
     external: disallowExternal,
     plugins: [rollupPluginPostCSS(postcssConfig), ...defaultPlugins],
   });
@@ -178,7 +178,7 @@ async function build() {
   );
 
   const swBundle = await rollup.rollup({
-    input: "src/lib/sw.js",
+    input: 'src/lib/sw.js',
     external: disallowExternal,
     plugins: [
       // This variable is defined by Webpack (and some other tooling), but not by Rollup. Set it to
@@ -202,8 +202,8 @@ async function build() {
   const swOutput = await singleOutput(
     swBundle.write({
       sourcemap: true,
-      dir: "dist",
-      format: "esm",
+      dir: 'dist',
+      format: 'esm',
     }),
   );
 

--- a/build.js
+++ b/build.js
@@ -41,7 +41,7 @@ process.on('unhandledRejection', (reason, p) => {
  */
 const virtualImports = {
   webdev_config: {
-    prod: isProd,
+    isProd,
     env: process.env.ELEVENTY_ENV || 'dev',
     version:
       'v' +
@@ -159,13 +159,13 @@ async function build() {
     dir: 'dist',
     format: 'esm',
   });
+  for (const {fileName} of appGenerated.output) {
+    generated.push(fileName);
+  }
 
   // Compress the generated source here, as we need the final files and hashes for the Service
   // Worker manifest.
   if (isProd) {
-    for (const {fileName} of appGenerated.output) {
-      generated.push(fileName);
-    }
     await compressOutput(generated);
   }
 
@@ -207,11 +207,11 @@ async function build() {
     }),
   );
 
+  const {fileName} = swOutput;
   if (isProd) {
-    const {fileName} = swOutput;
     await compressOutput([fileName]);
-    generated.push(fileName);
   }
+  generated.push(fileName);
 
   return generated.length;
 }

--- a/build.js
+++ b/build.js
@@ -152,16 +152,6 @@ async function build() {
     input: "src/lib/bootstrap.js",
     external: disallowExternal,
     plugins: [rollupPluginPostCSS(postcssConfig), ...defaultPlugins],
-    external(source, importer, isResolved) {
-      // We don't support any external imports. This most likely happens if you mistype a
-      // node_modules import or the package.json has changed.
-      if (isResolved && !source.match(/^\.{0,2}\//)) {
-        throw new Error(
-          `Unresolved external import: "${source}" (imported ` +
-            `by: ${importer}), did you forget to npm install?`,
-        );
-      }
-    },
   });
   const appGenerated = await appBundle.write({
     dynamicImportFunction: 'window._import',

--- a/build.js
+++ b/build.js
@@ -133,6 +133,7 @@ async function singleOutput(rollupPromise) {
  * to build the Service Worker.
  */
 async function build() {
+  const generated = [];
   const postcssConfig = {};
   if (isProd) {
     // nb. Only require() autoprefixer when used.
@@ -172,7 +173,6 @@ async function build() {
   // Compress the generated source here, as we need the final files and hashes for the Service
   // Worker manifest.
   if (isProd) {
-    const generated = [];
     for (const {fileName} of appGenerated.output) {
       generated.push(fileName);
     }

--- a/src/build/virtual-json.js
+++ b/src/build/virtual-json.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Helper that converts JSON into ESM that exports that JSON.
+ *
+ * This does not use a standard Rollup plugin as these files aren't coming from
+ * disk and don't have a "real" name.
+ */
+
+const validJSName = /^[\w_$][\w\d_$]*$/;
+
+function createVirtualExport(object) {
+  const parts = [`export default ${JSON.stringify(object)};`];
+
+  // If this is an object, use its keys as top-level exports, where the keys are valid JS variable
+  // names (e.g. "foo" will be exported but "foo-bar" will not).
+  if (object && typeof object === "object" && !Array.isArray(object)) {
+    for (const key in object) {
+      if (validJSName.test(key)) {
+        // nb. We use var for compatibility with old browsers (as our basic bundle is run there).
+        parts.push(`export var ${key} = ${JSON.stringify(object[key])};`);
+      }
+    }
+  }
+
+  return parts.join("\n");
+}
+
+module.exports = (all) => {
+  const out = {};
+  Object.keys(all).forEach((key) => {
+    out[key] = createVirtualExport(all[key]);
+  });
+  return out;
+};

--- a/src/build/virtual-json.js
+++ b/src/build/virtual-json.js
@@ -12,9 +12,9 @@ function createVirtualExport(object) {
 
   // If this is an object, use its keys as top-level exports, where the keys are valid JS variable
   // names (e.g. "foo" will be exported but "foo-bar" will not).
-  if (object && typeof object === "object" && !Array.isArray(object)) {
+  if (object && typeof object === 'object' && !Array.isArray(object)) {
     for (const key in object) {
-      if (validJSName.test(key) && key !== "default") {
+      if (validJSName.test(key) && key !== 'default') {
         // nb. This doesn't check for all JS keywords. Don't try to export "class".
         // nb. We use var for compatibility with old browsers (as our basic bundle is run there).
         parts.push(`export var ${key} = ${JSON.stringify(object[key])};`);
@@ -22,7 +22,7 @@ function createVirtualExport(object) {
     }
   }
 
-  return parts.join("\n");
+  return parts.join('\n');
 }
 
 module.exports = (all) => {

--- a/src/build/virtual-json.js
+++ b/src/build/virtual-json.js
@@ -14,7 +14,8 @@ function createVirtualExport(object) {
   // names (e.g. "foo" will be exported but "foo-bar" will not).
   if (object && typeof object === "object" && !Array.isArray(object)) {
     for (const key in object) {
-      if (validJSName.test(key)) {
+      if (validJSName.test(key) && key !== "default") {
+        // nb. This doesn't check for all JS keywords. Don't try to export "class".
         // nb. We use var for compatibility with old browsers (as our basic bundle is run there).
         parts.push(`export var ${key} = ${JSON.stringify(object[key])};`);
       }

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -5,15 +5,11 @@
  * correct entrypoint via our router.
  */
 
-import {version} from 'webdev_config';
 import './webcomponents-config'; // must go before -loader below
 import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
 import {swapContent, getPartial} from './loader';
 import * as router from './utils/router';
 import {store} from './store';
-
-// TODO(samthor): This forces a rehash of the JS on every deploy. Remove this.
-console.info('web.dev', version);
 
 WebComponents.waitFor(async () => {
   // TODO(samthor): This isn't quite the right class name because not all Web Components are ready

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -5,14 +5,15 @@
  * correct entrypoint via our router.
  */
 
-import config from 'webdev_config';
+import {version} from 'webdev_config';
 import './webcomponents-config'; // must go before -loader below
 import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
 import {swapContent, getPartial} from './loader';
 import * as router from './utils/router';
 import {store} from './store';
 
-console.info('web.dev', config.version);
+// TODO(samthor): This forces a rehash of the JS on every deploy. Remove this.
+console.info('web.dev', version);
 
 WebComponents.waitFor(async () => {
   // TODO(samthor): This isn't quite the right class name because not all Web Components are ready

--- a/src/lib/components/Codelab/index.js
+++ b/src/lib/components/Codelab/index.js
@@ -5,10 +5,8 @@
 
 import {html} from 'lit-element';
 import {BaseElement} from '../BaseElement';
-import config from 'webdev_config';
+import {env} from 'webdev_config';
 import './_styles.scss';
-
-const {env} = config;
 
 /**
  * Render codelab instructions and Glitch

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -1,12 +1,10 @@
-import config from 'webdev_config';
+import {firebaseConfig} from 'webdev_config';
 import {store} from './store';
 import {clearSignedInState} from './actions';
 import firestoreLoader from './firestore-loader';
 import {localStorage} from './utils/storage';
 
 /* eslint-disable require-jsdoc */
-
-const {firebaseConfig} = config;
 
 firebase.initializeApp(firebaseConfig);
 

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -2,7 +2,7 @@ import createStore from 'unistore';
 import devtools from 'unistore/devtools';
 import getMeta from './utils/meta';
 import {localStorage} from './utils/storage';
-import {prod as isProd} from 'webdev_config';
+import {isProd} from 'webdev_config';
 
 /* eslint-disable require-jsdoc */
 

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,8 +1,8 @@
 import createStore from 'unistore';
 import devtools from 'unistore/devtools';
 import getMeta from './utils/meta';
-import config from 'webdev_config';
 import {localStorage} from './utils/storage';
+import {prod as isProd} from 'webdev_config';
 
 /* eslint-disable require-jsdoc */
 
@@ -46,7 +46,7 @@ const initialState = {
   // cookie policy.
   // We automatically accept cookies in dev and test environments so the cookie
   // banner doesn't interfere with tests.
-  userAcceptsCookies: !config.prod,
+  userAcceptsCookies: !isProd,
 
   // Handle hiding/showing the snackbar.
   showingSnackbar: false,
@@ -54,7 +54,7 @@ const initialState = {
 };
 
 let store;
-if (config.prod) {
+if (isProd) {
   store = createStore(initialState);
 } else {
   store = devtools(createStore(initialState));


### PR DESCRIPTION
Extracted from #2410 which will get closed.

* Adds virtual imports to all our build bundles (since you can just _not_ import them if you don't need them in your code)
  * Exports individual keys (so our JS bundles aren't all including the whole config each)
  * Update some code to use these keys

* Adds comments to the build script
* Disallows all external imports—i.e., those which Rollup can't find—Rollup would normally allow mistypings or missing deps (for example, if you haven't run `npm install` in a while), now throw