### PR TITLE
Only render subhead if text exists.

### DIFF
--- a/src/site/_includes/components/BaseCard.js
+++ b/src/site/_includes/components/BaseCard.js
@@ -136,6 +136,20 @@ class BaseCard {
     `;
   }
 
+  renderSubhead(subhead) {
+    if (!subhead) {
+      return;
+    }
+
+    return html`
+      <a class="w-card-base__link" tabindex="-1" href="${this.url}">
+        <p class="w-card-base__subhead">
+          ${md(subhead)}
+        </p>
+      </a>
+    `;
+  }
+
   renderChips() {
     if (!this.displayedTags.length) {
       return;
@@ -164,6 +178,7 @@ class BaseCard {
   }
 
   render() {
+    // prettier-ignore
     return html`
       <div class="w-card ${this.className}" role="listitem">
         <article
@@ -198,11 +213,7 @@ class BaseCard {
               class="w-card-base__desc ${this.className &&
                 `${this.className}__desc`}"
             >
-              <a class="w-card-base__link" tabindex="-1" href="${this.url}">
-                <p class="w-card-base__subhead">
-                  ${md(this.data.subhead)}
-                </p>
-              </a>
+              ${this.renderSubhead(this.data.subhead)}
               ${this.renderChips()}
             </div>
           </div>


### PR DESCRIPTION
Related to #2554. If an article doesn't have a subhead it shouldn't render the subhead section. Otherwise it will render a link with no text inside of it which negatively affects our lighthouse a11y score. 

Changes proposed in this pull request:

- Adds a `renderSubhead` function to the BaseCard which is a noop if there is no subhead.
