### PR TITLE
webdev-live show sessions

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,6 +37,7 @@ const Compare = require(`./${componentsDir}/Compare`);
 const CompareCaption = require(`./${componentsDir}/CompareCaption`);
 const Details = require(`./${componentsDir}/Details`);
 const DetailsSummary = require(`./${componentsDir}/DetailsSummary`);
+const EventTable = require(`./${componentsDir}/EventTable`);
 const Hero = require(`./${componentsDir}/Hero`);
 const Instruction = require(`./${componentsDir}/Instruction`);
 const Label = require(`./${componentsDir}/Label`);
@@ -49,6 +50,7 @@ const YouTube = require(`./${componentsDir}/YouTube`);
 
 const collectionsDir = 'src/site/_collections';
 const authors = require(`./${collectionsDir}/authors`);
+const eventSchedule = require(`./${collectionsDir}/event-schedule`);
 const paginatedAuthors = require(`./${collectionsDir}/paginated-authors`);
 const paginatedBlogPosts = require(`./${collectionsDir}/paginated-blog-posts`);
 const paginatedNewsletters = require(`./${collectionsDir}/paginated-newsletters`);
@@ -151,6 +153,7 @@ module.exports = function(config) {
   // COLLECTIONS
   // ----------------------------------------------------------------------------
   config.addCollection('authors', authors);
+  config.addCollection('eventSchedule', eventSchedule);
   config.addCollection('blogPosts', blogPostsDescending);
   config.addCollection('postsWithLighthouse', postsWithLighthouse);
   config.addCollection('recentBlogPosts', recentBlogPosts);
@@ -213,6 +216,7 @@ module.exports = function(config) {
   config.addPairedShortcode('CompareCaption', CompareCaption);
   config.addPairedShortcode('Details', Details);
   config.addPairedShortcode('DetailsSummary', DetailsSummary);
+  config.addShortcode('EventTable', EventTable);
   config.addShortcode('Hero', Hero);
   config.addShortcode('Instruction', Instruction);
   config.addPairedShortcode('Label', Label);

--- a/.sasslintrc
+++ b/.sasslintrc
@@ -40,7 +40,6 @@
     "no-trailing-whitespace": 2,
     "no-transition-all": 2,
     "placeholder-in-extend": 2,
-    "property-sort-order": 2,
     "pseudo-element": 2,
     "quotes": 2,
     "shorthand-values": 2,

--- a/src/lib/components/Tabs/_styles.scss
+++ b/src/lib/components/Tabs/_styles.scss
@@ -22,6 +22,10 @@ web-tabs {
   flex: 1;
   flex-direction: column;
 
+  --primary-color: var(--hover-color, #{$SELF_ASSESSMENT_PRIMARY_COLOR});
+  --hover-color: var(--hover-color, #{$SELF_ASSESSMENT_HOVER_COLOR});
+  --active-color: var(--active-color, #{$SELF_ASSESSMENT_ACTIVE_COLOR});
+
   .web-tabs__tablist {
     @include scrollbars();
     border-bottom: 1px solid $GREY_300;
@@ -52,7 +56,7 @@ web-tabs {
   @include hover() {
     .web-tabs__tab:hover,
     .web-tabs__tab:focus {
-      background: $SELF_ASSESSMENT_HOVER_COLOR;
+      background: var(--hover-color);
     }
   }
 
@@ -62,12 +66,12 @@ web-tabs {
   }
 
   .web-tabs__tab:active {
-    background: $SELF_ASSESSMENT_ACTIVE_COLOR;
+    background: var(--active-color);
     box-shadow: none;
   }
 
   .web-tabs__tab[aria-selected="true"] {
-    color: $SELF_ASSESSMENT_PRIMARY_COLOR;
+    color: var(--primary-color);
   }
 
   .web-tabs__tab::after {
@@ -83,7 +87,7 @@ web-tabs {
   }
 
   .web-tabs__tab[aria-selected="true"]::after {
-    background: $SELF_ASSESSMENT_PRIMARY_COLOR;
+    background: var(--primary-color);
   }
 
   .web-tabs__text-label {

--- a/src/site/_collections/event-schedule.js
+++ b/src/site/_collections/event-schedule.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const data = require('../_data/event');
+const contributors = require('../_data/contributors');
+
+let alreadyUpdated = false;
+
+/**
+ * Provides the singleton event schedule for web.dev/LIVE.
+ *
+ * @return {!Array<{title: string, sessions: !Array}>}
+ */
+module.exports = () => {
+  if (alreadyUpdated) {
+    return data;
+  }
+
+  const buildFallback = (id) => {
+    return {name: {given: id, family: ''}};
+  };
+
+  // This updates the raw event data with links to the relevant contributor.
+  for (const {sessions} of data) {
+    for (const session of sessions) {
+      session.info =
+        contributors[session.speaker] || buildFallback(session.speaker);
+    }
+  }
+
+  alreadyUpdated = true;
+  return data;
+};

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Contains event data for web.dev/LIVE.
+ */
+
+module.exports = [
+  {
+    title: 'Day 1',
+    from: Date.UTC(2020, 5, 30, 16), // 4pm UTC = 9am PST
+    sessions: [
+      {
+        speaker: 'addyosmani',
+        title: 'How to optimize for Web Vitals',
+      },
+      {
+        speaker: 'rviscomi',
+        title: 'How to browse CrUX data on BigQuery',
+      },
+    ],
+  },
+  {
+    title: 'Day 2',
+    from: Date.UTC(2020, 5, 30, 16), // 4pm UTC = 9am PST
+    sessions: [
+      {
+        speaker: 'samthor',
+        title: 'App-Like UX for Better PWAs',
+      },
+    ],
+  },
+  {
+    title: 'Day 3',
+    from: Date.UTC(2020, 6, 2, 16), // 4pm UTC = 9am PST
+    sessions: [],
+  },
+];

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// const path = require('path');
+const {html} = require('common-tags');
+// const prettyDate = require('../../_filters/pretty-date');
+// const stripLanguage = require('../../_filters/strip-language');
+// const md = require('../../_filters/md');
+// const constants = require('../../_utils/constants');
+// const getSrcsetRange = require('../../_utils/get-srcset-range');
+// const postTags = require('../../_data/postTags');
+
+const Author = require('./Author');
+
+module.exports = (collections) => {
+  const schedule = collections.eventSchedule;
+
+  // TODO(MichaelSolati): "Author" needs a post but doesn't use it, we pass an empty object.
+  const renderSession = ({speaker, info, title}) => {
+    return html`
+      <tr>
+        <td class="w-event-schedule__speaker">
+          ${Author({post: {}, author: info, id: speaker, small: true})}
+        </td>
+        <td class="w-event-schedule__session">${title}</td>
+      </tr>
+    `;
+  };
+
+  const renderDay = ({title, sessions}) => {
+    return html`
+      <div data-label="${title}">
+        <div class="w-event-section__schedule_header">
+          <web-event-time></web-event-time>
+        </div>
+
+        <table class="w-event-schedule">
+          <tbody>
+            ${sessions.map(renderSession)}
+          </tbody>
+        </table>
+      </div>
+    `;
+  };
+
+  return html`
+    <web-tabs class="w-event-tabs">
+      ${schedule.map(renderDay)}
+    </web-tabs>
+  `;
+};

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -65,15 +65,7 @@ draft: true
     </div>
 
     <div class="w-event-section__column-right">
-      <web-tabs>
-        <div data-label="Day 1">
-        </div>
-        <div data-label="Day 2">
-        </div>
-        <div data-label="Day 3">
-        </div>
-      </web-tabs>
-
+{% EventTable collections %}
     </div>
 
   </section>

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -31,10 +31,12 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   object-fit: cover;
   overflow: hidden;
   width: 64px;
+  min-width: 64px; // prevent from being shrunk
 }
 
 .w-author__image--small {
   height: $AUTHOR_IMAGE_SIZE_SMALL;
+  min-width: $AUTHOR_IMAGE_SIZE_SMALL; // prevent from being shrunk
   width: $AUTHOR_IMAGE_SIZE_SMALL;
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -153,6 +153,28 @@
   }
 }
 
+web-tabs.w-event-tabs {
+  --primary-color: #{$WEB_PRIMARY_COLOR};
+  --hover-color: #{$GOOGLE_BLUE_50};
+  --active-color: #{$GOOGLE_BLUE_100};
+}
+
+table.w-event-schedule {
+  // TODO(robdodson): The generic table has `min-width: 512px`, which extends over the side of
+  // small devices.
+  min-width: auto;
+
+  td {
+    font-size: 14px;
+    line-height: 20px;
+  }
+}
+
+.w-event-schedule__title {
+  width: 60%;
+}
+
+
 @include bp(md) {
   .w-event-section__column-head {
     order: -1;


### PR DESCRIPTION
Shows sessions for web.dev/live.

Disables property-sort-order as it doesn't play nice with CSS Variables, see [issue](https://github.com/sasstools/sass-lint/issues/1224) (which has been going for ~2 years, has a PR, and seems to be being ignored).

Adds just a couple of sessions for now. We can fill them in.