### PR TITLE
redirect /foo => /foo/

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -164,7 +164,20 @@ workboxRouting.registerRoute(normalMatch, async ({url}) => {
   // it's otherwise missing.
   if (!pathname.endsWith('.html')) {
     if (!pathname.endsWith('/')) {
-      pathname += '/';
+      // Special-case a URL that doesn't end with "/". We must redirect before
+      // returning content as otherwise relative URLs don't work.
+      // This is not a problem as:
+      //   * this is occuring almost immediately (no network traffic)
+      //   * our webserver treats "/foo" and "/foo/" the same for other folders
+      //     and for the _redirects.yaml handler (i.e., a 404 on /foo and /foo/
+      //     will be treated the same way)
+      //   * a _real_ network request to "/foo" gets 301'ed to "/foo/"
+      const headers = new Headers();
+      headers.append('Location', pathname + '/');
+      return new Response('', {
+        status: 301,
+        headers,
+      });
     }
     pathname += 'index.html';
   }

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -173,7 +173,7 @@ workboxRouting.registerRoute(normalMatch, async ({url}) => {
       //     will be treated the same way)
       //   * a _real_ network request to "/foo" gets 301'ed to "/foo/"
       const headers = new Headers();
-      headers.append('Location', pathname + '/');
+      headers.append('Location', pathname + '/' + url.search);
       return new Response('', {
         status: 301,
         headers,


### PR DESCRIPTION
Fixes #2807.

I think I was too aggressive last time I changed this stuff. I can't see a reason not to reintroduce this blind redirect, fundamentally because our server that generates redirects (which will be hit if e.g., /foo/ 404's) _also_ doesn't care (i.e., normalizes) all URLs to end with a slash, too.