### PR TITLE
optimize text for speed versus legibility.

### DIFF
--- a/src/styles/settings/_type.scss
+++ b/src/styles/settings/_type.scss
@@ -17,7 +17,7 @@
 // Smoothing.
 $FONT_SMOOTHING_MOZ: grayscale;
 $FONT_SMOOTHING_WEBKIT: antialiased;
-$FONT_SMOOTHING_RENDERING: optimizeLegibility;
+$FONT_SMOOTHING_RENDERING: optimizeSpeed;
 
 // Fonts.
 $HEADLINE_FONT: 'Google Sans', sans-serif;

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -199,7 +199,7 @@
   -webkit-font-smoothing: antialiased; // @alternate
   font: normal normal normal 24px / 1 'Material Icons';
   font-feature-settings: 'liga';
-  text-rendering: optimizeLegibility;
+  text-rendering: optimizeSpeed;
   text-transform: none;
   word-wrap: normal;
 }

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -195,11 +195,11 @@
 // 'material-icons' class defined at http://fonts.googleapis.com/css?family=Material+Icons.
 // You can look up the name of an icon at https://material.io/icons/.
 @mixin font-material-icon() {
-  -moz-osx-font-smoothing: grayscale; // @alternate
-  -webkit-font-smoothing: antialiased; // @alternate
+  -moz-osx-font-smoothing: $FONT_SMOOTHING_MOZ; // @alternate
+  -webkit-font-smoothing: $FONT_SMOOTHING_WEBKIT; // @alternate
   font: normal normal normal 24px / 1 'Material Icons';
   font-feature-settings: 'liga';
-  text-rendering: optimizeSpeed;
+  text-rendering: $FONT_SMOOTHING_RENDERING;
   text-transform: none;
   word-wrap: normal;
 }


### PR DESCRIPTION
Random tidbit I came across while reading [A Modern CSS Reset](https://hankchizljaw.com/wrote/a-modern-css-reset/).

https://marco.org/2012/11/15/text-rendering-optimize-legibility

Changes proposed in this pull request:

- Changes our CSS to use `text-rendering: optimizeSpeed` instead of `optimizeLegibility`.
