### PR TITLE
fix(meta): remove double quote from text in meta attributes, fixes #2627

### DIFF
--- a/src/site/_filters/strip.js
+++ b/src/site/_filters/strip.js
@@ -18,15 +18,15 @@
  * Removes any characters that should not exist in a string.
  *
  * @param {(string|number)} [text] Text to clean
- * @param {(Array<string|RegExp>)} [additionallyForbidden] Additional rules to be removed.
+ * @param {Array<{ searchValue: (string|RegExp), replaceValue: string}>} [additionallyForbidden] Additional rules to be removed or replaced.
  * @return {string} A string of the pages title without any forbidden characters.
  */
 module.exports = (text, additionallyForbidden) => {
   let cleaned = String(text || '');
-  const forbidden = [/\`/g];
+  const forbidden = [{searchValue: /\`/g, replaceValue: ''}];
 
   [...forbidden, ...(additionallyForbidden || [])].forEach((rule) => {
-    cleaned = cleaned.replace(rule, '');
+    cleaned = cleaned.replace(rule.searchValue, rule.replaceValue);
   });
 
   return cleaned;

--- a/src/site/_filters/strip.js
+++ b/src/site/_filters/strip.js
@@ -15,10 +15,10 @@
  */
 
 /**
- * Removes any characters that should not exist in a string.
+ * Removes selected characters that should not be presented in a string.
  *
  * @param {(string|number)} [text] Text to clean
- * @param {Array<{ searchValue: (string|RegExp), replaceValue: string}>} [additionallyForbidden] Additional rules to be removed or replaced.
+ * @param {Array<{ searchValue: (string|RegExp), replaceValue: string}>} [additionallyForbidden] Additional replacement rules.
  * @return {string} A string of the pages title without any forbidden characters.
  */
 module.exports = (text, additionallyForbidden) => {

--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -21,6 +21,7 @@ const strip = require('../../_filters/strip');
 const {html} = require('common-tags');
 
 module.exports = (locale, page, collections, renderData = {}) => {
+  const forbiddenCharacters = [{searchValue: /"/g, replaceValue: "'"}];
   const pageData = {
     ...collections.all.find((item) => item.fileSlug === page.fileSlug).data,
     ...renderData,
@@ -43,8 +44,11 @@ module.exports = (locale, page, collections, renderData = {}) => {
         ? pageData.social[platform]
         : pageData;
 
-    const title = strip(social.title || social.path.title);
-    const description = social.description || social.path.description;
+    const title = strip(social.title || social.path.title, forbiddenCharacters);
+    const description = strip(
+      social.description || social.path.description,
+      forbiddenCharacters,
+    );
     let thumbnail = social.thumbnail || social.hero;
     const alt = social.alt || site.name;
 
@@ -120,7 +124,7 @@ module.exports = (locale, page, collections, renderData = {}) => {
   // prettier-ignore
   return html`
     <title>${strip(pageData.title || pageData.path.title || site.title)}</title>
-    <meta name="description" content="${pageData.description || pageData.path.description}" />
+    <meta name="description" content="${strip(pageData.description || pageData.path.description, forbiddenCharacters)}" />
 
     ${renderCanonicalMeta()}
     ${renderGoogleMeta()}


### PR DESCRIPTION
Fixes #2627

Replaces double quote's in attributes of meta tags using the `strip` function's `additionallyForbidden` argument.