### PR TITLE
Update styles for isPreEvent, isDuringEvent, and isPostEvent phases

### DIFF
--- a/src/lib/components/EventMap/_styles.scss
+++ b/src/lib/components/EventMap/_styles.scss
@@ -32,7 +32,7 @@ web-event-map {
   select {
     color: $GREY_700;
     font-size: 16px;
-    margin: 8px 0;
-    width: 140px;
+    margin: -14px 0 8px;
+    width: initial;
   }
 }

--- a/src/lib/components/LivestreamContainer/_styles.scss
+++ b/src/lib/components/LivestreamContainer/_styles.scss
@@ -3,6 +3,8 @@
 @import '../../../styles/tools/breakpoints';
 
 web-livestream-container {
+  background-color: $WHITE;
+  
   .web-livestream-container__col-yt {
     flex-basis: 880px;
   }
@@ -14,6 +16,10 @@ web-livestream-container {
 
     @include bp(md) {
       display: block;
+    }
+
+    @media (hover: none) {
+      display: none;
     }
   }
 

--- a/src/lib/components/LivestreamContainer/_styles.scss
+++ b/src/lib/components/LivestreamContainer/_styles.scss
@@ -4,15 +4,25 @@
 
 web-livestream-container {
   background-color: $WHITE;
+  border-left: 1px solid $GREY_300;
+  border-right: 1px solid $GREY_300;
+  display: flex;
+  margin: auto;
+  max-width: 1600px;
   
   .web-livestream-container__col-yt {
-    flex-basis: 880px;
+    max-width: 100%;
+    align-items: center;
+    background-color: $GREY_50;
+    display: flex;
+    flex: 1;
   }
 
   .web-livestream-container__col-chat {
-    flex-basis: 400px;
     border-left: 1px solid $GREY_300;
     display: none;
+    min-height: 600px;
+    width: 400px;
 
     @include bp(md) {
       display: block;
@@ -21,10 +31,6 @@ web-livestream-container {
     @media (hover: none) {
       display: none;
     }
-  }
-
-  .w-youtube {
-    height: 100%;
   }
 
   .w-youtube-chat {
@@ -40,7 +46,7 @@ web-livestream-container {
     justify-content: center;
   }
 
-  .w-youtube-disabled-chat__container {
+  .w-youtube-disabled-chat__text {
     max-width: 250px;
     color: $GREY_700;
   }

--- a/src/lib/components/LivestreamContainer/index.js
+++ b/src/lib/components/LivestreamContainer/index.js
@@ -49,7 +49,7 @@ class LivestreamContainer extends BaseStateElement {
           ` :
           html`
             <div class="w-youtube-disabled-chat">
-              <div class="w-youtube-disabled-chat__container">
+              <div class="w-youtube-disabled-chat__text">
                 <div>
                   Live Chat is currently disabled. Please head to YouTube and
                   ask your questions in the comments on the video.

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -404,6 +404,7 @@ const communityEvents = {
 };
 
 module.exports = {
+  isPreEvent: true,
   isDuringEvent: false,
   isPostEvent: false,
   days,

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -405,8 +405,8 @@ const communityEvents = {
 
 module.exports = {
   isPreEvent: false,
-  isDuringEvent: true,
-  isPostEvent: false,
+  isDuringEvent: false,
+  isPostEvent: true,
   days,
   communityEvents,
 };

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -23,7 +23,7 @@ const days = [
     title: 'Day 1',
     when: '2020-06-30T16:00Z', // 9am PDT (-7)
     duration: 3 * 60, // minutes
-    videoId: null,
+    videoId: 'oHHSSJDJ4oo',
     sessions: [
       {
         speaker: 'dalmaer',
@@ -124,7 +124,7 @@ const days = [
     title: 'Day 2',
     when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: null,
+    videoId: 'k6TWO-ESC6A',
     sessions: [
       {
         speaker: 'dalmaer',
@@ -244,7 +244,7 @@ const days = [
     title: 'Day 3',
     when: '2020-07-02T07:30Z', // 1pm IST (+5:30)
     duration: 3 * 60, // minutes
-    videoId: null,
+    videoId: 'cmGr0RszHc8',
     sessions: [
       {
         speaker: 'dalmaer',
@@ -404,8 +404,8 @@ const communityEvents = {
 };
 
 module.exports = {
-  isPreEvent: true,
-  isDuringEvent: false,
+  isPreEvent: false,
+  isDuringEvent: true,
   isPostEvent: false,
   days,
   communityEvents,

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -21,9 +21,9 @@
 const days = [
   {
     title: 'Day 1',
-    when: '2020-06-23T16:00Z', // 9am PDT (-7)
+    when: '2020-06-30T16:00Z', // 9am PDT (-7)
     duration: 3 * 60, // minutes
-    videoId: 'oHHSSJDJ4oo',
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -122,9 +122,9 @@ const days = [
   },
   {
     title: 'Day 2',
-    when: '2020-06-23T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
+    when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: 'h6fcK_fRYaI',
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -242,9 +242,9 @@ const days = [
   },
   {
     title: 'Day 3',
-    when: '2020-06-24T07:30Z', // 1pm IST (+5:30)
-    duration: 3 * 60, // minutes
-    videoId: 'Da-2h2B4faU',
+    when: '2020-07-02T07:30Z', // 1pm IST (+5:30)
+    duration: 4 * 60, // minutes
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -404,9 +404,8 @@ const communityEvents = {
 };
 
 module.exports = {
-  isPreEvent: false,
   isDuringEvent: false,
-  isPostEvent: true,
+  isPostEvent: false,
   days,
   communityEvents,
 };

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -23,7 +23,7 @@ const days = [
     title: 'Day 1',
     when: '2020-06-30T16:00Z', // 9am PDT (-7)
     duration: 3 * 60, // minutes
-    videoId: null,
+    videoId: 'ukVbZUPkxx0',
     sessions: [
       {
         speaker: 'dalmaer',

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -242,9 +242,9 @@ const days = [
   },
   {
     title: 'Day 3',
-    when: '2020-06-25T07:30Z', // 1pm IST (+5:30)
+    when: '2020-06-24T07:30Z', // 1pm IST (+5:30)
     duration: 3 * 60, // minutes
-    videoId: 'sNhhvQGsMEc',
+    videoId: 'Da-2h2B4faU',
     sessions: [
       {
         speaker: 'dalmaer',

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -21,7 +21,7 @@
 const days = [
   {
     title: 'Day 1',
-    when: '2020-06-30T16:00Z', // 9am PDT (-7)
+    when: '2020-06-23T16:00Z', // 9am PDT (-7)
     duration: 3 * 60, // minutes
     videoId: 'oHHSSJDJ4oo',
     sessions: [
@@ -122,9 +122,9 @@ const days = [
   },
   {
     title: 'Day 2',
-    when: '2020-07-01T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
+    when: '2020-06-23T12:00Z', // 12pm GMT/UTC (+0), note UK time will be 1pm
     duration: 3 * 60, // minutes
-    videoId: 'k6TWO-ESC6A',
+    videoId: 'h6fcK_fRYaI',
     sessions: [
       {
         speaker: 'dalmaer',
@@ -242,9 +242,9 @@ const days = [
   },
   {
     title: 'Day 3',
-    when: '2020-07-02T07:30Z', // 1pm IST (+5:30)
+    when: '2020-06-25T07:30Z', // 1pm IST (+5:30)
     duration: 3 * 60, // minutes
-    videoId: 'cmGr0RszHc8',
+    videoId: 'sNhhvQGsMEc',
     sessions: [
       {
         speaker: 'dalmaer',

--- a/src/site/_data/event.js
+++ b/src/site/_data/event.js
@@ -23,7 +23,7 @@ const days = [
     title: 'Day 1',
     when: '2020-06-30T16:00Z', // 9am PDT (-7)
     duration: 3 * 60, // minutes
-    videoId: 'ukVbZUPkxx0',
+    videoId: null,
     sessions: [
       {
         speaker: 'dalmaer',
@@ -404,6 +404,7 @@ const communityEvents = {
 };
 
 module.exports = {
+  isPreEvent: true,
   isDuringEvent: false,
   isPostEvent: false,
   days,

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -10,7 +10,7 @@ date: 2020-06-31
 <div class="w-live-landing-page">
 
   {% if event.isDuringEvent %}
-    <section class="w-livestream-section">
+    <section class="w-livestream-section w-live-flow">
       <web-livestream-container>
         <div class="web-livestream-container__skeleton-yt"></div>
         <div class="web-livestream-container__skeleton-chat"></div>
@@ -23,24 +23,23 @@ date: 2020-06-31
   {% endif %}
 
   {% if event.isPreEvent or event.isPostEvent %}
-    <div class="w-live-top">
-      <section class="w-event-section">
-
-        <div class="w-event-section__column-left w-event-heading">
-          <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
-            <video width="156" height="72" autoplay muted loop playsinline>
-              <source src="live.mp4" type="video/mp4" />
-              <img src="live.png" alt="live" />
-            </video>
-          </h1>
-          <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
+    <div class="w-hero-overflow w-live-flow">
+      <section class="w-event-section w-hero-section">
+        <div class="w-event-section__column-left">
+          <div class="w-event-heading">
+            <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
+              <video width="156" height="72" autoplay muted loop playsinline>
+                <source src="live.mp4" type="video/mp4" />
+                <img src="live.png" alt="live" />
+              </video>
+            </h1>
+            <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
+          </div>
         </div>
-
         <div class="w-event-section__column-head w-event-hero">
           <img src="hero.png" alt="" />
         </div>
-
-        <div class="w-event-section__column-right">
+        <div class="w-event-section__column-right w-event-section__column-right--extra-padding">
           <h2 class="w-mt--non">
             Bringing web developers together, from home
           </h2>
@@ -51,7 +50,6 @@ date: 2020-06-31
           <p>
             Join Google's Web Platform team, from the comfort of your homes, to celebrate our community's actions, learn modern web techniques and connect with each other.
           </p>
-
           <div class="w-event-buttons">
             <a class="w-button w-button--primary gc-analytics-event" data-category="web.dev" data-label="scroll-to-subscribe" data-action="click" href="#subscribe">
               Get notified
@@ -77,16 +75,13 @@ date: 2020-06-31
               </a>
             </div>
           </div>
-
         </div>
-
       </section>
     </div>
-    <hr />
+    <hr class="w-live-flow">
   {% endif %}
 
-  <section id="schedule" class="w-event-section">
-
+  <section id="schedule" class="w-event-section w-schedule-section w-live-flow">
     {% if event.isPreEvent %}
       <div class="w-event-section__column-left">
         <h3 class="w-mt--non">What to expect</h3>
@@ -98,29 +93,27 @@ date: 2020-06-31
       </div>
     {% endif %}
 
+    {% if event.isDuringEvent or event.isPostEvent %}
+      <web-event-carousel class="w-event-carousel w-event-carousel--mobile-only">
+        {# These just exist as dummy HTML elements for the first render. They're replaced by the
+            web-event-carousel CE when it loads. #}
+        <div class="w-event-carousel__day">
+          <div class="w-event-carousel__thumbnail"></div>
+          <div class="w-event-carousel__description">Day 1</div>
+        </div>
+        <div class="w-event-carousel__day">
+          <div class="w-event-carousel__thumbnail"></div>
+          <div class="w-event-carousel__description">Day 2</div>
+        </div>
+        <div class="w-event-carousel__day">
+          <div class="w-event-carousel__thumbnail"></div>
+          <div class="w-event-carousel__description">Day 3</div>
+        </div>
+      </web-event-carousel>
+    {% endif %}
+
     {% if event.isDuringEvent %}
       <div class="w-event-section__column-left">
-
-        {# TODO: Update with Sam's carousel when it lands #}
-        <div class="w-event-carousel">
-          <a href="#" class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-              <img src="" alt="" width="178" height="110">
-            </div>
-            <div>Day 1 — All sessions</div>
-          </a>
-          <div class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-            </div>
-            <div>Day 2 — Coming soon</div>
-          </div>
-          <div class="w-event-carousel__day">
-            <div class="w-event-carousel__thumbnail">
-            </div>
-            <div>Day 3 — Coming soon</div>
-          </div>
-        </div>
-
         <div class="w-event-heading w-event-heading--smaller">
           <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
             <video width="156" height="72" autoplay muted loop playsinline>
@@ -138,7 +131,12 @@ date: 2020-06-31
           on demand and leave your questions in the Comments section on YouTube
           and we'll try our best to respond over the three days of the event.
         </p>
-        <button class="w-feedback-button w-button w-button--primary">Share Feedback</button>
+        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdkWh94xheuR3Y_p0z6GML0AkdWLCa767KhFXBUPM3VI9-jCA/viewform" class="w-feedback-button w-button w-button--primary">
+          <svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H6l-4 4 .01-18c0-1.1.89-2 1.99-2zm0 14h16V4H4v12zm6.5-2H18v-2h-5.5l-2 2zm3.86-6.58c.2.2.2.51 0 .71L8.47 14H6v-2.47l5.88-5.88c.2-.2.51-.2.71 0l1.77 1.77z" fill="#fff"/>
+          </svg>
+          Share Feedback
+        </a>
         <a href="/community-guidelines/" class="w-event-link">Community guidelines</a>
       </div>
     {% endif %}
@@ -167,14 +165,11 @@ date: 2020-06-31
       {% endif %}
       {% EventTable event.days, collections.authors %}
     </div>
-
   </section>
-
-  <hr />
+  <hr class="w-live-flow">
 
   {% if event.isPostEvent %}
-    <section id="map" class="w-event-section">
-
+    <section id="map" class="w-event-section w-live-flow">
       <div class="w-event-section__column-left">
         <h3 class="w-mt--non">
           <svg class="w-event-icon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-.61.08-1.21.21-1.78L8.99 15v1c0 1.1.9 2 2 2v1.93C7.06 19.43 4 16.07 4 12zm11.99 4c.9 0 1.64.59 1.9 1.4A7.991 7.991 0 0020 12c0-3.35-2.08-6.23-5.01-7.41V5c0 1.1-.9 2-2 2h-2v2c0 .55-.45 1-1 1h-2v2h6c.55 0 1 .45 1 1v3h1z" fill="#5F6368"/></svg>
@@ -190,24 +185,22 @@ date: 2020-06-31
         <web-event-map key={{site.maps.apiKey}}></web-event-map>
       </div>
     </section>
+    <hr class="w-live-flow">
   {% endif %}
 
-  <hr />
-
-  <section id="subscribe" class="w-event-section w-event-section--subscribe">
+  <section id="subscribe" class="w-event-section w-event-section--subscribe w-live-flow">
     {% set subscribeTitle = "Sign up for web.dev updates" %}
     {% set subscribeNotes = "Get updates related to web.dev LIVE as well as the latest news and techniques straight to your inbox." %}
     {% include 'partials/subscribe.njk' %}
   </section>
+  <hr class="w-live-flow">
 
-  <hr />
-
-  <section id="share" class="w-event-section">
+  <section id="share" class="w-event-section w-live-flow">
     <div class="w-event-section__column-left">
       <div class="w-display--flex w-flex--column w-align-items--center w-justify-content--center">
-        <p class="w-mb--non">
+        <div>
           Share this event with your friends
-        </p>
+        </div>
         <div class="w-event-buttons">
           <share-action
             message=" web.dev LIVE, a three day digital event for web developers by Google."

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -22,78 +22,129 @@ date: 2020-06-31
     </section>
   {% endif %}
 
-  <div class="w-live-top">
-    <section class="w-event-section">
+  {% if event.isPreEvent or event.isPostEvent %}
+    <div class="w-live-top">
+      <section class="w-event-section">
 
-      <div class="w-event-section__column-left w-event-heading">
-        <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
-          <video width="156" height="72" autoplay muted loop playsinline>
-            <source src="live.mp4" type="video/mp4" />
-            <img src="live.png" alt="live" />
-          </video>
-        </h1>
-        <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
-      </div>
-
-      <div class="w-event-section__column-head w-event-hero">
-        <img src="hero.png" alt="" />
-      </div>
-
-      <div class="w-event-section__column-right">
-        <h2 class="w-mt--non">
-          Bringing web developers together, from home
-        </h2>
-        <p>
-          These are unprecedented times, with people worldwide looking to stay connected and informed.
-          The Web plays a special role here, and we're proud to see how the community has stepped up.
-        </p>
-        <p>
-          Join Google's Web Platform team, from the comfort of your homes, to celebrate our community's actions, learn modern web techniques and connect with each other.
-        </p>
-
-        <div class="w-event-buttons">
-          <a class="w-button w-button--primary gc-analytics-event" data-category="web.dev" data-label="scroll-to-subscribe" data-action="click" href="#subscribe">
-            Get notified
-          </a>
-          <div class="w-event-calendar">
-            <div class="w-event-calendar__note">
-              <span>Add to calendar</span>
-            </div>
-            <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to Google Calendar" data-action="click" target="_blank"
-              href="https://calendar.google.com/calendar/r?cid=webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
-              rel="noopener">
-              Google
-            </a>
-            <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to iCal" data-action="click" target="_blank"
-              href="webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
-              rel="noopener">
-              iCal
-            </a>
-            <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to Outlook" data-action="click" target="_blank"
-              href="webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
-              rel="noopener">
-              Outlook
-            </a>
-          </div>
+        <div class="w-event-section__column-left w-event-heading">
+          <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
+            <video width="156" height="72" autoplay muted loop playsinline>
+              <source src="live.mp4" type="video/mp4" />
+              <img src="live.png" alt="live" />
+            </video>
+          </h1>
+          <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
         </div>
 
-      </div>
+        <div class="w-event-section__column-head w-event-hero">
+          <img src="hero.png" alt="" />
+        </div>
 
-    </section>
-  </div>
+        <div class="w-event-section__column-right">
+          <h2 class="w-mt--non">
+            Bringing web developers together, from home
+          </h2>
+          <p>
+            These are unprecedented times, with people worldwide looking to stay connected and informed.
+            The Web plays a special role here, and we're proud to see how the community has stepped up.
+          </p>
+          <p>
+            Join Google's Web Platform team, from the comfort of your homes, to celebrate our community's actions, learn modern web techniques and connect with each other.
+          </p>
 
-  <hr />
+          <div class="w-event-buttons">
+            <a class="w-button w-button--primary gc-analytics-event" data-category="web.dev" data-label="scroll-to-subscribe" data-action="click" href="#subscribe">
+              Get notified
+            </a>
+            <div class="w-event-calendar">
+              <div class="w-event-calendar__note">
+                <span>Add to calendar</span>
+              </div>
+              <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to Google Calendar" data-action="click" target="_blank"
+                href="https://calendar.google.com/calendar/r?cid=webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
+                rel="noopener">
+                Google
+              </a>
+              <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to iCal" data-action="click" target="_blank"
+                href="webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
+                rel="noopener">
+                iCal
+              </a>
+              <a class="w-button w-button--secondary w-button--small gc-analytics-event" data-category="web.dev" data-label="live, add to Outlook" data-action="click" target="_blank"
+                href="webcal://calendar.google.com/calendar/ical/c_ta9vmmo7jqm7j2bqgg3bsn47oc%40group.calendar.google.com/public/basic.ics"
+                rel="noopener">
+                Outlook
+              </a>
+            </div>
+          </div>
+
+        </div>
+
+      </section>
+    </div>
+    <hr />
+  {% endif %}
 
   <section id="schedule" class="w-event-section">
 
-    <div class="w-event-section__column-left">
-      <h3 class="w-mt--non">What to expect</h3>
-      <p>
-        Over three days, we'll share quick tips on aspects of modern web development.
-        Each day, <strong>we'll "travel" to a new timezone</strong> to cover a couple of topics and answer your questions.
-      </p>
-      <a href="/community-guidelines/" class="w-event-link">Community guidelines</a>
-    </div>
+    {% if event.isPreEvent %}
+      <div class="w-event-section__column-left">
+        <h3 class="w-mt--non">What to expect</h3>
+        <p>
+          Over three days, we'll share quick tips on aspects of modern web development.
+          Each day, <strong>we'll "travel" to a new timezone</strong> to cover a couple of topics and answer your questions.
+        </p>
+        <a href="/community-guidelines/" class="w-event-link">Community guidelines</a>
+      </div>
+    {% endif %}
+
+    {% if event.isDuringEvent %}
+      <div class="w-event-section__column-left">
+
+        {# TODO: Update with Sam's carousel when it lands #}
+        <div class="w-event-carousel">
+          <a href="#" class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail">
+              <img src="" alt="" width="178" height="110">
+            </div>
+            <div>Day 1 — All sessions</div>
+          </a>
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail">
+            </div>
+            <div>Day 2 — Coming soon</div>
+          </div>
+          <div class="w-event-carousel__day">
+            <div class="w-event-carousel__thumbnail">
+            </div>
+            <div>Day 3 — Coming soon</div>
+          </div>
+        </div>
+
+        <div class="w-event-heading w-event-heading--smaller">
+          <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
+            <video width="156" height="72" autoplay muted loop playsinline>
+              <source src="live.mp4" type="video/mp4" />
+              <img src="live.png" alt="live" />
+            </video>
+          </h1>
+          <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
+        </div>
+        <p>
+          Thank you for joining us for web.dev LIVE! Over the three days, we'll
+          bring unique content to three different time zones and answer your
+          questions real-time, in your active hours. We encourage you to join us
+          on all three days but if that's not possible, you can watch the videos
+          on demand and leave your questions in the Comments section on YouTube
+          and we'll try our best to respond over the three days of the event.
+        </p>
+        <button class="w-feedback-button w-button w-button--primary">Share Feedback</button>
+        <a href="/community-guidelines/" class="w-event-link">Community guidelines</a>
+      </div>
+    {% endif %}
+
+    {% if event.isPostEvent %}
+    {% endif %}
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">
       {% if event.isDuringEvent or event.isPostEvent %}

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -115,6 +115,9 @@ date: 2020-06-31
     {% endif %}
 
     {% if event.isDuringEvent or event.isPostEvent %}
+      {# Note that we have more than one web-event-carousel.
+          We display one on mobile and a different one on desktop.
+          Their positions are pretty different so using two elements is the easiest approach. #}
       <web-event-carousel class="w-event-carousel w-display--mobile-only">
         {# These just exist as dummy HTML elements for the first render. They're replaced by the
             web-event-carousel CE when it loads. #}
@@ -194,6 +197,9 @@ date: 2020-06-31
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">
       {% if event.isDuringEvent or event.isPostEvent %}
+      {# Note that we have more than one web-event-carousel.
+          We display one on mobile and a different one on desktop.
+          Their positions are pretty different so using two elements is the easiest approach. #}
         <web-event-carousel class="w-event-carousel">
           {# These just exist as dummy HTML elements for the first render. They're replaced by the
              web-event-carousel CE when it loads. #}

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -164,7 +164,7 @@ date: 2020-06-31
 
     {% if event.isPostEvent %}
       <div class="w-event-section__column-left">
-        <div class="w-event-heading w-event-heading--smaller">
+        <div class="w-event-heading w-event-heading--smaller w-display--desktop-only">
           <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
             <video width="156" height="72" autoplay muted loop playsinline>
               <source src="live.mp4" type="video/mp4" />
@@ -182,11 +182,11 @@ date: 2020-06-31
         <div class="w-event-section__internal-links">
           <a href="#q-and-a">
             <svg class="w-event-icon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 11c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v14l4-4h10zm-1-9v7H2V2h11zm4 2h2c.55 0 1 .45 1 1v15l-4-4H5c-.55 0-1-.45-1-1v-2h13V4z" fill="#5F6368"/></svg>
-            Q &amp; A
+            <span>Q &amp; A</span>
           </a>
           <a href="#map">
             <svg class="w-event-icon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-.61.08-1.21.21-1.78L8.99 15v1c0 1.1.9 2 2 2v1.93C7.06 19.43 4 16.07 4 12zm11.99 4c.9 0 1.64.59 1.9 1.4A7.991 7.991 0 0020 12c0-3.35-2.08-6.23-5.01-7.41V5c0 1.1-.9 2-2 2h-2v2c0 .55-.45 1-1 1h-2v2h6c.55 0 1 .45 1 1v3h1z" fill="#5F6368"/></svg>
-            Regional events
+            <span>Regional events</span>
           </a>
         </div>
       </div>

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -163,6 +163,33 @@ date: 2020-06-31
     {% endif %}
 
     {% if event.isPostEvent %}
+      <div class="w-event-section__column-left">
+        <div class="w-event-heading w-event-heading--smaller">
+          <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
+            <video width="156" height="72" autoplay muted loop playsinline>
+              <source src="live.mp4" type="video/mp4" />
+              <img src="live.png" alt="live" />
+            </video>
+          </h1>
+          <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
+        </div>
+        <p>
+          web.dev LIVE is now over but you can watch the videos from all three
+          days here, go through the top community questions or join one of the
+          live regional events being hosted by Google Developer Groups across
+          the world!
+        </p>
+        <div class="w-event-section__internal-links">
+          <a href="#q-and-a">
+            <svg class="w-event-icon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 11c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v14l4-4h10zm-1-9v7H2V2h11zm4 2h2c.55 0 1 .45 1 1v15l-4-4H5c-.55 0-1-.45-1-1v-2h13V4z" fill="#5F6368"/></svg>
+            Q &amp; A
+          </a>
+          <a href="#map">
+            <svg class="w-event-icon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-.61.08-1.21.21-1.78L8.99 15v1c0 1.1.9 2 2 2v1.93C7.06 19.43 4 16.07 4 12zm11.99 4c.9 0 1.64.59 1.9 1.4A7.991 7.991 0 0020 12c0-3.35-2.08-6.23-5.01-7.41V5c0 1.1-.9 2-2 2h-2v2c0 .55-.45 1-1 1h-2v2h6c.55 0 1 .45 1 1v3h1z" fill="#5F6368"/></svg>
+            Regional events
+          </a>
+        </div>
+      </div>
     {% endif %}
 
     <div class="w-event-section__column-right w-event-section__column-right__schedule">

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -22,7 +22,7 @@ date: 2020-06-31
     </section>
   {% endif %}
 
-  {% if event.isPreEvent or event.isPostEvent %}
+  {% if event.isPreEvent%}
     <div class="w-hero-overflow w-live-flow">
       <section class="w-event-section w-hero-section">
         <div class="w-event-section__column-left">
@@ -81,6 +81,27 @@ date: 2020-06-31
     <hr class="w-live-flow">
   {% endif %}
 
+  {% if event.isPostEvent %}
+    <div class="w-hero-overflow w-live-flow">
+      <section class="w-event-section w-hero-section">
+        <div class="w-event-section__column-left">
+          <div class="w-event-heading w-event-heading--smaller w-display--mobile-only">
+            <h1 class="w-event-heading__logo">web.dev<span>/LIVE</span>
+              <video width="156" height="72" autoplay muted loop playsinline>
+                <source src="live.mp4" type="video/mp4" />
+                <img src="live.png" alt="live" />
+              </video>
+            </h1>
+            <p class="w-event-heading__subhead">June 30 &mdash; July 2, 2020</p>
+          </div>
+        </div>
+        <div class="w-event-section__column-head w-event-hero w-pb--non">
+          <img src="hero.png" alt="" />
+        </div>
+      </section>
+    </div>
+  {% endif %}
+
   <section id="schedule" class="w-event-section w-schedule-section w-live-flow">
     {% if event.isPreEvent %}
       <div class="w-event-section__column-left">
@@ -94,7 +115,7 @@ date: 2020-06-31
     {% endif %}
 
     {% if event.isDuringEvent or event.isPostEvent %}
-      <web-event-carousel class="w-event-carousel w-event-carousel--mobile-only">
+      <web-event-carousel class="w-event-carousel w-display--mobile-only">
         {# These just exist as dummy HTML elements for the first render. They're replaced by the
             web-event-carousel CE when it loads. #}
         <div class="w-event-carousel__day">
@@ -131,7 +152,7 @@ date: 2020-06-31
           on demand and leave your questions in the Comments section on YouTube
           and we'll try our best to respond over the three days of the event.
         </p>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdkWh94xheuR3Y_p0z6GML0AkdWLCa767KhFXBUPM3VI9-jCA/viewform" class="w-feedback-button w-button w-button--primary">
+        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdkWh94xheuR3Y_p0z6GML0AkdWLCa767KhFXBUPM3VI9-jCA/viewform" target="_blank" class="w-feedback-button w-button w-button--primary">
           <svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H6l-4 4 .01-18c0-1.1.89-2 1.99-2zm0 14h16V4H4v12zm6.5-2H18v-2h-5.5l-2 2zm3.86-6.58c.2.2.2.51 0 .71L8.47 14H6v-2.47l5.88-5.88c.2-.2.51-.2.71 0l1.77 1.77z" fill="#fff"/>
           </svg>

--- a/src/styles/components/_livestream-container.scss
+++ b/src/styles/components/_livestream-container.scss
@@ -10,12 +10,16 @@
 // =============================================================================
 
 web-livestream-container {
+  background-color: $WHITE;
   border-left: 1px solid $GREY_300;
   border-right: 1px solid $GREY_300;
   display: flex;
-  height: 670px;
   margin: auto;
   max-width: 1280px;
+
+  @include bp(md) {
+    height: 670px;
+  }
 }
 
 .web-livestream-container__skeleton-yt {
@@ -29,5 +33,9 @@ web-livestream-container {
 
   @include bp(md) {
     display: block;
+  }
+
+  @media (hover: none) {
+    display: none;
   }
 }

--- a/src/styles/components/_livestream-container.scss
+++ b/src/styles/components/_livestream-container.scss
@@ -15,21 +15,19 @@ web-livestream-container {
   border-right: 1px solid $GREY_300;
   display: flex;
   margin: auto;
-  max-width: 1280px;
-
-  @include bp(md) {
-    height: 670px;
-  }
+  max-width: 1600px;
 }
 
 .web-livestream-container__skeleton-yt {
-  flex-basis: 880px;
+  background-color: $GREY_50;
+  flex: 1;
 }
 
 .web-livestream-container__skeleton-chat {
   border-left: 1px solid $GREY_300;
   display: none;
-  flex-basis: 400px;
+  min-height: 600px;
+  width: 400px;
 
   @include bp(md) {
     display: block;

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -63,6 +63,11 @@ var {
   hyphens: none;
 }
 
+html {
+  scroll-padding-top: calc(#{$WEB_HEADER_HEIGHT} + 1.5rem);
+}
+
+// Fallback if scroll-padding-top is not supported
 *:not([href])[id]::before {
   content: ' ';
   display: block;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -299,6 +299,21 @@
   padding: 0 24px;
 }
 
+.w-event-section__internal-links {
+  margin-top: 32px;
+
+  a {
+    color: $GREY_800;
+    font-family: $HEADLINE_FONT;
+    font-weight: $FONT_WEIGHT_MEDIUM;
+  }
+
+  > * + * {
+    display: block;
+    margin-top: 24px;
+  }
+}
+
 .w-event-link {
   font-size: 14px;
   margin-top: 24px;

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -28,39 +28,51 @@
   }
 }
 
+// A utility for creating consistent vertical rhythm between sections.
+.w-live-flow + .w-live-flow {
+  margin-top: 48px;
+
+  @include bp(md) {
+    margin-top: 80px;
+  }
+}
+
 .w-livestream-section {
+  background-color: $GREY_50;
+
   @include bp(md) {
     border-bottom: 1px solid $GREY_300;
   }
+
+  .w-live-chat-notice {
+    align-items: center;
+    background-color: $WHITE;
+    color: $GREY_700;
+    display: flex;
+    font-size: 12px;
+    padding: 19px 16px;
+
+    > :first-child {
+      margin-right: 16px;
+    }
+
+    // Only display the notice if the device's primary pointing device does not
+    // support hover. This lets us filter out phones and tablets.
+    @media (hover: hover) {
+      display: none;
+    }
+
+  }
 }
 
-.w-live-chat-notice {
-  align-items: center;
-  color: $GREY_700;
-  display: flex;
-  font-size: 12px;
-  padding: 19px 16px;
-
-  // Hide the notice if we're at small desktop size and the primary pointing
-  // device supports hover. This should exclude iPads but include Pixelbooks.
-  @media (min-width: #{$BREAKPOINT_VALUE_MEDIUM}) and (hover: hover) {
-    display: none;
-  }
-
-  > :first-child {
-    margin-right: 16px;
-  }
-}
-
-.w-live-top {
-  // We need this as the live background extends outside the normal l/r of the
+.w-hero-overflow {
+  // We need this as the hero image extends outside the normal l/r of the
   // page. Contain it so it doesn't let users scroll.
   overflow-x: hidden;
+}
 
-  // jiwoong@
-  .w-event-section__column-right {
-    padding: 0 24px;
-  }
+.w-hero-section {
+  margin-top: 50px;
 }
 
 .w-event-buttons {
@@ -144,10 +156,10 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
-  margin: (64px - $WEB_HEADER_HEIGHT - 48px) auto 64px;
   max-width: 960px;
-  padding-top: ($WEB_HEADER_HEIGHT + 48px);
   text-align: center;  // for mobile
+  margin-left: auto;
+  margin-right: auto;
 
   &::before {
     display: none !important;
@@ -156,14 +168,6 @@
   @include bp(md) {
     text-align: inherit;
   }
-
-  &#schedule .w-event-section__column-left {
-    margin-bottom: 64px;
-  }
-
-  .w-event-schedule__blurb {
-    color: $GREY_700;
-  }
 }
 
 .w-event-section--subscribe {
@@ -171,11 +175,13 @@
   padding-right: 32px;
 
   // Make the subscribe area less huge as it has its own padding.
+  // TODO(michaelsolati): Remove the padding overrides in the subscribe include.
+  // The spacing for this element should be defined by the containing page.
   web-subscribe {
     margin-top: -32px;
+    margin-bottom: -32px;
   }
 }
-
 
 .w-event-hero {
   align-items: center;
@@ -184,8 +190,12 @@
   height: 192px;
   justify-content: center;
   margin: 0 auto;
-  padding: 0 0 64px;
+  padding: 0 0 50px;
   position: relative;
+
+  @include bp(md) {
+    padding: 0 0 64px;
+  }
 
   &::before {
     background-image: url('../live/hero-bg.png');
@@ -218,6 +228,7 @@
   display: flex;
   flex-flow: column wrap;
   flex-grow: 1;
+  max-width: 512px;
   padding: 0 32px;
   text-align: center;
   width: 100%;
@@ -230,14 +241,6 @@
     width: 37.5%;
   }
 
-  .w-event-carousel {
-    display: flex;
-
-    @include bp(md) {
-      display: none;
-    }
-  }
-
   h3 {
     font-size: 16px;
     margin: 0;
@@ -247,15 +250,10 @@
     margin: 0;
     margin-top: 24px;
     max-width: 512px;
-    
+
     @include bp(md) {
       max-width: 288px;
     }
-  }
-
-  .w-event-link {
-    font-size: 14px;
-    margin-top: 24px;
   }
 
   .w-event-buttons {
@@ -264,39 +262,21 @@
 
   .w-feedback-button {
     margin-top: 49px;
+
+    :first-child {
+      margin-right: 8px;
+    }
   }
 }
 
 .w-event-section__column-right {
-  max-width: 100%;
+  max-width: 512px;
   padding: 0 8px;
 
   @include bp(md) {
-    max-width: none;
     padding: 0 16px;
     width: 62.5%;
-  }
-
-  @media (min-width: 512px) {
-    max-width: 512px;
-  }
-
-  @include bp(sm) {
-    // On larger devices, force padding even on the schedule (this wins over
-    // ...__schedule, above).
-    padding: 0 16px !important;
-  }
-
-  &.w-event-section__column-right__schedule {
-    margin-top: -16px;
-
-    @include bp(md) {
-      padding: 0px;
-    }
-
-    @include bp(sm) {
-      padding: 0px !important;
-    }
+    max-width: 62.5%;
   }
 
   .w-event-carousel {
@@ -306,13 +286,20 @@
       display: flex;
     }
   }
+}
 
+.w-event-section__column-right--extra-padding {
+  padding: 0 24px;
+}
+
+.w-event-link {
+  font-size: 14px;
+  margin-top: 24px;
 }
 
 .w-event-carousel {
   display: flex;
   overflow-x: scroll;
-  margin-bottom: 12px;
   // Firefox only
   // sass-lint:disable no-misspelled-properties
   scrollbar-color: $GREY_500;
@@ -330,6 +317,12 @@
   &::-webkit-scrollbar-thumb {
     background-color: $GREY_500;
     border-radius: 8px;
+  }
+}
+
+.w-event-carousel--mobile-only {
+  @include bp(md) {
+    display: none;
   }
 }
 
@@ -373,19 +366,28 @@
   }
 }
 
-// Need to put top margin on the tabs instead of bottom margin on the
-// carousel because bottom margin will affect the carousel's scroll bar.
-.w-event-carousel + .w-event-tabs {
-  margin-top: 34px;
+web-event-schedule {
+  display: block;
+}
+
+.w-event-carousel + web-event-schedule {
+  margin-top: 12px;
 }
 
 web-tabs.w-event-tabs {
   --primary-color: #{$WEB_PRIMARY_COLOR};
   --hover-color: #{$GOOGLE_BLUE_50};
   --active-color: #{$GOOGLE_BLUE_100};
+
+  margin-top: 48px;
+
+  @include bp(md) {
+    margin-top: 0;
+  }
 }
 
 .w-event-schedule {
+  display: block;
   // Forces a stacking context.
   position: relative;
   text-align: left;
@@ -464,6 +466,10 @@ web-tabs.w-event-tabs {
       position: absolute;
       z-index: 0;
     }
+  }
+
+  .w-event-schedule__blurb {
+    color: $GREY_700;
   }
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -37,6 +37,12 @@
       display: none;
     }
   }
+
+  .w-display--desktop-only {
+    @media (max-width: #{$BREAKPOINT_VALUE_MEDIUM - 1px}) {
+      display: none;
+    }
+  }
 }
 
 // A utility for creating consistent vertical rhythm between sections.
@@ -301,16 +307,37 @@
 
 .w-event-section__internal-links {
   margin-top: 32px;
+  display: flex;
+
+  @include bp(md) {
+    display: block;
+  }
 
   a {
+    align-items: center;
     color: $GREY_800;
+    display: flex;
+    flex-direction: column;
     font-family: $HEADLINE_FONT;
     font-weight: $FONT_WEIGHT_MEDIUM;
+    justify-content: center;
+    padding: 0 16px;
+    width: 132px;
+
+    @include bp(md) {
+      display: block;
+      padding: 0;
+      width: auto;
+    }
   }
 
   > * + * {
-    display: block;
-    margin-top: 24px;
+    border-left: 1px solid $GREY_300;
+
+    @include bp(md) {
+      border: 0;
+      margin-top: 24px;
+    }
   }
 }
 
@@ -383,18 +410,6 @@
 }
 
 .w-schedule-section {
-  // If we're displaying the live chat is disabled banner (which we only do on
-  // touch devices) then we want to remove the normal 48px margin to move the
-  // schedule closer to the video.
-  @media (hover: none) {
-    --flow-space: 8px;
-  }
-
-  // Restore the usual flow-space value.
-  @include bp(md) {
-    --flow-space: 80px;
-  }
-
   .w-event-heading {
     margin-top: 56px;
 
@@ -409,6 +424,20 @@
     @include bp(md) {
       margin-top: 24px;
     }
+  }
+}
+
+.w-livestream-section + .w-schedule-section {
+  // If we're displaying the live chat is disabled banner (which we only do on
+  // touch devices) then we want to remove the normal 48px margin to move the
+  // schedule closer to the video.
+  @media (hover: none) {
+    --flow-space: 8px;
+  }
+
+  // Restore the usual flow-space value.
+  @include bp(md) {
+    --flow-space: 80px;
   }
 }
 
@@ -569,7 +598,9 @@ web-tabs.w-event-tabs {
 }
 
 .w-event-icon {
-  align-items: center;
   vertical-align: middle;
-  margin-right: 16px;
+  margin: 0 0 8px;
+  @include bp(md) {
+    margin: 0 16px 0 0;
+  }
 }

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -124,6 +124,22 @@
   }
 }
 
+.w-event-heading--smaller {
+  .w-event-heading__logo {
+    font-size: 33px;
+
+    @include bp(md) {
+      font-size: 33px;
+    }
+  }
+
+  .w-event-heading__subhead {
+    @include bp(md) {
+      font-size: 16px;
+    }
+  }
+}
+
 .w-event-section {
   display: flex;
   flex-flow: row wrap;
@@ -191,6 +207,10 @@
 
 .w-event-section__column-head {
   width: 100%;
+
+  @include bp(md) {
+    order: -1;
+  }
 }
 
 .w-event-section__column-left {
@@ -202,24 +222,48 @@
   text-align: center;
   width: 100%;
 
+  @include bp(md) {
+    align-items: flex-start;
+    flex-grow: 0;
+    padding-left: 16px;
+    text-align: inherit;
+    width: 37.5%;
+  }
+
+  .w-event-carousel {
+    display: flex;
+
+    @include bp(md) {
+      display: none;
+    }
+  }
+
   h3 {
     font-size: 16px;
     margin: 0;
   }
 
   p {
-    max-width: 288px;
     margin: 0;
     margin-top: 24px;
+    max-width: 512px;
+    
+    @include bp(md) {
+      max-width: 288px;
+    }
   }
 
   .w-event-link {
     font-size: 14px;
-    margin-top: 20px;
+    margin-top: 24px;
   }
 
   .w-event-buttons {
     margin: 16px 0;
+  }
+
+  .w-feedback-button {
+    margin-top: 49px;
   }
 }
 
@@ -227,8 +271,20 @@
   max-width: 100%;
   padding: 0 8px;
 
+  @include bp(md) {
+    max-width: none;
+    padding: 0 16px;
+    width: 62.5%;
+  }
+
   @media (min-width: 512px) {
     max-width: 512px;
+  }
+
+  @include bp(sm) {
+    // On larger devices, force padding even on the schedule (this wins over
+    // ...__schedule, above).
+    padding: 0 16px !important;
   }
 
   &.w-event-section__column-right__schedule {
@@ -243,11 +299,14 @@
     }
   }
 
-  @include bp(sm) {
-    // On larger devices, force padding even on the schedule (this wins over
-    // ...__schedule, above).
-    padding: 0 16px !important;
+  .w-event-carousel {
+    display: none;
+
+    @include bp(md) {
+      display: flex;
+    }
   }
+
 }
 
 .w-event-carousel {
@@ -444,26 +503,6 @@ web-tabs.w-event-tabs {
       opacity: initial;
       position: initial;
     }
-  }
-}
-
-@include bp(md) {
-  .w-event-section__column-head {
-    order: -1;
-  }
-
-  .w-event-section__column-left {
-    align-items: flex-start;
-    flex-grow: 0;
-    padding-left: 16px;
-    text-align: inherit;
-    width: 37.5%;
-  }
-
-  .w-event-section__column-right {
-    max-width: none;
-    padding: 0 16px;
-    width: 62.5%;
   }
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -31,6 +31,12 @@
   h6 {
     color: inherit;
   }
+
+  .w-display--mobile-only {
+    @include bp(md) {
+      display: none;
+    }
+  }
 }
 
 // A utility for creating consistent vertical rhythm between sections.
@@ -319,12 +325,6 @@
   &::-webkit-scrollbar-thumb {
     background-color: $GREY_500;
     border-radius: 8px;
-  }
-}
-
-.w-event-carousel--mobile-only {
-  @include bp(md) {
-    display: none;
   }
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -4,6 +4,11 @@
 
 .w-live-landing-page {
   color: $GREY_800;
+  --flow-space: 48px;
+
+  @include bp(md) {
+    --flow-space: 80px;
+  }
 
   p {
     font-size: 14px;
@@ -30,11 +35,7 @@
 
 // A utility for creating consistent vertical rhythm between sections.
 .w-live-flow + .w-live-flow {
-  margin-top: 48px;
-
-  @include bp(md) {
-    margin-top: 80px;
-  }
+  margin-top: var(--flow-space);
 }
 
 .w-livestream-section {
@@ -300,6 +301,7 @@
 .w-event-carousel {
   display: flex;
   overflow-x: scroll;
+  padding-bottom: 8px;
   // Firefox only
   // sass-lint:disable no-misspelled-properties
   scrollbar-color: $GREY_500;
@@ -332,7 +334,6 @@
   font-size: 14px;
   font-weight: $FONT_WEIGHT_MEDIUM;
   margin-right: 16px;
-  padding-bottom: 8px;
 
   &:hover,
   &:focus {
@@ -363,6 +364,36 @@
   > img {
     height: 100%;
     object-fit: cover;
+  }
+}
+
+.w-schedule-section {
+  // If we're displaying the live chat is disabled banner (which we only do on
+  // touch devices) then we want to remove the normal 48px margin to move the
+  // schedule closer to the video.
+  @media (hover: none) {
+    --flow-space: 8px;
+  }
+
+  // Restore the usual flow-space value.
+  @include bp(md) {
+    --flow-space: 80px;
+  }
+
+  .w-event-heading {
+    margin-top: 56px;
+
+    @include bp(md) {
+      margin-top: 0;
+    }
+  }
+
+  .w-event-heading + p {
+    margin-top: 32px;
+
+    @include bp(md) {
+      margin-top: 24px;
+    }
   }
 }
 

--- a/src/styles/pages/_live.scss
+++ b/src/styles/pages/_live.scss
@@ -276,7 +276,7 @@
   .w-feedback-button {
     margin-top: 49px;
 
-    :first-child {
+    svg:first-child {
       margin-right: 8px;
     }
   }


### PR DESCRIPTION
Fixes #3115, Fixes #3116

A bunch of CSS changes to make the pre event and during event pages look correct. We could land these now if we want. I still have some more changes for the during and post event pages but it might be good to break those apart. My hope is this will be the bigger of the two PRs because it contained a lot of cleanup.

Changes proposed in this pull request:

- Adds a second carousel that displays only on mobile and hides the carousel in the right column.
- A lot of CSS :\
- Adds a share feedback button
- Adds the correct header for the during event phase.
- Adds a `.w-live-flow` class which can be used for consistent vertical rhythm.