### PR TITLE
Add stale bot config.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,11 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 20
+daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
-  - accepted
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,6 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - security
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 20
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - accepted
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 7 days if no further activity occurs.
+  To prevent his from happening, leave a comment.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a config for [stalebot](https://github.com/probot/stale)
- Issues and PRs with no activity for 30 days will be marked stale.
- Issues with the `pinned` label are exempt. Also, did you know you can [pin an issue](https://help.github.com/en/github/managing-your-work-on-github/pinning-an-issue-to-your-repository)?