### PR TITLE
Add accepted label. Remove assignee exemption.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,8 +5,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-# Set to true to ignore issues with an assignee (defaults to false)
-exemptAssignees: true
+  - accepted
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Changes proposed in this pull request:

- Don't exempt issues with an assignee. Content team doesn't want this.
- Exempt issues with `accepted` label. Eng can use this to mark an issue to keep it alive.