### PR TITLE
community guidelines page

### DIFF
--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -115,11 +115,16 @@
     </nav>
     <nav class="w-footer__utility-nav">
       <ul class="w-footer__utility-list">
-        <li class="w-footer__utility-item
-            ">
+        <li class="w-footer__utility-item">
           <a class="w-footer__utility-link" href="https://policies.google.com/" data-category="Site-Wide Custom Events"
             data-label="Footer Terms and Privacy link">
             Terms &amp; Privacy
+          </a>
+        </li>
+        <li class="w-footer__utility-item">
+          <a class="w-footer__utility-link" href="/community-guidelines/" data-category="Site-Wide Custom Events"
+            data-label="Footer Community Guidelines link">
+            Community Guidelines
           </a>
         </li>
       </ul>
@@ -128,8 +133,8 @@
           Except as otherwise noted, the content of this page is licensed
           under the
           <a href="https://creativecommons.org/licenses/by/4.0/">
-          Creative Commons Attribution 4.0 License
-          </a>, and code samples are licensed under the
+          Creative Commons Attribution 4.0 License</a>,
+          and code samples are licensed under the
           <a href="https://www.apache.org/licenses/LICENSE-2.0">
           Apache 2.0 License</a>. For details, see the
           <a href="https://developers.google.com/site-policies">

--- a/src/site/_includes/partials/text.njk
+++ b/src/site/_includes/partials/text.njk
@@ -1,0 +1,10 @@
+<div class="w-layout-container--narrow">
+  <h1 class="w-headline--two w-font-weight--medium w-mt--non">{{ title | md | safe }}</h1>
+  {% if subhead %}
+    <p class="w-article-header__subhead w-mb--non">
+      {{ subhead | md | safe }}
+    </p>
+  {% endif %}
+
+  {{ content | safe }}
+</div>

--- a/src/site/_includes/text.njk
+++ b/src/site/_includes/text.njk
@@ -1,0 +1,6 @@
+---
+layout: layout
+permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
+---
+
+{% include 'partials/text.njk' %}

--- a/src/site/content/en/community-guidelines/index.md
+++ b/src/site/content/en/community-guidelines/index.md
@@ -10,11 +10,11 @@ Google is dedicated to providing a harassment-free and inclusive event experienc
 
 All participants of Google events, including in-person and online attendees, event staff, speakers, and Googlers, must abide by the following policy:
 
-## Be respectful to each other.
+## Be respectful to each other
 
-Treat everyone with respect. Participate while acknowledging that everyone deserves to be here — and each of us has the right to enjoy our experience without fear of harassment, discrimination, or condescension, whether blatant or via micro-aggressions. All forms of communication should not demean others. Consider what you are saying and how it would feel if it were said to you, or about you.
+Treat everyone with respect. Participate while acknowledging that everyone deserves to be here—and each of us has the right to enjoy our experience without fear of harassment, discrimination, or condescension, whether blatant or via micro-aggressions. All forms of communication should not demean others. Consider what you are saying and how it would feel if it were said to you, or about you.
 
-## Speak up if you see or hear something.
+## Speak up if you see or hear something
 
 Harassment is not tolerated, and you are empowered to politely engage when you or others are disrespected. The person making you feel uncomfortable may not be aware of what they are doing, and politely bringing their behavior to their attention is encouraged.
 
@@ -51,4 +51,4 @@ We have a **ZERO TOLERANCE POLICY** for in-person or online harassment of any ki
 
 Participants asked to stop any harassing behavior are expected to comply immediately. Our zero tolerance policy means that we will look into and review every allegation of violation of our Event Community Guidelines and Anti-Harassment Policy and respond appropriately.
 
-This policy extends to talks, forums, workshops, codelabs, social media, all attendees, partners, sponsors, volunteers, staff, etc. You catch our drift. Google reserves the right to refuse admittance to, or remove any person from, any Google hosted event (including future Google events) at any time in its sole discretion. This includes, but is not limited to, attendees behaving in a disorderly manner or failing to comply with this policy, and the terms and conditions herein. If a participant engages in harassing or uncomfortable behavior, the conference organizers may take any action they deem appropriate, including warning or expelling the offender from the conference with no refund or blocking the offender’s account from participating online.
+This policy extends to talks, forums, workshops, codelabs, social media, all attendees, partners, sponsors, volunteers, staff, etc. You catch our drift. Google reserves the right to refuse admittance to, or remove any person from, any Google hosted event (including future Google events) at any time in its sole discretion. This includes, but is not limited to, attendees behaving in a disorderly manner or failing to comply with this policy, and the terms and conditions herein. If a participant engages in harassing or uncomfortable behavior, the conference organizers may take any action they deem appropriate, including warning or expelling the offender from the conference with no refund or blocking the offender's account from participating online.

