### PR TITLE
Disable scheduled deploy during live event.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - master
-  schedule:
+  # schedule:
     # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
-    - cron: '0 15 * * 1-4'
+    # - cron: '0 15 * * 1-4'
 
 jobs:
   ci:


### PR DESCRIPTION
Changes proposed in this pull request:

- Disable the scheduled build while the live event is going on. Don't want to accidentally do any deploys while we're not looking :P