### PR TITLE
Update web-vitals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24401,9 +24401,9 @@
       }
     },
     "web-vitals": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.1.tgz",
-      "integrity": "sha512-2pdRlp6gJpOCg0oMMqwFF0axjk5D9WInc09RSYtqFgPXQ15+YKNQ7YnBBEqAL5jvmfH9WvoXDMb8DHwux7pIew=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.3.tgz",
+      "integrity": "sha512-6idlbUoL38El+QS320Qz6h4QSZLaWw3CHiJWBtQDmFGs72ro+fnukfavTxTdQSlsaoaBuNL/0bqlIhfdtlrx4A=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rollup-plugin-virtual": "^1.0.1",
     "terser": "^4.6.4",
     "unistore": "^3.4.1",
-    "web-vitals": "^0.2.1",
+    "web-vitals": "^0.2.3",
     "wicg-inert": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the `web-vitals` library to fix https://github.com/GoogleChrome/web-vitals/issues/57 (which I discovered while building a Web Vitals dashboard using web.dev data).