### PR TITLE
chore: update LHCI integration to use @lhci/cli@next

### DIFF
--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -36,4 +36,8 @@ jobs:
       - name: Install Canary Lighthouse CI
         run: npm install @lhci/cli@next
       - name: Lighthouse CI
-        run: npx lhci --config=./tools/lhci/lighthouserc.json --upload.serverBaseUrl=${{ secrets.LHCI_SERVER }} --upload.token=${{ secrets.LHCI_TOKEN }}
+        run: |
+          npx lhci autorun \
+          --config=./tools/lhci/lighthouserc.json \
+          --upload.serverBaseUrl=${{ secrets.LHCI_SERVER }} \
+          --upload.token=${{ secrets.LHCI_TOKEN }}

--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -33,10 +33,7 @@ jobs:
         env:
           ELEVENTY_ENV: prod
         run: npm ci && npm run build
+      - name: Install Canary Lighthouse CI
+        run: npm install @lhci/cli@next
       - name: Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v2
-        with:
-          runs: 3
-          configPath: ./tools/lhci/lighthouserc.json
-          serverBaseUrl: ${{ secrets.LHCI_SERVER }}
-          serverToken: ${{ secrets.LHCI_TOKEN }}
+        run: npx lhci --config=./tools/lhci/lighthouserc.json --upload.serverBaseUrl=${{ secrets.LHCI_SERVER }} --upload.token=${{ secrets.LHCI_TOKEN }}


### PR DESCRIPTION
fixes #2928 (Option 1 of 2)

Changes proposed in this pull request:

- Migrates to use @lhci/cli@next directly to continue using the canary LHCI server.
- The alternative is move to temporaryPublicStorage until a separate LHCI server can be setup (see #2937)
