### PR TITLE
Add "measure" app shortcut to web app manifest

### DIFF
--- a/src/misc/manifest.webmanifest
+++ b/src/misc/manifest.webmanifest
@@ -13,9 +13,15 @@
       "type": "image/png"
     },
     {
-        "src": "/images/android-chrome-512x512.png",
-        "sizes": "512x512",
-        "type": "image/png"
+      "src": "/images/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Measure",
+      "url": "/measure/"
     }
   ]
 }


### PR DESCRIPTION
This CL adds an app shortcut to the web app manifest so that users who installed web.dev PWA can use a shortcuts to "Measure".
See https://web.dev/app-shortcuts/ for what are app shortcuts.

![image](https://user-images.githubusercontent.com/634478/82866770-d557d480-9f29-11ea-8c44-e40a9972f3e0.png)

