### PR TITLE
Correct description of COOP `unsafe-none`

### DIFF
--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -217,8 +217,7 @@ Cross-Origin-Opener-Policy: unsafe-none
 ```
 
 `unsafe-none` is the default and allows the document to be added to its opener's
-browsing context group unless the opener itself has a COOP of `same-origin` or
-`same-origin-allow-popups`.
+browsing context group unless the opener itself has a COOP of `same-origin`.
 
 {% Aside %}
 The


### PR DESCRIPTION
Contrary to the current explanation, when an opener specifies a COOP of
`same-origin-allow-popups` and the opened resource specifies
`unsafe-none`, then the two documents *will* share the same browsing
context group.

This is supported by the explanation of `same-origin-allow-popups` which
precedes this section:

> A top-level document with `same-origin-allow-popups` retains
references to > any of its popups which either don't set COOP or which
opt out of isolation > by setting a COOP of `unsafe-none`.

It is also supported by the proposed specification text [1] which reads:

> To check if a response requires a browsing context group switch ,
> given a browsing context browsingContext , an origin responseOrigin
> and a cross-origin opener policy responseCOOP , run the followign
> steps:
>
> [...]
>
> 6. If all of the following are true:
>
>    - isInitialAboutBlank
>    - activeDocumentCOOP is " same-origin-allow-popups ".
>    - responseCOOP is " unsafe-none ".
>
>    then return false.

Update the explanation to only include the relevant condition (that is:
a COOP of `same-origin`).

[1] https://github.com/whatwg/html/pull/5334

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
