### PR TITLE
Control video tiles carousel

### DIFF
--- a/src/lib/components/EventCarousel/index.js
+++ b/src/lib/components/EventCarousel/index.js
@@ -63,7 +63,9 @@ class EventCarousel extends BaseStateElement {
               height="110"
             />
           </div>
-          <div class="w-event-carousel__description">${title} &mdash; All sessions</div>
+          <div class="w-event-carousel__description">
+            ${title} &mdash; All sessions
+          </div>
         </a>
       `;
     };

--- a/src/lib/components/EventCarousel/index.js
+++ b/src/lib/components/EventCarousel/index.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BaseStateElement} from '../BaseStateElement';
+import {html} from 'lit-element';
+
+/**
+ * @fileoverview A carousel manager which controls the video links for the top
+ * carousel of the event page.
+ *
+ * Note that this element just uses global styles for the Live page.
+ */
+
+class EventCarousel extends BaseStateElement {
+  static get properties() {
+    return {
+      eventDays: Object,
+    };
+  }
+
+  render() {
+    const renderDay = (day) => {
+      const {isComplete, videoId, title} = day;
+      const show = isComplete && videoId;
+
+      if (!show) {
+        return html`
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail"></div>
+            <div class="w-event-carousel__description">
+              ${title} &mdash; Coming soon
+            </div>
+          </div>
+        `;
+      }
+
+      return html`
+        <a
+          class="w-event-carousel__day"
+          href="https://youtu.be/${videoId}"
+          target="_blank"
+        >
+          <div class="w-event-carousel__thumbnail">
+            <img
+              alt="${title}"
+              src="https://img.youtube.com/vi/${videoId}/default.jpg"
+              width="178"
+              height="110"
+            />
+          </div>
+          <div class="w-event-carousel__description">${title}</div>
+        </a>
+      `;
+    };
+
+    return html`${this.eventDays.map(renderDay)}`;
+  }
+
+  onStateChanged({eventDays}) {
+    this.eventDays = eventDays;
+  }
+}
+
+customElements.define('web-event-carousel', EventCarousel);

--- a/src/lib/components/EventCarousel/index.js
+++ b/src/lib/components/EventCarousel/index.js
@@ -63,7 +63,7 @@ class EventCarousel extends BaseStateElement {
               height="110"
             />
           </div>
-          <div class="w-event-carousel__description">${title}</div>
+          <div class="w-event-carousel__description">${title} &mdash; All sessions</div>
         </a>
       `;
     };

