### PR TITLE
web-event-store for time management

### DIFF
--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -95,9 +95,9 @@ class EventSchedule extends HTMLElement {
 
     // If the user opens this page from externally on a specific session, make sure we're showing
     // the correct day of tab.
-    const index = this._tabsElement.indexOfTabParent(session);
+    const index = this._tabsElement.indexOfTabByChild(session);
     if (index !== -1) {
-      this._tabsElement.focusTab(index);
+      this._tabsElement.activeTab = index;
     }
 
     this._modalElement.sessionRow = clone;
@@ -187,7 +187,7 @@ class EventSchedule extends HTMLElement {
     // tabs, which is pretty safe, since it comes from the same source.
     // Don't change the tab for the user if a modal is already open.
     if (!this._modalElement.open && activeEventDay) {
-      this._tabsElement.focusTab(activeEventDay.index);
+      this._tabsElement.activeTab = activeEventDay.index;
     }
   }
 }

--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -162,7 +162,7 @@ class EventSchedule extends HTMLElement {
       }
 
       store.subscribe(this.onStateChanged);
-      this.onStateChanged(store.getState());
+      this.onStateChanged(store.getState()); // subscribe doesn't trigger listener
       this.onHashChange();
     });
   }

--- a/src/lib/components/EventStore/index.js
+++ b/src/lib/components/EventStore/index.js
@@ -24,7 +24,7 @@ const bufferMinutes = 60;
 const bufferChatMinutes = 10;
 
 // Run the timer every five minutes.
-const timerEvery = 60 * 1000 * 5;
+const timerEveryMillisecond = 60 * 1000 * 5;
 
 /**
  * @fileoverview Provides an element which publishes event data to Unistore, as well as finding
@@ -130,7 +130,7 @@ class EventStore extends HTMLElement {
     this._days = raw.days || [];
     this._update(true);
 
-    this._timer = window.setInterval(this._update, timerEvery);
+    this._timer = window.setInterval(this._update, timerEveryMillisecond);
   }
 
   disconnectedCallback() {

--- a/src/lib/components/EventStore/index.js
+++ b/src/lib/components/EventStore/index.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../EventScheduleModal';
+
+import {store} from '../../store';
+
+// Pretend the date is active within this buffer. This is useful so we can
+// reveal the player for a bit more time.
+const bufferHours = 1;
+
+/**
+ * @fileoverview Publishes event data to Unistore.
+ */
+
+class EventStore extends HTMLElement {
+  constructor() {
+    super();
+
+    this.onStateChanged = this.onStateChanged.bind(this);
+
+    this._timeOffset = 0;
+    this._data = [];
+  }
+
+  /**
+   * @param {boolean=} change this should force a change
+   */
+  _update(change = false) {
+    const now = +new Date() + this._timeOffset;
+    let activeEventDay = null;
+
+    for (const day of this._data) {
+      const start = +new Date(day.when);
+      start.setHours(start.getHours() - bufferHours);
+
+      const end = new Date(start);
+      end.setHours(end.getHours() + day.duration + bufferHours);
+
+      const update = {
+        complete: now >= end,
+        active: now >= start && now < end,
+      };
+
+      if (!day.state) {
+        // ok
+      } else if (
+        day.state.complete === update.complete &&
+        day.state.active === update.active
+      ) {
+        continue;
+      }
+      change = true;
+
+      // TODO(samthor): Should this be "active or next", so we prefill the video player?
+      if (update.active) {
+        activeEventDay = day;
+      }
+      day.state = update;
+    }
+
+    // Gate this with a boolean as to not trigger recursive updates.
+    if (change) {
+      store.setState({
+        eventDays: this._data,
+        activeEventDay,
+      });
+    }
+  }
+
+  connectedCallback() {
+    store.subscribe(this.onStateChanged);
+
+    const raw = JSON.parse(this.textContent.trim());
+    this._data = raw || [];
+    this._update(true);
+  }
+
+  disconnectedCallback() {
+    store.unsubscribe(this.onStateChanged);
+
+    this._data = [];
+    this._update(true);
+  }
+
+  onStateChanged({timeOffset}) {
+    if (this._timeOffset !== timeOffset) {
+      this._timeOffset = timeOffset;
+      this._update();
+    }
+  }
+}
+
+customElements.define('web-event-store', EventStore);

