### PR TITLE
Fix wording

### DIFF
--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -357,7 +357,7 @@ the article on [custom metrics](/custom-metrics/#element-timing-api).
 
 ## How to improve LCP
 
-LCP is primarily affected by four factors:
+LCP is primarily affected by the following factors:
 
 * Slow server response times
 * Render-blocking JavaScript and CSS

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -357,7 +357,7 @@ the article on [custom metrics](/custom-metrics/#element-timing-api).
 
 ## How to improve LCP
 
-LCP is primarily affected by three factors:
+LCP is primarily affected by four factors:
 
 * Slow server response times
 * Render-blocking JavaScript and CSS


### PR DESCRIPTION
Four factors are listed but the text says "three factors". This PR replaces "three" with "four".