### PR TITLE
add service-worker kill switch

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,9 @@ const cookieParser = require('cookie-parser');
 const localeHandler = require('./locale-handler.js');
 const buildRedirectHandler = require('./redirect-handler.js');
 
+// If true, we'll aggressively nuke the prod Service Worker. For emergencies.
+const serviceWorkerKill = false;
+
 const redirectHandler = (() => {
   // In development, Eleventy isn't guaranteed to have run, so read the actual
   // source file.
@@ -54,21 +57,28 @@ const notFoundHandler = (req, res, next) => {
   res.sendFile(`404/index.html`, options, (err) => err && next(err));
 };
 
-// Disallow invalid hostnames, and remove any active Service Worker too (users
-// may have loaded this and otherwise they'll be stuck forever).
+// Implement safety mechanics. Disallow invalid hostnames (and remove any
+// lasting Service Workers otherwise users could be stuck forever), and
+// optionally nuke our production Service Worker in an emergency.
 const invalidHostnames = ['www.web.dev', 'appengine-test.web.dev'];
-const invalidHostnameHandler = (req, res, next) => {
+const safetyHandler = (req, res, next) => {
+  const isServiceWorkerRequest = Boolean(req.headers['service-worker']);
   if (invalidHostnames.includes(req.hostname)) {
-    if (!req.headers['service-worker']) {
+    if (!isServiceWorkerRequest) {
       return res.redirect(301, 'https://web.dev' + req.url);
     }
+    // We always nuke the Service Worker for invalid hostnames.
+    req.url = '/nuke-sw.js';
+  } else if (serviceWorkerKill && isServiceWorkerRequest) {
+    // The kill switch is enabled, nuke the Service Worker.
     req.url = '/nuke-sw.js';
   }
+
   return next();
 };
 
 const handlers = [
-  invalidHostnameHandler,
+  safetyHandler,
   localeHandler,
   express.static('dist'),
   express.static('dist/en'),

--- a/src/misc/nuke-sw.js
+++ b/src/misc/nuke-sw.js
@@ -1,25 +1,30 @@
 // Inspired by https://github.com/GoogleChrome/devsummit/blob/master/src/nuke-sw.js
-// Not actually compiled, just served in places we no longer want a Service Worker
+// Not actually compiled, just served in places we no longer want a Service Worker.
+// This registers an empty Service Worker.
 
 // Is this actually being executed in a ServiceWorker?
-if (self instanceof ServiceWorkerGlobalScope) {
-  Promise.resolve()
-    .then(() => {
-      // Nuke the Service Worker.
-      return self.registration.unregister();
-    })
-    .then(() => {
-      // Match all window'ed pages.
-      return clients.matchAll({
+if (
+  typeof ServiceWorkerGlobalScope !== 'undefined' &&
+  self instanceof ServiceWorkerGlobalScope
+) {
+  self.addEventListener('install', (event) => {
+    event.waitUntil(self.skipWaiting());
+  });
+
+  self.addEventListener('activate', (event) => {
+    const p = (async () => {
+      await self.clients.claim();
+
+      const existingClients = await clients.matchAll({
         includeUncontrolled: true,
         type: 'window',
       });
-    })
-    .then((clients) => {
-      // Reload all pages (this isn't part of the promise chain, as we can block ourselves).
-      clients.forEach((client) => client.navigate(client.url));
-    })
-    .catch((err) => {
-      console.error(err);
-    });
+
+      // We must activate and claim our clients before forcing them to navigate,
+      // even for a basic reload.
+      existingClients.forEach((client) => client.navigate(client.url));
+    })();
+
+    event.waitUntil(p);
+  });
 }


### PR DESCRIPTION
Adds a quick boolean that we can use to nuke the SW if necessary.