### PR TITLE
chore: migrate off LHCI canary server

### DIFF
--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -38,5 +38,4 @@ jobs:
         with:
           runs: 3
           configPath: ./tools/lhci/lighthouserc.json
-          serverBaseUrl: ${{ secrets.LHCI_SERVER }}
-          serverToken: ${{ secrets.LHCI_TOKEN }}
+          temporaryPublicStorage: true


### PR DESCRIPTION
fixes #2928 (Option 2 of 2)
alternative option to #2936

Changes proposed in this pull request:

- Migrates to use temporary public storage instead of the LHCI server so the existing GitHub action can be preserved.
- The alternative is move to using LHCI canary CLI or setup your own LHCI server (see #2936)