### PR TITLE
Fix inconsistency in manifest file name

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -214,7 +214,7 @@ After creating the manifest, add a `<link>` tag to all the pages of your
 Progressive Web App. For example:
 
 ```html
-<link rel="manifest" href="/manifest.json">
+<link rel="manifest" href="/manifest.webmanifest">
 ```
 
 {% Aside 'gotchas' %}


### PR DESCRIPTION
It seems the document has manifest.webmanifest everywhere but one reference to manifest.json.

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Update file name to what seems to be the new file name to be used.