### PR TITLE
Fix link to field metrics in FCP

### DIFF
--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -65,9 +65,10 @@ available in the following tools:
 ### Measure FCP in JavaScript
 
 The easiest way to measure FCP (as well as all Web Vitals [field
-metrics]((/metrics/#in-the-field))) is with the [`web-vitals` JavaScript
-library](https://github.com/GoogleChrome/web-vitals), which wraps all the
-complexity of manually measuring FCP into a single function:
+metrics](https://web.dev/vitals/#field-tools-to-measure-core-web-vitals) 
+is with the [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals), 
+which wraps all the complexity of manually measuring FCP into a single
+function:
 
 ```js
 import {getFCP} from 'web-vitals';

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -65,7 +65,7 @@ available in the following tools:
 ### Measure FCP in JavaScript
 
 The easiest way to measure FCP (as well as all Web Vitals [field
-metrics](https://web.dev/vitals/#field-tools-to-measure-core-web-vitals) 
+metrics](/vitals/#field-tools-to-measure-core-web-vitals) 
 is with the [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals), 
 which wraps all the complexity of manually measuring FCP into a single
 function:


### PR DESCRIPTION
Link is broken on https://web.dev/fcp/: ctrl-f for `field metrics`. The link is: `https://web.dev/fcp/(/metrics/#in-the-field)`.

If it's easier to make the change yourself, that's good by me.