### PR TITLE
[Async Clipboard API article] Add prose why demo may fail

### DIFF
--- a/src/site/content/en/blog/image-support-for-async-clipboard/index.md
+++ b/src/site/content/en/blog/image-support-for-async-clipboard/index.md
@@ -5,7 +5,7 @@ authors:
   - thomassteiner
 description: Chrome 76 adds expands the functionality of the Async Clipboard API to add support for png images. Copying and pasting images to the clipboard has never been easier.
 date: 2019-07-03
-updated: 2020-03-19
+updated: 2020-05-14
 tags:
   - blog
   - capabilities
@@ -236,10 +236,18 @@ document.addEventListener('copy', async (e) => {
 
 ### Demo
 
+You can play with the Async Clipboard API in the demo below.
+You might get a `NotAllowedError` that is caused by a not yet
+implemented Feature Policy (see
+[this issue](https://github.com/w3c/webappsec-feature-policy/issues/322) for details).
+In this case just run the demo
+[directly on Glitch](https://async-clipboard-api.glitch.me/).
+
 <div class="glitch-embed-wrap" style="height: 500px; width: 100%;">
   <iframe
-    src="https://glitch.com/embed/#!/embed/async-clipboard-api?path=index.html&attributionHidden=true&previewSize=100"
-    alt="Async Clipboard on Glitch"
+    src="https://glitch.com/embed/#!/embed/async-clipboard-api?path=README.md&previewSize=100"
+    title="async-clipboard-api on Glitch"
+    allow="geolocation; microphone; camera; midi; vr; encrypted-media; clipboard; clipboard-read; clipboard-write"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>


### PR DESCRIPTION
Fixes #2876

Changes proposed in this pull request:

- The demo may fail due to a not yet implemented Feature Policy. Highlight this fact.