### PR TITLE
refactor(collections): create collections for `tags` and `authors` that derivative collections reference

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -58,6 +58,7 @@ const postDescending = require(`./${collectionsDir}/post-descending`);
 const postToCollections = require(`./${collectionsDir}/post-to-collections`);
 const postsWithLighthouse = require(`./${collectionsDir}/posts-with-lighthouse`);
 const recentPosts = require(`./${collectionsDir}/recent-posts`);
+const tags = require(`./${collectionsDir}/tags`);
 // nb. algoliaPosts is only require'd if needed, below
 
 const filtersDir = 'src/site/_filters';
@@ -158,6 +159,7 @@ module.exports = function(config) {
   config.addCollection('paginatedPostsByTag', paginatedPostsByTag);
   config.addCollection('paginatedTags', paginatedTags);
   config.addCollection('postToCollections', postToCollections);
+  config.addCollection('tags', tags);
   // Turn collection.all into a lookup table so we can use findBySlug
   // to quickly find collection items without looping.
   config.addCollection('memoized', function(collection) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -48,6 +48,7 @@ const Tooltip = require(`./${componentsDir}/Tooltip`);
 const YouTube = require(`./${componentsDir}/YouTube`);
 
 const collectionsDir = 'src/site/_collections';
+const authors = require(`./${collectionsDir}/authors`);
 const paginatedAuthors = require(`./${collectionsDir}/paginated-authors`);
 const paginatedBlogPosts = require(`./${collectionsDir}/paginated-blog-posts`);
 const paginatedPostsByAuthor = require(`./${collectionsDir}/paginated-posts-by-author`);
@@ -147,6 +148,7 @@ module.exports = function(config) {
   // ----------------------------------------------------------------------------
   // COLLECTIONS
   // ----------------------------------------------------------------------------
+  config.addCollection('authors', authors);
   config.addCollection('posts', postDescending);
   config.addCollection('postsWithLighthouse', postsWithLighthouse);
   config.addCollection('recentPosts', recentPosts);

--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require('fs');
+const path = require('path');
+const contributors = require('../_data/contributors');
+const livePosts = require('../_filters/live-posts');
+const setdefault = require('../_utils/setdefault');
+
+/**
+ * Generate map the posts by author's username/key
+ *
+ * @param {*} posts
+ * @return {Map<string, Array<any>>} Map of posts by author's username/key
+ */
+const findAuthorsPosts = (posts) => {
+  const authorsMap = new Map();
+  posts.forEach((post) => {
+    const authors = post.data.authors || [];
+    authors.forEach((author) => {
+      const postsByAuthor = setdefault(authorsMap, author, []);
+      postsByAuthor.push(post);
+      authorsMap.set(author, postsByAuthor);
+    });
+  });
+  return authorsMap;
+};
+
+/**
+ * Finds image of author, returns path.
+ *
+ * @param {string} key
+ * @return {string} Path for image.
+ */
+const findAuthorsImage = (key) => {
+  for (const size of ['@3x', '@2x', '']) {
+    if (
+      fs.existsSync(
+        path.join(
+          'src',
+          'site',
+          'content',
+          'en',
+          'images',
+          'authors',
+          `${key}${size}.jpg`,
+        ),
+      )
+    ) {
+      return path.join('/images', 'authors', `${key}${size}.jpg`);
+    }
+  }
+};
+
+/**
+ * Returns all authors with their posts.
+ *
+ * @param {any} collections Eleventy collection object
+ * @return {Array<{ description: string, title: string, key: string, href: string, url: string, data: { title: string, subhead: string, hero: string, alt: string }, elements: Array<any> }>}
+ */
+module.exports = (collections) => {
+  // Get all posts and sort them
+  const posts = collections
+    .getFilteredByGlob('**/*.md')
+    .filter(livePosts)
+    .sort((a, b) => b.date - a.date);
+
+  const authorsPosts = findAuthorsPosts(posts);
+
+  const authors = Object.values(contributors)
+    .sort((a, b) => a.title.localeCompare(b.title))
+    .map((author) => {
+      author.url = path.join('/en', author.href);
+      author.data = {
+        title: author.title,
+        subhead: author.description,
+      };
+      author.elements = authorsPosts.has(author.key)
+        ? authorsPosts.get(author.key)
+        : [];
+      const authorsImage = findAuthorsImage(author.key);
+      if (authorsImage) {
+        author.data.hero = authorsImage;
+        author.data.alt = author.title;
+      }
+      return author;
+    });
+
+  return authors;
+};

--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -81,7 +81,7 @@ module.exports = (collections) => {
 
   const authors = Object.values(contributors)
     .sort((a, b) => a.title.localeCompare(b.title))
-    .map((author) => {
+    .reduce((accumulator, author) => {
       author.url = path.join('/en', author.href);
       author.data = {
         title: author.title,
@@ -95,8 +95,13 @@ module.exports = (collections) => {
         author.data.hero = authorsImage;
         author.data.alt = author.title;
       }
-      return author;
-    });
+
+      if (author.elements.length > 0) {
+        accumulator.push(author);
+      }
+
+      return accumulator;
+    }, []);
 
   return authors;
 };

--- a/src/site/_collections/paginated-authors.js
+++ b/src/site/_collections/paginated-authors.js
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const fs = require('fs');
-const path = require('path');
-const contributors = require('../_data/contributors');
+const authorsCollection = require('./authors');
 const addPagination = require('../_utils/add-pagination');
 
 /**
@@ -26,9 +24,10 @@ const addPagination = require('../_utils/add-pagination');
  * paginate something already paginated... Pagination is effectively a loop, and we can't have an
  * embedded loop O^2.
  *
+ * @param {any} collections Eleventy collection object
  * @return {Array<{ title: string, href: string, description: string, elements: Array<object>, index: number, pages: number }>} An array where each element is a page with some meta data and n authors for the page.
  */
-module.exports = () => {
+module.exports = (collections) => {
   const testAuthors = [
     'robdodson',
     'samthor',
@@ -37,49 +36,14 @@ module.exports = () => {
     'addyosmani',
     'adamargyle',
   ];
-  let authors = Object.values(contributors).sort((a, b) =>
-    a.title.localeCompare(b.title),
-  );
+
+  let authors = authorsCollection(collections);
 
   if (process.env.PERCY) {
     authors = authors.filter((item) => testAuthors.includes(item.key));
   }
 
-  const elements = authors.map((author) => {
-    author.url = path.join('/en', author.href);
-    author.data = {
-      title: author.title,
-      subhead: author.description,
-    };
-
-    for (const size of ['@3x', '@2x', '']) {
-      if (
-        fs.existsSync(
-          path.join(
-            'src',
-            'site',
-            'content',
-            'en',
-            'images',
-            'authors',
-            `${author.key}${size}.jpg`,
-          ),
-        )
-      ) {
-        author.data.hero = path.join(
-          '/images',
-          'authors',
-          `${author.key}${size}.jpg`,
-        );
-        author.data.alt = author.title;
-        break;
-      }
-    }
-
-    return author;
-  });
-
-  return addPagination(elements, {
+  return addPagination(authors, {
     href: '/authors/',
   });
 };

--- a/src/site/_collections/paginated-posts-by-author.js
+++ b/src/site/_collections/paginated-posts-by-author.js
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-const contributors = require('../_data/contributors');
-const livePosts = require('../_filters/live-posts');
+const authorsCollection = require('./authors');
 const addPagination = require('../_utils/add-pagination');
-const setdefault = require('../_utils/setdefault');
 
 /**
  * Returns all posts as an array of paginated authors.
@@ -28,44 +26,16 @@ const setdefault = require('../_utils/setdefault');
  * paginate something already paginated... Pagination is effectively a loop, and we can't have an
  * embedded loop O^2.
  *
- * @param {any} collection Eleventy collection object
+ * @param {any} collections Eleventy collection object
  * @return {Array<{ title: string, href: string, description: string, elements: Array<object>, index: number, pages: number }>} An array where each element is a paged tag with some meta data and n posts for the page.
  */
-module.exports = (collection) => {
-  const posts = collection
-    .getFilteredByGlob('**/*.md')
-    .filter(livePosts)
-    .sort((a, b) => b.date - a.date);
+module.exports = (collections) => {
+  const authors = authorsCollection(collections);
+  let paginated = [];
 
-  // Map the posts by author's username
-  const authorsMap = new Map();
-  posts.forEach((post) => {
-    const authors = post.data.authors || [];
-    authors.forEach((author) => {
-      const postsByAuthor = setdefault(authorsMap, author, []);
-      postsByAuthor.push(post);
-      authorsMap.set(author, postsByAuthor);
-    });
+  authors.forEach((author) => {
+    paginated = paginated.concat(addPagination(author.elements, author));
   });
 
-  let authors = [];
-  authorsMap.forEach((value, key) => {
-    if (key in contributors) {
-      authors = authors.concat(addPagination(value, contributors[key]));
-    } else {
-      // Warn if the contributor ID is missing, including pointing to the paths of the source
-      // inputs that are invalid.
-      // This could also be run as part of generating author chips, but it is sufficient to explode
-      // at only one place.
-      const posts = authorsMap
-        .get(key)
-        .map((post) => post.inputPath)
-        .join(', ');
-      throw new Error(
-        `unknown contributor ${key} [${posts}], are they in _data/contributors.js?`,
-      );
-    }
-  });
-
-  return authors;
+  return paginated;
 };

--- a/src/site/_collections/paginated-posts-by-tag.js
+++ b/src/site/_collections/paginated-posts-by-tag.js
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-const postTags = require('../_data/postTags');
-const livePosts = require('../_filters/live-posts');
+const tagsCollection = require('./tags');
 const addPagination = require('../_utils/add-pagination');
-const setdefault = require('../_utils/setdefault');
 
 /**
  * Returns all posts as an array of paginated tags.
@@ -25,37 +23,16 @@ const setdefault = require('../_utils/setdefault');
  * Each element includes n number of posts as well as some basic information of that tag to pump into `_includes/partials/paged.njk`
  * This is because we can not paginate something already paginated... Pagination is effectively a loop, and we can't have an embedded loop O^2.
  *
- * @param {any} collection Eleventy collection object
+ * @param {any} collections Eleventy collection object
  * @return {Array<{ title: string, href: string, description: string, elements: Array<object>, index: number, pages: number }>} An array where each element is a paged tag with some meta data and n posts for the page.
  */
-module.exports = (collection) => {
-  const posts = collection
-    .getAll()
-    .filter(livePosts)
-    .sort((a, b) => b.date - a.date);
+module.exports = (collections) => {
+  const tags = tagsCollection(collections);
+  let paginated = [];
 
-  // Map the posts to various tags in the post
-  const tagsMap = new Map();
-  posts.forEach((post) => {
-    const postDataTags = post.data.tags || [];
-    postDataTags.forEach((postTag) => {
-      const tagsPosts = setdefault(tagsMap, postTag, []);
-      tagsPosts.push(post);
-      tagsMap.set(postTag, tagsPosts);
-    });
+  tags.forEach((tag) => {
+    paginated = paginated.concat(addPagination(tag.elements, tag));
   });
 
-  let tags = [];
-  Object.keys(postTags).forEach((tagName) => {
-    // Invalid tags will be skipped, assuming our linter will catch them later.
-    // Skips misspelled tags, internal tags, and tags that are not in `postTags.js`.
-    if (!tagsMap.has(tagName)) {
-      return;
-    }
-
-    const tagData = postTags[tagName];
-    tags = tags.concat(addPagination(tagsMap.get(tagName), tagData));
-  });
-
-  return tags;
+  return paginated;
 };

--- a/src/site/_collections/paginated-tags.js
+++ b/src/site/_collections/paginated-tags.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-const path = require('path');
-const postTags = require('../_data/postTags');
-const livePosts = require('../_filters/live-posts');
+const tagsCollection = require('./tags');
 const addPagination = require('../_utils/add-pagination');
 
 /**
@@ -40,21 +38,13 @@ module.exports = (collections) => {
     'webxr',
   ];
 
-  const elements = Object.values(postTags)
-    .filter((tag) => {
-      const posts = collections.getFilteredByTag(tag.key).filter(livePosts);
-      return process.env.PERCY ? testTags.includes(tag.key) : posts.length > 0;
-    })
-    .map((tag) => {
-      tag.url = path.join('/en', tag.href);
-      tag.data = {
-        title: tag.title,
-        subhead: tag.description,
-      };
-      return tag;
-    });
+  let tags = tagsCollection(collections);
 
-  return addPagination(elements, {
+  if (process.env.PERCY) {
+    tags = tags.filter((item) => testTags.includes(item.key));
+  }
+
+  return addPagination(tags, {
     href: '/tags/',
   });
 };

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const postTags = require('../_data/postTags');
+const livePosts = require('../_filters/live-posts');
+
+/**
+ * Returns all tags with posts.
+ *
+ * @param {any} collections Eleventy collection object
+ * @return {Array<{ title: string, key: string, description: string, href: string, url: string, data: { title: string, subhead: string }, elements: Array<object> }>} An array where each element is a paged tag with some meta data and n posts for the page.
+ */
+module.exports = (collections) => {
+  return Object.values(postTags).reduce((accumulator, tag) => {
+    tag.url = path.join('/en', tag.href);
+    tag.data = {
+      title: tag.title,
+      subhead: tag.description,
+    };
+    tag.elements = collections
+      .getFilteredByTag(tag.key)
+      .filter(livePosts)
+      .sort((a, b) => b.date - a.date);
+
+    if (tag.elements.length > 0) {
+      accumulator.push(tag);
+    }
+
+    return accumulator;
+  }, []);
+};


### PR DESCRIPTION
I moved most of the logic for the `paginated-tags`, `paginated-authors`, `paginated-posts-by-tags`,  and `paginated-posts-by-authors` into these "parent" collections (`authors` and `tags`). Since they had somewhat redundant logic/behavior I figured it would be good to apply all of that in one place.

Two reasons why this may be useful is:
1) We can now use the `authors` and `tags` collections to generate RSS feeds for each author and tag.
2) When we move to 11ty 0.11.0 there's a chance we can use computed data in order to do the pagination for the tags/authors landing pages and the individual tags/authors pages local data rather than creating multiple collections with similar data.

So it requires adding two collections for now, but it simplifies refactoring code for the derivative collections, allows for RSS feed, and may be used to remove the paginated collections down the road.