### PR TITLE
fix(postTags): set title in default description to lower case, fixes #2785

### DIFF
--- a/src/site/_data/postTags.js
+++ b/src/site/_data/postTags.js
@@ -202,7 +202,7 @@ Object.keys(tags).forEach((key) => {
   const tag = tags[key];
   const description = tag.description
     ? tag.description
-    : `Our latest news, updates, and stories about ${tag.title}.`;
+    : `Our latest news, updates, and stories about ${(tag.title).toLowerCase()}.`;
 
   postTags[key] = {
     ...tag,

--- a/src/site/_data/postTags.js
+++ b/src/site/_data/postTags.js
@@ -202,7 +202,7 @@ Object.keys(tags).forEach((key) => {
   const tag = tags[key];
   const description = tag.description
     ? tag.description
-    : `Our latest news, updates, and stories about ${(tag.title).toLowerCase()}.`;
+    : `Our latest news, updates, and stories about ${tag.title.toLowerCase()}.`;
 
   postTags[key] = {
     ...tag,

--- a/src/site/_data/postTags.js
+++ b/src/site/_data/postTags.js
@@ -1,12 +1,14 @@
 const tags = {
   '3d': {
     title: '3D',
+    description: 'Our latest news, updates, and stories about 3D.',
   },
   accessibility: {
     title: 'Accessibility',
   },
   amp: {
     title: 'AMP',
+    description: 'Our latest news, updates, and stories about AMP.',
   },
   analytics: {
     title: 'Analytics',
@@ -25,15 +27,20 @@ const tags = {
   },
   'case-study': {
     title: 'Case Study',
+    description: 'Our latest news, updates, and stories about case studies.',
   },
   cast: {
     title: 'Cast',
   },
   'chrome-ux-report': {
     title: 'Chrome UX Report',
+    description:
+      'Our latest news, updates, and stories about Chrome UX Report.',
   },
   'chrome-dev-summit': {
     title: 'Chrome Dev Summit',
+    description:
+      'Our latest news, updates, and stories about Chrome Dev Summit.',
   },
   'content-security-policy': {
     title: 'Content Security Policy',
@@ -43,21 +50,27 @@ const tags = {
   },
   cors: {
     title: 'CORS',
+    description: 'Our latest news, updates, and stories about CORS.',
   },
   css: {
     title: 'CSS',
+    description: 'Our latest news, updates, and stories about CSS.',
   },
   devtools: {
     title: 'DevTools',
+    description: 'Our latest news, updates, and stories about DevTools.',
   },
   dom: {
     title: 'DOM',
+    description: 'Our latest news, updates, and stories about DOM.',
   },
   encryption: {
     title: 'Encryption',
   },
   'engineering-blog': {
     title: 'Engineering Blog',
+    description:
+      'Our latest news, updates, and stories from our engineering team.',
   },
   'feature-policy': {
     title: 'Feature Policy',
@@ -73,6 +86,7 @@ const tags = {
   },
   fugu: {
     title: 'Fugu',
+    description: 'Our latest news, updates, and stories about Fugu.',
   },
   games: {
     title: 'Games',
@@ -82,6 +96,7 @@ const tags = {
   },
   houdini: {
     title: 'Houdini',
+    description: 'Our latest news, updates, and stories about Houdini.',
   },
   identity: {
     title: 'Identity',
@@ -97,15 +112,18 @@ const tags = {
   },
   iot: {
     title: 'IoT',
+    description: 'Our latest news, updates, and stories about IoT.',
   },
   javascript: {
     title: 'JavaScript',
+    description: 'Our latest news, updates, and stories about JavaScript.',
   },
   layout: {
     title: 'Layout',
   },
   lighthouse: {
     title: 'Lighthouse',
+    description: 'Our latest news, updates, and stories about Lighthouse.',
   },
   media: {
     title: 'Media',
@@ -154,6 +172,7 @@ const tags = {
   },
   puppeteer: {
     title: 'Puppeteer',
+    description: 'Our latest news, updates, and stories about Puppeteer.',
   },
   rendering: {
     title: 'Rendering',
@@ -163,6 +182,7 @@ const tags = {
   },
   seo: {
     title: 'SEO',
+    description: 'Our latest news, updates, and stories about SEO.',
   },
   'service-worker': {
     title: 'Service Worker',
@@ -172,12 +192,14 @@ const tags = {
   },
   svg: {
     title: 'SVG',
+    description: 'Our latest news, updates, and stories about SVG.',
   },
   testing: {
     title: 'Testing',
   },
   ux: {
     title: 'UX',
+    description: 'Our latest news, updates, and stories about UX.',
   },
   'virtual-reality': {
     title: 'Virtual Reality',
@@ -190,9 +212,11 @@ const tags = {
   },
   'web-vitals': {
     title: 'Web Vitals',
+    description: 'Our latest news, updates, and stories about Web Vitals.',
   },
   webxr: {
     title: 'WebXR',
+    description: 'Our latest news, updates, and stories about WebXR.',
   },
 };
 


### PR DESCRIPTION
Fixes #2785

Call `.toLowerCase()` on `tag.title` when generating a tag's description.