### PR TITLE
Adds PWA content to PWA landing page

### DIFF
--- a/src/site/_data/paths/progressive-web-apps.json
+++ b/src/site/_data/paths/progressive-web-apps.json
@@ -11,15 +11,7 @@
       "pathItems": [
         "what-are-pwas",
         "drive-business-success",
-        "define-install-strategy",
         "pwa-checklist"
-      ]
-    },
-    {
-      "title": "Capable",
-      "pathItems": [
-        "app-like-pwas",
-        "progressively-enhance-your-pwa"
       ]
     },
     {
@@ -29,6 +21,7 @@
     {
       "title": "Installable",
       "pathItems": [
+        "define-install-strategy",
         "install-criteria"
       ],
       "subtopics": [
@@ -47,6 +40,29 @@
             "codelab-make-installable"
           ]
         }
+      ]
+    },
+    {
+      "title": "Capable",
+      "pathItems": [
+        "app-like-pwas",
+        "progressively-enhance-your-pwa"
+      ],
+      "subtopics": [
+        {
+          "title": "Improve your experience with PWA-exclusive features",
+          "pathItems": [
+            "app-shortcuts",
+            "badging-api",
+            "web-share-target"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Advanced topics",
+      "pathItems": [
+        "multi-origin-pwas"
       ]
     }
   ]

--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -9,8 +9,8 @@ updated: 2020-06-04
 tags:
   - blog
   - capabilities
-  - badging
   - progressive-web-apps
+  - badging
   - notifications
 hero: hero.jpg
 alt: Phone showing several notification badges

--- a/src/site/content/en/blog/multi-origin-pwas/index.md
+++ b/src/site/content/en/blog/multi-origin-pwas/index.md
@@ -13,9 +13,7 @@ alt: Multiple Shifting Gears.
 description: Multi-origin architectures presents many challenges when building PWAs. Explore the good and bad uses of multiple origins, and some workarounds to build PWAs in multi-origin sites.
 tags:
   - blog
-  - PWA
-  - caching
-  - a2hs
+  - progressive-web-apps
   - service-worker
 ---
 

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -14,6 +14,7 @@ description: |
 tags:
   - blog
   - capabilities
+  - progressive-web-apps
 ---
 
 On a mobile device, sharing should be as simple as clicking the **Share** button,


### PR DESCRIPTION
Replaces #3578 - essentially the same, except content is not physically moved, it's just added to the PWA landing page.

Updates to the PWA info architecture 
- Re-orders top line topics to move install closer to the top since it's a key component of PWAs
- Moves `badging`, `app shortcuts`, and `share target` into the PWA folder
  - These were originally posted as blog posts, but have been moved into PWA area since they're only available to installed PWAs.
- Creates new advanced topics section where deeper dive content will go
  - Moves PWA multi-origin from blog into advanced topics

