### PR TITLE
[color-scheme article] Remove `light only` references completely

### DIFF
--- a/src/site/content/en/blog/color-scheme/index.md
+++ b/src/site/content/en/blog/color-scheme/index.md
@@ -6,6 +6,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2020-04-08
+updated: 2020-06-16
 hero: hero.jpg
 alt: Pigeons on a wall with a sharp black and white contrast in the background.
 description: |
@@ -147,8 +148,8 @@ with light background colors and dark foreground colors,
 whereas `dark` represents the opposite, with dark background colors and light foreground colors.
 
 {% Aside 'warning' %}
-  Per the specification, the allowed additional value `light only` indicates that the element
-  must be rendered with a light color scheme if possible,
+  Previously, the specification allowed an additional value `light only`
+  that indicated that the element had to be rendered with a light color scheme if possible,
   even if the user's preference is for a different color scheme.
   Authors *should not* use this value, and should instead ensure their page renders well
   with whatever color scheme the user prefers.


### PR DESCRIPTION
Changes proposed in this pull request:

- The value of `light only` was removed from the spec.