### PR TITLE
Remove unused and non-critical preconnects.

### DIFF
--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -24,16 +24,13 @@ show_banner: true
       {% Meta locale, page, collections, renderData %}
     {%- endif %}
 
-    <link rel="preconnect" href="//www.gstatic.com" crossorigin="" />
-    <link rel="preconnect" href="//fonts.gstatic.com" crossorigin="" />
-    <link rel="preconnect" href="//fonts.googleapis.com" crossorigin="" />
-    <link rel="preconnect" href="//www.google-analytics.com" crossorigin="" />
-    <link rel="preconnect" href="//firebaseremoteconfig.googleapis.com" crossorigin="" />
-    <link rel="preconnect" href="//firebaseinstallations.googleapis.com" crossorigin="" />
-    <link rel="preconnect" href="//webdev.imgix.net" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="" />
+    <link rel="preconnect" href="https://www.google-analytics.com" crossorigin="" />
+    <link rel="preconnect" href="https://webdev.imgix.net" crossorigin="" />
     <link
       rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:400,400italic,500,500italic|Roboto+Condensed:400,700|Roboto+Mono:400,500|Material+Icons"
+      href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:400,400italic,500,500italic|Roboto+Condensed:400,700|Roboto+Mono:400,500|Material+Icons"
     />
     <link rel="stylesheet" href="/app.css" />
     <link rel="manifest" href="/manifest.webmanifest" />
@@ -43,7 +40,7 @@ show_banner: true
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
-    <script async src="//www.google-analytics.com/analytics.js"></script>
+    <script async src="https://www.google-analytics.com/analytics.js"></script>
     <script defer src="/bootstrap.js"></script>
   </head>
   <body class="unresolved">


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes preconnects that we weren't using (www.gstatic, firebaseremoteconfig)
- Removes non-critical preconnects — anything not directly tied to LCP
- Adds https to preconnects — seems like a good idea since we use HSTS anyway to upgrade folks to https