### PR TITLE
Remove flex layout from details widget

### DIFF
--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -6,8 +6,6 @@ $CHEVRON_MARGIN: 12px;
 .w-details {
   border: 1px solid $BORDER_COLOR;
   border-width: 1px 0;
-  display: flex;
-  flex-wrap: wrap;
   margin: 36px 0;
   padding: 18px 0;
   position: relative;
@@ -21,7 +19,6 @@ $CHEVRON_MARGIN: 12px;
 .w-details__summary {
   -webkit-tap-highlight-color: transparent;
   cursor: pointer;
-  flex-grow: 1;
   font: inherit;
   list-style: none;
 


### PR DESCRIPTION
Fixes #3239 (inline elements are displayed as block elements in mobile Safari)

Changes proposed in this pull request:

- Remove flex layout from details widget. This fixes the Safari issue and doesn't change anything in other browsers.

**Before:**

![IMG_0087](https://user-images.githubusercontent.com/145676/84754168-438b3680-afc0-11ea-8afc-a75137769215.PNG)

**After:**

![IMG_0088](https://user-images.githubusercontent.com/145676/84754173-46862700-afc0-11ea-8ca5-8d9dbcfb416a.PNG)
