### PR TITLE
fix(lighthouse): correct use responsive images threshold

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -24,7 +24,7 @@ Resize these images to save data and improve page load time:
 For each image on the page,
 Lighthouse compares the size of the rendered image against the size of the actual image.
 The rendered size also accounts for device pixel ratio.
-If the rendered size is at least 25KiB smaller than the actual size,
+If the rendered size is at least 4KiB smaller than the actual size,
 then the image fails the audit.
 
 ## Strategies for properly sizing images


### PR DESCRIPTION
Changes proposed in this pull request:

- Not sure where this 25KiB came from but it was just bumped from 2KiB to 4KiB

noticed the typo in https://github.com/GoogleChrome/lighthouse/pull/11101/files
