### PR TITLE
chore(redirect): send users from `/subscribe` to `/newsletter`, fixes #2724

### DIFF
--- a/src/lib/components/Actions/index.js
+++ b/src/lib/components/Actions/index.js
@@ -105,8 +105,7 @@ class Actions extends BaseElement {
         data-category="web.dev"
         data-label="subscribe, newsletter"
         data-action="click"
-        href="https://web.dev/subscribe"
-        target="_blank"
+        href="/newsletter/"
       >
         <span>Subscribe</span>
       </a>

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -24,7 +24,7 @@ module.exports = {
   defaultLocale: locale.defaultLocale,
   url: 'https://web.dev',
   repo: 'https://github.com/GoogleChrome/web.dev',
-  subscribe: 'https://web.dev/subscribe',
+  subscribe: 'https://web.dev/newsletter',
   subscribeForm:
     'https://services.google.com/fb/submissions/591768a1-61a6-4f16-8e3c-adf1661539da/',
   thumbnail: '/images/social.png',

--- a/src/site/content/en/_redirects.yaml
+++ b/src/site/content/en/_redirects.yaml
@@ -22,7 +22,7 @@ redirects:
 # Newsletter
 
 - from: /subscribe
-  to: https://services.google.com/fb/forms/web-dev-subscribe/
+  to: /newsletter
 
 # Pre-v1 redirects
 


### PR DESCRIPTION
Fixes #2724

Add redirects from `/subscribe` to `/newletter`.