### PR TITLE
Fix closing figure tags

### DIFF
--- a/src/site/content/en/fast/preload-critical-assets/index.md
+++ b/src/site/content/en/fast/preload-critical-assets/index.md
@@ -25,14 +25,14 @@ Preloading is best suited for resources typically discovered late by the browser
 <figure class="w-figure">
 <img src="./network-waterfall-before.png" alt="Screenshot of Chrome DevTools Network panel.">
 <figcaption class="w-figcaption">In this example, Pacifico font is defined in the stylesheet with a <a href="https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#defining_a_font_family_with_font-face)"><code>@font-face</code></a> rule. The browser loads the font file only after it has finished downloading and parsing the stylesheet.</figcaption>
-<figure>
+</figure>
 
 By preloading a certain resource, you are telling the browser that you would like to fetch it sooner than the browser would otherwise discover it because you are certain that it is important for the current page.
 
 <figure class="w-figure">
 <img src="./network-waterfall-after.png" alt="Screenshot of Chrome DevTools Network panel after applying preloading.">
 <figcaption class="w-figcaption">In this example, Pacifico font is preloaded, so the download happens in parallel with the stylesheet.</figcaption>
-<figure>
+</figure>
 
 The critical request chain represents the order of resources that are prioritized and fetched by the browser. Lighthouse identifies assets that are on the third level of this chain as late-discovered. You can use the [**Preload key requests**](/uses-rel-preload) audit to identify which resources to preload.
 


### PR DESCRIPTION
Closing tags for the two figure elements are missing a slash.

Currently:

![image](https://user-images.githubusercontent.com/205226/79850111-5b2cb100-83bb-11ea-90fb-02dc3f24befc.png)

Fixed: 

![image](https://user-images.githubusercontent.com/205226/79850148-667fdc80-83bb-11ea-8c5f-bd37d4894455.png)
