### PR TITLE
Task/pr required checks

### DIFF
--- a/.github/workflows/lint-and-test-workflow.yml
+++ b/.github/workflows/lint-and-test-workflow.yml
@@ -6,6 +6,7 @@ on: pull_request
 
 jobs:
   lint_and_test:
+    name: Lint and test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/required-checks-workflow.yml
+++ b/.github/workflows/required-checks-workflow.yml
@@ -2,7 +2,7 @@ name: Required checks
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled]
 
 jobs:
   do_not_merge:


### PR DESCRIPTION
Changes proposed in this pull request:

- Make the 'DO NOT MERGE' label check run when a PR is created or reopened. We do this so we can make it a required check on PRs even if a label is never applied to them. Essentially it ensures that the check runs at least once.
- Give lint and test task a pretty name so it shows up nicer in the list of checks.
