### PR TITLE
Make percy record new snapshots for master.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -3,6 +3,16 @@ name: Percy
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.js'
+      - '**.json'
+      - '**.njk'
+      - '**.scss'
+      - '**.yml'
+      - '**.yaml'
   pull_request:
     paths:
       - '**.js'


### PR DESCRIPTION
Fixes an issue where percy was not recording new snapshots to PRs against master.

Changes proposed in this pull request:

- Make percy run checks against master if certain file types were changed.