### PR TITLE
Nested lists look ugly

### DIFF
--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -88,6 +88,11 @@ ol:not([class]) > li > p:last-child {
   margin-bottom: 0;
 }
 
+li > ul:not([class]),
+li > ol:not([class]) {
+  margin: 8px 0;
+}
+
 .w-unstyled-list {
   list-style: none;
 }


### PR DESCRIPTION
Simple list in web.dev looks great, but once it's nested, it looks ugly.

<img width="409" alt="Screen Shot 2020-07-10 at 17 04 01" src="https://user-images.githubusercontent.com/218144/87131711-c48fd200-c2cf-11ea-9463-4d64f417f99f.png">

The above image is current state with simple nested list. Notice there's unnecessary space before and after nested lists. These are because `ul` and `ol` tags have extra margin at the top and the bottom.

<img width="401" alt="Screen Shot 2020-07-10 at 17 02 56" src="https://user-images.githubusercontent.com/218144/87131794-e5f0be00-c2cf-11ea-9175-1089749a524b.png">

With this change, the nested lists look much better with minimized margin for top and bottom.

This change will make nested lists like [this](https://web.dev/chrome-ux-report-api/#what's-next) look better. (And I have a pull request to make it look better.)