### PR TITLE
explode on missing author posts/social

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -129,5 +129,13 @@ module.exports = (collections) => {
     authors[key] = author;
   });
 
+  // Only complain that authors are invalid if we've got any posts *at all*
+  // (we can do weird Eleventy builds with no posts, don't complain here).
+  const isRegularBuild = Boolean(allPosts.length);
+  if (isRegularBuild && invalidAuthors.length) {
+    const s = invalidAuthors.join(',');
+    throw new Error(`authors [${s}] have no posts and/or Twitter information`);
+  }
+
   return authors;
 };

--- a/src/site/_data/authorsData.json
+++ b/src/site/_data/authorsData.json
@@ -132,6 +132,7 @@
       "unit": "Chrome"
     },
     "country": "US",
+    "twitter": "shane_exterkamp",
     "github": "exterkamp",
     "description": {
       "en": "Shane is a SWE on Lighthouse"


### PR DESCRIPTION
Currently we just log loudly that someone has no posts and no social information.

Instead we should throw. Or possibly not. But the warning is annoying and doesn't help anyone.