### PR TITLE
fix: typo in srcset blog

### DIFF
--- a/src/site/content/en/blog/use-srcset-to-automatically-choose-the-right-image/index.md
+++ b/src/site/content/en/blog/use-srcset-to-automatically-choose-the-right-image/index.md
@@ -214,7 +214,7 @@ You can see this in action at
 
 {% Aside 'caution'%}
 `sizes` gives the browser information about the display width
-of on image element.
+of an image element.
 
 As with `srcset` it does NOT specify the size to display the image—you need
 CSS for that.


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixed a small typo I noticed in the srcset blog post
