### PR TITLE
Don't let carousel parent break layout.

### DIFF
--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -208,8 +208,12 @@
 }
 
 .w-event-section__column-right {
-  max-width: 512px;
+  max-width: 100%;
   padding: 0 8px;
+
+  @media (min-width: 512px) {
+    max-width: 512px;
+  }
 
   &.w-event-section__column-right__schedule {
     margin-top: 58px;


### PR DESCRIPTION
I noticed the carousel was causing the entire page to horizontally scroll on mobile because the parent had max-width: 512px. This limits that max-width to when the viewport is actually 512px.

Changes proposed in this pull request:

- Add specific media query for 512px right column, otherwise set it to 100%