### PR TITLE
Make petele codeowner of PWA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,4 +27,5 @@ content/en/angular/ @mgechev @kaycebasques
 # Exceptions
 src/site/_data/contributors.js @kaycebasques @robdodson
 src/site/_data/postTags.js @kaycebasques @robdodson
+src/site/_data/paths/progressive-web-apps.js @petele @kaycebasques
 src/site/content/en/progressive-web-apps/progressive-web-apps.11tydata.js @petele @kaycebasques


### PR DESCRIPTION
PR #3199 made me a code owner on the PWA `11ty.js` file. 

PR #3155 moves those files into a new location, and I lost my code ownership status. This gives me ownership over that file again.
