### PR TITLE
Updates codeowners for PWA 11tydata.js to add petele

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,5 @@ content/en/angular/ @mgechev @kaycebasques
 # Exceptions
 src/site/_data/contributors.js @kaycebasques @robdodson
 src/site/_data/postTags.js @kaycebasques @robdodson
+src/site/_data/postTags.js @kaycebasques @robdodson
+src/site/content/en/progressive-web-apps/progressive-web-apps.11tydata.js @petele @kaycebasques

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,5 +27,4 @@ content/en/angular/ @mgechev @kaycebasques
 # Exceptions
 src/site/_data/contributors.js @kaycebasques @robdodson
 src/site/_data/postTags.js @kaycebasques @robdodson
-src/site/_data/postTags.js @kaycebasques @robdodson
 src/site/content/en/progressive-web-apps/progressive-web-apps.11tydata.js @petele @kaycebasques


### PR DESCRIPTION
Changes to the [`pwa-11tydata.js`](https://github.com/GoogleChrome/web.dev/blob/master/src/site/content/en/progressive-web-apps/progressive-web-apps.11tydata.js) file requires approval from Rob or Sam (because it is a `js` file). 

If we're adding new content, it have to be reviewed and approved by Kayce. But it also needs approval from either Rob/Sam - because it touches a `.js` file. This extra approval feels unnecessary.

This PR adds @kaycebasques and me (the area/content owner) to the approval for the PWA `11tydata.js` file, so that either of us can approve any new content added to the PWA section.

