### PR TITLE
Fix broken algolia build.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -39,9 +39,13 @@ jobs:
       - name: Build
         env:
           ELEVENTY_ENV: prod
+        run: npm run build
+      
+      - name: Index algolia
+        env:
           ALGOLIA_APP: ${{ secrets.ALGOLIA_APP }}
           ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
-        run: npm ci && npm run build && node index-algolia.js
+        run: node index-algolia.js
 
       - name: Setup gcloud
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.1

--- a/src/site/_transforms/responsive-images/index.js
+++ b/src/site/_transforms/responsive-images/index.js
@@ -23,6 +23,10 @@ const cheerio = require('cheerio');
 const {determineImagePath} = require('./helpers');
 
 const responsiveImages = (content, outputPath) => {
+  if (!outputPath || !outputPath.endsWith('.html')) {
+    return content;
+  }
+
   const $ = cheerio.load(content);
   const $img = $('img');
   $img.each((i, elem) => {

--- a/test/site/_transforms/responsive-images/index.js
+++ b/test/site/_transforms/responsive-images/index.js
@@ -32,6 +32,19 @@ describe('responsive-images', function() {
         .pop();
     });
 
+    it('is a noop if there is no output path', function() {
+      outputPath = false;
+      $body.append(`<img src="./foo.jpg">`);
+      const actual = responsiveImages($.html(), outputPath);
+      $expected('body').append(`<img src="./foo.jpg">`);
+      assert.deepStrictEqual(actual, $expected.html());
+    });
+
+    it('is a noop if the file is not an html file', function() {
+      const actual = responsiveImages('{"foo": "bar"}', 'dist/en/foo.json');
+      assert.deepStrictEqual(actual, '{"foo": "bar"}');
+    });
+
     it('is a noop if there are no images', function() {
       const actual = responsiveImages($.html(), outputPath);
       assert.deepStrictEqual(actual, $expected.html());
@@ -113,15 +126,6 @@ describe('responsive-images', function() {
       $expected("body").append(
         `<img src="${new URL(path.join("handbook", "audience", "foo.jpg"), site.imageCdn)}"><img src="${new URL(path.join("handbook", "audience", "bar.jpg"), site.imageCdn)}">`,
       );
-      assert.deepStrictEqual(actual, $expected.html());
-    });
-
-    it('can handle pages with permalink: false', function() {
-      outputPath = false;
-      $body.append(`<img src="./foo.jpg">`);
-      const actual = responsiveImages($.html(), outputPath);
-      // prettier-ignore
-      $expected("body").append(`<img src="./foo.jpg">`);
       assert.deepStrictEqual(actual, $expected.html());
     });
 


### PR DESCRIPTION
Fixes #2609

Changes proposed in this pull request:

- Adds a check to the responsive images handler to make sure it ignores JSON files or files with no output path (aka files with `permalink: false` set).
- Changes the ci workflow so it doesn't run `npm ci` twice.
- Changes the ci workflow to separate out the Algolia step so it's easier to isolate what's causing the failure next time.
- Adds a test to verify that non html files are ignored by the responsive images transform.
- Rewords the description of the test that checks if outputPath is not set.
