### PR TITLE
subscribe copy just for live page

### DIFF
--- a/src/site/_includes/partials/subscribe.njk
+++ b/src/site/_includes/partials/subscribe.njk
@@ -1,11 +1,11 @@
-<web-subscribe id="subscribe" class="w-pt--l w-pb--l">
+<web-subscribe class="w-pt--l w-pb--l">
   <div class="w-subscribe">
     <div class="w-display--flex w-justify-content--center">
-      <h1 class="w-text--center">Developer Newsletter</h1>
+      <h1 class="w-text--center">{{ subscribeTitle | default('Developer Newsletter', false) }}</h1>
     </div>
     <div class="w-display--flex w-justify-content--center">
       <div class="w-subscribe--padded">
-        <p class="w-text--center w-mt--non w-subscribe__message">Get the latest news, techniques and updates straight to your inbox.</p>
+        <p class="w-text--center w-mt--non w-subscribe__message">{{ subscribeNotes | default('Get the latest news, techniques and updates straight to your inbox.', false) }}</p>
       </div>
     </div>
     <form class="w-subscribe__form" action="{{ site.subscribeForm }}" method="post">

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -55,7 +55,7 @@ draft: true
 
   <hr />
 
-  <section class="w-event-section">
+  <section id="schedule" class="w-event-section">
 
     <div class="w-event-section__column-left">
       <h3>What to expect</h3>
@@ -73,7 +73,9 @@ draft: true
 
   <hr />
 
-  <section class="w-layout-container">
+  <section id="subscribe" class="w-layout-container">
+    {% set subscribeTitle = "Sign up for web.dev updates" %}
+    {% set subscribeNotes = "Enjoying the content of web.dev LIVE? Get the latest news and techniques about web development straight to your inbox." %}
     {% include 'partials/subscribe.njk' %}
   </section>
 


### PR DESCRIPTION
Fixes #2903

Fixes #2901

I don't believe we use the `id="subscribe"` on `<web-subscribe>` directly for any reason, so I've repurposed it for the copy page.

There's still an issue; the subscribe element repositions itself because the event table and its tabs size is unknown until the JS loads. I'll create this issue when this PR is merged.