### PR TITLE
schedule modal

### DIFF
--- a/src/lib/components/BaseModalElement/index.js
+++ b/src/lib/components/BaseModalElement/index.js
@@ -42,7 +42,8 @@ export class BaseModalElement extends BaseElement {
 
     this.open_ = false;
     this.animatable = false;
-    this.inert = true;
+    // TODO(samthor): This sets properties/attributes on creation, and Chrome barfs.
+    // this.inert = true;
     this.overflow = false;
     this._triggerElement = null;
     this._parent = null;

--- a/src/lib/components/BaseModalElement/index.js
+++ b/src/lib/components/BaseModalElement/index.js
@@ -58,6 +58,7 @@ export class BaseModalElement extends BaseElement {
     this.addEventListener('click', this.onClick);
     // Set tabindex to -1 so modal can be focused when it's opened.
     this.tabIndex = -1;
+    this.inert = !this.open;
   }
 
   disconnectedCallback() {
@@ -103,6 +104,7 @@ export class BaseModalElement extends BaseElement {
     this.addEventListener('animationend', this.onAnimationEnd, {
       once: true,
     });
+    this.inert = this.open; // starts the wrong way around, and flips onAnimationEnd
 
     this.requestUpdate('open', oldVal);
   }

--- a/src/lib/components/BaseModalElement/index.js
+++ b/src/lib/components/BaseModalElement/index.js
@@ -42,8 +42,6 @@ export class BaseModalElement extends BaseElement {
 
     this.open_ = false;
     this.animatable = false;
-    // TODO(samthor): This sets properties/attributes on creation, and Chrome barfs.
-    // this.inert = true;
     this.overflow = false;
     this._triggerElement = null;
     this._parent = null;

--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A schedule manager which opens and closes modals based on
+ * the current href. Looks in children for content.
+ *
+ * This does not inherit from BaseStateElement as it is not a LitElement.
+ */
+
+class EventSchedule extends HTMLElement {
+  constructor() {
+    super();
+
+    this._positionElement = document.createElement('div');
+    this._positionElement.className = 'w-event-modal-position';
+    this._positionElement.textContent = 'Hello';
+    this._positionElement.tabIndex = -1;
+
+    this._positionElement.addEventListener(
+      'blur',
+      () => {
+        console.info('active element', document.activeElement);
+
+        window.setTimeout(() => {
+          console.debug(
+            'after a frame, hash=',
+            window.location.hash,
+            'session=',
+            this._currentSession,
+            'active=',
+            this.activeElement,
+          );
+          if (!this._currentSession) {
+            return;
+          }
+
+          const url = window.location.pathname + window.location.search;
+          window.history.pushState(null, null, url);
+          this._updateHash();
+        }, 0);
+      },
+      {passive: true, capture: true},
+    );
+
+    this._currentSession = null;
+    this._updateHash = this._updateHash.bind(this);
+    this._updatePosition = this._updatePosition.bind(this);
+  }
+
+  _updateHash() {
+    const id = this.isConnected ? window.location.hash.substr(1) : '';
+    const session =
+      (id && this.querySelector(`[data-session-id="${id}"]`)) || null;
+
+    if (session === this._currentSession) {
+      return;
+    }
+
+    this._currentSession = session;
+    if (!session) {
+      this._positionElement.remove();
+      return;
+    }
+
+    this._updatePosition();
+    this._positionElement.focus();
+    this._positionElement.scrollIntoView(true);
+  }
+
+  _updatePosition() {
+    const bounds = this._currentSession.getBoundingClientRect();
+    this._positionElement.style.top = window.scrollY + bounds.top + 'px';
+    this._positionElement.style.left = window.scrollX + bounds.left + 'px';
+    this._positionElement.style.width = bounds.width + 'px';
+    this.append(this._positionElement);
+  }
+
+  connectedCallback() {
+    window.addEventListener('hashchange', this._updateHash);
+    window.addEventListener('resize', this._updatePosition);
+    this._updateHash();
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('hashchange', this._updateHash);
+    window.removeEventListener('resize', this._updatePosition);
+    this._updateHash();
+  }
+}
+
+customElements.define('web-event-schedule', EventSchedule);

--- a/src/lib/components/EventScheduleModal/_styles.scss
+++ b/src/lib/components/EventScheduleModal/_styles.scss
@@ -1,9 +1,39 @@
+@import '../../../styles/settings/colors';
+@import '../../../styles/tools/breakpoints';
+
 web-event-schedule-modal {
-  main {
-    border-radius: 16px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, .5);
-    margin: 8px;
-    padding: 12px;
+  .modal {
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .25);
+    padding: 16px 16px 8px;
     background: white;
+    max-width: 100%; // modal puts us in 1em padding anyway
+    width: 512px;
+
+    @include bp(sm) {
+      padding: 16px 24px;
+    }
+  }
+
+  h2 {
+    margin: 0 0 12px;
+  }
+
+  // Modify the default button to match the mocks.
+  button.w-button.close {
+    letter-spacing: 0;
+    text-transform: none;
+    float: right;
+  }
+
+  p {
+    color: $GREY_600;
+    font: inherit;
+    font-size: 14px;
+    margin: 8px 0;
+
+    &:first-of-type {
+      margin-top: 16px;
+    }
   }
 }

--- a/src/lib/components/EventScheduleModal/_styles.scss
+++ b/src/lib/components/EventScheduleModal/_styles.scss
@@ -1,0 +1,27 @@
+web-event-schedule-modal {
+  &.web-modal {
+    position: static;
+    background: transparent;
+    display: block;
+
+    &::before {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.2);
+      backdrop-filter: blur(2px);
+      z-index: -1;
+      content: '';
+    }
+  }
+
+  main {
+    border-radius: 16px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, .5);
+    margin: 8px;
+    padding: 12px;
+    background: white;
+  }
+}

