### PR TITLE
fix SW bundling which wasn't working

### DIFF
--- a/build-sw.js
+++ b/build-sw.js
@@ -89,11 +89,11 @@ async function build() {
     input: 'src/lib/sw.js',
     external: disallowExternal,
     manualChunks: (id) => {
-      const chunkNames = ['idb-keyval', 'virtual', 'workbox'];
-      for (const chunkName of chunkNames) {
-        if (id.includes(`/node_modules/${chunkName}/`)) {
-          return 'sw-' + chunkName;
-        }
+      if (id.includes('/node_modules/idb-keyval')) {
+        return 'sw-idb-keyval';
+      }
+      if (/\/node_modules\/workbox-.*\//.exec(id)) {
+        return 'sw-workbox';
       }
     },
     plugins: [


### PR DESCRIPTION
Adds a few conditions for different SW bundles rather than trying to enumerate through stuff, as we weren't bundling Workbox together.