### PR TITLE
web.dev/live local time component

### DIFF
--- a/src/lib/components/EventTime/_styles.scss
+++ b/src/lib/components/EventTime/_styles.scss
@@ -6,7 +6,7 @@ web-event-time {
     display: flex;
   }
 
-  .et-date-feat {
+  .date {
     text-align: left;
     align-items: center;
     display: flex;
@@ -16,21 +16,21 @@ web-event-time {
     width: 68px;
   }
 
-  .et-date-feat__month {
+  .date__month {
     text-transform: uppercase;
   }
 
-  .et-date-feat__day {
+  .date__day {
     font-size: 44px;
     line-height: 1;
     text-transform: uppercase;
   }
 
-  .et-time-feat {
+  .time {
     text-align: left;
   }
 
-  .et-time-feat__timezone {
+  .time__timezone {
     color: $GREY_500;
   }
 }

--- a/src/lib/components/EventTime/_styles.scss
+++ b/src/lib/components/EventTime/_styles.scss
@@ -7,13 +7,13 @@ web-event-time {
   }
 
   .date {
-    text-align: left;
     align-items: center;
     display: flex;
     flex-flow: column;
     font-family: 'Google Sans', sans-serif;
     padding: 16px;
-    width: 68px;
+    text-align: left;
+    width: 80px;
   }
 
   .date__month {

--- a/src/lib/components/EventTime/_styles.scss
+++ b/src/lib/components/EventTime/_styles.scss
@@ -1,0 +1,36 @@
+@import '../../../styles/settings/colors';
+
+web-event-time {
+  time {
+    align-items: center;
+    display: flex;
+  }
+
+  .et-date-feat {
+    text-align: left;
+    align-items: center;
+    display: flex;
+    flex-flow: column;
+    font-family: 'Google Sans', sans-serif;
+    padding: 16px;
+    width: 68px;
+  }
+
+  .et-date-feat__month {
+    text-transform: uppercase;
+  }
+
+  .et-date-feat__day {
+    font-size: 44px;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .et-time-feat {
+    text-align: left;
+  }
+
+  .et-time-feat__timezone {
+    color: $GREY_500;
+  }
+}

--- a/src/lib/components/EventTime/index.js
+++ b/src/lib/components/EventTime/index.js
@@ -25,13 +25,17 @@ const connected = new Set();
 let timezoneCheckInterval = 0;
 let previous = 0;
 
-const checkTimezone = () => {
+/**
+ * This runs every ten minutes while any `web-event-time` element exists on the page. It checks for
+ * the rare but frustrating case where a user's timezone changes while the page is open.
+ */
+function checkTimezone() {
   const now = new Date().getTimezoneOffset();
   if (now !== previous) {
     previous = now;
     connected.forEach((node) => node.requestUpdate());
   }
-};
+}
 
 /**
  * Renders an event's time in the user's local timezone, including optional duration.

--- a/src/lib/components/EventTime/index.js
+++ b/src/lib/components/EventTime/index.js
@@ -78,6 +78,7 @@ class EventTime extends BaseElement {
       if (this.datetime) {
         const d = new Date(Date.parse(this.datetime));
         if (+d) {
+          // +d checks the validity of the parsed date (0 if invalid).
           this._date = d;
         }
       }
@@ -89,7 +90,7 @@ class EventTime extends BaseElement {
   render() {
     if (!this._date) {
       return html`
-        <time>?</time>
+        <!-- Invalid time "${this.datetime || ''}" -->
       `;
     }
 
@@ -109,20 +110,20 @@ class EventTime extends BaseElement {
 
     return html`
       <time datetime=${this._date.toISOString()}>
-        <div class="et-date-feat">
-          <div class="et-date-feat__month">
+        <div class="date">
+          <div class="date__month">
             ${months[this._date.getMonth()]}
           </div>
-          <div class="et-date-feat__day">
+          <div class="date__day">
             ${this._date.getDate()}
           </div>
         </div>
-        <div class="et-time-feat">
-          <div class="et-time-feat__value">
+        <div class="time">
+          <div class="time__value">
             ${format(this._date, {hour: 'numeric', minute: '2-digit'})}
             ${durationPart}
           </div>
-          <div class="et-time-feat__timezone">
+          <div class="time__timezone">
             ${options.timeZoneName || options.timeZone || 'Local Time'}
           </div>
         </div>

--- a/src/lib/components/EventTime/index.js
+++ b/src/lib/components/EventTime/index.js
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Element that renders a time in local timezone.
+ */
+
+import {html} from 'lit-element';
+import {BaseElement} from '../BaseElement';
+import './_styles.scss';
+
+const months = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+const connected = new Set();
+let timezoneCheckInterval = 0;
+let previous = 0;
+
+const checkTimezone = () => {
+  const now = new Date().getTimezoneOffset();
+  if (now !== previous) {
+    previous = now;
+    connected.forEach((node) => node.requestUpdate());
+  }
+};
+
+/**
+ * Renders code block that can easily be copied.
+ *
+ * @extends {BaseElement}
+ * @final
+ */
+class EventTime extends BaseElement {
+  static get properties() {
+    return {
+      datetime: {type: String},
+      duration: {type: Number},
+    };
+  }
+
+  constructor() {
+    super();
+    this._date = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    if (connected.size === 0) {
+      // Every 10 minutes, check if we're in the same timezone.
+      timezoneCheckInterval = window.setInterval(checkTimezone, 10 * 60 * 1000);
+    }
+    connected.add(this);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    connected.delete(this);
+    if (connected.size === 0) {
+      window.clearInterval(timezoneCheckInterval);
+    }
+  }
+
+  shouldUpdate(changedProperties) {
+    if (changedProperties.has('datetime')) {
+      this._date = null;
+
+      if (this.datetime) {
+        const d = new Date(Date.parse(this.datetime));
+        if (+d) {
+          this._date = d;
+        }
+      }
+    }
+
+    return super.shouldUpdate(changedProperties);
+  }
+
+  render() {
+    if (!this._date) {
+      return html`
+        <time>?</time>
+      `;
+    }
+
+    const format = (d, options) => {
+      return new Intl.DateTimeFormat('default', options).format(d);
+    };
+    const options = new Intl.DateTimeFormat().resolvedOptions();
+
+    let durationPart = '';
+    if (this.duration > 0) {
+      const end = new Date(this._date);
+      end.setHours(end.getHours() + this.duration);
+      durationPart = html`
+        &mdash; ${format(end, {hour: 'numeric', minute: '2-digit'})}
+      `;
+    }
+
+    return html`
+      <time datetime=${this._date.toISOString()}>
+        <div class="et-date-feat">
+          <div class="et-date-feat__month">
+            ${months[this._date.getMonth()]}
+          </div>
+          <div class="et-date-feat__day">
+            ${this._date.getDate()}
+          </div>
+        </div>
+        <div class="et-time-feat">
+          <div class="et-time-feat__value">
+            ${format(this._date, {hour: 'numeric', minute: '2-digit'})}
+            ${durationPart}
+          </div>
+          <div class="et-time-feat__timezone">
+            ${options.timeZoneName || options.timeZone || 'Local Time'}
+          </div>
+        </div>
+      </time>
+    `;
+  }
+}
+
+customElements.define('web-event-time', EventTime);

--- a/src/lib/components/EventTime/index.js
+++ b/src/lib/components/EventTime/index.js
@@ -34,7 +34,7 @@ const checkTimezone = () => {
 };
 
 /**
- * Renders code block that can easily be copied.
+ * Renders an event's time in the user's local timezone, including optional duration.
  *
  * @extends {BaseElement}
  * @final

--- a/src/lib/pages/live.js
+++ b/src/lib/pages/live.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for web.dev LIVE page.
  */
 
+import '../components/EventTime';
 import '../components/Subscribe';
 import '../components/Tabs';
 

--- a/src/site/_collections/event-schedule.js
+++ b/src/site/_collections/event-schedule.js
@@ -34,10 +34,18 @@ module.exports = () => {
   };
 
   // This updates the raw event data with links to the relevant contributor.
-  for (const {sessions} of data) {
-    for (const session of sessions) {
+  for (const day of data) {
+    for (const session of day.sessions) {
       session.info =
         contributors[session.speaker] || buildFallback(session.speaker);
+    }
+
+    // ... and parses the JS date of the start time.
+    day.date = new Date(Date.parse(day.when)) || null;
+    if (!day.date) {
+      throw new TypeError(
+        `each conference day needs a valid date, source: ${day.when}`,
+      );
     }
   }
 

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -21,7 +21,8 @@
 module.exports = [
   {
     title: 'Day 1',
-    from: Date.UTC(2020, 5, 30, 16), // 4pm UTC = 9am PST
+    when: '2020-06-30T16:00Z',
+    duration: 8,
     sessions: [
       {
         speaker: 'addyosmani',
@@ -35,7 +36,8 @@ module.exports = [
   },
   {
     title: 'Day 2',
-    from: Date.UTC(2020, 5, 30, 16), // 4pm UTC = 9am PST
+    when: '2020-07-01T16:00Z',
+    duration: 8,
     sessions: [
       {
         speaker: 'samthor',
@@ -45,7 +47,8 @@ module.exports = [
   },
   {
     title: 'Day 3',
-    from: Date.UTC(2020, 6, 2, 16), // 4pm UTC = 9am PST
+    when: '2020-07-02T16:00Z',
+    duration: 8,
     sessions: [],
   },
 ];

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -35,6 +35,8 @@ module.exports = (collections) => {
   };
 
   const renderDay = (day) => {
+    // nb. prettyDate is used as a fallback if the `web-event-time` Web Component doesn't wake up
+    // and render a fancy timestamp in the user's local time.
     return html`
       <div data-label="${day.title}">
         <div class="w-event-section__schedule_header">

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-// const path = require('path');
 const {html} = require('common-tags');
-// const prettyDate = require('../../_filters/pretty-date');
-// const stripLanguage = require('../../_filters/strip-language');
-// const md = require('../../_filters/md');
-// const constants = require('../../_utils/constants');
-// const getSrcsetRange = require('../../_utils/get-srcset-range');
-// const postTags = require('../../_data/postTags');
+const prettyDate = require('../../_filters/pretty-date');
 
 const Author = require('./Author');
 
@@ -40,16 +34,20 @@ module.exports = (collections) => {
     `;
   };
 
-  const renderDay = ({title, sessions}) => {
+  const renderDay = (day) => {
     return html`
-      <div data-label="${title}">
+      <div data-label="${day.title}">
         <div class="w-event-section__schedule_header">
-          <web-event-time></web-event-time>
+          <web-event-time
+            datetime="${day.date.toISOString()}"
+            duration="${day.duration}"
+            >${prettyDate(day.date)}</web-event-time
+          >
         </div>
 
         <table class="w-event-schedule">
           <tbody>
-            ${sessions.map(renderSession)}
+            ${day.sessions.map(renderSession)}
           </tbody>
         </table>
       </div>

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -3,7 +3,7 @@ layout: layout
 title: web.dev LIVE
 description: |
   Bringing web developers together, from home
-date: 2020-12-31
+date: 2020-06-31
 draft: true
 ---
 
@@ -19,7 +19,7 @@ draft: true
   <img src="live.png" title="LIVE" />
 </video>
         </h1>
-        <p class="w-event-heading__subhead">Smarch 28 &mdash; Crtober 1, 2020</p>
+        <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
       </div>
 
       <div class="w-event-section__column-head w-event-hero">


### PR DESCRIPTION
Adds time component to web.dev/live. Supports start time (assumed in UTC) and optional duration in hours.

This displays in local timezone. Looks like this:

<img width="341" alt="Screen Shot 2020-05-15 at 17 52 32" src="https://user-images.githubusercontent.com/119184/82025837-346d4c00-96d5-11ea-936e-79e063f4a64c.png">

Matches mocks.