### PR TITLE
Fix 404ing redirect with query strings.

### DIFF
--- a/redirect-handler.js
+++ b/redirect-handler.js
@@ -68,7 +68,7 @@ module.exports = function buildRedirectHandler(filename, code = 301) {
   groupMatcher = new RegExp(`^(${escaped.join('|')})`);
 
   return (req, res, next) => {
-    const url = ensureTrailingSlashOnly(req.url);
+    const url = ensureTrailingSlashOnly(req.path);
     if (url in singleRedirect) {
       return res.redirect(code, singleRedirect[url]);
     }


### PR DESCRIPTION
Fixes #3079

The redirect handler was trying to match the url's pathname against the pathnames in the redirects.yaml. However, because we were using `req.url` it was including the query string in the match and not properly finding the redirect.

Changes proposed in this pull request:

- Use `req.path` instead of `req.url`. `req.path` is the pathname and will not include query strings.

I'll do a follow up PR to add the query params back to the redirected string. But I'd like to first fix the 404s.