### PR TITLE
Update talk title.

### DIFF
--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -101,8 +101,7 @@ const eventData = [
       },
       {
         speaker: 'thomassteiner',
-        title:
-          "Building for Modern Browsers and Progressively Enhancing Like It's 2003",
+        title: "Progressively Enhancing Like It's 2003",
       },
       {
         speaker: 'demianrenzulli',


### PR DESCRIPTION
Fixes #3040

Changes proposed in this pull request:

- Update talk title from "Building for Modern Browsers and Progressively Enhancing Like It's 2003" to "Progressively Enhancing Like It's 2003".