### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -148,14 +148,6 @@ considered.
 Web pages often load in stages, and as a result, it's possible that the largest
 element on the page might change.
 
-To handle this potential for change, the browser dispatches a
-[`PerformanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)
-of type `largest-contentful-paint` identifying the largest contentful element
-as soon as the browser has painted the first frame. But then, after rendering
-subsequent frames, it will dispatch another
-[`PerformanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)
-any time the largest contentful element changes.
-
 For example, on a page with text and a hero image the browser may initially just render the text—at which point the browser would dispatch a `largest-contentful-paint` entry whose `element` property would likely reference a `<p>` or `<h1>`. Later, once the hero image finishes loading, a second `largest-contentful-paint` entry would be dispatched and its `element` property would reference the `<img>`.
 
 It's important to note that an element can only be considered the largest


### PR DESCRIPTION
Suggest rm this section because it's misleading.

This doesn't seem to be the case any more. While I see LCP on my timeline, I cannot find any such marks or measures in `Performance.entries()`.

I do see entries of type `paint` (not `largest-contentful-paint`), but not the largest-contentful-paint.

I would update with the new/correct way to get this measure, but I can't figure out how to see it, maybe it's no longer gettable?

![image](https://user-images.githubusercontent.com/548809/89109880-f93c0880-d3f9-11ea-804e-8090c5decc32.png)


<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
