### PR TITLE
Fix mistake in the example

### DIFF
--- a/src/site/content/en/blog/storage-for-the-web/index.md
+++ b/src/site/content/en/blog/storage-for-the-web/index.md
@@ -128,7 +128,7 @@ if (navigator.storage && navigator.storage.estimate) {
   // quota.quota -> Maximum number of bytes available.
   const percentageUsed = (quota.usage / quota.quota) * 100;
   console.log(`You've used ${percentageUsed}% of the available storage.`);
-  const remaining = quota.quota - quota.used;
+  const remaining = quota.quota - quota.usage;
   console.log(`You can write up to ${remaining} more bytes.`);
 }
 ```


### PR DESCRIPTION
Changes proposed in this pull request:
- field `used` does not exist on resolved value, I belive it's a type and `usage` should be used

<img width="380" alt="usage" src="https://user-images.githubusercontent.com/544082/80867840-9d48d300-8c96-11ea-822f-c01f07ebb9cf.png">
