### PR TITLE
chore: Enable scheduled builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - master
-  # schedule:
+  schedule:
     # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
-    # - cron: '0 15 * * 1-4'
+    - cron: '0 15 * * 1-4'
 
 jobs:
   ci:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - master
   schedule:
-    # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Thursday.
-    - cron: '0 15 * * 1-4'
+    # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Friday.
+    - cron: '0 15 * * 1-5'
 
 jobs:
   ci:


### PR DESCRIPTION
During web.dev LIVE I disabled scheduled builds so we wouldn't accidentally deploy over the running site. This PR enables schedule builds again and sets them to run on Fridays (previously they did Mon-Thur). It seems like an easy mistake for an author to assume that a scheduled build would happen on Friday and since it's first thing in the morning I think there's less concern about deploying the site. I would still like to avoid deploying the site at the _end_ of Friday so folks don't have to stress about it going down over the weekend :)

Changes proposed in this pull request:

- Enable schedule builds
- Run scheduled builds on Fridays