### PR TITLE
Fix Lighthouse TTI score threshold

### DIFF
--- a/src/site/content/en/lighthouse-performance/interactive/index.md
+++ b/src/site/content/en/lighthouse-performance/interactive/index.md
@@ -62,24 +62,20 @@ This table shows how to interpret your TTI score:
       <tr>
         <th>TTI metric<br>(in seconds)</th>
         <th>Color-coding</th>
-        <th>TTI score<br>(HTTP Archive percentile)</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>0–5.2</td>
+        <td>0–3.8</td>
         <td>Green (fast)</td>
-        <td>75–100</td>
       </tr>
       <tr>
-        <td>5.3–7.3</td>
+        <td>3.9–7.3</td>
         <td>Orange (moderate)</td>
-        <td>50–74</td>
       </tr>
       <tr>
         <td>Over 7.3</td>
         <td>Red (slow)</td>
-        <td>0–49</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Looks like this was a typo back in the original commit (the thresholds haven't changed since then). "Fast" threshold is set [here in `interactive.js`](https://github.com/GoogleChrome/lighthouse/blob/a4535f32e16b862550aec5091243bf8dc6994135/lighthouse-core/audits/metrics/interactive.js#L50).

I also removed the HTTP Archive column because that seems like what newer LH documentation is doing (e.g. the [LCP docs](https://github.com/GoogleChrome/web.dev/blob/2a7caf37b7cc8de0fece7de63773b77cccf8d75b/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md#how-lighthouse-determines-your-lcp-score)) and it's kind of confusing :)