### PR TITLE
Document redirects in the Handbook

### DIFF
--- a/src/site/content/en/handbook/handbook.11tydata.js
+++ b/src/site/content/en/handbook/handbook.11tydata.js
@@ -51,10 +51,7 @@ module.exports = {
       },
       {
         title: 'Content infrastructure',
-        pathItems: [
-          'handbook/resolving-glitch-issues',
-          'handbook/redirects',
-        ],
+        pathItems: ['handbook/resolving-glitch-issues', 'handbook/redirects'],
       },
     ],
   },

--- a/src/site/content/en/handbook/handbook.11tydata.js
+++ b/src/site/content/en/handbook/handbook.11tydata.js
@@ -35,7 +35,6 @@ module.exports = {
           'handbook/use-media',
           'handbook/word-list',
           'handbook/tooling-and-libraries',
-          'handbook/resolving-glitch-issues',
         ],
       },
       {
@@ -48,6 +47,13 @@ module.exports = {
           'handbook/markup-code',
           'handbook/markup-sample-app',
           'handbook/self-assessment-components',
+        ],
+      },
+      {
+        title: 'Content infrastructure',
+        pathItems: [
+          'handbook/resolving-glitch-issues',
+          'handbook/redirects',
         ],
       },
     ],

--- a/src/site/content/en/handbook/redirects/index.md
+++ b/src/site/content/en/handbook/redirects/index.md
@@ -1,0 +1,35 @@
+---
+layout: handbook
+title: Redirects
+date: 2020-04-29
+description: |
+  Learn how to redirect content.
+---
+
+This guide explains how to redirect content.
+
+## Redirect a single page
+
+1. Open [`src/site/content/en/_redirects.yaml`][source].
+1. Add an entry similar to the following:
+
+   ```yaml
+   from: /path/to/old/page
+   to: /path/to/new/page
+   ```
+
+## Redirect multiple pages in a directory
+
+It's possible to redirect a subdirectory of content, but this feature
+is probably no longer useful because web.dev now uses a [flat URL structure][flat].
+
+1. Open [`src/site/content/en/_redirects.yaml`][source].
+1. Add an entry similar to the following:
+
+   ```yaml
+   from: /path/to/old/subdirectory/...
+   to: /path/to/new/subdirectory/...
+   ```
+
+[source]: https://github.com/GoogleChrome/web.dev/blob/master/src/site/content/en/_redirects.yaml
+[flat]: https://joeyhoer.com/flat-vs-hierarchical-url-structure-420f178c


### PR DESCRIPTION
Fixes #2195

Changes:

* Adds instructions on how to do redirects.
* Adds a new `Content infrastructure` section to the Handbook.