### PR TITLE
Fix typo on CONTRIBUTING.md name

### DIFF
--- a/src/site/content/en/blog/introducing-tooling-report/index.md
+++ b/src/site/content/en/blog/introducing-tooling-report/index.md
@@ -90,5 +90,5 @@ these outcomes are welcome.
   
 If you want to write tests for tools we did not include in the initial set, we welcome that too!
 Please see
-[CONTRIUBTING.md](https://github.com/GoogleChromeLabs/tooling.report/blob/dev/CONTRIBUTING.md) for
+[CONTRIBUTING.md](https://github.com/GoogleChromeLabs/tooling.report/blob/dev/CONTRIBUTING.md) for
 more information. 


### PR DESCRIPTION
Changes proposed in this pull request:

- Just fixing a typo in a link to a `CONTRIBUTING.md` file.
