### PR TITLE
allow for ::before to push heading down

### DIFF
--- a/src/styles/components/_topic.scss
+++ b/src/styles/components/_topic.scss
@@ -18,9 +18,7 @@ $TOPIC_SPACING_SIZE_SMALL: 32px;
 }
 
 .w-topic__header {
-  align-items: center;
   color: $WEB_PRIMARY_COLOR;
-  display: flex;
   margin-left: $TOPIC_SPACING_SIZE_SMALL;
   overflow: visible;
 
@@ -37,9 +35,7 @@ $TOPIC_SPACING_SIZE_SMALL: 32px;
 }
 
 .w-topic > .w-topic__subtopic-header {
-  align-items: center;
   color: $PRIMARY_TEXT_COLOR;
-  display: flex;
   margin-left: $TOPIC_SPACING_SIZE_SMALL;
   overflow: visible;
 


### PR DESCRIPTION
Fixes #2470 

This was `display: flex` for some reason that I don't understand and doesn't seem to matter, so the extra `::before` element didn't work.