### PR TITLE
Update instructions component to use Lighthouse.

### DIFF
--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -137,7 +137,7 @@ module.exports = (type, listStyle = 'ul') => {
     case 'devtools-memory':
     case 'devtools-application':
     case 'devtools-security':
-    case 'devtools-audits':
+    case 'devtools-lighthouse':
       instruction = html`${shared.devtools}`;
       substitution = type.substring('devtools-'.length);
       if (substitution) {

--- a/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
+++ b/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
@@ -29,7 +29,7 @@ used independently to achieve performance results.
 Run Lighthouse to identify opportunities for improvement aligned with the PRPL
 techniques:
 
-{% Instruction 'devtools-audits', 'ol' %}
+{% Instruction 'devtools-lighthouse', 'ol' %}
 1. Select the **Performance** and **Progressive Web App** checkboxes.
 1. Click **Run Audits** to generate a report.
 

--- a/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
+++ b/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
@@ -26,7 +26,7 @@ This responsive ice cream gallery is built with [Bootstrap](https://getbootstrap
 
 To run a Lighthouse audit on this site:
 
-{% Instruction 'devtools-audits', 'ol' %}
+{% Instruction 'devtools-lighthouse', 'ol' %}
 1. Click **Mobile**.
 1. Select the **Performance** checkbox.
 1. Clear the rest of the checkboxes in the Audits section.

--- a/src/site/content/en/fast/codelab-optimize-third-party-javascript/index.md
+++ b/src/site/content/en/fast/codelab-optimize-third-party-javascript/index.md
@@ -47,7 +47,7 @@ First open the sample app in the fullscreen view:
 
 Run a [Lighthouse](https://developers.google.com/web/tools/lighthouse/) [performance audit](/lighthouse-performance) on the page to establish baseline performance:
 
-{% Instruction 'devtools-audits', 'ol' %}
+{% Instruction 'devtools-lighthouse', 'ol' %}
 1. Click **Mobile**.
 1. Select the **Performance** checkbox. (You can clear the rest of the checkboxes in the Audits section.)
 1. Click **Simulated Fast 3G, 4x CPU Slowdown**.

--- a/src/site/content/en/fast/identify-slow-third-party-javascript/index.md
+++ b/src/site/content/en/fast/identify-slow-third-party-javascript/index.md
@@ -28,7 +28,7 @@ The Lighthouse [Performance audit](/lighthouse-performance) helps you discover o
 
 To run an audit:
 
-{% Instruction 'devtools-audits', 'ol' %}
+{% Instruction 'devtools-lighthouse', 'ol' %}
 1. Click **Mobile**.
 1. Select the **Performance** checkbox. (You can clear the rest of the checkboxes in the Audits section.)
 1. Click **Simulated Fast 3G, 4x CPU Slowdown**.


### PR DESCRIPTION
Fixes #3609

Changes proposed in this pull request:

- Change the instructions component to say "Click the Lighthouse panel" instead of the "Audits" panel. The name of the panel is inferred from the argument passed to the shortcode, i.e. {% devtools-**lighthouse** %}
- Updates existing articles to use devtools-lighthouse
