### PR TITLE
fix cleanup paths

### DIFF
--- a/.github/workflows/cleanup-versions-workflow.yml
+++ b/.github/workflows/cleanup-versions-workflow.yml
@@ -17,7 +17,7 @@ jobs:
           service_account_key: ${{ secrets.GCLOUD_KEY }}
 
       # Cleanup web-dev-staging
-      - run: node tools/cleanup-versions/index.js web-dev-staging
+      - run: node ./tools/cleanup-versions/index.js web-dev-staging
 
       # Cleanup web-dev-production-1
-      - run: node tools/cleanup-versions/index.js web-dev-production-1
+      - run: node ./tools/cleanup-versions/index.js web-dev-production-1


### PR DESCRIPTION
This job failed, but I can't really work out why. It seems like the paths are a bit confused.

I'm just mirroring more what we do inside `package.json` now, where we always prefix with "./". ¯‍\‍_‍(‍ツ‍)‍_‍/‍¯