### PR TITLE
Run lhci less often.

### DIFF
--- a/.github/workflows/lighthouse-ci-workflow.yml
+++ b/.github/workflows/lighthouse-ci-workflow.yml
@@ -9,11 +9,12 @@ on:
   pull_request:
     paths:
       - '**.js'
-      - '**.json'
+      - '!src/site/_data/contributors.js'
+      - '!src/site/_data/countries.js'
+      - '!src/site/_data/postTags.js'
+      - 'package.json'
       - '**.njk'
       - '**.scss'
-      - '**.yml'
-      - '**.yaml'
 
 jobs:
   lhci:


### PR DESCRIPTION
Changes proposed in this pull request:

- LHCI is running _way_ too often. Usually because a post will touch `contributors.j` and then the reviewer will accept a ton of changes, which runs LHCI many times. This throttles it to only run if important files were touched. The pattern is the same one we use for other actions.