### PR TITLE
Add live page event data and bootstrap code.

### DIFF
--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -18,11 +18,12 @@
  * @fileoverview Contains event data for web.dev/LIVE.
  */
 
-const eventData = [
+const days = [
   {
     title: 'Day 1',
     when: '2020-06-30T16:00Z', // 9am PDT (-7)
     duration: 3,
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -101,6 +102,7 @@ const eventData = [
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3,
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -203,6 +205,7 @@ const eventData = [
     title: 'Day 3',
     when: '2020-07-02T07:30Z', // 1pm IST (+5:30)
     duration: 3,
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -306,10 +309,15 @@ const eventData = [
 ];
 
 // Include parsed Date objects for each day.
-for (const day of eventData) {
+for (const day of days) {
   // nb. We specify dates with a "Z" suffix, which effectively means 'parse in
   // UTC'.
   day.date = new Date(day.when);
 }
 
-module.exports = eventData;
+module.exports = {
+  isPreEvent: true,
+  isDuringEvent: false,
+  isPostEvent: false,
+  days,
+};

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -20,19 +20,19 @@ const slugify = require('slugify');
 const AuthorsDate = require('./AuthorsDate');
 
 /**
- * @param {!Array<{title: string, from: !Date, sessions: !Array<any>}>} event
+ * @param {!Array<{title: string, from: !Date, sessions: !Array<any>}>} days
  * @param {Object.<string, Author>} authorsCollection
  * @return {string}
  */
-module.exports = (event, authorsCollection) => {
+module.exports = (days, authorsCollection) => {
   // Find the default day to show, as a very basic non-JS fallback. Pick the
   // first day where the build time is before the end time of the sessions.
   // This isn't a very good fallback as our build happens at minimum of once per
   // day, but it's better than nothing.
   const now = new Date();
   let defaultScheduleDay = 0;
-  for (let i = 0; i < event.length; ++i) {
-    const {date, duration} = event[i];
+  for (let i = 0; i < days.length; ++i) {
+    const {date, duration} = days[i];
     const endTime = new Date(date);
     endTime.setHours(endTime.getHours() + duration);
 
@@ -112,7 +112,7 @@ module.exports = (event, authorsCollection) => {
   return html`
     <web-event-schedule>
       <web-tabs class="w-event-tabs unresolved" label="schedule">
-        ${event.map(renderDay)}
+        ${days.map(renderDay)}
       </web-tabs>
     </web-event-schedule>
   `;

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -83,7 +83,10 @@ date: 2020-06-31
     </div>
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">
-      {% EventTable event, collections.authors %}
+      {% if event.isDuringEvent or event.isPostEvent %}
+        {# Include carousel #}
+      {% endif %}
+      {% EventTable event.days, collections.authors %}
     </div>
 
   </section>
@@ -128,3 +131,7 @@ date: 2020-06-31
   </section>
 
 </div>
+
+<code id="event-data" style="display: none;">
+  {{ event.days | dump | safe }}
+</code>


### PR DESCRIPTION
Fixes #3242

Changes proposed in this pull request:

- Expands the event data to include flags for each day. Renames eventData to days and updates relevant shortcode.
- Bootstraps the page with event data, similar to what we do on /measure. This is so our client side js can poll and know when it needs to switch the video player.
- Adds an example of how we'd include different widgets based on the flags.
