### PR TITLE
fix(sitemap): use `canonicalUrl` for pages with a `url`, fixes #3352

### DIFF
--- a/src/site/content/sitemap.xml.njk
+++ b/src/site/content/sitemap.xml.njk
@@ -7,7 +7,7 @@ permalink: "/sitemap.xml"
 {%- for page in collections.all %}
 {%- if not page.data.noindex and not page.data.draft %}
   {%- if page.url %}
-  {% set absoluteUrl %}{{ page.url | absoluteUrl(site.url) }}{% endset %}
+  {% set absoluteUrl %}{{ page.fileSlug | absoluteUrl(site.url) }}{% endset %}
   <url>
     <loc>{{ absoluteUrl }}</loc>
     {%- if page.data.updated %}

--- a/src/site/content/sitemap.xml.njk
+++ b/src/site/content/sitemap.xml.njk
@@ -6,6 +6,9 @@ permalink: "/sitemap.xml"
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all %}
 {%- if not page.data.noindex and not page.data.draft %}
+  {# Verify that the page has a permalink so we don't pull in things like #}
+  {# the service worker partial. #}
+  {# But use the page's fileSlug so we can strip out the language directory. #}
   {%- if page.url %}
   {% set absoluteUrl %}{{ page.fileSlug | absoluteUrl(site.url) }}{% endset %}
   <url>

--- a/src/site/content/sitemap.xml.njk
+++ b/src/site/content/sitemap.xml.njk
@@ -10,7 +10,7 @@ permalink: "/sitemap.xml"
   {# the service worker partial. #}
   {# But use the page's fileSlug so we can strip out the language directory. #}
   {%- if page.url %}
-  {% set absoluteUrl %}{{ page.fileSlug | absoluteUrl(site.url) }}{% endset %}
+  {% set absoluteUrl %}{{ page.data.canonicalUrl }}{% endset %}
   <url>
     <loc>{{ absoluteUrl }}</loc>
     {%- if page.data.updated %}


### PR DESCRIPTION
Fixes #3352

This way we can do away with the language, as it's not in the file slug.