### PR TITLE
Only run percy against PRs.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -3,9 +3,6 @@ name: Percy
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - '**.js'


### PR DESCRIPTION
We hit our free Percy limit of 5000 screenshots this month so I upgraded us to the paid plan. We made two changes recently that I think contributed to this overage:

- We were running Percy every time something got merged into master, even if we were just merging in markdown files of text. This also means we were running it at least twice for every PR (once during the PR review and once when it merged).
- I added an additional size to our [.percy.config.yml](https://github.com/GoogleChrome/web.dev/blob/6572b7c0bb5a2f8c6102ebec47747205caf23bb1/tools/percy/.percy.conf.yml#L3) file so we could take screenshots of tablets. So every PR generates at least three screenshots per synchronization.

Changes proposed in this pull request:

- Only run percy against pull requests. Don't bother running it when stuff merges into master. We shouldn't be pushing directly to master anyway. Hopefully this cuts down on a lot of excess.