### PR TITLE
[WebHID article] Replace colon entity with just :

### DIFF
--- a/src/site/content/en/blog/hid-examples/index.md
+++ b/src/site/content/en/blog/hid-examples/index.md
@@ -1,5 +1,5 @@
 ---
-title: Human interface devices on the web&#58; a few quick examples
+title: Human interface devices on the web: a few quick examples
 subhead: Connecting to uncommon devices from your app.
 authors:
   - joemedley


### PR DESCRIPTION
Changes proposed in this pull request:

- The entity `&#58;` appears like that in search. We can just use a colon instead. 
