### PR TITLE
Make EventStore a bit more stateless. Get LiveStream working with unistore.

### DIFF
--- a/src/lib/components/LivestreamContainer/_styles.scss
+++ b/src/lib/components/LivestreamContainer/_styles.scss
@@ -1,4 +1,5 @@
 @import '../../../styles/settings/colors';
+@import '../../../styles/settings/type';
 @import '../../../styles/tools/breakpoints';
 
 web-livestream-container {
@@ -23,5 +24,26 @@ web-livestream-container {
   .w-youtube-chat {
     height: 100%;
     width: 100%;
+  }
+
+  .w-youtube-disabled-chat {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+  }
+
+  .w-youtube-disabled-chat__container {
+    max-width: 250px;
+    color: $GREY_700;
+  }
+
+  .w-youtube-disabled-chat__link {
+    display: block;
+    font-family: $HEADLINE_FONT;
+    font-weight: $FONT_WEIGHT_MEDIUM;
+    font-size: 14px;
+    margin-top: 16px;
   }
 }

--- a/src/lib/components/LivestreamContainer/index.js
+++ b/src/lib/components/LivestreamContainer/index.js
@@ -7,14 +7,14 @@ class LivestreamContainer extends BaseStateElement {
   static get properties() {
     return {
       videoId: {type: String},
-      isChatEnabled: {type: Boolean},
+      isChatActive: {type: Boolean},
     };
   }
 
   constructor() {
     super();
     this.videoId = null;
-    this.isChatEnabled = true;
+    this.isChatActive = true;
   }
 
   render() {
@@ -23,6 +23,7 @@ class LivestreamContainer extends BaseStateElement {
     }
 
     // prettier-ignore
+    /* eslint-disable indent */
     return html`
       <div class="web-livestream-container__col-yt">
         <div class="w-youtube">
@@ -37,11 +38,30 @@ class LivestreamContainer extends BaseStateElement {
       </div>
 
       <div class="web-livestream-container__col-chat">
-        <iframe
-          class="w-youtube-chat"
-          src="https://www.youtube.com/live_chat?v=${this.videoId}&amp;embed_domain=${location.hostname}"
-          frameborder="0"
-        ></iframe>
+        ${this.isChatActive ?
+          html`
+            <iframe
+              class="w-youtube-chat"
+              src="https://www.youtube.com/live_chat?v=${this.videoId}&amp;embed_domain=${location.hostname}"
+              frameborder="0"
+            ></iframe>
+          ` :
+          html`
+            <div class="w-youtube-disabled-chat">
+              <div class="w-youtube-disabled-chat__container">
+                <div>
+                  Live Chat is currently disabled. Please head to YouTube and
+                  ask your questions in the comments on the video.
+                </div>
+                <a
+                  class="w-youtube-disabled-chat__link" 
+                  href="https://www.youtube.com/watch?v=${this.videoId}">
+                  Go to YouTube
+                </a>
+              </div>
+            </div>
+          `
+        }
       </div>
     `;
   }
@@ -49,12 +69,14 @@ class LivestreamContainer extends BaseStateElement {
   /**
    * @param {!Object<string, *>} state
    */
-  onStateChanged() {
-    // Example implementation depending on what we end up putting in our
-    // state object:
-    // const {videoId, isChatEnabled} = state;
-    // this.videoId = videoId;
-    // this.isChatEnabled = isChatEnabled;
+  onStateChanged({activeEventDay}) {
+    if (!activeEventDay) {
+      return;
+    }
+
+    const {videoId, isChatActive} = activeEventDay;
+    this.videoId = videoId;
+    this.isChatActive = isChatActive;
   }
 }
 

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -62,7 +62,6 @@ const initialState = {
   // Data for the current web.dev/LIVE event.
   eventDays: [],
   activeEventDay: null, // livestream shown for this day
-  isChatActive: false, // chat active for this day
 };
 
 let store;


### PR DESCRIPTION
Fixes #3143, Fixes #3074

I tested the following scenarios:

- [x] Before day 1, video shows day 1, chat is disabled
- [x] Before day 1, chat transitions from disabled -> active
- [x] Refresh during day 1, video and chat are active
- [x] After day 1 video buffer, video is marked isComplete
- [x] User leaves their tab open:
  - [x] After day 1 chat buffer, chat is disabled
  - [x] After day 1 video buffer, video transitions to day 2 (not what we intended, but also totally fine).
  - [x] After day 2 video buffer start, video transitions to day 2
  - [x] After day 2 chat buffer start, chat transitions to day 2
- [x] Refresh during day 2, day 2 video and chat are active
- [x] After day 3, chat is disabled, video stays on day 3 as a fallback.

The `isChatActive` code wasn't working because day 3 in the loop was setting `this._isChatActive` to false which then updated it in the store. So I changed some of the code in EventStore to make it always call setState and to make it a bit more stateless. Genuinely not trying to step on toes or anything 😅  I found it made it easier for me to reason through the code if it always called setState and if it left the decision of whether or not to render up to the components themselves. I don't think lit triggers a render if you set the same value over and over so I didn't need to add any guards to the elements. I watched the iframe src's in the elements panel and they stayed the same every tick.

Changes proposed in this pull request:

- Set the update interval to 1 minute instead of 5. Just in case folks have the tab open before the event and are wondering why it hasn't started yet.
- Adds disabled chat state to livestream
- Connects LivestreamContainer to unistore