### PR TITLE
Disable updated hook.

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -2,7 +2,6 @@
   "//1": "Use git commit --no-verify to bypass the pre-commit hook",
   "//2": "Use git push --no-verify to bypass the pre-push hook",
   "hooks": {
-    "pre-commit": "npm run precommit",
     "pre-push": "npm run lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:scss": "sass-lint -v -q",
     "lint": "npm-run-all lint:md lint:scss lint:js",
     "percy": "PERCY=true npm-run-all build --parallel --race start snapshots",
-    "precommit": "node ./tools/update-updated/index.js",
+    "updated": "node ./tools/update-updated/index.js",
     "rollup": "node build.js",
     "rollup-sw": "node build-sw.js",
     "sass": "node ./compile-css.js",

--- a/tools/update-updated/index.js
+++ b/tools/update-updated/index.js
@@ -1,5 +1,9 @@
 /**
  * @fileoverview Task for updating `updated` YAML field.
+ * Run this command while you have dirty files and it will update their
+ * `updated` YAML field.
+ *
+ * Example: npm run updated && git commit -am 'Updated some blog posts'
  *
  * @author Matt Gaunt & Rob Dodson 💕
  */


### PR DESCRIPTION
Fixes #3368

Changes proposed in this pull request:

- Don't run `update-updated` as a pre-commit hook.
- Rename npm script from `precommit` to `updated`. If folks want to use the script they can still do `npm run updated`.
