### PR TITLE
make 404s always go to network

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,12 +40,18 @@ const redirectHandler = (() => {
 
 // 404 handlers aren't special, they just run last.
 const notFoundHandler = (req, res, next) => {
-  // This 404 handler is vaguely approximated on Netlify in our staging environment.
+  res.status(404);
+
+  const extMatch = /(\.[^.]*)$/.exec(req.url);
+  if (extMatch && extMatch[1] !== '.html') {
+    // If this had an extension and it was not ".html", don't send any bytes.
+    // This is just a minor optimization to not waste bytes.
+    // Pages without extensions won't match here: e.g., "/foo" will still send HTML.
+    return res.end();
+  }
+
   const options = {root: 'dist/en'};
-  const suffix = req.url.endsWith('.json') ? 'json' : 'html';
-  res
-    .status(404)
-    .sendFile(`404/index.${suffix}`, options, (err) => err && next(err));
+  res.sendFile(`404/index.html`, options, (err) => err && next(err));
 };
 
 // Disallow invalid hostnames, and remove any active Service Worker too (users

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -108,6 +108,9 @@ workboxRouting.registerRoute(
  *   - /index.json
  *   - /foo-bar/index.json
  *   - /foo-bar/many/parts/test.json
+ *
+ * This matches all JSON files, but the only JSON files served on our domain are
+ * partials.
  */
 const partialPathRe = new RegExp('^/([\\w-]+/)*\\w+\\.json$');
 const partialStrategy = new workboxStrategies.NetworkFirst({

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -104,8 +104,10 @@ workboxRouting.registerRoute(
 );
 
 /**
- * Match fetches for patials, for SPA requests. Matches "/foo-bar/index.json" and
- * "/foo-bar/many/parts/test.json", for partial SPA requests.
+ * Match fetches for partials, for SPA requests. Matches requests like:
+ *   - /index.json
+ *   - /foo-bar/index.json
+ *   - /foo-bar/many/parts/test.json
  */
 const partialPathRe = new RegExp('^/([\\w-]+/)*\\w+\\.json$');
 const partialStrategy = new workboxStrategies.NetworkFirst({
@@ -140,9 +142,9 @@ workboxRouting.registerRoute(
  * This won't match any URL that contains a "." except for a trailing ".html".
  *
  * Internally, the handler fetches the required partial using `partialStrategy`,
- * and generates the page's real HTML based on the layout template. If the
- * partial fails to load, it _then_ tries a real network request (for
- * redirects).
+ * and generates the page's real HTML based on the layout template. This can be
+ * an offline page if there was a network failure, but other failures (including
+ * a 404) fall through to the catch handler which does a network fetch.
  */
 const normalMatch = matchSameOriginRegExp(
   new RegExp('^/[\\w-/]*(?:|\\.html)$'),
@@ -182,7 +184,7 @@ workboxRouting.registerRoute(normalMatch, async ({url}) => {
   // redirect handlers.
   if (!response.ok) {
     throw new Error(
-      `unhandled status for normal route '${pathname}': ${response.status}`,
+      `unhandled status for normal route '${url.pathname}': ${response.status}`,
     );
   }
   const partial = await response.json();

--- a/src/site/content/en/_redirects.yaml
+++ b/src/site/content/en/_redirects.yaml
@@ -1,3 +1,16 @@
+# Master redirects file for web.dev. This mirrors the old DevSite file.
+# There are two types of redirects:
+#
+#  (1) Simple redirects, e.g., "from: /foo"
+#      - These don't match anything under this URL, like "/foo/bar"
+#      - No trailing slash is required, as this matches "/foo", "/foo/" and
+#        "/foo/index.html"
+#
+#  (2) Group redirects, e.g., "from: /foo/...", which will match the top-level
+#      path (with the same rules as (1)) as well as any descendant paths
+#
+# WARNING! Redirects DO NOT take priority over static content.
+
 redirects:
 
 # Policies
@@ -168,13 +181,10 @@ redirects:
 - from: /pwa
   to: /progressive-web-apps/
 
-- from: /pwa/
-  to: /progressive-web-apps/
-
-- from: /installable/
+- from: /installable
   to: /progressive-web-apps/#installable
 
-- from: /discover-installable/
+- from: /discover-installable
   to: /progressive-web-apps/#installable
 
 # Redirect for spec name changes

--- a/src/site/content/en/_redirects.yaml
+++ b/src/site/content/en/_redirects.yaml
@@ -2,14 +2,15 @@
 # There are two types of redirects:
 #
 #  (1) Simple redirects, e.g., "from: /foo"
-#      - These don't match anything under this URL, like "/foo/bar"
-#      - No trailing slash is required, as this matches "/foo", "/foo/" and
-#        "/foo/index.html"
+#      - These don't match subpaths, like "/foo/bar"
+#      - But it will match similar URLs "/foo", "/foo/" and "/foo/index.html"
 #
 #  (2) Group redirects, e.g., "from: /foo/...", which will match the top-level
 #      path (with the same rules as (1)) as well as any descendant paths
 #
 # WARNING! Redirects DO NOT take priority over static content.
+# For example, if you try to redirect "/foo" but the site contains a static file
+# "/foo/index.html", the static file will always win.
 
 redirects:
 


### PR DESCRIPTION
Fixes #2488 and #2529.

This (hopefully...) simplifies our SW a bit by treating 404's as unrecoverable errors that always go to the network. This occurs in the Service Worker as well as in the SPA routing (so a 404 will "break" the SPA). We just don't know if there's really a redirect backing whatever page 404'ed otherwise.

I've also added a comment to the redirects YAML to make it clear that trailing slashes there are unnecessary.