### PR TITLE
Add author homepage and switch to flex layout

### DIFF
--- a/src/site/_includes/components/AuthorInfo.js
+++ b/src/site/_includes/components/AuthorInfo.js
@@ -60,9 +60,7 @@ module.exports = ({post, author, id, showSocialMedia = false}) => {
   function renderHomepage({homepage}) {
     return html`
       <li class="w-author__link-listitem">
-        <a class="w-author__link" href="${homepage}"
-          >Homepage</a
-        >
+        <a class="w-author__link" href="${homepage}">Blog</a>
       </li>
     `;
   }
@@ -73,7 +71,7 @@ module.exports = ({post, author, id, showSocialMedia = false}) => {
         ${author.twitter && renderTwitter(author)}
         ${author.github && renderGitHub(author)}
         ${author.glitch && renderGlitch(author)}
-        ${author.homepage && renderGlitch(author)}
+        ${author.homepage && renderHomepage(author)}
       </ul>
     `;
   }

--- a/src/site/_includes/components/AuthorInfo.js
+++ b/src/site/_includes/components/AuthorInfo.js
@@ -57,12 +57,23 @@ module.exports = ({post, author, id, showSocialMedia = false}) => {
     `;
   }
 
+  function renderHomepage({homepage}) {
+    return html`
+      <li class="w-author__link-listitem">
+        <a class="w-author__link" href="${homepage}"
+          >Homepage</a
+        >
+      </li>
+    `;
+  }
+
   function renderSocialMedia(author) {
     return html`
       <ul class="w-author__link-list">
         ${author.twitter && renderTwitter(author)}
         ${author.github && renderGitHub(author)}
         ${author.glitch && renderGlitch(author)}
+        ${author.homepage && renderGlitch(author)}
       </ul>
     `;
   }

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -1,6 +1,5 @@
 @import '../settings/colors';
 @import '../tools/mixins';
-@import '../tools/breakpoints';
 
 // =============================================================================
 // AUTHOR OVERVIEW
@@ -13,18 +12,9 @@
 $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 
 .w-authors {
-  display: grid;
-  grid-column-gap: 16px;
-  grid-row-gap: 32px;
-  grid-template-columns: 1fr;
-
-  @include bp(sm) {
-    grid-template-columns: 256px 256px;
-  }
-
-  @include bp(md) {
-    grid-template-columns: 256px 256px 256px;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
 }
 
 .w-author {
@@ -69,7 +59,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   }
 }
 
-// Specificty required here because `a` tags in `.w-post-content` have higher priority.
+// Specificity required here because `a` tags in `.w-post-content` have higher priority.
 .w-post-content .w-author__name-link {
   text-decoration: none;
 
@@ -122,14 +112,6 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   display: flex;
   flex-direction: row;
   margin-bottom: 12px;
-
-  @include bp(sm) {
-    grid-template-columns: 256px 256px;
-  }
-
-  @include bp(md) {
-    grid-template-columns: 256px 256px 256px;
-  }
 }
 
 .w-author__image--row {

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -14,7 +14,7 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 .w-authors {
   display: flex;
   flex-wrap: wrap;
-  gap: 32px;
+  gap: 32px; // sass-lint:disable-line no-misspelled-properties
 }
 
 .w-author {
@@ -78,7 +78,8 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 }
 
 .w-author__link-list {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
   list-style: none;
   margin: 0;
   overflow: hidden;


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds the author's homepage to the social link list. 
- Switches authors markup to flex layout to avoid horizontal overflow.

  - Before:
     <img width="612" alt="Screen Shot 2020-05-13 at 11 30 56" src="https://user-images.githubusercontent.com/145676/81801295-756a3280-9514-11ea-9294-a8b1fba7dca5.png">
  - After:
     <img width="1177" alt="Screen Shot 2020-05-13 at 12 23 29" src="https://user-images.githubusercontent.com/145676/81801370-9b8fd280-9514-11ea-8144-f227e53df2a8.png">


