### PR TITLE
Add unit for Max-Age duration

### DIFF
--- a/src/site/content/en/secure/cross-origin-resource-sharing/index.md
+++ b/src/site/content/en/secure/cross-origin-resource-sharing/index.md
@@ -214,5 +214,5 @@ Access-Control-Allow-Methods: GET, DELETE, HEAD, OPTIONS
 ```
 
 The server response can also include an `Access-Control-Max-Age` header to
-specify the duration to cache preflight results so the client does not need to
+specify the duration (in seconds) to cache preflight results so the client does not need to
 make a preflight request every time it sends a complex request.


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

Added unit info for `Access-Control-Max-Age`
