### PR TITLE
Fix a11y score by hiding decorative banner image.

### DIFF
--- a/src/site/content/en/index.njk
+++ b/src/site/content/en/index.njk
@@ -63,8 +63,8 @@ date: 2018-11-05
 
   <section class="w-home-promo" id="cds">
     <div class="w-home-promo__grid">
-      <div class="w-home-promo__box">
-        <a href="/covid19/" tabindex="-1"><img src="/covid19/banner.jpg" width="1320" height="739" /></a>
+      <div class="w-home-promo__box" aria-hidden="true">
+        <a href="/covid19/" tabindex="-1"><img src="/covid19/banner.jpg" alt="" width="1320" height="739" /></a>
       </div>
       <div>
         <p>


### PR DESCRIPTION
Changes proposed in this pull request:

- Noticed the covid banner was knocking 10 points off our LH a11y score cuz the link and image didn't have accessible names. Since the image is decorative we can just hide it and rely on the link in the paragraph on the right.