### PR TITLE
Add dimensions to masthead images.

### DIFF
--- a/src/site/_includes/page.njk
+++ b/src/site/_includes/page.njk
@@ -15,7 +15,7 @@ layout: layout
         <p class="w-masthead-path__description">{{description}}</p>
       </div>
       <div class="w-masthead-path__right">
-        <img class="w-masthead-path__image" src="{{masthead}}" alt="">
+        <img class="w-masthead-path__image" src="{{masthead}}" alt="" width="420" height="280">
       </div>
     </div>
   </header>


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes layout shift on the /vitals page because masthead image needed initial dimensions.