### PR TITLE
Sw banner

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -28,8 +28,8 @@ module.exports = {
   subscribeForm:
     'https://services.google.com/fb/submissions/591768a1-61a6-4f16-8e3c-adf1661539da/',
   thumbnail: '/images/social.png',
-  isBannerEnabled: false,
-  banner: ``,
+  isBannerEnabled: true,
+  banner: `Join us for web.dev LIVE, a digital event from June 30th to July 2nd to learn modern web techniques. More at [web.dev/live](/live/).`,
   // Note that the imageCdn value is only used when we do a production build
   // of the site. Otherwise all image paths are local. This means you can
   // develop locally without having to mess with the CDN at all.

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout
 permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
+show_banner: false
 ---
 
 <div class="codelab-landing-page">

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -147,10 +147,10 @@ show_banner: true
       </a>
     </web-side-nav>
     <main>
-      {% if show_banner %}
-        {% include 'partials/banner.njk' %}
-      {% endif %}
       <div id="content">
+        {% if show_banner %}
+          {% include 'partials/banner.njk' %}
+        {% endif %}
         {{ content | safe }}
       </div>
     </main>

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -1,3 +1,7 @@
+---
+show_banner: true
+---
+
 <!DOCTYPE html>
 {% set lang = "en" %}
 {% set locale="en_US" %}
@@ -143,7 +147,9 @@
       </a>
     </web-side-nav>
     <main>
-      {% include 'partials/banner.njk' %}
+      {% if show_banner %}
+        {% include 'partials/banner.njk' %}
+      {% endif %}
       <div id="content">
         {{ content | safe }}
       </div>

--- a/src/site/content/en/index.njk
+++ b/src/site/content/en/index.njk
@@ -4,6 +4,7 @@ title: web.dev
 description: |
   Get the web's modern capabilities on your own sites and apps with useful
   guidance and analysis from web.dev.
+show_banner: false
 date: 2018-11-05
 ---
 

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -3,6 +3,7 @@ layout: layout
 title: web.dev LIVE
 description: |
   Bringing web developers together, from home
+show_banner: false
 date: 2020-06-31
 draft: true
 ---

--- a/src/site/content/sw-partial-layout.njk
+++ b/src/site/content/sw-partial-layout.njk
@@ -3,6 +3,7 @@ lang: ''
 layout: layout
 nometa: true
 permalink: /sw-partial-layout.partial
+show_banner: false
 ---
 {# Defines the layout used by the Service Worker. For now, uses a magic
    string that is replace at serve time. #}

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -1,4 +1,5 @@
 @import '../settings/colors';
+@import '../settings/dimensions';
 @import '../tools/breakpoints';
 
 // =============================================================================
@@ -21,6 +22,11 @@
   @include bp(md) {
     padding: 24px 64px;
   }
+}
+
+.w-banner--fixed {
+  position: fixed;
+  top: $WEB_HEADER_HEIGHT;
 }
 
 .w-banner--info {

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -1,5 +1,4 @@
 @import '../settings/colors';
-@import '../settings/dimensions';
 @import '../tools/breakpoints';
 
 // =============================================================================
@@ -9,24 +8,29 @@
 // Note that the banner is not absolutely or fixed positioned.
 // It is intended to scroll away as the user scrolls down the page.
 //
+// The banner can also be displayed inline with body content using the
+// w-banner--body modifier.
+//
 // =============================================================================
 
 .w-banner {
+  // Hide the top banner on small devices as it takes up too much space.
+  // We also hide hero images at this size for the same reason.
+  display: none;
   font-size: .889rem;
-  padding: 16px;
 
   @include bp(sm) {
+    display: block;
     padding: 24px 32px;
   }
 
   @include bp(md) {
     padding: 24px 64px;
   }
-}
 
-.w-banner--fixed {
-  position: fixed;
-  top: $WEB_HEADER_HEIGHT;
+  a {
+    text-decoration: underline;
+  }
 }
 
 .w-banner--info {
@@ -48,11 +52,9 @@
   border-width: 1px 0;
 }
 
+// This modifier is for banners that are inline with page content.
 .w-banner--body {
+  display: block;
   font: inherit;
   padding: 24px;
-}
-
-.w-banner__link {
-  text-decoration: underline;
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Enables the cross-site banner to promote the event.
- Adds a YAML property, `show_banner`, that pages can use to opt-out of displaying the banner. For instance, it doesn't make sense for `/live/` to display a banner promoting the live event :P
- Changes the sw-partial to not display any banner by default. Otherwise client side routing and service worker pages would display the banner.
- Moves the Banner into the content area. This makes it so the service-worker-partials transform properly captures it for pages that do and don't want to display it.
- Removes `.w-banner__link`. It looks like the shortcode doesn't use this. I replaced it with a style that handles any anchors appearing inside of the banner.

Note, don't merge this boi until the 26th.