### PR TITLE
Flexbox gap patch

### DIFF
--- a/src/site/content/en/blog/flexbox-gap/index.md
+++ b/src/site/content/en/blog/flexbox-gap/index.md
@@ -181,7 +181,7 @@ In the first 2 examples (without Flexbox `gap`), the children are targeted and a
 With these updates come changes to Chromium DevTools, notice how the **Styles** pane handles `grid-gap` and `gap` now 👍
 
 <figure class="w-figure">
-  <img src="./devtools-gap.png" alt="An office with two people working at a table." style="width: 400px; border-radius: 10px;">
+  <img src="./devtools-gap.png" alt="An office with two people working at a table." style="border-radius: 10px;" width="400">
   <figcaption class="w-figcaption">Devtools shows the both grid-gap and gap, with gap shown used below grid-gap as to let the cascade use the latest syntax.</figcaption>
 </figure>
 

--- a/src/site/content/en/blog/flexbox-gap/index.md
+++ b/src/site/content/en/blog/flexbox-gap/index.md
@@ -221,4 +221,4 @@ Pretty cool.
 
 ## Summary
 
-Flex gap wasn't all that came with Chromium 85, either. There was also a big multi-year refactor of flexbox: [flexNG](#). Enjoy performance enhancements and new features. It's a great day. 
+Flex gap wasn't all that will come with Chromium 85, either. There will also be a release of a big multi-year refactor of flexbox called flexNG. Stay tuned, mind the gaps. 

--- a/src/site/content/en/blog/flexbox-gap/index.md
+++ b/src/site/content/en/blog/flexbox-gap/index.md
@@ -181,7 +181,7 @@ In the first 2 examples (without Flexbox `gap`), the children are targeted and a
 With these updates come changes to Chromium DevTools, notice how the **Styles** pane handles `grid-gap` and `gap` now 👍
 
 <figure class="w-figure">
-  <img src="./devtools-gap.png" alt="An office with two people working at a table." style="max-width: 400px; border-radius: 10px;">
+  <img src="./devtools-gap.png" alt="An office with two people working at a table." style="width: 400px; border-radius: 10px;">
   <figcaption class="w-figcaption">Devtools shows the both grid-gap and gap, with gap shown used below grid-gap as to let the cascade use the latest syntax.</figcaption>
 </figure>
 


### PR DESCRIPTION
Fixes
- devtools image width extending beyond viewport on mobile
- removes dead link found on [twitter](https://twitter.com/tuhoojabotti/status/1258534267769901057?s=19) and [github](https://github.com/GoogleChrome/web.dev/commit/ed011f6897324c9c5f7f4984a2f24644b9186c28#commitcomment-39089105)