### PR TITLE
Fix broken link in setting up a payment method

### DIFF
--- a/src/site/content/en/payments/setting-up-a-payment-method/index.md
+++ b/src/site/content/en/payments/setting-up-a-payment-method/index.md
@@ -23,12 +23,12 @@ payment app to be properly discovered and invoked by a browser.
 If you are new to the concept of Web Payments or how a payment transaction works
 through payment apps, read the following articles first:
 
-- [Empowering payment apps with Web Payments](/empowering-payment-apps)
+- [Empowering payment apps with Web Payments](/empowering-payment-apps-with-web-payments)
 - [Life of a payment transaction](/life-of-a-payment-transaction)
 
 ## How a browser discovers a payment app
 
-Every payment app needs to provide the following: 
+Every payment app needs to provide the following:
 
 - URL-based payment method identifier
 - Payment method manifest (except when the payment method identifier is
@@ -36,7 +36,7 @@ Every payment app needs to provide the following:
 - Web app manifest
 
 <figure class="w-figure">
-  <img src="diagram_direct.png" 
+  <img src="diagram_direct.png"
        alt="Diagram: How a browser discovers the payment app from a URL-based payment
 method identifier">
 </figure>
@@ -346,7 +346,7 @@ payment app appears in the Payment Request UI.
 </div>
 
 <figure class="w-figure">
-  <img class="w-screenshot" src="./web-app-manifest.png" 
+  <img class="w-screenshot" src="./web-app-manifest.png"
        alt="Payment app with an icon.">
   <figcaption class="w-figcaption">
     Payment app label and icon.
@@ -437,7 +437,7 @@ launch a payment app directly without showing the Payment Request UI when
     <source src="https://storage.googleapis.com/web-dev-assets/payments/skip-the-sheet.mp4" type="video/mp4">
   </video>
   <figcaption class="w-figcaption">
-    Skip the Payment Request UI and launch the payment app directly. 
+    Skip the Payment Request UI and launch the payment app directly.
   </figcaption>
 </figure>
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/3101

Changes proposed in this pull request:

- Fix wrong link in setting up a payment method : '_Empowering payment apps with Web Payments_'
