### PR TITLE
fix web-codelab fouc

### DIFF
--- a/src/lib/components/Codelab/_styles.scss
+++ b/src/lib/components/Codelab/_styles.scss
@@ -3,16 +3,9 @@
 @import '../../../styles/tools/breakpoints';
 
 web-codelab {
-  display: flex;
-
-  flex-flow: column;
-  @include bp(md) {
-    flex-flow: row;
-  }
+  // This is `display: flex` inside styles/pages/_codelab.scss.
 
   .w-sizer {
-    padding: 16px 32px;
-
     &.w-test {
       @include bp(md) {
         display: flex;
@@ -28,31 +21,20 @@ web-codelab {
     }
 
     .w-aside {
-      margin: 0;
+      margin: 16px;
     }
 
     @include bp(md) {
-      padding: 16px;
       position: sticky;
-      top: $WEB_HEADER_HEIGHT;
-      height: calc(100vh - #{$WEB_HEADER_HEIGHT});
+      top: $WEB_HEADER_HEIGHT + 16px;
+      height: calc(100vh - #{$WEB_HEADER_HEIGHT + 32px});
     }
   }
 
   .web-codelab__headline {
-    margin-top: 0;
-    margin-bottom: 8px;
+    padding-top: 0;
   }
-  
-  .web-codelab__instructions {
-    padding: 32px;
 
-    @include bp(md) {
-      // on desktop, set the maximum size so the Glitch can fit to the right
-      width: 600px;
-    }
-  }
-  
   .web-codelab__glitch {
     flex: 1;
 

--- a/src/styles/pages/_all.scss
+++ b/src/styles/pages/_all.scss
@@ -1,6 +1,7 @@
 @import 'home';
 @import 'about';
 @import 'author';
+@import 'codelab';
 @import 'learn';
 @import 'measure';
 @import 'pagination';

--- a/src/styles/pages/_codelab.scss
+++ b/src/styles/pages/_codelab.scss
@@ -1,0 +1,42 @@
+@import '../tools/breakpoints';
+
+web-codelab {
+  // This spacing is put above the heading on mobile, so we can later load a 
+  // warning into it saying "not available on mobile". (Sorry.)
+  $CODELAB_TOP_BUFFER: 160px;
+
+  display: flex;
+  flex-flow: column;
+  padding: 16px;
+
+  @include bp(md) {
+    // At md or above, we show the Glitch to the right.
+    flex-flow: row;
+
+    .web-codelab__instructions {
+      padding-right: 32px;
+      width: 600px;
+    }
+  }
+
+  .web-codelab__instructions {
+    padding: 16px;
+  }
+
+  .web-codelab__headline {
+    // We use padding instead of margin, so we don't merge with any neighbour
+    // margin of the page broadly (although it's `padding` above).
+    margin-bottom: 8px;
+    margin-top: 0;
+    padding-top: $CODELAB_TOP_BUFFER;
+
+    @include bp(md) {
+      padding-top: 0;
+    }
+  }
+
+  .web-codelab__glitch {
+    min-height: $CODELAB_TOP_BUFFER;
+  }
+}
+


### PR DESCRIPTION
Fixes #2572. Probably.

This is to be fair a bit awkward as now it merges `web-codelab` styles in two places, buuut, I think it's the right answer for now. (at least until we have SD and rewrite a bunch of elements)