### PR TITLE
firebase loading fix

### DIFF
--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -16,7 +16,9 @@ const firestorePromiseLoader = (() => {
     if (p) {
       return p;
     }
-    p = firebasePromise.then(() => loadFirebase('firestore')).then(() => {
+    // We don't have to block on the top-level Promise, as the scripts run
+    // in-order of being added to the page (async=false).
+    p = loadFirebase('firestore').then(() => {
       const firestore = window.firebase.firestore();
       return firestore;
     });

--- a/src/lib/fb.js
+++ b/src/lib/fb.js
@@ -4,7 +4,9 @@ import {clearSignedInState} from './actions';
 import loadFirebase from './utils/firebase-loader';
 import {trackError} from './analytics';
 
-const firebasePromise = loadFirebase('app', 'auth', 'performance').then(() => window.firebase);
+const firebasePromise = loadFirebase('app', 'auth', 'performance').then(
+  () => window.firebase,
+);
 firebasePromise.then(initialize).catch((err) => {
   console.error('failed to load Firebase', err);
   trackError(err, 'firebase load');

--- a/src/lib/utils/firebase-loader.js
+++ b/src/lib/utils/firebase-loader.js
@@ -34,23 +34,11 @@ function internalLoad(library) {
 }
 
 /**
- * Generates a function, which when called, loads a number of named Firebase
- * libraries (or returns their cached loads).
- *
- * Returning a function here is helpful as we don't want to load e.g., Firestore
- * before it's needed.
+ * Loads a number of named Firebase libaries (or their cached previous loads).
  *
  * @param {...string} names to load
- * @return {function(): !Promise}
+ * @return {!Promise<void>}
  */
-export default function buildLoader(...names) {
-  let promise = null;
-
-  return () => {
-    if (promise) {
-      return promise;
-    }
-    promise = Promise.all(names.map(internalLoad));
-    return promise;
-  };
+export default function loadFirebase(...names) {
+  return Promise.all(names.map(internalLoad));
 }

--- a/src/lib/utils/firebase-loader.js
+++ b/src/lib/utils/firebase-loader.js
@@ -23,6 +23,7 @@ function internalLoad(library) {
   const p = new Promise((resolve, reject) => {
     const s = document.createElement('script');
     s.src = `${firebasePrefix}/firebase-${library}.js`;
+    s.async = false; // prevent misordered execution
 
     s.onerror = reject;
     s.onload = () => resolve();

--- a/test/unit/src/lib/utils/firebase-loader.js
+++ b/test/unit/src/lib/utils/firebase-loader.js
@@ -19,13 +19,13 @@ describe('firebase-loader', function() {
       let nodes = [];
 
       try {
-        nodes = document.head.querySelector(
+        nodes = document.head.querySelectorAll(
           'script[src^="//www.gstatic.com/firebasejs/"]',
         );
         assert(nodes.length === 1);
 
         loadFirebase('app', 'performance');
-        nodes = document.head.querySelector(
+        nodes = document.head.querySelectorAll(
           'script[src^="//www.gstatic.com/firebasejs/"]',
         );
         assert(nodes.length === 2, 'nodes should only contain one additional');

--- a/test/unit/src/lib/utils/firebase-loader.js
+++ b/test/unit/src/lib/utils/firebase-loader.js
@@ -44,7 +44,9 @@ describe('firebase-loader', function() {
       try {
         assert(nodes.length === 2, 'JS should be added for uniques');
         assert(nodes[0].src.endsWith('-app.js'));
+        assert(!nodes[0].async);
         assert(nodes[1].src.endsWith('-performance.js'));
+        assert(!nodes[1].async);
       } finally {
         // This isn't an async test, we don't check that the scripts actually
         // load, so just remove them immediately after run.

--- a/test/unit/src/lib/utils/firebase-loader.js
+++ b/test/unit/src/lib/utils/firebase-loader.js
@@ -1,6 +1,9 @@
 const {assert} = require('../assert');
 const loadFirebase = require('../../../../../src/lib/utils/firebase-loader');
 
+// TODO(samthor): This test doesn't clear the internal cache between tests, as
+// it uses a singleton loading cache. Add a reset for test method.
+
 describe('firebase-loader', function() {
   describe('loader', function() {
     it('should return a Promise', async function() {
@@ -14,39 +17,24 @@ describe('firebase-loader', function() {
       assert(node === null, 'no firebase loads requested');
     });
 
-    it('should not add multiple nodes', async function() {
-      loadFirebase('app');
-      let nodes = [];
-
-      try {
-        nodes = document.head.querySelectorAll(
-          'script[src^="//www.gstatic.com/firebasejs/"]',
-        );
-        assert(nodes.length === 1);
-
-        loadFirebase('app', 'performance');
-        nodes = document.head.querySelectorAll(
-          'script[src^="//www.gstatic.com/firebasejs/"]',
-        );
-        assert(nodes.length === 2, 'nodes should only contain one additional');
-      } finally {
-        // This isn't an async test, we don't check that the scripts actually
-        // load, so just remove them immediately after run.
-        nodes.forEach((node) => node.remove());
-      }
-    });
-
     it('should add script tags after invocation', function() {
       loadFirebase('app', 'performance', 'app');
-      const nodes = document.head.querySelectorAll(
-        'script[src^="//www.gstatic.com/firebasejs/"]',
-      );
+      let nodes = [];
       try {
+        nodes = document.head.querySelectorAll(
+          'script[src^="//www.gstatic.com/firebasejs/"]',
+        );
         assert(nodes.length === 2, 'JS should be added for uniques');
         assert(nodes[0].src.endsWith('-app.js'));
         assert(!nodes[0].async);
         assert(nodes[1].src.endsWith('-performance.js'));
         assert(!nodes[1].async);
+
+        loadFirebase('app');
+        nodes = document.head.querySelectorAll(
+          'script[src^="//www.gstatic.com/firebasejs/"]',
+        );
+        assert(nodes.length === 2, 'JS should remain the same');
       } finally {
         // This isn't an async test, we don't check that the scripts actually
         // load, so just remove them immediately after run.


### PR DESCRIPTION
I inadvertently introduced two issues to the Firebase code in #2767.

* We weren't returning the `firestore` object from its associated `Promise`
* We weren't setting `.async = false` on the dynamic scripts, so if e.g. Firebase's performance script loaded _before_ app, the load would fail.
(This didn't really show up in testing since cached files executed in element order.)