### PR TITLE
use bootstrap.js/app.css again

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,6 +79,7 @@ const removeDrafts = require(`./${filtersDir}/remove-drafts`);
 const strip = require(`./${filtersDir}/strip`);
 const stripBlog = require(`./${filtersDir}/strip-blog`);
 const stripLanguage = require(`./${filtersDir}/strip-language`);
+const stripQueryParamsDev = require(`./${filtersDir}/strip-query-params-dev`);
 const getPaths = require(`./${filtersDir}/get-paths`);
 
 const transformsDir = 'src/site/_transforms';
@@ -190,6 +191,7 @@ module.exports = function (config) {
   config.addFilter('removeDrafts', removeDrafts);
   config.addFilter('stripBlog', stripBlog);
   config.addFilter('stripLanguage', stripLanguage);
+  config.addFilter('stripQueryParamsDev', stripQueryParamsDev);
   config.addFilter('getPaths', getPaths);
   config.addFilter('strip', strip);
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,12 +17,11 @@
 const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
+const resourcePath = require('./src/build/resource-path');
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
 const markdownItAttrs = require('markdown-it-attrs');
 const slugify = require('slugify');
-const fs = require('fs');
-const path = require('path');
 
 const componentsDir = 'src/site/_includes/components';
 const ArticleNavigation = require(`./${componentsDir}/ArticleNavigation`);
@@ -249,25 +248,15 @@ module.exports = function (config) {
   if (isProd) {
     // We generate the paths to our JS and CSS entrypoints as a side-effect
     // of their build scripts, so make sure they exist in prod builds.
-    const checkJSONDataPath = (name) => {
-      const f = `src/site/_data/${name}.json`;
+    ['css', 'js'].forEach((name) => {
       try {
-        const raw = JSON.parse(fs.readFileSync(f), 'utf-8');
-        if (!raw['path']) {
-          throw new Error(`could not find 'path' key in: ${f}`);
-        }
-        const check = path.join('dist', raw['path']);
-        if (!fs.existsSync(check)) {
-          throw new Error(`path did not exist: ${check}`);
-        }
+        resourcePath(name);
       } catch (e) {
         throw new Error(
           `could not find valid JSON path inside src/site/_data/: ${name} (${e})`,
         );
       }
-    };
-    checkJSONDataPath('resourceCSS');
-    checkJSONDataPath('resourceJS');
+    });
   }
 
   // ----------------------------------------------------------------------------

--- a/build-sw.js
+++ b/build-sw.js
@@ -24,6 +24,7 @@ const rollupPluginReplace = require('rollup-plugin-replace');
 const OMT = require('@surma/rollup-plugin-off-main-thread');
 const rollup = require('rollup');
 const {getManifest} = require('workbox-build');
+const resourcePath = require('./src/build/resource-path');
 const buildVirtualJSON = require('./src/build/virtual-json');
 const minifySource = require('./src/build/minify-js');
 
@@ -41,20 +42,6 @@ const {buildDefaultPlugins, disallowExternal} = require('./src/build/common');
  * before the Rollup build script.
  */
 async function buildCacheManifest() {
-  const resourcePath = (named) => {
-    const raw = JSON.parse(
-      fs.readFileSync(`src/site/_data/${named}.json`, 'utf-8'),
-    );
-    if (!raw['path']) {
-      throw new Error(`could not find path/hash of resource: ${named}`);
-    }
-    let p = raw['path'];
-    if (p.startsWith('/')) {
-      p = p.substr(1);
-    }
-    return p;
-  };
-
   const config = {
     // JS or CSS files that include hashes don't need their own revision fields.
     dontCacheBustURLsMatching: /-[0-9a-f]{8}\.(css|js)/,
@@ -73,11 +60,11 @@ async function buildCacheManifest() {
   };
   if (isProd) {
     config.additionalManifestEntries = [
-      {url: resourcePath('resourceJS'), revision: null},
-      {url: resourcePath('resourceCSS'), revision: null},
+      {url: resourcePath('js'), revision: null},
+      {url: resourcePath('css'), revision: null},
     ];
   } else {
-    // Don't use hash revisions in dev.
+    // Don't use hash revisions in dev, or even check that the files exist.
     config.globPatterns.push('bootstrap.js', 'app.css');
   }
 

--- a/build-sw.js
+++ b/build-sw.js
@@ -17,7 +17,6 @@
 require('dotenv').config();
 const isProd = process.env.ELEVENTY_ENV === 'prod';
 
-const fs = require('fs');
 const log = require('fancy-log');
 const rollupPluginVirtual = require('rollup-plugin-virtual');
 const rollupPluginReplace = require('rollup-plugin-replace');

--- a/compile-css.js
+++ b/compile-css.js
@@ -121,17 +121,15 @@ function renderTo(result, fileName) {
 const out = compileCSS('src/styles/all.scss');
 const hash = hashForContent(out.css);
 
-// We write an unhashed CSS file (as well as the hashed one) for two reasons:
-//  - to not force an Eleventy rebuild during dev
-//  - to work around #3363 (prod clients loaded before 2020-06-16 will see an unstyled page flash)
+// We write an unhashed CSS file due to unfortunate real-world caching problems with a hash inside
+// the CSS name (we see our old HTML cached longer than the assets are available).
 renderTo(out, `dist/app.css`);
-renderTo(out, `dist/app-${hash}.css`);
 
-// Write the CSS entrypoint to a known file for Eleventy to read. In dev, use the unhashed version.
-const resourcePath = isProd ? `/app-${hash}.css` : '/app.css';
+// Write the CSS entrypoint to a known file, with a query hash, for Eleventy to read.
+const resourceName = `app.css?v=${hash}`;
 fs.writeFileSync(
   'src/site/_data/resourceCSS.json',
-  JSON.stringify({path: resourcePath}),
+  JSON.stringify({path: `/${resourceName}`}),
 );
 
-log(`Finished CSS! (app-${hash}.css)`);
+log(`Finished CSS! (${resourceName})`);

--- a/src/build/hash.js
+++ b/src/build/hash.js
@@ -3,19 +3,11 @@
  */
 
 const crypto = require('crypto');
+const fs = require('fs');
 
 const hashLength = 8;
 
-/**
- * Hashes the passed content.
- *
- * @param {string} files to hash
- * @return {string}
- */
-function hashForContent(contents) {
-  const c = crypto.createHash('sha1');
-  c.update(contents);
-
+function generateAndValidateHash(c) {
   const hash = c.digest('hex').substr(0, hashLength);
   if (hash.length !== hashLength) {
     throw new TypeError(`could not hash content`);
@@ -23,6 +15,38 @@ function hashForContent(contents) {
   return hash;
 }
 
+/**
+ * Hashes the passed content.
+ *
+ * @param {string} contents to hash
+ * @return {string}
+ */
+function hashForContent(contents) {
+  const c = crypto.createHash('sha1');
+  c.update(contents);
+  return generateAndValidateHash(c);
+}
+
+/**
+ * Hashes the passed files. Requires at least one.
+ *
+ * @param {string} file base file to hash
+ * @param {...string} rest additional files to hash
+ */
+function hashForFiles(file, ...rest) {
+  const files = [file].concat(rest);
+
+  const c = crypto.createHash('sha1');
+
+  for (const file of files) {
+    const b = fs.readFileSync(file);
+    c.update(b);
+  }
+
+  return generateAndValidateHash(c);
+}
+
 module.exports = {
   hashForContent,
+  hashForFiles,
 };

--- a/src/build/resource-path.js
+++ b/src/build/resource-path.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Helper that reads and checks the resource path
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Finds the resource path for the given name, and confirms that the file exists (throwing an
+ * Error otherwise). Returns the path including any query parameters, but without any leading "/",
+ * for use in caching.
+ *
+ * @param {string} name
+ * @return {string}
+ */
+function resourcePath(name) {
+  name = name.toUpperCase();
+
+  const f = path.join(
+    __dirname,
+    '../../src/site/_data',
+    `resource${name}.json`,
+  );
+
+  const raw = JSON.parse(fs.readFileSync(f), 'utf-8');
+
+  const {path: rawPath} = raw;
+  if (rawPath === undefined) {
+    throw new Error(`could not find 'path' key in: ${f}`);
+  }
+
+  const cleanPath = rawPath.split('?')[0]; // remove trailing query params
+  const check = path.join(__dirname, '../../dist', cleanPath);
+  if (!fs.existsSync(check)) {
+    throw new Error(`path did not exist: ${check}`);
+  }
+
+  return rawPath[0] === '/' ? rawPath.substr(1) : rawPath;
+}
+
+module.exports = resourcePath;

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -16,12 +16,16 @@ import {matchSameOriginRegExp} from './utils/sw-match.js';
 const cacheNames = {webdevCore: 'webdev-core', ...workboxCacheNames};
 
 /**
- * Configure default cache for some common web.dev assets: images, CSS, JS, partial template.
+ * Configure default cache for some common web.dev assets: images, CSS, JS, partial template. This
+ * doesn't match general HTML or other files, so we disable directoryIndex and cleanURLs.
  *
  * This must occur first, as we cache images that are also matched by runtime handlers below. See
  * this workbox issue for updates: https://github.com/GoogleChrome/workbox/issues/2402
  */
-precacheAndRoute(manifest);
+precacheAndRoute(manifest, {
+  cleanURLs: false,
+  directoryIndex: '',
+});
 
 // Architecture revision of the Service Worker. If the previously saved revision doesn't match,
 // then this will cause clients to be aggressively claimed and reloaded on install/activate.

--- a/src/site/_filters/strip-query-params-dev.js
+++ b/src/site/_filters/strip-query-params-dev.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const isProd = process.env.ELEVENTY_ENV === 'prod';
+const noop = (url) => url;
+const strip = (url) => url.split('?')[0];
+
+// Strip query params from URLs in dev only. Used for lazy cache-busting
+// e.g. in non-prod, app.css?blah => app.css
+module.exports = isProd ? noop : strip;

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -36,7 +36,7 @@ tags: []
       rel="stylesheet"
       href="//fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:400,400italic,500,500italic|Roboto+Condensed:400,700|Roboto+Mono:400,500|Material+Icons"
     />
-    <link rel="stylesheet" href="{{resourceCSS.path}}" />
+    <link rel="stylesheet" href="{{ resourceCSS.path | stripQueryParamsDev }}" />
     <link rel="manifest" href="/manifest.webmanifest" />
     {# Include default icon even though we have a manifest #}
     <link rel="shortcut icon" href="/images/favicon.ico">
@@ -45,7 +45,7 @@ tags: []
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
     <script async src="//www.google-analytics.com/analytics.js"></script>
-    <script defer src="{{resourceJS.path}}"></script>
+    <script defer src="{{ resourceJS.path | stripQueryParamsDev }}"></script>
   </head>
   <body class="unresolved">
     {#

--- a/test/integration/build-test.js
+++ b/test/integration/build-test.js
@@ -30,6 +30,8 @@ describe('Build test', function () {
       path.join('images', 'favicon.ico'),
       path.join('images', 'lockup.svg'),
       '_redirects.yaml',
+      'app.css',
+      'bootstrap.js',
       'manifest.webmanifest',
       'nuke-sw.js',
       'robots.txt',
@@ -47,22 +49,13 @@ describe('Build test', function () {
 
     // Check that there's a Rollup-generated file with the given name that looks
     // like `[name]-[hash].js`.
-    ['bootstrap', 'app', 'measure', 'newsletter', 'default'].forEach(
-      (chunked) => {
-        const re = new RegExp(`^${chunked}-\\w+\\.js$`);
-        assert(
-          contents.find((file) => re.test(file)),
-          `Could not find Rollup output: ${chunked}`,
-        );
-      },
-    );
-
-    // Check that there's an "app-[hash].css" file.
-    const re = new RegExp(`^app-\\w+\\.css$`);
-    assert(
-      contents.find((file) => re.test(file)),
-      `Could not find Sass output: app`,
-    );
+    ['app', 'measure', 'newsletter', 'default'].forEach((chunked) => {
+      const re = new RegExp(`^${chunked}-\\w+\\.js$`);
+      assert(
+        contents.find((file) => re.test(file)),
+        `Could not find Rollup output: ${chunked}`,
+      );
+    });
 
     // Check that there's NOT a web.dev/LIVE partial. We confirm that partials
     // are generally created above, in the list of common checks.


### PR DESCRIPTION
We're seeing odd caching problems in the Real World(™) whereby older HTML files are being served, which request hashed CSS/JS files that don't exist. This was mitigated by #3392 but this PR cleans up the behavior further.

- instead of generating "app-hashed.css" and serving it at all "app.css", "app-whatever.css", this PR now generates _only_ "app.css" and also catches "app-whatever.css".
- we include a cache-busting query param in our layout (e.g., "app.css?v=1234")
- this same exact URL, including cache-busting, is cached by our SW (avoiding #3363)

So if we see odd caching issues, "app.css" and "bootstrap.js" will _still be served_, because the server is ignoring the query string.

This will effect the "bigger refactor" in #3362 but that's fine.

