### PR TITLE
Update WebOTP blog to clarify that "host" should be used

### DIFF
--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -321,7 +321,7 @@ was called.
 
 The message must adhere to the following formatting:
 
-* The origin part of the URL of the website that invoked the API must be
+* The host part of the URL of the website that invoked the API must be
   preceded by `@`.
 * The URL must contain a pound sign ('`#`') followed by the OTP.
 * Optionally, the message may contain additional text for the user.


### PR DESCRIPTION
Per [spec](https://wicg.github.io/sms-one-time-codes/#parsing) the item after the '@' is the **host** part of the URL.

Origin includes scheme, and port as well which we don't want authors to include in the SMS as
there are automatically set to 'https' and 'null' by user agent to produce an origin given the host.

