### PR TITLE
Fixed the URL to Reduce server response times (TTFB)

### DIFF
--- a/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
+++ b/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
@@ -47,5 +47,5 @@ There are many possible causes of slow server responses, and therefore many poss
 
 ## Resources
 
-- [Source code for **Reduce server response times (TTFB)** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/time-to-first-byte.js)
+- [Source code for **Reduce server response times (TTFB)** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/server-response-time.js)
 - [Adaptive Serving with Network Information API](/adaptive-serving-based-on-network-quality)


### PR DESCRIPTION
Changes proposed in this pull request:

- Updated link to **Reduce server response times (TTFB)**  after the file was [renamed](https://github.com/GoogleChrome/lighthouse/commit/5162e5bbd989f8f1e915069dd3be0cf121adfd70#diff-7a82ec6e0314d8aebd8cf986bb7aaef5)
