### PR TITLE
[Bugfix] Fixes link on one line layouts article

### DIFF
--- a/src/site/content/en/blog/one-line-layouts/index.md
+++ b/src/site/content/en/blog/one-line-layouts/index.md
@@ -26,7 +26,7 @@ Modern CSS layouts enable developers to write really meaningful and robust styli
   </iframe>
 </div>
 
-To follow along or play with these demos on your own, check out the Glitch embed above, or visit [1linelayouts.glitch.me](1linelayouts.glitch.me).
+To follow along or play with these demos on your own, check out the Glitch embed above, or visit [1linelayouts.glitch.me](https://1linelayouts.glitch.me).
 
 ## 01. Super Centered: `place-items: center`
 


### PR DESCRIPTION
Link was broken as it was pointing inside the site. Added `https://` to have it point outwards.