### PR TITLE
Remove /live/ from nav and banner.

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -30,9 +30,8 @@ module.exports = {
   subscribeForm:
     'https://services.google.com/fb/submissions/591768a1-61a6-4f16-8e3c-adf1661539da/',
   thumbnail: '/images/social.png',
-  isBannerEnabled: true,
-  banner:
-    'web.dev LIVE is now over! Head to [web.dev/live](/live/) to watch all the sessions, top Q&A and more.',
+  isBannerEnabled: false,
+  banner: '',
   // Note that the imageCdn value is only used when we do a production build
   // of the site. Otherwise all image paths are local. This means you can
   // develop locally without having to mess with the CDN at all.

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -99,15 +99,6 @@ eleventyComputed:
           </a>
 
           <a
-            href="/live/"
-            class="web-header__link gc-analytics-event"
-            data-category="Site-Wide Custom Events"
-            data-label="Tab: Live"
-          >
-            Live
-          </a>
-
-          <a
             href="/about/"
             class="web-header__link gc-analytics-event"
             data-category="Site-Wide Custom Events"


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes the banner linking to /live/
- Removes /live/ from the top nav