### PR TITLE
Enable linking directly to the schedule

### DIFF
--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -65,7 +65,7 @@ draft: true
       </p>
     </div>
 
-    <div class="w-event-section__column-right w-event-section__column-right__schedule">
+    <div class="w-event-section__column-right w-event-section__column-right__schedule" id="schedule">
       {% EventTable event %}
     </div>
 


### PR DESCRIPTION
This enables linking to https://web.dev/live/#schedule, which comes in handy for a demo I'm working on for my web.dev LIVE talk. How meta!

