### PR TITLE
Add missing body argument to banner.

### DIFF
--- a/src/site/content/en/blog/more-variable-font-options-in-chromium-83/index.md
+++ b/src/site/content/en/blog/more-variable-font-options-in-chromium-83/index.md
@@ -174,7 +174,7 @@ Click **Remix to Edit** in the Glitch below to get an editable copy of the Glitc
 
 macOS 10.15 added new features to its system font, and in macOS 10.15 a tricky `system-ui` bug was logged in the Chromium bug tracker. I wonder if they are related!?
 
-{% Banner 'neutral' %}The image for this article was made with CSS and `system-ui`. Here's the [codepen](https://codepen.io/argyleink/pen/eYpbwWd).{% endBanner %}
+{% Banner 'neutral', 'body' %}The image for this article was made with CSS and `system-ui`. Here's the [codepen](https://codepen.io/argyleink/pen/eYpbwWd).{% endBanner %}
 
 ## Appendix: The `system-ui` regression {: #regression }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds missing body argument to shortcode. This just makes the font and padding match other stuff in the body. I'm making some changes to the base banner class to be fixed position but banner--body will still be statically positioned. Wanted to add this argument so we don't break this article.