### PR TITLE
Remove broken warning on getInstalledRelatedApps

### DIFF
--- a/src/site/content/en/blog/get-installed-related-apps/index.md
+++ b/src/site/content/en/blog/get-installed-related-apps/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
 description: The getInstalledRelatedApps() API is a new web platform API that allows your web app to check whether your native app or PWA is installed on the user's device.
 date: 2018-12-20
-updated: 2020-06-04
+updated: 2020-06-11
 tags:
   - blog
   - capabilities
@@ -13,12 +13,6 @@ tags:
 hero: hero.jpg
 alt: mobile device with app panel open
 ---
-
-{% Aside 'warning' %}
-  `getInstalledRelatedApps()` is currently broken on Chrome for Android. It
-  will silently fail, and not return any results. The fix is being tracked in
-  [Chromium Issue #1086686](https://bugs.chromium.org/p/chromium/issues/detail?id=1086686).
-{% endAside %}
 
 ## What is the getInstalledRelatedApps() API? {: #what }
 
@@ -232,12 +226,11 @@ relatedApps.forEach((app) => {
 });
 ```
 
-{% Aside 'caution' %}
+{% Aside %}
 `getInstalledRelatedApps()` is currently supported on the following platforms:
 
-* Chrome - Android ([currently broken](https://bugs.chromium.org/p/chromium/issues/detail?id=1086686)),
-  Windows (coming soon)
-* Edge - Windows (coming soon)
+* Android: Chrome 80+
+* Windows: Edge (coming soon), Chrome (coming soon)
 {% endAside %}
 
 To prevent sites from testing an overly broad set of their own apps,


### PR DESCRIPTION
The bug affecting `getInstalledRelatedApps` has been fixed and deployed to all users. This PR removes the warning from the updates post.