--- a/src/lib/components/EventCarousel/index.js
+++ b/src/lib/components/EventCarousel/index.js
@@ -47,6 +47,8 @@ class EventCarousel extends BaseStateElement {
         `;
       }
 
+      // We use "maxresdefault" as the other images have black bars as they try
+      // to fit 4:3 rendering.
       return html`
         <a
           class="w-event-carousel__day"
@@ -56,7 +58,7 @@ class EventCarousel extends BaseStateElement {
           <div class="w-event-carousel__thumbnail">
             <img
               alt="${title}"
-              src="https://img.youtube.com/vi/${videoId}/default.jpg"
+              src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg"
               width="178"
               height="110"
             />

--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -177,21 +177,8 @@ class EventSchedule extends HTMLElement {
     this._tabsElement = null;
   }
 
-  onStateChanged({eventDays, activeEventDay}) {
+  onStateChanged({activeEventDay}) {
     this._activeEventDay = activeEventDay;
-
-    eventDays.forEach(({isComplete, videoId}, index) => {
-      const el = this.querySelector(`[data-index="${index}"]`);
-      if (!el) {
-        return;
-      }
-      // TODO(samthor): Update description ("Coming soon" vs "All sessions")
-      if (isComplete) {
-        el.setAttribute('href', 'https://youtu.be/' + videoId);
-      } else {
-        el.removeAttribute('href');
-      }
-    });
 
     // This relies on the event data being in the same shape as the rendered
     // tabs, which is pretty safe, since it comes from the same source.

--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -177,11 +177,21 @@ class EventSchedule extends HTMLElement {
     this._tabsElement = null;
   }
 
-  onStateChanged({activeEventDay}) {
-    if (this._activeEventDay === activeEventDay) {
-      return;
-    }
+  onStateChanged({eventDays, activeEventDay}) {
     this._activeEventDay = activeEventDay;
+
+    eventDays.forEach(({isComplete, videoId}, index) => {
+      const el = this.querySelector(`[data-index="${index}"]`);
+      if (!el) {
+        return;
+      }
+      // TODO(samthor): Update description ("Coming soon" vs "All sessions")
+      if (isComplete) {
+        el.setAttribute('href', 'https://youtu.be/' + videoId);
+      } else {
+        el.removeAttribute('href');
+      }
+    });
 
     // This relies on the event data being in the same shape as the rendered
     // tabs, which is pretty safe, since it comes from the same source.

--- a/src/lib/components/EventStore/index.js
+++ b/src/lib/components/EventStore/index.js
@@ -53,6 +53,7 @@ class EventStore extends HTMLElement {
   _update() {
     const now = +new Date() + this._timeOffset;
 
+    let daysPropertiesChange = false;
     let activeDay = null;
 
     // If there was a previously active day (because the user has their tab open for a long time),
@@ -88,7 +89,10 @@ class EventStore extends HTMLElement {
 
       // Are we past the completion of this day? This allows the YT link to show up.
       const isComplete = now >= activeEnd;
-      day.isComplete = isComplete;
+      if (day.isComplete !== isComplete) {
+        day.isComplete = isComplete;
+        daysPropertiesChange = true;
+      }
       if (!isComplete && nextPendingDay === null) {
         // The first time we find an incomplete day (e.g., tomorrow's event day), mark it as the
         // next pending day we use as the active fallback.
@@ -103,7 +107,10 @@ class EventStore extends HTMLElement {
 
       // Is this the active day for chat (within the actual time range)?
       const isChatActive = now >= chatStart && now < chatEnd;
-      day.isChatActive = isChatActive;
+      if (day.isChatActive !== isChatActive) {
+        day.isChatActive = isChatActive;
+        daysPropertiesChange = true;
+      }
     }
 
     // If there was no previously active day, then choose the upcoming day.
@@ -112,6 +119,12 @@ class EventStore extends HTMLElement {
       activeDay = nextPendingDay
         ? nextPendingDay
         : this._days[this._days.length - 1];
+    }
+
+    // If there was a property change on any particular day, change the Array
+    // reference so listeners can use simple comparisons to force a refresh.
+    if (daysPropertiesChange) {
+      this._days = this._days.slice();
     }
 
     store.setState({

--- a/src/lib/pages/live.js
+++ b/src/lib/pages/live.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for web.dev LIVE page.
  */
 
+import '../components/EventCarousel';
 import '../components/EventMap';
 import '../components/EventSchedule';
 import '../components/EventStore';

--- a/src/lib/utils/time-offset.js
+++ b/src/lib/utils/time-offset.js
@@ -31,6 +31,7 @@ export function getTimeOffset(raw) {
     'wdl-day1': '2020-06-30T16:02Z',
     'wdl-preday2': '2020-07-01T10:59Z', // before 1hr buffer
     'wdl-day2': '2020-07-01T12:00Z',
+    'wdl-day3': '2020-07-02T07:30Z',
   };
 
   raw = overrides[raw] || raw;

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -124,7 +124,7 @@ const days = [
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: 'ukVbZUPkxx0',
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -404,7 +404,7 @@ const communityEvents = {
 };
 
 module.exports = {
-  isDuringEvent: true,
+  isDuringEvent: false,
   isPostEvent: false,
   days,
   communityEvents,

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -124,7 +124,7 @@ const days = [
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: 'T0fAznO1wA8',
+    videoId: 'ukVbZUPkxx0',
     sessions: [
       {
         speaker: 'dalmaer',

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -124,7 +124,7 @@ const days = [
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: null,
+    videoId: 'T0fAznO1wA8',
     sessions: [
       {
         speaker: 'dalmaer',
@@ -404,8 +404,7 @@ const communityEvents = {
 };
 
 module.exports = {
-  isPreEvent: true,
-  isDuringEvent: false,
+  isDuringEvent: true,
   isPostEvent: false,
   days,
   communityEvents,

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -113,29 +113,26 @@ module.exports = (days, authorsCollection, showCarousel) => {
     `;
   };
 
-  const renderCarouselDay = ({title, videoId}, index) => {
-    const previewImage = videoId
-      ? html`<img
-          src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg"
-        />`
-      : '';
+  const renderCarouselDay = ({title}) => {
     return html`
-      <a data-index="${index}" class="w-event-carousel__day">
-        <div class="w-event-carousel__thumbnail">${previewImage}</div>
+      <a class="w-event-carousel__day">
+        <div class="w-event-carousel__thumbnail"></div>
         <div class="w-event-carousel__description">${title}</div>
       </a>
     `;
   };
 
+  // If we're showing the carousel, then include a set of dummy elements with the same number of
+  // days. These are then updated by the web-event-carousel element.
   const carousel = showCarousel
-    ? html` <div class="w-event-carousel">
+    ? html` <web-event-carousel class="w-event-carousel">
         ${days.map(renderCarouselDay)}
-      </div>`
+      </web-event-carousel>`
     : '';
 
   return html`
+    ${carousel}
     <web-event-schedule>
-      ${carousel}
       <web-tabs class="w-event-tabs unresolved" label="schedule">
         ${days.map(renderDay)}
       </web-tabs>

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -22,9 +22,10 @@ const AuthorsDate = require('./AuthorsDate');
 /**
  * @param {!Array<{title: string, from: !Date, sessions: !Array<any>}>} days
  * @param {Object.<string, Author>} authorsCollection
+ * @param {boolean} showCarousel
  * @return {string}
  */
-module.exports = (days, authorsCollection) => {
+module.exports = (days, authorsCollection, showCarousel) => {
   // Find the default day to show, as a very basic non-JS fallback. Pick the
   // first day where the build time is before the end time of the sessions.
   // This isn't a very good fallback as our build happens at minimum of once per
@@ -112,8 +113,24 @@ module.exports = (days, authorsCollection) => {
     `;
   };
 
+  const renderCarouselDay = ({title, videoId}, index) => {
+    const previewImage = videoId ? html`<img src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg"` : '';
+    return html`
+<a data-index=${index} class="w-event-carousel__day">
+  <div class="w-event-carousel__thumbnail">${previewImage}</div>
+  <div class="w-event-carousel__description">${title}</div>
+</a>
+    `;
+  };
+
+  const carousel = showCarousel ? html`
+    <div class="w-event-carousel">
+      ${days.map(renderCarouselDay)}
+    </div>` : '';
+
   return html`
     <web-event-schedule>
+      ${carousel} 
       <web-tabs class="w-event-tabs unresolved" label="schedule">
         ${days.map(renderDay)}
       </web-tabs>

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -22,10 +22,9 @@ const AuthorsDate = require('./AuthorsDate');
 /**
  * @param {!Array<{title: string, from: !Date, sessions: !Array<any>}>} days
  * @param {Object.<string, Author>} authorsCollection
- * @param {boolean} showCarousel
  * @return {string}
  */
-module.exports = (days, authorsCollection, showCarousel) => {
+module.exports = (days, authorsCollection) => {
   // Find the default day to show, as a very basic non-JS fallback. Pick the
   // first day where the build time is before the end time of the sessions.
   // This isn't a very good fallback as our build happens at minimum of once per
@@ -113,25 +112,7 @@ module.exports = (days, authorsCollection, showCarousel) => {
     `;
   };
 
-  const renderCarouselDay = ({title}) => {
-    return html`
-      <a class="w-event-carousel__day">
-        <div class="w-event-carousel__thumbnail"></div>
-        <div class="w-event-carousel__description">${title}</div>
-      </a>
-    `;
-  };
-
-  // If we're showing the carousel, then include a set of dummy elements with the same number of
-  // days. These are then updated by the web-event-carousel element.
-  const carousel = showCarousel
-    ? html` <web-event-carousel class="w-event-carousel">
-        ${days.map(renderCarouselDay)}
-      </web-event-carousel>`
-    : '';
-
   return html`
-    ${carousel}
     <web-event-schedule>
       <web-tabs class="w-event-tabs unresolved" label="schedule">
         ${days.map(renderDay)}

--- a/src/site/_includes/components/EventTable.js
+++ b/src/site/_includes/components/EventTable.js
@@ -114,23 +114,28 @@ module.exports = (days, authorsCollection, showCarousel) => {
   };
 
   const renderCarouselDay = ({title, videoId}, index) => {
-    const previewImage = videoId ? html`<img src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg"` : '';
+    const previewImage = videoId
+      ? html`<img
+          src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg"
+        />`
+      : '';
     return html`
-<a data-index=${index} class="w-event-carousel__day">
-  <div class="w-event-carousel__thumbnail">${previewImage}</div>
-  <div class="w-event-carousel__description">${title}</div>
-</a>
+      <a data-index="${index}" class="w-event-carousel__day">
+        <div class="w-event-carousel__thumbnail">${previewImage}</div>
+        <div class="w-event-carousel__description">${title}</div>
+      </a>
     `;
   };
 
-  const carousel = showCarousel ? html`
-    <div class="w-event-carousel">
-      ${days.map(renderCarouselDay)}
-    </div>` : '';
+  const carousel = showCarousel
+    ? html` <div class="w-event-carousel">
+        ${days.map(renderCarouselDay)}
+      </div>`
+    : '';
 
   return html`
     <web-event-schedule>
-      ${carousel} 
+      ${carousel}
       <web-tabs class="w-event-tabs unresolved" label="schedule">
         ${days.map(renderDay)}
       </web-tabs>

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -97,26 +97,8 @@ date: 2020-06-31
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">
       {% if event.isDuringEvent or event.isPostEvent %}
-        <div class="w-event-carousel">
-          <a href="#" class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-              <img src="" alt="" width="178" height="110">
-            </div>
-            <div>Day 1 — All sessions</div>
-          </a>
-          <div class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-            </div>
-            <div>Day 2 — Coming soon</div>
-          </div>
-          <div class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-            </div>
-            <div>Day 3 — Coming soon</div>
-          </div>
-        </div>
       {% endif %}
-      {% EventTable event.days, collections.authors %}
+      {% EventTable event.days, collections.authors, event.isDuringEvent or event.isPostEvent %}
     </div>
 
   </section>

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -97,8 +97,24 @@ date: 2020-06-31
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">
       {% if event.isDuringEvent or event.isPostEvent %}
+        <web-event-carousel class="w-event-carousel">
+          {# These just exist as dummy HTML elements for the first render. They're replaced by the
+             web-event-carousel CE when it loads. #}
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail"></div>
+            <div class="w-event-carousel__description">Day 1</div>
+          </div>
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail"></div>
+            <div class="w-event-carousel__description">Day 2</div>
+          </div>
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail"></div>
+            <div class="w-event-carousel__description">Day 3</div>
+          </div>
+        </web-event-carousel>
       {% endif %}
-      {% EventTable event.days, collections.authors, event.isDuringEvent or event.isPostEvent %}
+      {% EventTable event.days, collections.authors %}
     </div>
 
   </section>

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -253,7 +253,7 @@
 .w-event-carousel {
   display: flex;
   overflow-x: scroll;
-  padding-bottom: 12px;
+  margin-bottom: 12px;
   // Firefox only
   // sass-lint:disable no-misspelled-properties
   scrollbar-color: $GREY_500;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -285,6 +285,13 @@
   &:focus {
     outline: 0;
     opacity: .9;
+    text-decoration: none;
+  }
+
+  &:focus {
+    .w-event-carousel__description {
+      outline: 1px solid $FOCUS_COLOR;
+    }
   }
 
   &:last-child {

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -253,6 +253,7 @@
 .w-event-carousel {
   display: flex;
   overflow-x: scroll;
+  padding-bottom: 12px;
   // Firefox only
   // sass-lint:disable no-misspelled-properties
   scrollbar-color: $GREY_500;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -291,7 +291,7 @@
 
   &:focus {
     .w-event-carousel__description {
-      outline: 1px solid $FOCUS_COLOR;
+      box-shadow: inset 0 0 0 1px $FOCUS_COLOR;
     }
   }
 
@@ -482,4 +482,3 @@ web-tabs.w-event-tabs {
   vertical-align: middle;
   margin-right: 16px;
 }
-


### PR DESCRIPTION
Adds `<web-event-carousel>` to control whether the YouTube elements are clickable and have a thumbnail.

Shows enabled if there's a valid videoId and if the day is complete.