### PR TITLE
Add note that the Contact Picker is available on mobile only

### DIFF
--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
 description: Access to the user's contacts has been a feature of native apps since (almost) the dawn of time. The Contact Picker API is an on-demand API  that allows users to select an entry or entries from their contact list and share limited details of the selected contact(s) with a website. It allows users to share only what they want, when they want, and makes it easier for users to reach and connect with their friends and family.
 date: 2019-08-07
-updated: 2020-04-14
+updated: 2020-04-15
 tags:
   - post
   - capabilities
@@ -35,7 +35,7 @@ alt: Telephone on yellow background.
   </a>
 </figure>
 
-Access to the user's contacts has been a feature of native apps since
+Access to the user's contacts on a mobile device has been a feature of native apps since
 (almost) the dawn of time. It's one of the most common feature requests
 I hear from web developers, and is often the key reason they build a native
 app.
@@ -68,7 +68,7 @@ which friends have already joined.
 | 2. Create initial draft of specification   | [Complete][spec]             |
 | 3. Gather feedback & iterate on design     | [Complete][spec]             |
 | 4. Origin trial                            | Complete                     |
-| **5. Launch**                              | **Chrome 80**                |
+| **5. Launch**                              | **Chrome 80**<br>Available on mobile only.        |
 
 </div>
 
@@ -127,7 +127,7 @@ user gesture.
 ### Detecting available properties
 
 {% Aside 'caution' %}
-  While the Contacts Picker API was launched in Chrome 80, the newly added
+  While the Contacts Picker API was launched in Chrome 80 on Android, the newly added
   properties `'address'` and `'icon'` require registering for an [origin
   trial](https://developers.chrome.com/origintrials/#/view_trial/-6951306024846360575)
   until at least Chrome 83.


### PR DESCRIPTION
The docs didn't specify the Contact Picker is only available on mobile devices. This PR makes it more clear that they're mobile only.
