### PR TITLE
See if cranking up percy snapshot wait time helps with flakiness.

### DIFF
--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -48,7 +48,7 @@ PercyScript.run(
     for (page of pagesToTest) {
       await browser.goto(`http://localhost:8080/${page.url}`);
       // Wait for the SPA to update the active link in the top nav.
-      await browser.waitFor(2000);
+      await browser.waitFor(5000);
       await percySnapshot(`${page.title}`);
     }
   },


### PR DESCRIPTION
Changes proposed in this pull request:

- It seems like /learn/ on mobile pretty consistently has flaky image loading issues. Seeing if increasing the time that percy waits before doing a snapshot helps any.