### PR TITLE
Remove use of sizes in cards.

### DIFF
--- a/src/site/_includes/components/BaseCard.js
+++ b/src/site/_includes/components/BaseCard.js
@@ -66,7 +66,6 @@ class BaseCard {
       <figure class="w-card-base__figure">
         <img
           class="w-card-base__image"
-          sizes="365px"
           srcset="${srcsetRange.map(
             (width) => html`
               ${imagePath}?auto=format&fit=max&w=${width} ${width}w,


### PR DESCRIPTION
I noticed thumbnails on the /blog page were looking really pixelated. It turns out our use of `sizes` is working against us here. I think using `365px` was making it ignore the screen density, so it was selecting an image that was close to 365px which looked fuzzy on retina. Just removing sizes in this case and leaving the srcset that the cards provide fixes the issue. Now it selects the closest retina image.

Changes proposed in this pull request:

- Remove `sizes=""` on card elements.

Compare the word "iframe" in the images below:

**Before**:
![Screen Shot 2020-05-05 at 2 41 27 PM](https://user-images.githubusercontent.com/1066253/81119455-a678b080-8edf-11ea-950e-329345e2494c.png)

**After**:
![Screen Shot 2020-05-05 at 2 41 42 PM](https://user-images.githubusercontent.com/1066253/81119473-ad072800-8edf-11ea-9fff-f51c633bec0c.png)
