### PR TITLE
Add message property to share button.

### DIFF
--- a/src/lib/components/ShareAction/index.js
+++ b/src/lib/components/ShareAction/index.js
@@ -49,11 +49,18 @@ class ShareAction extends HTMLElement {
   }
 
   get shareText() {
-    let authorText = '';
+    // Check for a custom message.
+    const messageText = this.getAttribute('message');
+    if (messageText && messageText.length) {
+      return messageText;
+    }
 
-    const raw = this.getAttribute('authors') || '';
-    if (raw && raw.length) {
-      const authors = raw
+    // If no custom message is found, fallback to using the page title
+    // plus the author's names.
+    let authorText = '';
+    const rawAuthors = this.getAttribute('authors') || '';
+    if (rawAuthors && rawAuthors.length) {
+      const authors = rawAuthors
         .split('|')
         .map((x) => x.trim())
         .filter(Boolean);

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -103,6 +103,7 @@ date: 2020-06-31
       </p>
       <div class="w-event-buttons">
         <share-action
+          message=" web.dev LIVE, a three day digital event for web developers by Google."
           data-category="web.dev"
           data-label="share"
           data-action="click"


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a `message` attribute to the share button so we can provide our own text. If no message is provided it will fallback to the original behavior of using the page title + author names.