### PR TITLE
Don't switch tabs if the user is opening/closing the schedule modal

### DIFF
--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -38,6 +38,7 @@ class EventSchedule extends HTMLElement {
     this._activeEventDay = null;
     this._currentSession = null;
     this._tabsElement = null;
+    this._wasModalOpen = false;
 
     // This just creates an element, we're not yet making it part of the DOM, so it's allowed here
     // in the constructor.
@@ -177,15 +178,25 @@ class EventSchedule extends HTMLElement {
     this._tabsElement = null;
   }
 
-  onStateChanged({activeEventDay}) {
+  onStateChanged({activeEventDay, isModalOpen}) {
     this._activeEventDay = activeEventDay;
 
-    // This relies on the event data being in the same shape as the rendered
-    // tabs, which is pretty safe, since it comes from the same source.
-    // Don't change the tab for the user if a modal is already open.
-    if (!this._modalElement.open && activeEventDay) {
-      this._tabsElement.activeTab = activeEventDay.index;
+    // If the user has clicked to a different day, opened and closed a modal
+    // then don't do anything.
+    // If this is not the case then it means that either we're loading the
+    // page for the first time, or the user has left the tab open and we're
+    // transitioning to the next day. In that case, update the tabs element
+    // to reflect the current day.
+    if (!this._wasModalOpen) {
+      // This relies on the event data being in the same shape as the rendered
+      // tabs, which is pretty safe, since it comes from the same source.
+      // Don't change the tab for the user if a modal is already open.
+      if (!this._modalElement.open && activeEventDay) {
+        this._tabsElement.activeTab = activeEventDay.index;
+      }
     }
+
+    this._wasModalOpen = isModalOpen;
   }
 }
 

--- a/src/lib/components/EventSchedule/index.js
+++ b/src/lib/components/EventSchedule/index.js
@@ -182,18 +182,16 @@ class EventSchedule extends HTMLElement {
     this._activeEventDay = activeEventDay;
 
     // If the user has clicked to a different day, opened and closed a modal
-    // then don't do anything.
-    // If this is not the case then it means that either we're loading the
-    // page for the first time, or the user has left the tab open and we're
-    // transitioning to the next day. In that case, update the tabs element
-    // to reflect the current day.
-    if (!this._wasModalOpen) {
-      // This relies on the event data being in the same shape as the rendered
-      // tabs, which is pretty safe, since it comes from the same source.
-      // Don't change the tab for the user if a modal is already open.
-      if (!this._modalElement.open && activeEventDay) {
-        this._tabsElement.activeTab = activeEventDay.index;
-      }
+    // then don't do anything. Similarly, if the modal is currently open, don't
+    // do anything.
+    // If this is not the case then it means either we're loading the page for
+    // the first time, or the user has left the tab open and we're transitioning
+    // to the next day. In that case, update the tabs element to reflect the
+    // current day.
+    // This relies on the event data being in the same shape as the rendered
+    // tabs, which is pretty safe, since it comes from the same source.
+    if (!this._wasModalOpen && !this._modalElement.open && activeEventDay) {
+      this._tabsElement.activeTab = activeEventDay.index;
     }
 
     this._wasModalOpen = isModalOpen;


### PR DESCRIPTION
Fixes #3336.

Changes proposed in this pull request:

- Adds a wasModalOpen internal flag to EventSchedule to help it know when to reflect the current day in the tabs.
