### PR TITLE
chore(ci): run lighthouse CI on master

### DIFF
--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 # By default, runs when a pull_request's activity type is opened, synchronize,
-# or reopened
+# or reopened and on master so comparisons to ancestors can be made.
 on:
   push:
     branches: 

--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -3,6 +3,9 @@ name: Lighthouse CI
 # By default, runs when a pull_request's activity type is opened, synchronize,
 # or reopened
 on:
+  push:
+    branches: 
+      - master
   pull_request:
     paths:
       - '**.js'


### PR DESCRIPTION
Sorry for the double PR today but just updated the LHCI server and noticed there weren't any datapoints from master in the past 2 months. Double checked the config and looks like the move to GitHub actions disabled running on master. It's best to run on master so that individual PRs *delta* can be surfaced in LHCI.

Changes proposed in this pull request:
- Runs LHCI on master commits as well to establish a baseline
