### PR TITLE
Update image guidelines in the Handbook

### DIFF
--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -2,21 +2,48 @@
 layout: handbook
 title: Images and video
 date: 2019-06-26
-updated: 2020-04-01
+updated: 2020-04-29
 description: |
   Learn how to create the Markdown for images and video for web.dev.
 ---
 
 This post is about how to format and store images on web.dev. For guidance about how to select or create images to support your writing goals, see the [Use images and video effectively](/handbook/use-media) post.
 
-## All images
-Images that appear in a post should live in the same directory as the post's `index.md` file.
+## General guidelines for all images {: #general }
 
-Use lossless images whenever possible. They'll be optimized automatically at build time.
+* Images that appear in a post should live in the same directory as the post's `index.md` file.
+* Make sure images are [accessible](/handbook/inclusion-and-accessibility#use-inclusive-images).
 
-Make sure images are [accessible](/handbook/inclusion-and-accessibility#use-inclusive-images).
+## Image format guidelines (JPG, PNG, or SVG) {: #format }
 
-## Hero images
+* JPG is usually better than PNG for photos and screenshots because it can be optimized more.
+  PNG is good for preserving fine detail but in practice most web.dev images don't need to be
+  preserved in fine detail.
+* SVG is best for graphics because its file size is usually quite small and it can be infinitely
+  scaled.
+
+Source: [Selecting the right image format][format]
+
+## Image sizing guidelines {: #sizing }
+
+* [Hero images](#hero) should be `3200px` wide and `960px` tall.
+* [Thumbnail images](#thumbnail) should be `376px` wide and `240px` tall.
+* [Body images](#body) should be `800px` at a minimum and `1600px` wide at a maximum.
+
+## Image optimization guidelines {: #optimization }
+
+* Hero images should only be **lightly** optimized with [Squoosh][squoosh].
+  Try to reduce the size of the image with no noticeable reduction in quality whatsoever.
+  The goal here is to reduce bloat in the web.dev git repository. The web.dev image CDN
+  optimizes hero images on the fly, so if you over-optimize with Squoosh, the hero image
+  will end up grainy.
+* Body images should be strongly optimized with [Squoosh][squoosh] or [TinyPNG][tinypng]
+  (which also supports JPG). Body images are not optimized through web.dev's image CDN
+  so the main goal here is to keep web.dev pages loading fast.
+
+## Hero images {: #hero }
+
+Add the following code to your post's front matter:
 
 ```yaml
 ---
@@ -31,11 +58,15 @@ alt: A description of the hero. # Also used by the thumbnail (when applicable).
 If your post does not contain a hero image it will not be displayed on the homepage.
 {% endAside %}
 
-Hero images should be 3200 px x 960 px.
+* Hero images should be `3200px` wide and `960px` tall.
+* You can adjust hero image positioning using the 
+  [`hero_position`](/handbook/markup-post-codelab/#set-up-the-yaml) front matter field.
+* See [Image optimization guidelines](#optimization) for information on how to optimize
+  hero images.
 
-Adjust hero image positioning using the [`hero_position`](/handbook/markup-post-codelab/#set-up-the-yaml) field in the YAML at the start of the post's Markdown file.
+## Thumbnail images {: #thumbnail }
 
-## Thumbnail images
+Add the following code to your post's front matter:
 
 ```yaml
 ---
@@ -46,25 +77,28 @@ alt: A description of the thumbnail. # Also used by the hero.
 ---
 ```
 
-When a post is displayed on the home page or the blog it can contain a thumbnail.
+* When a post is displayed on the home page or the blog it can contain a thumbnail.
+* Thumbnails should be `376px` wide and `240px` tall.
+* If you don't provide a thumbnail, the post will attempt to reuse the hero image.
+* If there is no hero image, the post will omit the thumbnail entirely.
 
-Thumbnails should be 376 px x 240 px.
+## Body images {: #body }
 
-If you don't provide a thumbnail, the post will attempt to reuse the hero image.
-If there is no hero image, the post will omit the thumbnail entirely.
+* Images intended to fill the full width of the content column should be `800px` wide at a minimum,
+  and `1600px` wide at a maximum (to account for screens that use 2x resolution).
 
-## Body images
+### Standalone images
 
-Images intended to fill the full width of the content column should be `800px` wide at a minimum,
-and `1600px` wide at a maximum (to account for screens that use 2x resolution).
-
-Use Markdown syntax for standard standalone images:
+Use Markdown syntax:
 
 ```markdown
 ![alt text](./image-name.png)
 ```
 
-Use a `<figure>` tag when you need a caption or you need special presentation (e.g., for screenshots):
+### Images with captions
+
+Use a `<figure>` tag. Make sure the `w-figure` class is applied to the `<figure>` element
+and the `w-figcaption` class is applied to the `<figcaption>` element.
 
 ```html
 <figure class="w-figure">
@@ -78,7 +112,7 @@ Use a `<figure>` tag when you need a caption or you need special presentation (e
   <figcaption class="w-figcaption">A standard image.</figcaption>
 </figure>
 
-### Differences between `alt` and `figcaption` {: #alt-vs-figcaption }
+#### Differences between `alt` and `figcaption` {: #alt-vs-figcaption }
 
 `alt` and `figcaption` should have different text because they're both announced by assistive
 technology. If the text is duplicated, the assistive technology will announce the same text twice.
@@ -88,8 +122,18 @@ title, the painter's name, and perhaps a description of what the painter was try
 
 See [Alternative Text](https://webaim.org/techniques/alttext/) for more information.
 
-### Styling body images
+### Images that extend slightly beyond the content column {: #fullbleed }
+
 To make an image extend slightly beyond the width of the content column (for emphasis), add the `w-figure--fullbleed` class to the `figure` element and the `w-figcaption--fullbleed` class to the `figcaption` element:
+
+```html
+<figure class="w-figure w-figure--fullbleed">
+  <img src="./a.jpg" alt="An office with two people working at a table.">
+  <figcaption class="w-figcaption w-figcaption--fullbleed">
+    A full-bleed image.
+  </figcaption>
+</figure>
+```
 
 <figure class="w-figure w-figure--fullbleed">
   <img src="./a.jpg" alt="An office with two people working at a table.">
@@ -98,7 +142,20 @@ To make an image extend slightly beyond the width of the content column (for emp
   </figcaption>
 </figure>
 
+### Specifying a size for an image
+
 To keep an image from growing beyond a specified size, add the `w-figure` class to the `figure` element and add a `width` attribute to the `img` element. For example, `width="400"`. All images will have a `max-width` of `100%` on mobile:
+
+```html
+<figure class="w-figure">
+  <img src="./image-small.png" 
+       alt="A screenshot of a section of the Chrome DevTools user interface." 
+       width="400">
+  <figcaption class="w-figcaption">
+    A small, centered image.
+    </figcaption>
+</figure>
+```
 
 <figure class="w-figure">
   <img src="./image-small.png" alt="A screenshot of a section of the Chrome DevTools user interface." width="400">
@@ -107,7 +164,20 @@ To keep an image from growing beyond a specified size, add the `w-figure` class 
     </figcaption>
 </figure>
 
+### Inline images 
+
 To place an image inline with text, add the `w-figure--inline-left` or `w-figure--inline-right` class to the `figure` element, depending on what alignment you want:
+
+```html
+<figure class="w-figure w-figure--inline-left">
+  <img class="w-screenshot" src="./image-inline.png"
+       alt="A diagram of the interactions between a client, a service worker, and the server."
+       width="200">
+  <figcaption class="w-figcaption">
+    A left-aligned inline image.
+  </figcaption>
+</figure>
+```
 
 <figure class="w-figure w-figure--inline-left">
   <img class="w-screenshot" src="./image-inline.png" alt="A diagram of the interactions between a client, a service worker, and the server." width="200">
@@ -119,7 +189,21 @@ To place an image inline with text, add the `w-figure--inline-left` or `w-figure
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at quam sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at quam sem.
 </p>
 
+### Screenshots
+
+#### Partial screenshots
+
 To include a part of a screenshot, add the `w-screenshot` class to the `img` element:
+
+```html
+<figure class="w-figure">
+  <img class="w-screenshot" src="./img2.png" 
+       alt="A screenshot of optimization opportunities presented in Lighthouse.">
+  <figcaption class="w-figcaption">
+    A partial screenshot.
+  </figcaption>
+</figure>
+```
 
 <figure class="w-figure">
   <img class="w-screenshot" src="./img2.png" alt="A screenshot of optimization opportunities presented in Lighthouse.">
@@ -128,7 +212,21 @@ To include a part of a screenshot, add the `w-screenshot` class to the `img` ele
   </figcaption>
 </figure>
 
-To include an entire screenshot, add the `w-screenshot-filled` class to the `img` element:
+#### Entire screenshots
+
+To include an entire screenshot, also add the `w-screenshot-filled` class to the `img` element
+(in addition to the `w-screenshot` class):
+
+```html
+<figure class="w-figure">
+  <img class="w-screenshot w-screenshot--filled" 
+       src="./image-screenshot.png" 
+       alt="A screenshot of the console log for the Chrome DevTools webpage.">
+  <figcaption class="w-figcaption">
+    A full screenshot.
+  </figcaption>
+</figure>
+```
 
 <figure class="w-figure">
   <img class="w-screenshot w-screenshot--filled" src="./image-screenshot.png" alt="A screenshot of the console log for the Chrome DevTools webpage.">
@@ -137,8 +235,8 @@ To include an entire screenshot, add the `w-screenshot-filled` class to the `img
   </figcaption>
 </figure>
 
+## How to take screenshots
 
-## Screenshots
 To take a screenshot on Windows:
 1. Check out Microsoft's [Use Snipping Tool to capture screenshots](https://support.microsoft.com/en-us/help/13776/windows-use-snipping-tool-to-capture-screenshots) page.
 1. In the Snipping Tool, use the pen to add a red box around any highlighted areas.
@@ -152,9 +250,11 @@ To take a screenshot on Mac:
 ## Video
 
 ### Video hosted on YouTube
+
 To embed a YouTube video, use the web.dev `YouTube` [component](/handbook/web-dev-components).
 
 ### Video hosted on web.dev
+
 Always use video, not animated GIFs. (Check out the [Replace animated GIFs with video for faster page loads](/replace-gifs-with-videos/) post to learn how to use [FFmpeg](https://www.ffmpeg.org/) to convert GIFs to video.)
 
 Once you have a video ready, message your content reviewer, and they'll help you upload it to the web.dev Google Cloud Storage bucket.
@@ -182,4 +282,9 @@ Embed the video in your post or codelab by following this example:
 </figure>
 
 ### Full-bleed video
+
 If you want any video to be full-bleed, put it in a `figure` element with the `w-figure--fullbleed` class. (Make sure to add the `w-figcaption--fullbleed` class to the `figcaption` element if you have one.)
+
+[squoosh]: https://squoosh.app/
+[tinypng]: https://tinypng.com/
+[format]: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization#selecting_the_right_image_format


### PR DESCRIPTION
Fixes #2030 

Changes proposed in this pull request:

- Adds image optimization guidelines
- Makes image sizing guidelines easier to scan
- Splits the content up into easy-to-scan sections
- Adds code samples to start of each section
