### PR TITLE
Hashes

### DIFF
--- a/build.js
+++ b/build.js
@@ -241,9 +241,6 @@ async function build() {
     await compressOutput(outputFiles);
   }
 
-  // We don't generate a manifest in dev, so Workbox doesn't do a default cache step.
-  const manifest = isProd ? await buildCacheManifest() : [];
-
   const swBundle = await rollup.rollup({
     input: 'src/lib/sw.js',
     manualChunks: (id) => {
@@ -262,11 +259,6 @@ async function build() {
       rollupPluginReplace({
         'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : ''),
       }),
-      rollupPluginVirtual(
-        buildVirtualJSON({
-          'cache-manifest': manifest,
-        }),
-      ),
       ...buildDefaultPlugins(),
       OMT(),
     ],

--- a/build.js
+++ b/build.js
@@ -87,8 +87,11 @@ async function buildCacheManifest() {
       // We don't include jpg files, as they're used for authors and hero
       // images, which are part of articles, and not the top-level site.
       'images/**/*.{png,svg}',
+
+      // If any of these fail to match, the warning will trigger a failure.
       '*.css',
       '*.js',
+      '*.partial',
     ],
     globIgnores: [
       // This removes large shared PNG files that are used only for articles.
@@ -241,11 +244,6 @@ async function build() {
   // We don't generate a manifest in dev, so Workbox doesn't do a default cache step.
   const manifest = isProd ? await buildCacheManifest() : [];
 
-  const layoutTemplate = await fs.readFile(
-    path.join('dist', 'sw-partial-layout.partial'),
-    'utf-8',
-  );
-
   const swBundle = await rollup.rollup({
     input: 'src/lib/sw.js',
     manualChunks: (id) => {
@@ -267,7 +265,6 @@ async function build() {
       rollupPluginVirtual(
         buildVirtualJSON({
           'cache-manifest': manifest,
-          'layout-template': layoutTemplate,
         }),
       ),
       ...buildDefaultPlugins(),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web.dev",
   "version": "2.0.0",
   "scripts": {
-    "build": "npm-run-all clean sass eleventy gulp rollup",
+    "build": "npm-run-all clean sass rollup eleventy gulp",
     "clean": "rm -rf dist",
     "coverage:integration": "c8 npm-run-all test:lib test:unit test:integration",
     "coverage:unit": "c8 npm run test:unit",
@@ -23,7 +23,7 @@
     "lint": "npm-run-all lint:md lint:scss lint:js",
     "percy": "PERCY=true npm-run-all build --parallel --race start snapshots",
     "precommit": "node ./tools/update-updated/index.js",
-    "rollup": "eleventy --input src/site/content/sw-partial-layout.njk; node build.js",
+    "rollup": "node build.js",
     "sass": "node ./compile-css.js src/styles/all.scss dist/app.css",
     "snapshots": "percy exec --config ./tools/percy/.percy.conf.yml -- node tools/percy/snapshots.js",
     "stage:personal": "ELEVENTY_ENV=dev npm run build && gcloud app deploy --project web-dev-staging --quiet --no-promote",

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -10,7 +10,6 @@ import {CacheableResponsePlugin} from 'workbox-cacheable-response';
 import {ExpirationPlugin} from 'workbox-expiration';
 import {cacheNames as workboxCacheNames} from 'workbox-core';
 import {matchSameOriginRegExp} from './utils/sw-match.js';
-import {matchPrecache, precache} from 'workbox-precaching';
 
 const idbKeys = Object.freeze({
   architecture: 'arch',

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -75,6 +75,8 @@ const jsVersion = hashFor('dist/bootstrap.js');
 // This represents a general version all our assets (excluding images), and is
 // used to work out if a partial was built for a different version.
 // In dev, it's blank, since we always want to fetch our latest partial.
+/* eslint-disable */
+// TODO(robdodson): eslint cannot decide what this should format as.
 const resourcesVersion = isProd
   ? hashFor(
     'dist/app.css',
@@ -82,6 +84,7 @@ const resourcesVersion = isProd
     'src/site/_includes/layout.njk',
   )
   : '';
+/* eslint-enable */
 
 module.exports = {
   cssVersion,

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -22,6 +22,8 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
+// TODO(robdodson): This should really be "NOT anywhere we run `npm run dev`".
+const isProd = process.env.ELEVENTY_ENV === 'prod';
 const hashLength = 8;
 
 function randomHash() {
@@ -50,7 +52,7 @@ function hashFor(...files) {
       const contents = fs.readFileSync(f);
       c.update(contents);
     } catch (e) {
-      if (process.env.ELEVENTY_ENV === 'prod') {
+      if (isProd) {
         throw new Error(`could not hash: ${f}`);
       }
 
@@ -70,7 +72,20 @@ function hashFor(...files) {
 const cssVersion = hashFor('dist/app.css');
 const jsVersion = hashFor('dist/bootstrap.js');
 
+// This represents a general version all our assets (excluding images), and is
+// used to work out if a partial was built for a different version.
+// In dev, it's blank, since we always want to fetch our latest partial.
+const resourcesVersion = isProd
+  ? hashFor(
+    'dist/app.css',
+    'dist/bootstrap.js',
+    'src/site/_includes/layout.njk',
+  )
+  : '';
+
 module.exports = {
   cssVersion,
   jsVersion,
+  resourcesVersion,
+  builtAt: +new Date(),
 };

--- a/src/site/_data/eleventyComputed.js
+++ b/src/site/_data/eleventyComputed.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Provides hashes of static assets referenced inside Eleventy's
+ * templates.
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+
+const hashLength = 8;
+
+function randomHash() {
+  // Randomly pick a number in [1,2] and multiply by 'length' hex digits to
+  // generate a fake hash. Just used to enforce cache busting in JS.
+  return Math.floor((1 + Math.random()) * Math.pow(16, hashLength))
+    .toString(16)
+    .substr(0, hashLength);
+}
+
+/**
+ * Hashes the passed path. If the file doesn't exist, return a random hash. If
+ * we're in prod, then crash.
+ *
+ * @param {string} files to hash
+ * @return {string}
+ */
+function hashFor(...files) {
+  if (!files.length) {
+    throw new Error(`must hash at least one file`);
+  }
+
+  const c = crypto.createHash('sha1');
+  for (const f of files) {
+    try {
+      const contents = fs.readFileSync(f);
+      c.update(contents);
+    } catch (e) {
+      if (process.env.ELEVENTY_ENV === 'prod') {
+        throw new Error(`could not hash: ${f}`);
+      }
+
+      // If we can't load this file in dev, just return a random hash. This just
+      // gives us cache-busting behavior every build.
+      return randomHash();
+    }
+  }
+
+  const hash = c.digest('hex').substr(0, hashLength);
+  if (hash.length !== hashLength) {
+    throw new TypeError(`could not hash: ${files.join(',')}`);
+  }
+  return hash;
+}
+
+const cssVersion = hashFor('dist/app.css');
+const jsVersion = hashFor('dist/bootstrap.js');
+
+module.exports = {
+  cssVersion,
+  jsVersion,
+};

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -35,7 +35,7 @@ show_banner: true
       rel="stylesheet"
       href="//fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:400,400italic,500,500italic|Roboto+Condensed:400,700|Roboto+Mono:400,500|Material+Icons"
     />
-    <link rel="stylesheet" href="/app.css?v=8868799e608cd" />
+    <link rel="stylesheet" href="/app.css?v={{cssVersion}}" />
     <link rel="manifest" href="/manifest.webmanifest" />
     {# Include default icon even though we have a manifest #}
     <link rel="shortcut icon" href="/images/favicon.ico">
@@ -44,7 +44,7 @@ show_banner: true
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
     <script async src="//www.google-analytics.com/analytics.js"></script>
-    <script defer src="/bootstrap.js"></script>
+    <script defer src="/bootstrap.js?v={{jsVersion}}"></script>
   </head>
   <body class="unresolved">
     {#

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -46,7 +46,7 @@ show_banner: true
     <script async src="//www.google-analytics.com/analytics.js"></script>
     <script defer src="/bootstrap.js?v={{jsVersion}}"></script>
   </head>
-  <body class="unresolved">
+  <body class="unresolved" data-resources-version="{{resourcesVersion}}">
     {#
       Make the snackbar the first item in the DOM so we don't have to steal the
       user's focus on initial visit to show them a cookie banner. Instead, the

--- a/src/site/_transforms/service-worker-partials/index.js
+++ b/src/site/_transforms/service-worker-partials/index.js
@@ -26,6 +26,8 @@ const path = require('path');
 const cheerio = require('cheerio');
 
 const computedData = require('../../_data/eleventyComputed');
+const {getManifest} = require('workbox-build');
+const isProd = process.env.ELEVENTY_ENV === 'prod';
 
 const revision = {
   // Refers to the version of the site the partial was built at, and the build timestamp. We use
@@ -53,8 +55,47 @@ const getPartial = (content) => {
 };
 
 const writeTemplate = async (to, raw) => {
+  const manifest = [];
+
+  // In prod, fetch manifest assets. We don't bother in dev as we're not sure
+  // of the execution order.
+  if (isProd) {
+    const toplevelManifest = await getManifest({
+      // JS files that include hashes don't need their own revision fields.
+      globDirectory: 'dist',
+      globPatterns: [
+        // We don't include jpg files, as they're used for authors and hero
+        // images, which are part of articles, and not the top-level site.
+        'images/**/*.{png,svg}',
+        '*.css',
+        '*.js',
+        '*.partial',
+      ],
+      globIgnores: [
+        // This removes large shared PNG files that are used only for articles.
+        'images/{shared}/**',
+      ],
+    });
+    if (toplevelManifest.warnings.length) {
+      throw new Error(`toplevel manifest: ${toplevelManifest.warnings}`);
+    }
+    manifest.push(...toplevelManifest.manifestEntries);
+
+    // We need this manifest to be separate as we pretend it's rooted at the
+    // top-level, even though it comes from "dist/en".
+    const contentManifest = await getManifest({
+      globDirectory: 'dist/en',
+      globPatterns: ['offline/index.json'],
+    });
+    if (contentManifest.warnings.length) {
+      throw new Error(`content manifest: ${contentManifest.warnings}`);
+    }
+    manifest.push(...contentManifest.manifestEntries);
+  }
+
   const o = {
     template: raw,
+    manifest,
     ...revision,
   };
   await fs.writeFile(to, JSON.stringify(o));


### PR DESCRIPTION
Fixes #3243. Although I suspect it has a bunch of issues so I'm marking it DO NOT MERGE :)

This does a couple of things.

1. Adds hashes to the CSS/JS files (as "?v=hash") based on Eleventy computed data
2. Reorders the build process a bit, and makes the App Shell template fetched and cached by the Service Worker (previously we inlined it as a variable)
3. Adds a "resource version", which is the hash of CSS/JS/template, and includes it in both:
  - all partials
  - the payload which includes the App Shell template
4. If we load a new page, which involves fetching the partial and hydrating the template, we check if there's a version mismatch: if so, _immediately_ refetch the template and fetch its associated assets

To be clear, I couldn't just do 1 and 2 on their own. The build process now looks like:

a. Rollup and SASS (can happen independently)
b. Eleventy (as it needs generated hashes)

Rollup depended on knowing about the partial, as it used Workbox's `getManifest` helper. So instead, we actually generate a manifest inside Eleventy, and include this in what is effectively the App Shell template (it's now included in a JSON file).

An important implication of this design is that we _do not_ include general resources and hashes in the SW (to pass to e.g., `precacheAndRoute`). My goal here is actually to make it so that CSS, JS and template changes, and misc 'top level assets', do **not** cause a change in the Service Worker. This means we'll have very few SW changes (which currently causes a site refresh) and more consistency about what's being served, because an updated partial forces an update.

Some TODOs:

- We only force a template update when the SW tries to build a page (on opening a full page), _not_ on internal navigation
  - This only effects a user who has the site open, we do a deploy, and then they navigate—we need to force a refresh here but it's less important
  - ... I still need to build this
  - ... This is as broken as it is now

PTAL @jeffposnick. I've left some comments for you, mostly around whether inserting directly into the cache makes sense, e.g. sw.js line 309.