### PR TITLE
fix: a typo in the custom-metrics content

### DIFF
--- a/src/site/content/en/metrics/custom-metrics/index.md
+++ b/src/site/content/en/metrics/custom-metrics/index.md
@@ -358,7 +358,7 @@ try {
 }
 ```
 
-Another metric developers who user service worker may care about is the service
+Another metric developers who use service worker may care about is the service
 worker startup time for navigation requests. This is the amount of time it takes
 the browser to start the service worker thread before it can start intercepting
 fetch events.


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes a typo

Changes proposed in this pull request:

- a grammatical typo in the `Navigation Timing API section`
- 
- 
