### PR TITLE
Content Indexing update: launchUrl is now url

### DIFF
--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -5,7 +5,7 @@ authors:
   - jeffposnick
 description: Your PWA might cache articles and media files, but how will your users know that your pages work while offline? The Content Indexing API is one answer to this question currently in an origin trial. Once the index is populated with content from your PWA, as well as any other installed PWAs, it will show up in dedicated areas of supported browsers.
 date: 2019-12-12
-updated: 2020-03-31
+updated: 2020-04-15
 tags:
   - post
   - capabilities
@@ -190,7 +190,9 @@ await registration.index.add({
   // Required; set to something unique within your web app.
   id: 'article-123',
 
-  // Required; this URL needs to be an offline-capable HTML page.
+  // Required; url needs to be an offline-capable HTML page.
+  // For compatibility during the Origin Trial, include launchUrl as well.
+  url: '/articles/123',
   launchUrl: '/articles/123',
 
   // Required; used in user-visible lists of content.
@@ -211,6 +213,12 @@ await registration.index.add({
   category: 'article',
 });
 ```
+
+{% Aside 'note' %}
+  The `add()` method previously took a `launchUrl` parameter, which has been renamed to `url`.
+  During the Origin Trial period, you should include both `url` and `launchUrl`, set to the same
+  value. Following the Origin Trial, only `url` will be supported.
+{% endAside %}
 
 Adding an entry only affects the content index; it does not add anything to the
 [Cache Storage

--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -220,6 +220,7 @@ await registration.index.add({
   value. Following the Origin Trial, only `url` will be supported.
 {% endAside %}
 
+
 Adding an entry only affects the content index; it does not add anything to the
 [Cache Storage
 API](https://developers.google.com/web/fundamentals/instant-and-offline/web-storage/cache-api).


### PR DESCRIPTION
This addresses a change to the Content Indexing API that will go into effect after the Origin Trial period ends, along with guidance about compatibility during the Origin Trial.

CC: @rayankans to confirm the details.