--- a/src/site/content/en/community-guidelines/index.md
+++ b/src/site/content/en/community-guidelines/index.md
@@ -2,8 +2,7 @@
 layout: text
 title: Google Community Guidelines and Anti-Harassment Policy for In-Person and Virtual Events
 description: Community Guidelines
-date: 2020-06-31
-draft: true
+noindex: true
 ---
 
 Google is dedicated to providing a harassment-free and inclusive event experience for everyone regardless of gender identity and expression, sexual orientation, disabilities, neurodiversity, physical appearance, body size, ethnicity, nationality, race, age, religion, or other protected category. We do not tolerate harassment of event participants in any form. Google takes violations of our policy seriously and will respond appropriately.

--- a/src/site/content/en/community-guidelines/index.md
+++ b/src/site/content/en/community-guidelines/index.md
@@ -1,0 +1,54 @@
+---
+layout: text
+title: Google Community Guidelines and Anti-Harassment Policy for In-Person and Virtual Events
+description: Community Guidelines
+date: 2020-06-31
+draft: true
+---
+
+Google is dedicated to providing a harassment-free and inclusive event experience for everyone regardless of gender identity and expression, sexual orientation, disabilities, neurodiversity, physical appearance, body size, ethnicity, nationality, race, age, religion, or other protected category. We do not tolerate harassment of event participants in any form. Google takes violations of our policy seriously and will respond appropriately.
+
+All participants of Google events, including in-person and online attendees, event staff, speakers, and Googlers, must abide by the following policy:
+
+## Be respectful to each other.
+
+Treat everyone with respect. Participate while acknowledging that everyone deserves to be here — and each of us has the right to enjoy our experience without fear of harassment, discrimination, or condescension, whether blatant or via micro-aggressions. All forms of communication should not demean others. Consider what you are saying and how it would feel if it were said to you, or about you.
+
+## Speak up if you see or hear something.
+
+Harassment is not tolerated, and you are empowered to politely engage when you or others are disrespected. The person making you feel uncomfortable may not be aware of what they are doing, and politely bringing their behavior to their attention is encouraged.
+
+We have a **ZERO TOLERANCE POLICY** for in-person or online harassment of any kind, including but not limited to:
+
+* Stalking/following
+* Deliberate intimidation
+* Harassing photography or recording
+* Sustained disruption of talks or other events
+* Offensive verbal language
+* Verbal language that reinforces social structures of domination
+* Sexual imagery and language in public spaces
+* Inappropriate physical contact
+* Unwelcome sexual or physical attention
+* Physical or cyber threats
+
+**In relation to, but not limited to:**
+
+* Neurodiversity
+* Race
+* Color
+* National origin
+* Gender identity
+* Gender expression
+* Sexual orientation
+* Age
+* Body size
+* Disabilities
+* Appearance
+* Religion
+* Pregnancy
+* Military status
+* Social demographic
+
+Participants asked to stop any harassing behavior are expected to comply immediately. Our zero tolerance policy means that we will look into and review every allegation of violation of our Event Community Guidelines and Anti-Harassment Policy and respond appropriately.
+
+This policy extends to talks, forums, workshops, codelabs, social media, all attendees, partners, sponsors, volunteers, staff, etc. You catch our drift. Google reserves the right to refuse admittance to, or remove any person from, any Google hosted event (including future Google events) at any time in its sole discretion. This includes, but is not limited to, attendees behaving in a disorderly manner or failing to comply with this policy, and the terms and conditions herein. If a participant engages in harassing or uncomfortable behavior, the conference organizers may take any action they deem appropriate, including warning or expelling the offender from the conference with no refund or blocking the offender’s account from participating online.

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -27,7 +27,7 @@ draft: true
       </div>
 
       <div class="w-event-section__column-right">
-        <h2>
+        <h2 class="w-mt--non">
           Bringing web developers together, from home
         </h2>
         <p>
@@ -71,7 +71,7 @@ draft: true
   <section id="schedule" class="w-event-section">
 
     <div class="w-event-section__column-left">
-      <h3>What to expect</h3>
+      <h3 class="w-mt--non">What to expect</h3>
       <p>
         Over three days, we'll share quick tips on aspects of modern web development.
         Each day, we'll "travel" to a new timezone to cover a couple aspects in short 10-20 min sessions and answer your questions.

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -140,10 +140,6 @@
     max-width: 512px - 64px;
   }
 
-  h3:first-of-type {
-    margin-top: 0;
-  }
-
   .w-event-buttons {
     margin: 16px 0;
   }
@@ -161,10 +157,6 @@
     // On larger devices, force padding even on the schedule (this wins over
     // ...__schedule, above).
     padding: 0 16px !important;
-  }
-
-  h2:first-of-type {
-    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
Fixes #2931.

This page will be immediately live and just linked to from the shared footer. There's not a specific place for it in the web.dev/live design yet.

This also adds a generic "text" layout for this, as this content isn't a post or falls into any other category.