### PR TITLE
Create separate performance section on /learn, update captions

### DIFF
--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -3,7 +3,7 @@
   "cover": "/images/collections/fast.svg",
   "title": "Fast load times",
   "updated": "July 17, 2020",
-  "description": "Guarantee your site loads quickly to avoid user drop off.",
+  "description": "Techniques for improving site performance.",
   "overview": "When you're building a modern web experience, it's important to measure, optimize, and monitor if you're to get fast and stay fast. Performance plays a significant role in the success of any online venture, as high performing sites engage and retain users better than poorly performing ones.\n\nSites should focus on optimizing for user-centric happiness metrics. Tools like Lighthouse (baked into web.dev!) highlight these metrics and help you take the right steps toward improving your performance. To \"stay fast\", set and enforce performance budgets to help your team work within the constraints needed to continue loading fast and keeping users happy after your site has launched.",
   "topics": [
     {

--- a/src/site/_data/paths/metrics.json
+++ b/src/site/_data/paths/metrics.json
@@ -2,7 +2,7 @@
   "slug": "metrics",
   "cover": "/images/collections/metrics.svg",
   "title": "Metrics",
-  "description": "Measure and optimize performance and user experience",
+  "description": "Measuring performance and user experience.",
   "overview": "User-centric performance metrics are a critical tool in understanding and improving the experience of your site in a way that benefits real users.",
   "topics": [
     {

--- a/src/site/_data/paths/vitals.json
+++ b/src/site/_data/paths/vitals.json
@@ -2,7 +2,7 @@
   "slug": "vitals",
   "cover": "/vitals/web-vitals.svg",
   "title": "Web Vitals",
-  "description": "Essential metrics for a healthy site",
+  "description": "Overview of Web Vitals.",
   "topics": [
     {
       "title": "Web Vitals",

--- a/src/site/content/en/learn/index.njk
+++ b/src/site/content/en/learn/index.njk
@@ -21,8 +21,21 @@ date: 2018-11-05
   </div>
   <section class="w-grid">
     <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three">
+      <h3 id="frameworks" class="w-learn-heading">
+        Performance
+        <a class="w-headline-link" href="#performance" aria-hidden="true">#</a>
+      </h3>
+    </div>
+    <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three" role="list">
+      {% for collection in learn.performance %}
+        {% PathCard collection, lang %}
+      {% endfor %}
+    </div>
+  </section>
+  <section class="w-grid">
+    <div class="w-grid__columns w-grid__columns--gapless w-grid__columns--three">
       <h3 id="principles" class="w-learn-heading">
-        Realize what the web can be
+        Build excellent websites
         <a class="w-headline-link" href="#principles" aria-hidden="true">#</a>
       </h3>
     </div>

--- a/src/site/content/en/learn/learn.11tydata.js
+++ b/src/site/content/en/learn/learn.11tydata.js
@@ -11,16 +11,19 @@ const allPaths = require('../../../_data/paths');
 
 module.exports = function () {
   const paths = [
-    allPaths['vitals'],
     allPaths['progressive-web-apps'],
     allPaths['accessible'],
-    allPaths['fast'],
     allPaths['reliable'],
     allPaths['secure'],
     allPaths['discoverable'],
-    allPaths['metrics'],
     allPaths['payments'],
   ].filter(livePaths);
+
+  const performance = [
+    allPaths['vitals'],
+    allPaths['metrics'],
+    allPaths['fast'],
+  ];
 
   const frameworks = [allPaths['react'], allPaths['angular']].filter(livePaths);
 
@@ -35,6 +38,7 @@ module.exports = function () {
   return {
     learn: {
       paths,
+      performance,
       frameworks,
       audits,
     },


### PR DESCRIPTION
Given that /vitals, /metrics, and /fast are highly coupled, I think grouping them together makes it easier to locate content - for both the "performance" and "realize what the web can be" sections.

Before
<img width="715" alt="current layout" src="https://user-images.githubusercontent.com/6076184/87725760-e1bf1780-c78b-11ea-9bb1-d799fa060160.png">

After
<img width="693" alt="Screen Shot 2020-07-16 at 5 36 13 PM" src="https://user-images.githubusercontent.com/6076184/87726041-4da18000-c78c-11ea-8033-e3cea692a8fe.png">

cc @philipwalton 
