### PR TITLE
List the CrUX Dash guide in the blog

### DIFF
--- a/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
@@ -9,9 +9,10 @@ description: |
   dashboards on top of big data sources, like the Chrome UX Report. In this
   guide, learn how to create your own custom CrUX Dashboard to track an origin's
   user experience.
-date: 2020-06-12
+date: 2020-06-19
 tags:
   - performance
+  - blog
 ---
 
 [Data Studio](https://marketingplatform.google.com/about/data-studio/) is a

--- a/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
+++ b/src/site/content/en/fast/chrome-ux-report-data-studio-dashboard/index.md
@@ -9,7 +9,7 @@ description: |
   dashboards on top of big data sources, like the Chrome UX Report. In this
   guide, learn how to create your own custom CrUX Dashboard to track an origin's
   user experience.
-date: 2020-06-19
+date: 2020-06-22
 tags:
   - performance
   - blog


### PR DESCRIPTION
Changes proposed in this pull request:

- Add the `blog` tag to make this guide appear in the blog
- Update the date to today
