### PR TITLE
Replace a Google-internal link with a public one.

### DIFF
--- a/src/site/content/en/blog/web-bundles/index.md
+++ b/src/site/content/en/blog/web-bundles/index.md
@@ -39,7 +39,7 @@ images, or stylesheets.
 
  Web Bundles, more formally known as [Bundled HTTP
  Exchanges](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html),
- are part of the [Web Packaging](https://goto.google.com/webpackaging-one-pager)
+ are part of the [Web Packaging](https://github.com/WICG/webpackage)
  proposal.
 
 <figure class="w-figure">


### PR DESCRIPTION
The "Web Packaging proposal" has a public home at https://github.com/WICG/webpackage.

Fixes #3271.