### PR TITLE
Set custom dimensions to strings.

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -75,5 +75,6 @@ document.addEventListener('click', (e) => {
 // We log pageviews only in bootstrap.js (on entry, for all browsers) and in
 // loader.js (for dynamic SPA page loads, part of our core bundle).
 store.subscribe(({isSignedIn}) => {
-  ga('set', dimensions.SIGNED_IN, isSignedIn ? 1 : 0);
+  // nb. Analytics requires dimension values to be strings.
+  ga('set', dimensions.SIGNED_IN, isSignedIn ? '1' : '0');
 });

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -23,8 +23,9 @@ import removeServiceWorkers from './utils/sw-remove';
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 ga('create', id);
 ga('set', 'transport', 'beacon');
-ga('set', dimensions.SIGNED_IN, localStorage['webdev_isSignedIn'] ? 1 : 0);
-ga('set', dimensions.TRACKING_VERSION, version);
+// nb. Analytics requires dimension values to be strings.
+ga('set', dimensions.SIGNED_IN, localStorage['webdev_isSignedIn'] ? '1' : '0');
+ga('set', dimensions.TRACKING_VERSION, version.toString());
 ga('send', 'pageview');
 
 // In future, we can feature-detect other things here and prevent loading core


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes places where we set custom dimensions to use strings instead of numbers. This makes the GA debug extension stop logging warnings on every event.