### PR TITLE
Add percy test for tablets. Fix PostCards on tablet.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "precommit": "node ./tools/update-updated/index.js",
     "rollup": "eleventy --input src/site/content/sw-partial-layout.njk; node build.js",
     "sass": "node ./compile-css.js src/styles/all.scss dist/app.css",
-    "snapshots": "percy exec -- node tools/percy/snapshots.js",
+    "snapshots": "percy exec --config ./tools/percy/.percy.conf.yml -- node tools/percy/snapshots.js",
     "stage:personal": "ELEVENTY_ENV=dev npm run build && gcloud app deploy --project web-dev-staging --quiet --no-promote",
     "stage": "ELEVENTY_ENV=dev npm run build && gcloud app deploy --project web-dev-staging --quiet",
     "start": "node ./server.js",

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -1,3 +1,5 @@
+@import 'grid';
+
 @import 'actions';
 @import 'article-header';
 @import 'article-navigation';
@@ -16,7 +18,6 @@
 @import 'cross-links';
 @import 'details';
 @import 'footer';
-@import 'grid';
 @import 'header';
 @import 'icon-list';
 @import 'images';

--- a/tools/percy/.percy.conf.yml
+++ b/tools/percy/.percy.conf.yml
@@ -1,0 +1,3 @@
+version: 1
+snapshot:
+  widths: [375, 865, 1280]


### PR DESCRIPTION
I think #2384 may have inadvertently broken the layout of the PostCard on tablets. The first card should have a 'featured' class that makes it lay out with the image on the left and the text on the right on tablets.

It looks like the cause of the bug is because we changed the ordering of our CSS. `_post-card.scss` used to come after `_grid.scss` and would override the grid. But when it was renamed to `_base-card.scss` the ordering swapped.

As a short term fix I moved the grid to the top of the file. But, as discussed with Michael, I'd love for us to take a crack at refactoring the cards so they're smaller and more composable and less dependent on overrides. There's also a lot of grid/typography/vertical rhythm stuff I'd like to improve in our CSS. Maybe if there's time we can dedicate some of Q2 to CSS cleanup.

Changes proposed in this pull request:

- Adds a percy config file so we can snapshot at different sizes, includes a tablet size.
- Moves `grid.scss` to the top of the file.