### PR TITLE
Reorders topics on home & learn page

### DIFF
--- a/src/site/content/en/en.11tydata.js
+++ b/src/site/content/en/en.11tydata.js
@@ -11,12 +11,12 @@ const allPaths = require('../../_data/paths');
 
 module.exports = function () {
   const paths = [
-    allPaths['fast'],
+    allPaths['vitals'],
+    allPaths['progressive-web-apps'],
     allPaths['accessible'],
+    allPaths['fast'],
     allPaths['reliable'],
     allPaths['secure'],
-    allPaths['progressive-web-apps'],
-    allPaths['vitals'],
   ].filter(livePaths);
 
   const lang = 'en';

--- a/src/site/content/en/learn/learn.11tydata.js
+++ b/src/site/content/en/learn/learn.11tydata.js
@@ -11,14 +11,14 @@ const allPaths = require('../../../_data/paths');
 
 module.exports = function () {
   const paths = [
-    allPaths['fast'],
+    allPaths['vitals'],
+    allPaths['progressive-web-apps'],
     allPaths['accessible'],
+    allPaths['fast'],
     allPaths['reliable'],
     allPaths['secure'],
     allPaths['discoverable'],
-    allPaths['progressive-web-apps'],
     allPaths['metrics'],
-    allPaths['vitals'],
     allPaths['payments'],
   ].filter(livePaths);
 


### PR DESCRIPTION
@kaycebasques - we talked about moving PWA higher up in the topic listing page, it fell off my plate and I am only finally getting around to it now.

Changes proposed in this pull request:
- Reorders the Topics on the Home and Learn page to put our more critical content higher up. Vitals and PWA are now the top two items, followed by the other content. 

