### PR TITLE
web.dev/live share

### DIFF
--- a/src/lib/components/EventShare/index.js
+++ b/src/lib/components/EventShare/index.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Element that renders configurable per-page actions.
+ */
+
+import {html} from 'lit-element';
+import {BaseElement} from '../BaseElement';
+import {isWebShareSupported} from '../../utils/web-share';
+
+/**
+ * Renders configurable per-page actions. This is expected to be created by
+ * page content.
+ *
+ * @extends {BaseElement}
+ * @final
+ */
+class EventShare extends BaseElement {
+  static get properties() {
+    return {
+      // Whether the Web Share API is supported
+      _webShareSupported: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this._webShareSupported = isWebShareSupported();
+  }
+
+  onWebShare() {
+    navigator.share({
+      url: this.shareUrl,
+      text: this.shareText,
+    });
+  }
+
+  onShare(e) {
+    e.preventDefault();
+    window.open(e.target.href, 'share-window', 'width=550,height=235');
+  }
+
+  get shareUrl() {
+    return window.location.href;
+  }
+
+  get shareText() {
+    return document.title;
+  }
+
+  get shareTemplate() {
+    if (this._webShareSupported) {
+      return html`
+        <button
+          class="w-actions__fab w-actions__fab--share gc-analytics-event"
+          data-category="web.dev"
+          data-label="share, web"
+          data-action="click"
+          @click=${this.onWebShare}
+        >
+          <span>Share</span>
+        </button>
+      `;
+    }
+
+    // Otherwise, fall back to a Twitter popup.
+    const url = new URL('https://twitter.com/share');
+    url.searchParams.set('url', this.shareUrl);
+    url.searchParams.set('text', this.shareText);
+    return html`
+      <a
+        class="w-actions__fab w-actions__fab--share gc-analytics-event"
+        data-category="web.dev"
+        data-label="share, twitter"
+        data-action="click"
+        href="${url}"
+        target="_blank"
+        rel="noreferrer"
+        @click=${this.onTwitterShare}
+      >
+        <span>Share</span>
+      </a>
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="w-actions w-actions--inline">
+        ${this.shareTemplate}
+      </div>
+    `;
+  }
+}
+
+customElements.define('web-event-share', EventShare);

--- a/src/lib/pages/live.js
+++ b/src/lib/pages/live.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for web.dev LIVE page.
  */
 
+import '../components/EventShare';
 import '../components/Subscribe';
 import '../components/Tabs';
 

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -23,7 +23,7 @@ draft: true
       </div>
 
       <div class="w-event-section__column-head w-event-hero">
-        <img src="hero.png" />
+        <img src="hero.png" width="1572" height="394" />
       </div>
 
       <div class="w-event-section__column-right">
@@ -83,5 +83,20 @@ draft: true
   <section class="w-layout-container">
     {% include 'partials/subscribe.njk' %}
   </section>
+
+  <hr />
+
+  <section class="w-event-section">
+    <div class="w-event-section__column-left w-event-share">
+      <p>
+        Share this event with your friends
+      </p>
+      <web-event-share></web-event-share>
+    </div>
+    <div class="w-event-section__column-right">
+      <img src="hero.png" width="1572" height="394" />
+    </div>
+  </section>
+
 
 </div>

--- a/src/styles/components/_actions.scss
+++ b/src/styles/components/_actions.scss
@@ -8,6 +8,9 @@
 //
 // A material floating action button ('FAB').
 //
+// TODO(samthor): This is only used by <web-actions> and <web-event-share>.
+// Merge this CSS inline with those elements, and merge those elements.
+//
 // =============================================================================
 
 $W_FAB_LARGE_RADIUS: 28px;
@@ -20,6 +23,23 @@ $W_FAB_LARGE_RADIUS: 28px;
   position: fixed;
   right: 24px;
   z-index: 100;
+
+  &.w-actions--inline {
+    position: static;
+    z-index: auto;
+
+    .w-actions__fab {
+      box-shadow: initial;
+      transition: box-shadow $TRANSITION_SPEED;
+
+      &:hover {
+        box-shadow:
+          0 2px 4px -1px rgba($BLACK, .2),
+          0 4px 5px 0 rgba($BLACK, .14),
+          0 1px 10px 0 rgba($BLACK, .12);
+      }
+    }
+  }
 }
 
 .w-actions__fab {

--- a/src/styles/components/_actions.scss
+++ b/src/styles/components/_actions.scss
@@ -34,9 +34,9 @@ $W_FAB_LARGE_RADIUS: 28px;
 
       &:hover {
         box-shadow:
-          0 2px 4px -1px rgba($BLACK, .2),
-          0 4px 5px 0 rgba($BLACK, .14),
-          0 1px 10px 0 rgba($BLACK, .12);
+        0 2px 4px -1px rgba($BLACK, .2),
+        0 4px 5px 0 rgba($BLACK, .14),
+        0 1px 10px 0 rgba($BLACK, .12);
       }
     }
   }

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -10,6 +10,7 @@
     @include bp(sm) {
       font-size: 16px;
     }
+
   }
 
   h2 {
@@ -119,6 +120,7 @@
   img {
     max-height: 100%;
     min-width: 560px;
+    object-fit: contain;
   }
 }
 
@@ -152,6 +154,14 @@
     margin-top: 0;
   }
 }
+
+.w-event-share {
+  p,
+  web-event-share {
+    margin-bottom: 12px;
+  }
+}
+
 
 @include bp(md) {
   .w-event-section__column-head {


### PR DESCRIPTION
Adds a sharing button and section to the web.dev/LIVE page.

This is the path of least resistance but I'm also not proud. I just forked the `<web-actions>` element, which is implicitly a FAB ("floating action button", fixed in bottom right).

I think getting this in now makes sense but we should fix it up soon after—the right way is probably to add more options to the element, and make the floating-ness part of the top-level page.

This also fixes the hero image by giving it a known w/h.