### PR TITLE
Fixed the typo in the index.md for the blog native-file-system

### DIFF
--- a/src/site/content/en/blog/native-file-system/index.md
+++ b/src/site/content/en/blog/native-file-system/index.md
@@ -323,7 +323,7 @@ async function verifyPermission(fileHandle, withWrite) {
   if (await fileHandle.requestPermission(opts) === 'granted') {
     return true;
   }
-  // The user did nt grant permission, return false.
+  // The user didn't grant permission, return false.
   return false;
 }
 ```


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #2828

Changes proposed in this pull request:

- Fixed a simple typo in the `index.md` file in the blog for `native file system`

Here's the typo ->

![Capture](https://user-images.githubusercontent.com/39026437/81393539-5c433980-9142-11ea-97b7-3044fe2d4925.png)
