### PR TITLE
Skip waiting for load event to load app.js

### DIFF
--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -37,18 +37,10 @@ ga('send', 'pageview');
 // site code. This includes Shadow DOM.
 const browserSupport = 'noModule' in HTMLScriptElement.prototype;
 if (browserSupport) {
-  const prepare = () => {
-    const s = document.createElement('script');
-    s.type = 'module';
-    s.src = '/' + entrypoint;
-    document.head.append(s);
-  };
-
-  if (document.readyState === 'complete') {
-    prepare();
-  } else {
-    window.addEventListener('load', prepare);
-  }
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.src = '/' + entrypoint;
+  document.head.append(s);
 } else {
   // If we've transitioned into becoming an unsupported browser, then any
   // previous Service Worker won't be updated. Aggressively remove on load.


### PR DESCRIPTION
Changes proposed in this pull request:

- I'm not sure if waiting for the load event is helping us. In fact it may be hurting us in LH if it counts against our TTI or FID. I think(?) it's safe to just go ahead and starting loading our additional scripts once bootstrap loads.