### PR TITLE
Make select look all pretty and stuff.

### DIFF
--- a/src/site/_includes/partials/subscribe.njk
+++ b/src/site/_includes/partials/subscribe.njk
@@ -28,7 +28,7 @@
       </div>
       <div class="w-subscribe__field w-display--flex">
         <label class="w-visually-hidden" for="sub-country">Country</label>
-        <select id="sub-country" name="Country" required>
+        <select class="w-subscribe__select w-select--full-width" id="sub-country" name="Country" required>
           {% for country in countries %}
             {% if country[1] === "United States" %}
               <option selected value="{{country[0]}}">{{country[1]}}</option>
@@ -45,7 +45,7 @@
         <div class="w-subscribe__field w-subscribe--padded">
           <div class="w-display--inline-flex">
             <input id="sub-newsletter" name="WebDevNewsletter" required value="Unconfirmed" class="w-checkbox" type="checkbox" />
-            <label for="sub-newsletter" class="w-ml--l w-text--left">Add me to the web.dev mailing list.</label>
+            <label for="sub-newsletter" class="w-ml--std w-text--left">Add me to the web.dev mailing list.</label>
           </div>
         </div>
       </div>
@@ -53,7 +53,7 @@
         <div class="w-subscribe__field w-subscribe--padded">
           <div class="w-display--inline-flex">
             <input id="sub-pii-spii" name="collects-pii-spii-checkbox" required value="Unconfirmed" class="w-checkbox" type="checkbox" />
-            <label for="sub-pii-spii" class="w-ml--l w-text--left">
+            <label for="sub-pii-spii" class="w-ml--std w-text--left">
               I accept Google's <a href="https://policies.google.com/terms" target="_blank" rel="noopener">Terms and Conditions</a> and acknowledge that my information will be used in accordance with Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
             </label>
           </div>

--- a/src/styles/components/_subscribe.scss
+++ b/src/styles/components/_subscribe.scss
@@ -33,6 +33,10 @@ web-subscribe:not(:defined) {
   width: 100%;
 }
 
+.w-subscribe__select {
+  padding: 14px 8px;
+}
+
 .w-subscribe__notice {
   color: $GREY_700;
   font: inherit;

--- a/src/styles/generic/_forms.scss
+++ b/src/styles/generic/_forms.scss
@@ -10,8 +10,3 @@ textarea {
   height: auto;
   min-height: 50px;
 }
-
-// Make select elements 100% width by default
-select {
-  width: 100%;
-}

--- a/src/styles/generic/_select.scss
+++ b/src/styles/generic/_select.scss
@@ -1,27 +1,65 @@
 @import '../settings/colors';
 
+// Select styles based on this amazing article by Scott Jehl
+// https://www.filamentgroup.com/lab/select-css.html
+
 select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
   background-color: $WHITE;
+  // Use an escaped svg to add a small grey arrow to the end of the select
+  // sass-lint:disable quotes
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 10L12 15L17 10H7Z' fill='%235F6368'/%3E%3C/svg%3E%0A");
+  background-position: right .5em top 50%;
+  background-repeat: no-repeat;
+  // Set the width of the arrow background image and let the height default to auto
+  background-size: 1.5em;
+  border-radius: 1px;
   border: 1px solid $GREY_300;
-  font: inherit;
-  height: 52px;
-  // The native select has a built-in 4px left margin in its shadow dom.
-  // Add 4px of padding to make values left align with our other form fields.
-  // Annoyingly the little down arrow on the right is not styleable.
-  padding-left: 4px;
-  width: 100%;
+  box-sizing: border-box;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  font-size: 1em;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 100%;
+  padding: .6em 3em .5em .8em;
+}
 
-  &.w-select--borderless {
-    border-color:  transparent;
+select::-ms-expand {
+  display: none;
+}
 
-    &:focus {
-      border: 1px solid $WEB_PRIMARY_COLOR;
-    }
-  }
+// This will remove the dotted outline inside of the select when it is focused
+// in Firefox.
+// The trick is to make the text transparent (which makes the dotted outline
+// transparent) and then "display" the text again using a 0 offset text-shadow.
+// Note that this forces the text to be black when it is focused in Firefox.
+// To change that color, change the value of the text-shadow.
+select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
 
-  &:focus {
-    border-color: $WEB_PRIMARY_COLOR;
-    outline: none;
+select:hover {
+  border-color: $GREY_500;
+}
+
+select option {
+  font-weight: normal;
+}
+
+.w-select--borderless {
+  border-color:  transparent;
+
+  &:hover {
+    border-color: transparent;
+    background-color: $GREY_100;
   }
 }
 
+.w-select--full-width {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes #3372 

Changes proposed in this pull request:

- Make our selects look fancy in all browsers 📸
- Add `.w-select--full-width` modifier class
- Updates subscribe form and /live/ sections to use the new styles

Here's what it looks like in Safari, Firefox, and Chrome:
![Screen Shot 2020-06-26 at 5 03 25 PM](https://user-images.githubusercontent.com/1066253/85909504-34319780-b7cf-11ea-89aa-d2cc6507c563.png)

Focus state just uses our site's default focus outline:
![Screen Shot 2020-06-26 at 5 02 54 PM](https://user-images.githubusercontent.com/1066253/85909512-3e539600-b7cf-11ea-887e-1ea464234ee0.png)

`.w-select--borderless` looks like this:
![Screen Shot 2020-06-26 at 5 04 04 PM](https://user-images.githubusercontent.com/1066253/85909521-49a6c180-b7cf-11ea-868e-2ce4ba38f968.png)

`.w-select--borderless` hover style:
![Screen Shot 2020-06-26 at 5 04 12 PM](https://user-images.githubusercontent.com/1066253/85909536-5a573780-b7cf-11ea-93e3-34f26d0be5a4.png)


