### PR TITLE
Make percy wait for network idle.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18168,6 +18168,12 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "scroll-to-bottomjs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-to-bottomjs/-/scroll-to-bottomjs-1.1.0.tgz",
+      "integrity": "sha512-+e7MRrUwY7M1V93ebqxIyPwIC8rPkvcmmmdSrOnNnCpbDP2Fpva3B6RadoRQ+ubZoYdYxye3Cculgbzb/CZiGw==",
+      "dev": true
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "sass": "^1.22.7",
     "sass-lint": "^1.12.1",
+    "scroll-to-bottomjs": "^1.1.0",
     "slugify": "^1.3.4",
     "unified-lint-rule": "^1.0.5",
     "unist-util-map": "^1.0.5",

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -1,4 +1,5 @@
 const PercyScript = require('@percy/script');
+const scrollToBottom = require('scroll-to-bottomjs');
 const pagesToTest = [
   {
     url: '/',
@@ -48,6 +49,7 @@ PercyScript.run(
     for (page of pagesToTest) {
       const url = new URL(page.url, 'http://localhost:8080').href;
       await browser.goto(url, {waitUntil: 'networkidle0'});
+      await page.evaluate(scrollToBottom);
       // Wait for the SPA to update the active link in the top nav.
       await browser.waitFor(2000);
       await percySnapshot(`${page.title}`);

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -51,7 +51,7 @@ PercyScript.run(
       await browser.goto(url, {waitUntil: 'networkidle0'});
       await page.evaluate(scrollToBottom);
       // Wait for the SPA to update the active link in the top nav.
-      await browser.waitFor(2000);
+      await browser.waitFor(5000);
       await percySnapshot(`${page.title}`);
     }
   },

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -49,7 +49,7 @@ PercyScript.run(
     for (page of pagesToTest) {
       const url = new URL(page.url, 'http://localhost:8080').href;
       await browser.goto(url, {waitUntil: 'networkidle0'});
-      await page.evaluate(scrollToBottom);
+      await browser.evaluate(scrollToBottom);
       // Wait for the SPA to update the active link in the top nav.
       await browser.waitFor(5000);
       await percySnapshot(`${page.title}`);

--- a/tools/percy/snapshots.js
+++ b/tools/percy/snapshots.js
@@ -47,9 +47,9 @@ PercyScript.run(
   async (browser, percySnapshot) => {
     for (page of pagesToTest) {
       const url = new URL(page.url, 'http://localhost:8080').href;
-      await browser.goto(url);
+      await browser.goto(url, {waitUntil: 'networkidle0'});
       // Wait for the SPA to update the active link in the top nav.
-      await browser.waitFor(5000);
+      await browser.waitFor(2000);
       await percySnapshot(`${page.title}`);
     }
   },


### PR DESCRIPTION
In my ongoing saga to make percy not flaky, I have stumbled across the networkidle option for puppeteer. Giving it a shot 🤞

Changes proposed in this pull request:

- Tell percy to wait for the network to be idle before snapshotting.