### PR TITLE
update: Standardization of iframe lazyload

### DIFF
--- a/src/site/content/en/fast/native-lazy-loading/index.md
+++ b/src/site/content/en/fast/native-lazy-loading/index.md
@@ -18,10 +18,6 @@ tags:
   - performance
 ---
 
-{% Aside %}
-  Please note `<iframe loading=lazy>` is currently non-standard. While implemented in Chromium, it does not yet have a specification and is subject to future change when this does happen. We suggest not to lazy-load iframes using the loading attribute until it becomes part of the specification.
-{% endAside %}
-
 Support for natively lazy-loading images and iframes is coming to the web! This video shows
 a [demo](https://mathiasbynens.be/demo/img-loading-lazy) of the feature:
 


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #3469 

Changes proposed in this pull request:

-  Removed the note that it is non standard
