### PR TITLE
Ignore more files so we do not deploy them.

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -23,3 +23,13 @@ node_modules/
 /glitches/
 /lib/
 /src/
+/test/
+/tools/
+build.js
+CODE_OF_CONDUCT.md
+compile-css.js
+CONTRIBUTING.md
+gulpfile.js
+index-algolia.js
+karma.conf.js
+netlify.toml


### PR DESCRIPTION
Changes proposed in this pull request:

- As I was fixing a recent bug related to our deploy I noticed there's a number of files we send up to app engine that should be ignored. This just ignores those extra files.