### PR TITLE
fix: remove bug notice from lighthouse offscreen images

### DIFF
--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -22,11 +22,6 @@ to lower [Time to Interactive](/interactive):
 
 See also [Lazy load offscreen images with lazysizes codelab](/codelab-use-lazysizes-to-lazyload-images).
 
-## Bug: `loading="lazy"` images are incorrectly flagged
-
-This audit incorrectly flags [natively lazy-loaded images](/native-lazy-loading/).
-See [issue #6677](https://github.com/GoogleChrome/lighthouse/issues/6677) for details.
-
 ## Resources
 
 - [Source code for **Defer offscreen images** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/offscreen-images.js)


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes the bug notice from the Lighthouse document on offscreen images audit now that it has been fixed.

Alternative: change the text to mention that this only applies to v5 and earlier.
