### PR TITLE
When sw updates, don't refresh the page.

### DIFF
--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -17,7 +17,6 @@
 import {dimensions, id, version} from 'webdev_analytics';
 import entrypoint from 'webdev_entrypoint';
 import {localStorage} from './utils/storage';
-import removeServiceWorkers from './utils/sw-remove';
 
 window.ga =
   window.ga ||
@@ -41,8 +40,4 @@ if (browserSupport) {
   s.type = 'module';
   s.src = '/' + entrypoint;
   document.head.append(s);
-} else {
-  // If we've transitioned into becoming an unsupported browser, then any
-  // previous Service Worker won't be updated. Aggressively remove on load.
-  removeServiceWorkers();
 }


### PR DESCRIPTION
Fixes #3089

Changes proposed in this pull request:

- Feature detect and register sw after load event.
- Consolidate removeServiceWorker calls.
- Don't refresh the page if the service worker has been updated.