### PR TITLE
Standardize on `capabilities` for tags

### DIFF
--- a/src/site/_data/postTags.js
+++ b/src/site/_data/postTags.js
@@ -27,6 +27,8 @@ const tags = {
   },
   capabilities: {
     title: 'Capabilities',
+    description:
+      'Our latest news, updates, and stories about new web capabilities (aka Project Fugu).',
   },
   'case-study': {
     title: 'Case Study',
@@ -86,10 +88,6 @@ const tags = {
   },
   forms: {
     title: 'Forms',
-  },
-  fugu: {
-    title: 'Fugu',
-    description: 'Our latest news, updates, and stories about Fugu.',
   },
   games: {
     title: 'Games',
@@ -172,6 +170,8 @@ const tags = {
   },
   'progressive-web-apps': {
     title: 'Progressive Web Apps',
+    description:
+      'Our latest news, updates, and stories about Progressive Web Apps.',
   },
   puppeteer: {
     title: 'Puppeteer',

--- a/src/site/content/en/blog/app-shortcuts/index.md
+++ b/src/site/content/en/blog/app-shortcuts/index.md
@@ -12,7 +12,6 @@ description: App shortcuts give quick access to a handful of common actions that
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - capabilities
-  - fugu
   - progressive-web-apps
 ---
 

--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -9,11 +9,9 @@ updated: 2020-06-04
 tags:
   - blog
   - capabilities
-  - fugu
   - badging
   - progressive-web-apps
   - notifications
-  - origin-trial
 hero: hero.jpg
 alt: Phone showing several notification badges
 origin_trial:

--- a/src/site/content/en/blog/betty-crocker/index.md
+++ b/src/site/content/en/blog/betty-crocker/index.md
@@ -19,7 +19,6 @@ tags:
   - case-study
   - wake-lock
   - capabilities
-  - fugu
 ---
 For nearly a century, Betty Crocker has been America's source for modern cooking instruction
 and trusted recipe development.

--- a/src/site/content/en/blog/contact-picker/index.md
+++ b/src/site/content/en/blog/contact-picker/index.md
@@ -9,7 +9,6 @@ updated: 2020-06-04
 tags:
   - blog
   - capabilities
-  - fugu
   - contacts
   - chrome80
 hero: hero.jpg

--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -9,7 +9,6 @@ updated: 2020-05-26
 tags:
   - blog
   - capabilities
-  - fugu
   - service-worker
   - chrome80
   - index

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -6,7 +6,6 @@ updated: 2020-04-13
 tags:
   - blog
   - capabilities
-  - fugu
 ---
 
 {% Aside %}

--- a/src/site/content/en/blog/get-installed-related-apps/index.md
+++ b/src/site/content/en/blog/get-installed-related-apps/index.md
@@ -9,7 +9,6 @@ updated: 2020-06-11
 tags:
   - blog
   - capabilities
-  - fugu
 hero: hero.jpg
 alt: mobile device with app panel open
 ---

--- a/src/site/content/en/blog/idle-detection/index.md
+++ b/src/site/content/en/blog/idle-detection/index.md
@@ -12,7 +12,6 @@ updated: 2020-05-19
 tags:
   - blog
   - idle-detection
-  - fugu
   - capabilities
 hero: hero.jpg #https://images.unsplash.com/photo-1544239265-ee5eedde5469?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1900&q=80
 alt: Abandoned computer on a bed with someone's leg next to it.
@@ -109,7 +108,7 @@ this definition is left to the user agent.
 
 The first step when using the Idle Detection API is
 to ensure the `'notifications'` permission is granted.
-If the permission is not granted, you need to 
+If the permission is not granted, you need to
 [request it](https://developers.google.com/web/fundamentals/push-notifications/subscribing-a-user#requesting_permission).
 
 ```js
@@ -141,7 +140,7 @@ try {
     const screenState = idleDetector.screenState;
     console.log(`Idle change: ${userState}, ${screenState}.`);
   });
-  
+
   await idleDetector.start({
     threshold: 60000,
     signal,

--- a/src/site/content/en/blog/image-support-for-async-clipboard/index.md
+++ b/src/site/content/en/blog/image-support-for-async-clipboard/index.md
@@ -9,7 +9,6 @@ updated: 2020-06-04
 tags:
   - blog
   - capabilities
-  - fugu
   - chrome76
   - cutandcopy
   - execcommand

--- a/src/site/content/en/blog/maskable-icon/index.md
+++ b/src/site/content/en/blog/maskable-icon/index.md
@@ -13,7 +13,6 @@ alt: Icons contained inside white circles compared to icons covering its entire 
 tags:
   - blog
   - capabilities
-  - fugu
   - progressive-web-apps
 ---
 

--- a/src/site/content/en/blog/native-file-system/index.md
+++ b/src/site/content/en/blog/native-file-system/index.md
@@ -9,10 +9,9 @@ updated: 2020-04-13
 tags:
   - blog
   - capabilities
-  - fugu
-  - origin-trial
+  - origin-trials
   - file
-  - filesystem
+  - file-system
   - native-file-system
 hero: hero.jpg
 alt: Image of hard disk platters

--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -15,7 +15,6 @@ origin_trial:
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - capabilities
-  - fugu
 ---
 
 {% Aside %}

--- a/src/site/content/en/blog/notification-triggers/index.md
+++ b/src/site/content/en/blog/notification-triggers/index.md
@@ -15,8 +15,7 @@ hero_position: center
 tags:
   - blog
   - capabilities
-  - fugu
-  - origin-trial
+  - origin-trials
   - notification-triggers
 ---
 

--- a/src/site/content/en/blog/periodic-background-sync/index.md
+++ b/src/site/content/en/blog/periodic-background-sync/index.md
@@ -17,7 +17,6 @@ description: |
   of a native app.
 tags:
   - capabilities
-  - fugu
   - blog
   - progressive-web-apps
   - service-worker

--- a/src/site/content/en/blog/shape-detection/index.md
+++ b/src/site/content/en/blog/shape-detection/index.md
@@ -9,8 +9,7 @@ updated: 2020-06-04
 tags:
   - blog
   - capabilities
-  - fugu
-  - origin-trial
+  - origin-trials
   - shape-detection
   - progressive-web-apps
   - webapp

--- a/src/site/content/en/blog/text-fragments/index.md
+++ b/src/site/content/en/blog/text-fragments/index.md
@@ -16,10 +16,9 @@ description: |
   When navigating to a URL with such a text fragment, the browser can emphasize
   and/or bring it to the user's attention.
 tags:
-  - post # post is a required tag for the article to show up in the blog.
+  - blog
   - text-fragments
   - capabilities
-  - fugu
 ---
 ## Fragment Identifiers
 

--- a/src/site/content/en/blog/wakelock/index.md
+++ b/src/site/content/en/blog/wakelock/index.md
@@ -16,8 +16,6 @@ origin_trial:
 tags:
   - blog
   - capabilities
-  - fugu
-  - behind-a-flag
   - wake-lock
 ---
 

--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -16,7 +16,6 @@ tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - identity
   - capabilities
-  - fugu
   - otp
 ---
 

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -14,7 +14,6 @@ description: |
 tags:
   - blog
   - capabilities
-  - fugu
 ---
 
 On a mobile device, sharing should be as simple as clicking the **Share** button,

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -15,7 +15,6 @@ description: |
 tags:
   - blog
   - capabilities
-  - fugu
 ---
 
 With the Web Share API, web apps are able to use the same system-provided share

--- a/src/site/content/en/blog/websocketstream/index.md
+++ b/src/site/content/en/blog/websocketstream/index.md
@@ -18,7 +18,6 @@ tags:
   - websocket
   - websocketstream
   - capabilities
-  - fugu
 origin_trial:
   url: https://developers.chrome.com/origintrials/#/view_trial/1977080236415647745
 ---

--- a/src/site/content/en/blog/workbox-share-targets/index.md
+++ b/src/site/content/en/blog/workbox-share-targets/index.md
@@ -14,7 +14,6 @@ alt: Two pairs of hands holding a cup of tomatoes.
 tags:
   - blog
   - capabilities
-  - fugu
   - workbox
   - test-post
 ---

--- a/src/site/content/en/progressive-web-apps/app-like-pwas/index.md
+++ b/src/site/content/en/progressive-web-apps/app-like-pwas/index.md
@@ -11,8 +11,6 @@ date: 2020-06-15
 updated: 2020-06-15
 tags:
   - capabilities
-  - progressive-web-apps
-  - fugu
 ---
 
 When you play Progressive Web App buzzword bingo, it is a safe bet to set on "PWAs are just websites". Microsoft's PWA documentation [agrees](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/#progressive-web-apps-on-windows:~:text=PWAs%20are%20just%20websites), we [say it](https://web.dev/progressive-web-apps/#content:~:text=Progressive%20Web%20Apps,Websites) on this very site, and even PWA nominators Frances Berriman and Alex Russell [write so](https://infrequently.org/2015/06/progressive-apps-escaping-tabs-without-losing-our-soul/#post-2263:~:text=they%E2%80%99re%20just%20websites), too. Yes, PWAs are just websites, but they are also way more than that. If done right, a PWA will not feel like a website, but like a "real" app. Now what does it mean to feel like a real app?


### PR DESCRIPTION
Fixes #2227 

Changes proposed in this pull request:
- Changes all posts to use the `capabilities` tag 
- Removes `fugu` tag from all posts
- Adds description on capabilities tag page and include Project Fugu.
- Removes some misc tags that were no longer applicable.