--- a/src/lib/components/EventScheduleModal/_styles.scss
+++ b/src/lib/components/EventScheduleModal/_styles.scss
@@ -1,22 +1,4 @@
 web-event-schedule-modal {
-  &.web-modal {
-    position: static;
-    background: transparent;
-    display: block;
-
-    &::before {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(255, 255, 255, 0.2);
-      backdrop-filter: blur(2px);
-      z-index: -1;
-      content: '';
-    }
-  }
-
   main {
     border-radius: 16px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, .5);

--- a/src/lib/components/EventScheduleModal/_styles.scss
+++ b/src/lib/components/EventScheduleModal/_styles.scss
@@ -18,6 +18,9 @@ web-event-schedule-modal {
   h2 {
     margin: 0 0 12px;
   }
+  h4 {
+    margin: 12px 0;
+  }
 
   // Modify the default button to match the mocks.
   button.w-button.close {

--- a/src/lib/components/EventScheduleModal/index.js
+++ b/src/lib/components/EventScheduleModal/index.js
@@ -27,6 +27,8 @@ class EventScheduleModal extends BaseModalElement {
     return {
       sessionRow: Element,
       _sessionName: String,
+      _authorsPart: Element,
+      _abstractPart: Element,
     };
   }
 
@@ -35,15 +37,25 @@ class EventScheduleModal extends BaseModalElement {
       return false;
     }
 
+    this._authorsPart = null;
+    this._abstractPart = null;
     this._sessionName = '';
+
     if (!this.sessionRow) {
       return true;
     }
+    const row = this.sessionRow;
+
+    // Extract the authors' collection and abstract.
+    this._authorsPart = row.querySelector('.w-event-schedule__speaker');
+    this._abstractPart = row.querySelector('.w-event-schedule__abstract');
+    if (this._abstractPart) {
+      this._abstractPart.removeAttribute('hidden');
+    }
 
     // Remove the link that was used to open us.
-    const link = this.sessionRow.querySelector('.w-event-schedule__open');
+    const link = row.querySelector('.w-event-schedule__open');
     if (link) {
-      link.remove();
       this._sessionName = link.textContent;
     }
     return true;
@@ -51,11 +63,12 @@ class EventScheduleModal extends BaseModalElement {
 
   render() {
     return html`
-      <main>
-        <h1>${this._sessionName || '?'}</h1>
-        ${this.sessionRow}
+      <div class="modal">
+        <h2>${this._sessionName || '?'}</h2>
+        ${this._authorsPart || ''}
+        ${this._abstractPart || ''}
         <button
-          class="w-button w-button--secondary gc-analytics-event"
+          class="w-button close gc-analytics-event"
           data-category="web.dev"
           data-label="live, close session modal"
           data-action="click"

--- a/src/lib/components/EventScheduleModal/index.js
+++ b/src/lib/components/EventScheduleModal/index.js
@@ -23,12 +23,46 @@ import './_styles.scss';
  */
 
 class EventScheduleModal extends BaseModalElement {
+  static get properties() {
+    return {
+      sessionRow: Element,
+      _sessionName: String,
+    };
+  }
+
+  shouldUpdate(changedProperties) {
+    if (!changedProperties.has('sessionRow')) {
+      return false;
+    }
+
+    this._sessionName = '';
+    if (!this.sessionRow) {
+      return true;
+    }
+
+    // Remove the link that was used to open us.
+    const link = this.sessionRow.querySelector('.w-event-schedule__open');
+    if (link) {
+      link.remove();
+      this._sessionName = link.textContent;
+    }
+    return true;
+  }
+
   render() {
-    // TODO(samthor): Doesn't show anything interesting right now.
     return html`
       <main>
-        <h2>Title of talk</h2>
-        <a href="#">Close</a>
+        <h1>${this._sessionName || '?'}</h1>
+        ${this.sessionRow}
+        <button
+          class="w-button w-button--secondary gc-analytics-event"
+          data-category="web.dev"
+          data-label="live, close session modal"
+          data-action="click"
+          @click=${() => (this.open = false)}
+        >
+          Close
+        </button>
       </main>
     `;
   }

--- a/src/lib/components/EventScheduleModal/index.js
+++ b/src/lib/components/EventScheduleModal/index.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BaseModalElement} from '../BaseModalElement';
+import {html} from 'lit-element';
+import './_styles.scss';
+
+/**
+ * @fileoverview Modal element for session information.
+ */
+
+class EventScheduleModal extends BaseModalElement {
+  render() {
+    // TODO(samthor): Doesn't show anything interesting right now.
+    return html`
+      <main>
+        <h2>Title of talk</h2>
+        <a href="#">Close</a>
+      </main>
+    `;
+  }
+}
+
+customElements.define('web-event-schedule-modal', EventScheduleModal);

--- a/src/lib/components/EventScheduleModal/index.js
+++ b/src/lib/components/EventScheduleModal/index.js
@@ -17,6 +17,7 @@
 import {BaseModalElement} from '../BaseModalElement';
 import {html} from 'lit-element';
 import './_styles.scss';
+import {generateIdSalt} from '../../utils/generate-salt';
 
 /**
  * @fileoverview Modal element for session information.
@@ -29,7 +30,14 @@ class EventScheduleModal extends BaseModalElement {
       _sessionName: String,
       _authorsPart: Element,
       _abstractPart: Element,
+      _titleId: String,
     };
+  }
+
+  constructor() {
+    super();
+
+    this._titleId = generateIdSalt();
   }
 
   shouldUpdate(changedProperties) {
@@ -63,8 +71,8 @@ class EventScheduleModal extends BaseModalElement {
 
   render() {
     return html`
-      <div class="modal">
-        <h2>${this._sessionName || '?'}</h2>
+      <div class="modal" aria-modal="true" aria-labelledby="${this._titleId}">
+        <h2 id=${this._titleId}>${this._sessionName || '?'}</h2>
         ${this._authorsPart || ''}
         ${this._abstractPart || ''}
         <button

--- a/src/lib/components/EventScheduleModal/index.js
+++ b/src/lib/components/EventScheduleModal/index.js
@@ -26,11 +26,11 @@ import {generateIdSalt} from '../../utils/generate-salt';
 class EventScheduleModal extends BaseModalElement {
   static get properties() {
     return {
-      sessionRow: Element,
-      _sessionName: String,
-      _authorsPart: Element,
-      _abstractPart: Element,
-      _titleId: String,
+      sessionRow: {type: Object},
+      _sessionName: {type: String},
+      _authorsPart: {type: Object},
+      _abstractPart: {type: Object},
+      _titleId: {type: String},
     };
   }
 
@@ -42,7 +42,7 @@ class EventScheduleModal extends BaseModalElement {
 
   shouldUpdate(changedProperties) {
     if (!changedProperties.has('sessionRow')) {
-      return false;
+      return super.shouldUpdate(changedProperties);
     }
 
     this._authorsPart = null;
@@ -72,6 +72,7 @@ class EventScheduleModal extends BaseModalElement {
   render() {
     return html`
       <div class="modal" aria-modal="true" aria-labelledby="${this._titleId}">
+        <h4>About this session</h4>
         <h2 id=${this._titleId}>${this._sessionName || '?'}</h2>
         ${this._authorsPart || ''}
         ${this._abstractPart || ''}

--- a/src/lib/pages/live.js
+++ b/src/lib/pages/live.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for web.dev LIVE page.
  */
 
+import '../components/EventSchedule';
 import '../components/EventTime';
 import '../components/Subscribe';
 import '../components/ShareAction';

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -51,6 +51,9 @@ const eventData = [
       {
         speaker: ['nainar', 'sebabenz'],
         title: 'AMP at Your Service',
+        abstract: [
+          "The one where Naina and Sebastian discuss how AMP makes web development less painful and why it's time to move away from paired AMP.",
+        ],
       },
       {
         speaker: ['crystallambert', 'morss'],

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -28,7 +28,7 @@ const eventData = [
         speaker: 'dalmaer',
         title: 'Welcome to Day One',
         abstract: [
-          "On day 1, we'll welcome developers, especially from the Americas, and address some of the most pertinent events that have affected us as a community and society. We'll also cover some of the key updates made to the platform and tools with some guest speakers from the community.",
+          "On day 1, we kick things off by sharing why we are coming together as a community, including a guest speaker from CA.gov. We'll then cover some of the key updates made to the platform around performance, security and privacy, as well as a look at build tools and rich content.",
           'Special Guest: Aaron Hans, Tech lead, CA.Gov',
         ],
       },
@@ -106,7 +106,7 @@ const eventData = [
         speaker: 'dalmaer',
         title: 'Day Two Opening Note',
         abstract: [
-          "On day 2, we travel virtually to an EMEA friendly timezone and welcome all developers who can join us real time. We'll focus the second day opener on success stories from Europe, share more updates from our side and bring some very special guests from Firefox to share their own updates.",
+          "On day 2, we travel virtually to an EMEA friendly timezone and welcome all developers who can join us real time. We'll dive into the top pain points and how we are looking to address them, the state of CSS and layout, and the latest on developers tools that you use every day, including some very special guests from Mozilla to share their own updates.",
           'Special Guests: Kadir Topal & Victoria Wang, Firefox',
         ],
       },
@@ -208,7 +208,7 @@ const eventData = [
         speaker: 'dalmaer',
         title: 'Day Three Opening Note',
         abstract: [
-          'Day 3 will have us move to the Asia and Australia continents where we greet our developers with inspirational stories of the ecosystem stepping in times of crisis and using the platform for good, and continue our saga of updates and news with a special guest from the Vue.js world.',
+          'Day 3 will have us move to the Asia and Australia continents where we we will get insights from Evan You, the founder of Vue.js, share the latest on PWA and new capabilities that allow you to build rich web applications, and show how you can understand your applications deeply through the latest updates to Lighthouse.',
           'Special guest: Evan You, Vue.js',
         ],
       },

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -27,26 +27,47 @@ const eventData = [
       {
         speaker: 'dalmaer',
         title: 'Welcome to Day One',
+        abstract: [
+          "On day 1, we'll welcome developers, especially from the Americas, and address some of the most pertinent events that have affected us as a community and society. We'll also cover some of the key updates made to the platform and tools with some guest speakers from the community.",
+          'Special Guest: Aaron Hans, Tech lead, CA.Gov',
+        ],
       },
       {
         speaker: 'egsweeny',
         title: "What's New in Speed Tooling",
+        abstract: [
+          "Our understanding of how to effectively measure and optimize a users' experience is continually evolving, and we keep our metrics and tooling updated to reflect the latest in our learnings. This talk will cover where to measure your Core Web Vitals in the lab and in the field, as well as how to leverage the newest features and products to build and maintain exceptionally fast experiences for all of your users. ",
+        ],
       },
       {
         speaker: 'addyosmani',
         title: 'How to Optimize for Web Vitals',
+        abstract: [
+          "In this hands-on talk, we'll cover tips & tricks for optimizing your user-experience to meet the Core Web Vitals. We'll use tools like Lighthouse & DevTools, show you code snippets for fixes and highlight how you too can get fast and stay fast.",
+          "Optimizing for quality of user experience is key to the long-term success of any site on the web. Whether you're a business owner, marketer, or developer, Core Web Vitals can help you quantify the experience of your site and identify opportunities to improve.",
+        ],
       },
       {
         speaker: 'rviscomi',
         title: 'Mastering the Chrome UX Report on BigQuery',
+        abstract: [
+          "There is so much information in the Chrome UX Report dataset on BigQuery, it could feel overwhelming at first. We've been hard at work making sure that the treasure trove of web transparency data is accessible to every developer. Learn how to query the Chrome UX Report using our new summary datasets and shortcut functions, so you can extract insights quickly and cheaply like a pro.",
+        ],
       },
       {
         speaker: 'houssein',
         title: 'How to Analyze Your JavaScript Bundles',
+        abstract: [
+          'Learn how to analyze your bundled JavaScript code and to spot common issues that can easily bloat up your application size.',
+        ],
       },
       {
         speaker: ['paullewis', 'philipwalton'],
         title: 'Core Web Vitals in the DevTools Timeline',
+        abstract: [
+          "The Core Web Vitals are a great way to assess the UX impact of page load performance. In this talk we'll cover what the vitals are, where they came from, and how you can use Chrome's DevTools to explore your site or app's vitals values.",
+          'For more on Core Web Vitals check out <a href="https://web.dev/vitals/">https://web.dev/vitals/</a>',
+        ],
       },
       {
         speaker: ['nainar', 'sebabenz'],
@@ -58,14 +79,21 @@ const eventData = [
       {
         speaker: ['crystallambert', 'morss'],
         title: 'Workerized JavaScript Made Easy',
+        abstract: [
+          "When JavaScript lives in a Worker, it runs in a separate thread. Thus, it can't block the browser from creating smooth user experiences! Unfortunately, since Workers can't access the DOM directly, you can't just stick your JavaScript into a Worker. Fortunately, last year, AMP introduced &lt;amp-script&gt;, a component that makes this straightforward. In this talk we chat about how to use &lt;amp-script&gt; to create your very own Workerized JS browser interactions!",
+        ],
       },
       {
         speaker: 'martinsplitt',
         title: 'Debugging JavaScript SEO issues',
+        abstract: ['Debugging JavaScript SEO issues'],
       },
       {
         speaker: 'martinsplitt',
         title: 'Implementing Structured Data with JavaScript',
+        abstract: [
+          'If you are building a great website with JavaScript, you want it to stand out in Google Search, too. To be eligible for rich results, you need to add structured data to your pages. In this session we walk through typical approaches to do this both in popular frameworks as well as vanilla JavaScript.',
+        ],
       },
     ],
   },
@@ -77,54 +105,97 @@ const eventData = [
       {
         speaker: 'dalmaer',
         title: 'Day Two Opening Note',
+        abstract: [
+          "On day 2, we travel virtually to an EMEA friendly timezone and welcome all developers who can join us real time. We'll focus the second day opener on success stories from Europe, share more updates from our side and bring some very special guests from Firefox to share their own updates.",
+          'Special Guests: Kadir Topal & Victoria Wang, Firefox',
+        ],
       },
       {
         speaker: 'paullewis',
         title: "What's New in DevTools",
+        abstract: [
+          "Let's take a look at the latest and greatest features in Chrome's DevTools. We'll cover how you can use the Performance Panel to assess your page load metrics, how you can locate issues with your pages, debug your Web Assembly, and even emulate color vision deficiencies.",
+        ],
       },
       {
         speaker: ['syg', 'leszeks'],
         title: "What's New in V8/JavaScript",
+        abstract: [
+          "What exciting things happened in the JavaScript language and the V8 engine in 2019? Shu and Leszek take a tour of some new features and improvements. For JavaScript, you'll learn about new syntax, like optional chaining and nullish coalescing, that make expressing common patterns a breeze, as well as the powerful new weak references that may help plug memory leaks. For V8, you'll learn how the engine got faster with streaming parsing and slimmer with pointer compression.",
+        ],
       },
       {
         speaker: 'mathiasbynens',
         title: "What's New in Puppeteer",
+        abstract: [
+          'The Chrome team maintains Puppeteer, a Node.js library to automate Chromium and other browsers using a simple and modern JavaScript API. This session gives an overview of recent changes in Puppeteer, including new features, architectural changes, and a sneak peek of what’s coming next.',
+        ],
       },
       {
         speaker: 'andreban',
         title: 'Shipping a PWA as an Android app',
+        abstract: [
+          'Increase the reach of your Progressive Web App by using it as an Android app. In this session you will learn about Bubblewrap, a new tool that developers can use to transform their PWAs into an Android application, without having to write native code or learn native tooling. You’ll watch us to transform an existing PWA into a native app from start to finish, in just a few minutes.',
+        ],
       },
       {
         speaker: 'demianrenzulli',
         title: 'How to Define your Install Strategy',
+        abstract: [
+          'Best practices for combining different installation offerings to increase installation rates and avoid platform competition and cannibalization.',
+        ],
       },
       {
         speaker: 'thomassteiner',
         title: "Progressively Enhancing Like It's 2003",
+        abstract: [
+          'Back in March 2003, Nick Finck and Steve Champeon stunned the web design world with the concept of progressive enhancement, a strategy for web design that emphasizes core webpage content first, and that then progressively adds more nuanced and technically rigorous layers of presentation and features on top of the content. While in 2003, progressive enhancement was about using at the time modern CSS features, unobtrusive JavaScript, and even Scalable Vector Graphics, progressive enhancement in 2020 is about using modern browser capabilities.',
+          'In this talk, we will show at the example of a greeting card web application how new and upcoming browser capabilities can progressively enhance this application so that it remains useful on all modern browsers, but delivers an advanced experience on browsers that support capabilities like native file system access, system clipboard access, contacts retrieval, periodic background sync, screen wake lock, sharing features, and many more.',
+          'After the talk, developers will have a solid understanding of how to progressively enhance their web applications with new browser features, all while not putting a download burden on the subset of their users that happen to be on incompatible browsers, and, most importantly, while not excluding them from using the web application in the first place.',
+        ],
       },
       {
         speaker: 'demianrenzulli',
         title: 'Advanced PWA Patterns',
+        abstract: [
+          'Advanced PWA recipes, that combine several modern web APIs, and how companies are using them to create app-like experiences on their sites.',
+        ],
       },
       {
         speaker: ['pjmclachlan', 'andreban'],
         title: 'Giving Your PWA Superpowers 🦹‍♀️',
+        abstract: [
+          'In this session we’ll introduce new features for installed PWAs, including capabilities previously reserved for native apps. You’ll learn approaches for building better PWAs, including Play apps that use PWAs. Finally, we’ll answer frequently asked developer questions about the design and future of PWAs.',
+        ],
       },
       {
         speaker: 'samthor',
         title: 'App-Like UX for Better PWAs',
+        abstract: [
+          "The uncanny valley between native apps and web apps can be off putting to your users. But there are techniques that you can use to smooth over that valley and provide a seamless experience that won't take those users out of their comfort zone. Adding user experiences like pull to refresh—instead of the default reload—makes a huge difference. This talk will dive into case studies as well as giving some practical advice.",
+        ],
       },
       {
         speaker: 'pjmclachlan',
         title: 'Quieter Notifications Permissions',
+        abstract: [
+          'Notifications on the web help users receive important updates for a wide range of applications including messaging, calendars, email clients, ride sharing, social media and delivery services. Unfortunately, notifications are also used for abusive purposes. Browser notifications can be used to spam, mislead, show ads, phish or promote malware.',
+          'This year we’ve made major changes in Chrome to reduce abuse of notifications and create a safer, better web browsing experience for Chrome users.  This session will review the recent changes, demo techniques for improving your website’s use of notifications and discuss the future of notifications on the web.',
+        ],
       },
       {
         speaker: 'petelepage',
         title: 'Storage for the Web',
+        abstract: [
+          "How should we be storing data and caching our critical app resources on the client? Is IndexedDB still the best option? What about Local Storage? Let's dive into web storage to learn about the best way to store data in the browser, how much you can safely store, how to check your quota, how browser eviction works, how you can start Chrome with limited storage to test quota exceeded errors, and more.",
+        ],
       },
       {
         speaker: 'nattestad',
         title: 'Zoom on Web: Getting Connected with Advanced Web Technology',
+        abstract: [
+          'Now more than ever, having a dependable and performant video connection to your friends and family is critical. The Chrome team has been collaborating with Zoom over the past few months to enable the development of a truly modern web based.',
+        ],
       },
     ],
   },
@@ -136,54 +207,99 @@ const eventData = [
       {
         speaker: 'dalmaer',
         title: 'Day Three Opening Note',
+        abstract: [
+          'Day 3 will have us move to the Asia and Australia continents where we greet our developers with inspirational stories of the ecosystem stepping in times of crisis and using the platform for good, and continue our saga of updates and news with a special guest from the Vue.js world.',
+          'Special guest: Evan You, Vue.js',
+        ],
       },
       {
         speaker: 'kosamari',
         title: 'Building Better in the World of Build Tools',
+        abstract: [
+          "Build tools are an integral part of modern web development, making it possible to build great apps that are bandwidth-friendly and delivered as-needed. However, it's surprisingly difficult to choose and configure build tools in a way that produces consistent and good results. We're often forced to make tradeoff decisions in our tooling, which can stand in the way of delivering the best possible applications on the web.",
+          "We developed a guide to help you choose tools which are best suited for your next project with example of how to set one up. Come find out how we defined what's the best tool for a job and how we investigated and tested each one.",
+        ],
       },
       {
         speaker: 'una',
         title: '10 Modern Layouts in 1 Line of CSS',
+        abstract: [
+          'In this dynamic talk, Una will go over the power of modern CSS layout techniques by highlighting a few key terms and how much detail can be described in a single line of code. You’ll learn a few layout tricks you can implement in your codebase today, and be able to write entire swaths of layout with just a few lines of code.',
+        ],
       },
       {
         speaker: ['developit', 'jakearchibald'],
         title: 'Writing Build Plugins',
+        abstract: [
+          "It's really common to use a build tool as part of development, but most folks don't think about writing their own plugins, which is totally understandable, as it can be pretty daunting. However, knowing how to write plugins gives you insight into how the build tool works, and makes it easier to debug the rest of your build.",
+          "In this session we'll develop the same plugin for both Rollup and webpack, showing the difference between the two systems.",
+        ],
       },
       {
         speaker: ['jakearchibald', 'surma'],
         title: 'Image Compression Deep-dive',
+        abstract: [
+          'Images are often the biggest assets in a web page, so compressing them well can be a huge saving for users.',
+          'There are some rough rules for which image format you should use in a given situation, but this session will dive into why, and explore some of the lesser-known capabilities of popular image formats.',
+        ],
       },
       {
         speaker: 'sfluin',
         title: 'How to Stay Fast and Fresh with Angular',
+        abstract: [
+          'Watch a live coding demo walking through the top principles and tools you can use to make your applications shine when it comes to startup performance and bundle size.',
+        ],
       },
       {
         speaker: ['maudn', 'samdutton'],
         title: 'Security and Privacy for the Open Web',
+        abstract: [
+          "What's the role of the browser in enabling security and privacy by default on the open web? How are browsers changing to balance trade-offs and mitigate risk? How can you get involved?",
+        ],
       },
       {
         speaker: 'rowan_m',
         title: 'Cookie Recipes - SameSite and Beyond',
+        abstract: [
+          "Cookies really can make everything better! However, you need the right recipes and you shouldn't take too many. Hopefully you've already updated your cookies for the new SameSite changes, but that one change is just a taste of what's possible. Learn about the different cookie attributes and naming conventions that will help you tailor your cookies for the right situation.",
+        ],
       },
       {
         speaker: 'agektmr',
         title: 'Prevent Info Leaks and Enable Powerful Features: COOP and COEP',
+        abstract: [
+          'Cross-Origin Embedder Policy (COEP) and Cross-Origin Opener Policy (COOP) isolate your origin and enable powerful features. This session helps you understand how it works and why this is important.',
+        ],
       },
       {
         speaker: 'samdutton',
         title: 'Find and Fix Problems with Chrome DevTools Issues Tab',
+        abstract: [
+          'Fed up with wading through browser messages in the console?',
+          'The Chrome DevTools Issues Panel provides a more structured, actionable approach to deprecations and other warnings from the browser.',
+          'This video shows you how to use the Issues Panel to find and fix problems with your website.',
+        ],
       },
       {
         speaker: ['maudn', 'rowan_m'],
         title: 'Just the Data you Need',
+        abstract: [
+          "User-Agent Client Hints provide a privacy focused approach for sites to request information about the browser that's viewing them. Moving forward from the legacy of the User-Agent string is a challenge, so now is the time to experiment and give feedback.",
+        ],
       },
       {
         speaker: 'samdutton',
         title: 'Sign-in Form Best Practice',
+        abstract: [
+          'Use built-in, cross-platform browser features to create signin forms that are secure, accessible and easy to use.',
+        ],
       },
       {
         speaker: 'agektmr',
         title: "What's New in Web Payments",
+        abstract: [
+          "What's happening with Web Payments? How is it different from Google Pay or Apple Pay? This session demystifies some of the misconceptions developers may have and provides an update on topics around Web Payments.",
+        ],
       },
     ],
   },

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -194,7 +194,7 @@ const eventData = [
         speaker: 'nattestad',
         title: 'Zoom on Web: Getting Connected with Advanced Web Technology',
         abstract: [
-          'Now more than ever, having a dependable and performant video connection to your friends and family is critical. The Chrome team has been collaborating with Zoom over the past few months to enable the development of a truly modern web based.',
+          'Now more than ever, having a dependable and performant video chat connection to your friends and family is critical. The Chrome team has been collaborating with Zoom over the past few months to explore advanced new APIs that will allow for a dramatically improved web experience.',
         ],
       },
     ],

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -15,6 +15,7 @@
  */
 
 const {html} = require('common-tags');
+const slugify = require('slugify');
 
 const AuthorsDate = require('./AuthorsDate');
 
@@ -41,17 +42,34 @@ module.exports = (event, authorsCollection) => {
     }
   }
 
+  const slugs = {};
+  const slugForTitle = (title) => {
+    // Find a slug for this title, but prevent duplicate IDs.
+    const base = slugify(title);
+    let id = base;
+    let suffix = 0;
+    while (id in slugs) {
+      id = base + (++suffix);
+    }
+    slugs[id] = title;
+    return id;
+  };
+
   const renderSession = ({speaker, title}) => {
     // Always pass an Array of author IDs.
     const authors = typeof speaker === 'string' ? [speaker] : speaker;
 
+    const id = slugForTitle(title);
+
     return html`
-      <tr>
-        <td class="w-event-schedule__speaker">
+      <div class="w-event-schedule__row" data-session-id=${id}>
+        <div class="w-event-schedule__cell w-event-schedule__speaker">
           ${AuthorsDate({authors}, authorsCollection)}
-        </td>
-        <td class="w-event-schedule__session">${title}</td>
-      </tr>
+        </div>
+        <div class="w-event-schedule__cell w-event-schedule__session">
+          <a class="w-event-schedule__open" href="#${id}">${title}</a>
+        </div>
+      </div>
     `;
   };
 
@@ -70,11 +88,9 @@ module.exports = (event, authorsCollection) => {
           ></web-event-time>
         </div>
 
-        <table class="w-event-schedule">
-          <tbody>
-            ${day.sessions.map(renderSession)}
-          </tbody>
-        </table>
+        <div class="w-event-schedule">
+          ${day.sessions.map(renderSession)}
+        </div>
       </div>
     `;
   };

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -45,7 +45,11 @@ module.exports = (event, authorsCollection) => {
   const slugs = {};
   const slugForTitle = (title) => {
     // Find a slug for this title, but prevent duplicate IDs.
-    const base = slugify(title, {lower: true, strict: true, remove: /'/});
+    const base = slugify(title, {
+      lower: true,
+      strict: true,
+      remove: /[^-\w _]/, // remove anything not in: basic word chars, space, - and _
+    });
     let id = base;
     let suffix = 0;
     while (id in slugs) {
@@ -72,7 +76,9 @@ module.exports = (event, authorsCollection) => {
           ${AuthorsDate({authors}, authorsCollection)}
         </div>
         <div class="w-event-schedule__cell w-event-schedule__session">
-          <a class="w-event-schedule__open" href="#${id}">${title}</a>
+          <a class="w-event-schedule__open" href="#${id}">
+            <span>${title}</span>
+          </a>
           <div class="w-event-schedule__abstract" hidden>
             ${abstract.map((part) => html`<p>${part}</p>`)}
           </div>

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -55,11 +55,16 @@ module.exports = (event, authorsCollection) => {
     return id;
   };
 
-  const renderSession = ({speaker, title}) => {
+  const renderSession = ({speaker, title, abstract}) => {
     // Always pass an Array of author IDs.
     const authors = typeof speaker === 'string' ? [speaker] : speaker;
 
     const id = slugForTitle(title);
+
+    // Coerce to array or empty array.
+    abstract =
+      (abstract && (typeof abstract === 'string' ? [abstract] : abstract)) ||
+      [];
 
     return html`
       <div class="w-event-schedule__row" data-session-id=${id}>
@@ -68,6 +73,9 @@ module.exports = (event, authorsCollection) => {
         </div>
         <div class="w-event-schedule__cell w-event-schedule__session">
           <a class="w-event-schedule__open" href="#${id}">${title}</a>
+          <div class="w-event-schedule__abstract" hidden>
+            ${abstract.map((part) => html`<p>${part}</p>`)}
+          </div>
         </div>
       </div>
     `;

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -96,8 +96,10 @@ module.exports = (event, authorsCollection) => {
   };
 
   return html`
-    <web-tabs class="w-event-tabs unresolved" label="schedule">
-      ${event.map(renderDay)}
-    </web-tabs>
+    <web-event-schedule>
+      <web-tabs class="w-event-tabs unresolved" label="schedule">
+        ${event.map(renderDay)}
+      </web-tabs>
+    </web-event-schedule>
   `;
 };

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -45,11 +45,11 @@ module.exports = (event, authorsCollection) => {
   const slugs = {};
   const slugForTitle = (title) => {
     // Find a slug for this title, but prevent duplicate IDs.
-    const base = slugify(title);
+    const base = slugify(title, {lower: true, strict: true, remove: /'/});
     let id = base;
     let suffix = 0;
     while (id in slugs) {
-      id = base + (++suffix);
+      id = base + ++suffix;
     }
     slugs[id] = title;
     return id;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -326,10 +326,3 @@ web-tabs.w-event-tabs {
     object-fit: cover;
   }
 }
-
-.w-event-modal-position {
-  position: absolute;
-  margin-top: -100px;
-  padding-top: 100px;
-  z-index: 100; // creates stacking context for modal
-}

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -183,7 +183,10 @@ web-tabs.w-event-tabs {
 }
 
 .w-event-schedule {
+  // Forces a stacking context.
+  position: relative;
   text-align: left;
+  z-index: 0;
 
   // Measures the width of the left-hand cell, containing speaker information.
   // Uses a mix of fixed size (for small devices, down to 320px) and percentage
@@ -200,6 +203,11 @@ web-tabs.w-event-tabs {
 
   .w-event-schedule__speaker {
     width: #{$WIDTH_SPEAKER};
+
+    a {
+      z-index: 10;
+      position: relative;
+    }
   }
 
   .w-event-schedule__session {
@@ -224,33 +232,32 @@ web-tabs.w-event-tabs {
   }
 
   .w-event-schedule__open {
-    display: block;
+    pointer-events: auto;
+    display: inline-block;
+    color: inherit;
+
+    span {
+      z-index: 1;
+      position: relative;
+    }
 
     // This creates a large clickable area around the link itself, but which
     // doesn't extend into the speakers area on the left.
-    &::after {
+    &::before {
       content: '';
       top: 0;
-      bottom: 0;
+      left: 0;
       right: 0;
-      width: calc(100% - #{$WIDTH_SPEAKER});
+      bottom: 0;
       display: block;
       position: absolute;
+      z-index: 0;
     }
 
     // When the link is hovered, highlight the whole row, even though the
     // speakers' area isn't clickable.
     &:hover::before {
-      content: '';
       background: rgba(0, 0, 0, .05);
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: -10;
-      display: block;
-      position: absolute;
-      pointer-events: none;
     }
   }
 }

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -182,17 +182,28 @@ web-tabs.w-event-tabs {
   --active-color: #{$GOOGLE_BLUE_100};
 }
 
-table.w-event-schedule {
-  // TODO(robdodson): The generic table has `min-width: 512px`, which extends over the side of
-  // small devices.
-  min-width: auto;
+.w-event-schedule {
+  text-align: left;
+  $width-speaker: calc(10% + 180px);
 
-  .w-event-schedule__speaker {
-    min-width: 180px;
-    max-width: 50vw;
+  .w-event-schedule__row {
+    border-bottom: 1px solid #dadce0;
+    min-height: 48px;
+    position: relative;
+    display: flex;
+    align-items: center;
   }
 
-  td {
+  .w-event-schedule__speaker {
+    width: #{$width-speaker};
+  }
+
+  .w-event-schedule__session {
+    flex-grow: 1;
+    width: 50%;
+  }
+
+  .w-event-schedule__cell {
     font-size: 14px;
     line-height: 20px;
     padding: 8px;
@@ -206,6 +217,37 @@ table.w-event-schedule {
     // TODO(samthor): This margin is unnessecary for our schedule, and
     // needlessly pads out each row.
     margin-bottom: 0;
+  }
+
+  .w-event-schedule__open {
+    display: block;
+
+    // This creates a large clickable area around the link itself, but which
+    // doesn't extend into the speakers area on the left.
+    &::after {
+      content: '';
+      top: 0;
+      bottom: 0;
+      right: 0;
+      width: calc(100% - #{$width-speaker});
+      display: block;
+      position: absolute;
+    }
+
+    // When the link is hovered, highlight the whole row, even though the
+    // speakers' area isn't clickable.
+    &:hover::before {
+      content: '';
+      background: rgba(0, 0, 0, 0.05);
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: -10;
+      display: block;
+      position: absolute;
+      pointer-events: none;
+    }
   }
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -326,3 +326,10 @@ web-tabs.w-event-tabs {
     object-fit: cover;
   }
 }
+
+.w-event-modal-position {
+  position: absolute;
+  background: red;
+  margin-top: -100px;
+  padding-top: 100px;
+}

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -184,7 +184,11 @@ web-tabs.w-event-tabs {
 
 .w-event-schedule {
   text-align: left;
-  $width-speaker: calc(10% + 180px);
+
+  // Measures the width of the left-hand cell, containing speaker information.
+  // Uses a mix of fixed size (for small devices, down to 320px) and percentage
+  // (to give more space on larger screens).
+  $WIDTH_SPEAKER: calc(10% + 180px);
 
   .w-event-schedule__row {
     border-bottom: 1px solid #dadce0;
@@ -195,7 +199,7 @@ web-tabs.w-event-tabs {
   }
 
   .w-event-schedule__speaker {
-    width: #{$width-speaker};
+    width: #{$WIDTH_SPEAKER};
   }
 
   .w-event-schedule__session {
@@ -229,7 +233,7 @@ web-tabs.w-event-tabs {
       top: 0;
       bottom: 0;
       right: 0;
-      width: calc(100% - #{$width-speaker});
+      width: calc(100% - #{$WIDTH_SPEAKER});
       display: block;
       position: absolute;
     }
@@ -238,7 +242,7 @@ web-tabs.w-event-tabs {
     // speakers' area isn't clickable.
     &:hover::before {
       content: '';
-      background: rgba(0, 0, 0, 0.05);
+      background: rgba(0, 0, 0, .05);
       top: 0;
       left: 0;
       right: 0;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -329,7 +329,7 @@ web-tabs.w-event-tabs {
 
 .w-event-modal-position {
   position: absolute;
-  background: red;
   margin-top: -100px;
   padding-top: 100px;
+  z-index: 100; // creates stacking context for modal
 }

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -199,6 +199,11 @@ web-tabs.w-event-tabs {
     position: relative;
     display: flex;
     align-items: center;
+
+    &:hover,
+    &:focus-within {
+      background: rgba(0, 0, 0, .05);
+    }
   }
 
   .w-event-schedule__speaker {
@@ -236,6 +241,10 @@ web-tabs.w-event-tabs {
     display: inline-block;
     color: inherit;
 
+    &:hover {
+      text-decoration: none;
+    }
+
     span {
       z-index: 1;
       position: relative;
@@ -252,12 +261,6 @@ web-tabs.w-event-tabs {
       display: block;
       position: absolute;
       z-index: 0;
-    }
-
-    // When the link is hovered, highlight the whole row, even though the
-    // speakers' area isn't clickable.
-    &:hover::before {
-      background: rgba(0, 0, 0, .05);
     }
   }
 }


### PR DESCRIPTION
Creates a modal for schedule content. Positions this on the correct row. Works reasonably well on mobile even without CSS changes.

<img width="784" alt="Screen Shot 2020-06-13 at 13 08 24" src="https://user-images.githubusercontent.com/119184/84558612-91612e00-ad77-11ea-93a7-8590dc08af48.png">
<img width="582" alt="Screen Shot 2020-06-13 at 13 08 27" src="https://user-images.githubusercontent.com/119184/84558615-94f4b500-ad77-11ea-8c41-16b8af2d43a0.png">

I've made changes based on feedback. You can now click whole row to select and I've addressed some accessibility feedback.

This is ready for review _but_ I've not imported everyone's abstracts. The original design calls for a single line inline with each session, but since most abstracts are at most one line _anyway_, I'm less inclined to show it there.

If you're happy I'll import everyone's abstract before submit.