--- a/src/lib/components/EventTime/index.js
+++ b/src/lib/components/EventTime/index.js
@@ -104,7 +104,7 @@ class EventTime extends BaseElement {
     let durationPart = '';
     if (this.duration > 0) {
       const end = new Date(this._date);
-      end.setHours(end.getHours() + this.duration);
+      end.setMinutes(end.setMinutes() + this.duration);
       durationPart = html`
         &mdash; ${format(end, {hour: 'numeric', minute: '2-digit'})}
       `;

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -103,8 +103,10 @@ class Tabs extends BaseElement {
   }
 
   panelTemplate(i, child) {
+    const index = i - 1; // i is 1-indexed
     return html`
       <div
+        data-index=${index}
         id="web-tab-${this.idSalt}-${i}-panel"
         class="web-tabs__panel"
         role="tabpanel"
@@ -232,10 +234,9 @@ class Tabs extends BaseElement {
   focusTab(index) {
     const tabs = this.querySelectorAll('.web-tabs__tab');
 
-    if (!tabs[index]) {
-      throw new RangeError('There is no tab at the specified index.');
+    if (tabs[index]) {
+      tabs[index].focus();
     }
-    tabs[index].focus();
   }
 
   // If previous tab exists, make it active. If not, make last tab active.
@@ -266,6 +267,19 @@ class Tabs extends BaseElement {
     const tabs = this.querySelectorAll('.web-tabs__tab');
 
     this.activeTab = tabs.length - 1;
+  }
+
+  /**
+   * @param {!Node} node to check
+   * @return {number} the index of the tab containing this node
+   */
+  indexOfTabParent(node) {
+    const panel = node.closest('[class="web-tabs__panel"]');
+    if (!this.contains(panel)) {
+      return -1;
+    }
+    const index = parseInt(panel.getAttribute('data-index'));
+    return isNaN(index) ? -1 : index;
   }
 }
 

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -271,9 +271,9 @@ class Tabs extends BaseElement {
 
   /**
    * @param {!Node} node to check
-   * @return {number} the index of the tab containing this node
+   * @return {number} the index of the tab containing this node, or -1 for none
    */
-  indexOfTabParent(node) {
+  indexOfTabByChild(node) {
     const panel = node.closest('[class="web-tabs__panel"]');
     if (!this.contains(panel)) {
       return -1;

--- a/src/lib/pages/live.js
+++ b/src/lib/pages/live.js
@@ -3,6 +3,7 @@
  */
 
 import '../components/EventSchedule';
+import '../components/EventStore';
 import '../components/EventTime';
 import '../components/Subscribe';
 import '../components/ShareAction';

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,29 +1,12 @@
 import createStore from 'unistore';
 import devtools from 'unistore/devtools';
 import getMeta from './utils/meta';
+import {getTimeOffset} from './utils/time-offset';
 import {localStorage} from './utils/storage';
 import {isProd} from 'webdev_config';
 
 const initialParams = new URLSearchParams(window.location.search);
-
-let timeOffset = 0;
-if (initialParams.has('_now')) {
-  const overrides = {
-    'wdl-day1': '2020-06-30T16:02Z',
-    'wdl-preday2': '2020-07-01T10:59Z', // before 1hr buffer
-    'wdl-day2': '2020-07-01T12:00Z',
-  };
-
-  let raw = initialParams.get('_now');
-  raw = overrides[raw] || raw;
-
-  const d = new Date(raw);
-  if (+d) {
-    const now = new Date();
-    timeOffset = d - now;
-    console.warn('debug time start at', d);
-  }
-}
+const timeOffset = getTimeOffset(initialParams.get('_now'));
 
 const initialState = {
   // The first time the app boots we won't know whether the user is signed
@@ -73,12 +56,13 @@ const initialState = {
 
   userPrefferedLanguage: '',
 
-  // Used to override the current time for parts of the site which care about time.
+  // Used to override the current time for web.dev/LIVE testing.
   timeOffset,
 
   // Data for the current web.dev/LIVE event.
   eventDays: [],
-  activeEventDay: null,
+  activeEventDay: null, // livestream shown for this day
+  activeChatDay: null, // chat shown for this day
 };
 
 let store;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -10,8 +10,8 @@ let timeOffset = 0;
 if (initialParams.has('_now')) {
   const overrides = {
     'wdl-day1': '2020-06-30T16:02Z',
-    'wdl-preday2': '2020-07-01T11:58Z',
-    'wdl-day2': '2020-07-01T12:02Z',
+    'wdl-preday2': '2020-07-01T10:59Z', // before 1hr buffer
+    'wdl-day2': '2020-07-01T12:00Z',
   };
 
   let raw = initialParams.get('_now');

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -7,20 +7,21 @@ import {isProd} from 'webdev_config';
 const initialParams = new URLSearchParams(window.location.search);
 
 let timeOffset = 0;
-if (initialParams.has('_time')) {
+if (initialParams.has('_now')) {
   const overrides = {
     'wdl-day1': '2020-06-30T16:02Z',
-    'wdl-preday1': '2020-06-30T15:58Z',
+    'wdl-preday2': '2020-07-01T11:58Z',
+    'wdl-day2': '2020-07-01T12:02Z',
   };
 
-  let raw = initialParams.get('_time');
+  let raw = initialParams.get('_now');
   raw = overrides[raw] || raw;
 
   const d = new Date(raw);
   if (+d) {
     const now = new Date();
     timeOffset = d - now;
-    console.warn('debug time set', d, 'offset is', timeOffset);
+    console.warn('debug time start at', d);
   }
 }
 
@@ -77,6 +78,7 @@ const initialState = {
 
   // Data for the current web.dev/LIVE event.
   eventDays: [],
+  activeEventDay: null,
 };
 
 let store;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -62,7 +62,7 @@ const initialState = {
   // Data for the current web.dev/LIVE event.
   eventDays: [],
   activeEventDay: null, // livestream shown for this day
-  activeChatDay: null, // chat shown for this day
+  isChatActive: false, // chat active for this day
 };
 
 let store;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -4,6 +4,26 @@ import getMeta from './utils/meta';
 import {localStorage} from './utils/storage';
 import {isProd} from 'webdev_config';
 
+const initialParams = new URLSearchParams(window.location.search);
+
+let timeOffset = 0;
+if (initialParams.has('_time')) {
+  const overrides = {
+    'wdl-day1': '2020-06-30T16:02Z',
+    'wdl-preday1': '2020-06-30T15:58Z',
+  };
+
+  let raw = initialParams.get('_time');
+  raw = overrides[raw] || raw;
+
+  const d = new Date(raw);
+  if (+d) {
+    const now = new Date();
+    timeOffset = d - now;
+    console.warn('debug time set', d, 'offset is', timeOffset);
+  }
+}
+
 const initialState = {
   // The first time the app boots we won't know whether the user is signed
   // in or out.
@@ -51,6 +71,12 @@ const initialState = {
   snackbarType: null,
 
   userPrefferedLanguage: '',
+
+  // Used to override the current time for parts of the site which care about time.
+  timeOffset,
+
+  // Data for the current web.dev/LIVE event.
+  eventDays: [],
 };
 
 let store;

--- a/src/lib/utils/time-offset.js
+++ b/src/lib/utils/time-offset.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Provides a helper for calculating relative time.
+ */
+
+/**
+ * @param {?string} raw a date-like string
+ * @return {number} the number of milliseconds we're pretending to be offset by
+ */
+export default function getTimeOffset(raw) {
+  if (!raw) {
+    return 0;
+  }
+
+  const overrides = {
+    'wdl-day1': '2020-06-30T16:02Z',
+    'wdl-preday2': '2020-07-01T10:59Z', // before 1hr buffer
+    'wdl-day2': '2020-07-01T12:00Z',
+  };
+
+  raw = overrides[raw] || raw;
+
+  const d = new Date(raw);
+  if (+d) {
+    const now = new Date();
+    console.warn('debug time start at', d);
+    return d - now;
+  }
+  return 0;
+}

--- a/src/lib/utils/time-offset.js
+++ b/src/lib/utils/time-offset.js
@@ -22,7 +22,7 @@
  * @param {?string} raw a date-like string
  * @return {number} the number of milliseconds we're pretending to be offset by
  */
-export default function getTimeOffset(raw) {
+export function getTimeOffset(raw) {
   if (!raw) {
     return 0;
   }

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -22,7 +22,7 @@ const days = [
   {
     title: 'Day 1',
     when: '2020-06-30T16:00Z', // 9am PDT (-7)
-    duration: 3,
+    duration: 3 * 60, // minutes
     videoId: null,
     sessions: [
       {
@@ -123,7 +123,7 @@ const days = [
   {
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
-    duration: 3,
+    duration: 3 * 60, // minutes
     videoId: null,
     sessions: [
       {
@@ -243,7 +243,7 @@ const days = [
   {
     title: 'Day 3',
     when: '2020-07-02T07:30Z', // 1pm IST (+5:30)
-    duration: 3,
+    duration: 3 * 60, // minutes
     videoId: null,
     sessions: [
       {

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -34,7 +34,7 @@ module.exports = (days, authorsCollection) => {
   for (let i = 0; i < days.length; ++i) {
     const {date, duration} = days[i];
     const endTime = new Date(date);
-    endTime.setHours(endTime.getHours() + duration);
+    endTime.setMinutes(endTime.setMinutes() + duration);
 
     if (now < endTime) {
       defaultScheduleDay = i;

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -149,6 +149,4 @@ date: 2020-06-31
 
 </div>
 
-<code id="event-data" style="display: none;">
-  {{ event.days | dump | safe }}
-</code>
+<web-event-store style="display: none;">{{ event.days | dump | safe }}</web-event-store>

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -149,4 +149,4 @@ date: 2020-06-31
 
 </div>
 
-<web-event-store style="display: none;">{{ event.days | dump | safe }}</web-event-store>
+<web-event-store style="display: none;">{{ event | dump | safe }}</web-event-store>


### PR DESCRIPTION
Adds `<web-event-store>` and a few things to help manage the 'active day' of the event.

- you can pass e.g. "?_now=wdl-day2" to demo the event at a specific time
- the schedule is made available in unistore (with a boolean `.complete` as to whether the day is over)
- the active day is available in unistore—it prefers the upcoming day, but will retain the previous day until an hour before the next day (in case the user is still using the embed)
- I made it so deep-linking to a session ensures that tab is open when you load the page
- but otherwise it focuses the correct tab on load (this is _also_ done by the server, but maybe it's out of whack or we don't deploy properly)
