### PR TITLE
Fix broken gulp image output.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,7 @@ gulp.task('copy-content-assets', () => {
           const parts = assetPath.dirname.split('/');
           // Landing pages should keep their assets.
           // e.g. en/vitals, en/about
-          if (parts.length === 2) {
+          if (parts.length <= 2) {
             return;
           }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const path = require('path');
 const gulp = require('gulp');
 const mozjpeg = require('imagemin-mozjpeg');
 const pngquant = require('imagemin-pngquant');
@@ -67,13 +66,30 @@ gulp.task('copy-content-assets', () => {
       // they belong to.
       .pipe(
         rename((assetPath) => {
-          const leftPart = assetPath.dirname.split('/')[1];
-          // Let certain path's images to pass through.
-          const imagePassThroughs = ['handbook', 'newsletter'];
-          if (imagePassThroughs.includes(leftPart)) {
+          const parts = assetPath.dirname.split('/');
+          // Landing pages should keep their assets.
+          // e.g. en/vitals, en/about
+          if (parts.length === 2) {
             return;
           }
-          return (assetPath.dirname = path.basename(assetPath.dirname));
+
+          // Let images pass through if they're special, i.e. part of the
+          // handbook or newsletter. We don't treat these URLs like the
+          // rest of the site and they're allowed to nest.
+          const subdir = parts[1];
+          const imagePassThroughs = ['handbook', 'newsletter'];
+          if (imagePassThroughs.includes(subdir)) {
+            return;
+          }
+
+          // Some assets are nested under directories which aren't part of
+          // their url. For example, we have /en/blog/some-post/foo.jpg.
+          // For these assets we need to remove the /blog/ directory so they
+          // can live at /en/some-post/foo.jpg since that's what we'll actually
+          // serve in production.
+          // e.g. en/blog/foo/bar.jpg -> en/foo/bar.jpg
+          parts.splice(1, 1);
+          assetPath.dirname = parts.join('/');
         }),
       )
       .pipe(gulp.dest('./dist/'))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "coverage:unit": "c8 npm run test:unit",
     "coverage": "npm-run-all coverage:unit coverage:integration",
     "debug:eleventy": "node --inspect-brk ./node_modules/.bin/eleventy",
+    "debug:gulp": "node --inspect-brk ./node_modules/.bin/gulp",
     "debug:test:integration": "node --inspect-brk ./node_modules/.bin/mocha ./test/integration",
     "debug:test:lib": "TEST_MODE=debug npm-run-all clean rollup --parallel watch:rollup karma",
     "debug:test:unit": "node --inspect-brk ./node_modules/.bin/mocha ./test/unit",


### PR DESCRIPTION
I think as part of the i18n work we started outputting html/json into language directories, but we didn't update the gulpfile to move their image assets to the right location. So we were outputting:

```
dist/
  foo/
    a.jpg
  en/
    foo/
      index.html
      index.json
```

This didn't break the site because our express server will look in the top dir, and then the en dir for assets. But we really want the images to live with their html files.

Changes proposed in this pull request:

- Update the gulpfile so images in dist/ end up in the same directory as their html file.
