### PR TITLE
Ignore paths that were triggering percy.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -8,19 +8,21 @@ on:
       - master
     paths:
       - '**.js'
-      - '**.json'
+      - '!src/site/_data/contributors.js'
+      - '!src/site/_data/countries.js'
+      - '!src/site/_data/postTags.js'
+      - 'package.json'
       - '**.njk'
       - '**.scss'
-      - '**.yml'
-      - '**.yaml'
   pull_request:
     paths:
       - '**.js'
-      - '**.json'
+      - '!src/site/_data/contributors.js'
+      - '!src/site/_data/countries.js'
+      - '!src/site/_data/postTags.js'
+      - 'package.json'
       - '**.njk'
       - '**.scss'
-      - '**.yml'
-      - '**.yaml'
 
 jobs:
   percy:


### PR DESCRIPTION
Some files like contributors.js get touched when an article gets published, and then percy runs every time someone pushes a change to that article during review. This limits the number of files percy cares about to just the subset that I think would actually affect the appearance of the site.