### PR TITLE
Make content team the owners for author images.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,15 +6,16 @@
 * @GoogleChrome/web-dev-eng
 
 # Docs
-content/ @GoogleChrome/web-dev-content
-content/en/angular/ @mgechev @GoogleChrome/web-dev-content
-content/en/authors/ @GoogleChrome/web-dev-eng
-content/en/metrics/ @philipwalton @GoogleChrome/web-dev-content
-content/en/newsletter/ @GoogleChrome/web-dev-eng
-content/en/progressive-web-apps/ @petele @GoogleChrome/web-dev-content
-content/en/react/ @housseindjirdeh @GoogleChrome/web-dev-content
-content/en/tags/ @GoogleChrome/web-dev-eng
-content/en/vitals/ @philipwalton @GoogleChrome/web-dev-content
+src/site/content/ @GoogleChrome/web-dev-content
+src/images/authors/ @GoogleChrome/web-dev-content
+src/site/content/en/angular/ @mgechev @GoogleChrome/web-dev-content
+src/site/content/en/authors/ @GoogleChrome/web-dev-eng
+src/site/content/en/metrics/ @philipwalton @GoogleChrome/web-dev-content
+src/site/content/en/newsletter/ @GoogleChrome/web-dev-eng
+src/site/content/en/progressive-web-apps/ @petele @GoogleChrome/web-dev-content
+src/site/content/en/react/ @housseindjirdeh @GoogleChrome/web-dev-content
+src/site/content/en/tags/ @GoogleChrome/web-dev-eng
+src/site/content/en/vitals/ @philipwalton @GoogleChrome/web-dev-content
 
 # File types
 # These should override docs directory owners.


### PR DESCRIPTION
Changes proposed in this pull request:

- Makes web-dev-content team the owners for src/images/authors. This will prevent the eng team from getting tagged in on content PRs.
- Switches to using full directory paths (content/ -> src/site/content)
