### PR TITLE
Fix @property post typos

### DIFF
--- a/src/site/content/en/blog/at-property/index.md
+++ b/src/site/content/en/blog/at-property/index.md
@@ -77,7 +77,7 @@ value when overriding it, the CSS rendering engine will send the initial value
 Consider the example below. The `--colorPrimary` variable has an
 `initial-value` of `magenta`. But the developer has given it the invalid
 value "23". Without `@property`, the CSS parser would ignore the
-invalid code. Now, the parser falls back to `megenta`. This allows for
+invalid code. Now, the parser falls back to `magenta`. This allows for
 true fallbacks and testing within CSS. Neat!
 
 ```css
@@ -182,7 +182,7 @@ This will now enable that smooth gradient transition.
 
 ## Conclusion 
 
-The `@property` makes an exciting technology even more accessible by
+The `@property` rule makes an exciting technology even more accessible by
 allowing you to write semantically meaningful CSS within CSS itself. To learn
 more about CSS Houdini and the Properties and Values API, check out these
 resources:

--- a/src/site/content/en/blog/at-property/index.md
+++ b/src/site/content/en/blog/at-property/index.md
@@ -137,7 +137,7 @@ In this example, the gradient stop percentage is being animated from a starting
 value of 40% to an ending value of 100% via a hover interaction. You should see a
 smooth transition of that top gradient color downward.
 
-The browser on the right supports the Houdini Properties and Values API,
+The browser on the left supports the Houdini Properties and Values API,
 enabling a smooth gradient stop transition. The browser on the right does not. The
 non-supporting browser is only able to understand this change as a string going
 from point A to point B. There is no opportunity to interpolate the values, and


### PR DESCRIPTION
Fixes some typos in the @property post:

- Change `megenta` to `magenta`
- Add `rule` to give `@property` context
- Change `right` to `left` to describe image