### PR TITLE
Fix broken link to command menu page

### DIFF
--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -79,7 +79,7 @@ before painting a single pixel on the screen.
 To optimize this page, you need to know which classes are considered "critical".
 You'll use the the [Coverage Tool](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) for that:
 
-1. In DevTools, open the [Command Menu](https://developers.google.com/web/tools/chrome-devtools/ui#command-menu), by pressing `Control+Shift+P` or `Command+Shift+P` (Mac).
+1. In DevTools, open the [Command Menu](https://developers.google.com/web/tools/chrome-devtools/command-menu), by pressing `Control+Shift+P` or `Command+Shift+P` (Mac).
 1. Type "Coverage" and select **Show Coverage**.
 1. Click the **Reload** button, to reload the page and start capturing the
    coverage.


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes https://github.com/GoogleChrome/web.dev/issues/3186

Changes proposed in this pull request:

- Fix Broken link to command menu page
