### PR TITLE
search tab index bug

### DIFF
--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -138,6 +138,7 @@ class Search extends BaseElement {
               data-label="search, open Google"
               data-action="click"
               target="_blank"
+              tabindex="-1"
               href=${searchUrl}
             >
               Google search


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #2346 

Changes proposed in this pull request:

- remove `a` tag tab order inside search result box