### PR TITLE
Make kayce a codeowner for contributors and tags.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,3 +23,7 @@ content/en/angular/ @mgechev @kaycebasques
 *.yaml @robdodson @samthor
 *.toml @robdodson @samthor
 *.sh @robdodson @samthor
+
+# Exceptions
+src/site/_data/contributors.js @kaycebasques @robdodson
+src/site/_data/postTags.js @kaycebasques @robdodson


### PR DESCRIPTION
Changes proposed in this pull request:

- Add @kaycebasques to codeowners for contributors and tags file.