### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/blog/at-property/index.md
+++ b/src/site/content/en/blog/at-property/index.md
@@ -149,7 +149,7 @@ In this example, the gradient stop percentage is being animated from a starting
 value of 40% to an ending value of 100% via a hover interaction. You should see a
 smooth transition of that top gradient color downward.
 
-The browser on the right supports the Houdini Properties and Values API,
+The browser on the left supports the Houdini Properties and Values API,
 enabling a smooth gradient stop transition. The browser on the right does not. The
 non-supporting browser is only able to understand this change as a string going
 from point A to point B. There is no opportunity to interpolate the values, and


### PR DESCRIPTION
> "The browser on the right supports the Houdini Properties and Values API, enabling a smooth gradient stop transition. The browser on the right does not"

The first "right" should be, should have been, "left", _viz_ 

"The browser on the left supports the Houdini Properties and Values API, enabling a smooth gradient stop transition. The browser on the right does not"

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER  - Nope.

Changes proposed in this pull request:

- Fixes a typo 
