### PR TITLE
Add manual build trigger and updated scheduled build cron to be hourly.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -4,11 +4,9 @@ on:
   # manually deploy the site.
   workflow_dispatch:
   
-  # Automatically build and deploy the site hourly,
-  # between the hours of 5am and 5pm
-  # every day-of-week from Monday through Thursday.
+  # Automatically build and deploy the site hourly, Mon-Fri
   schedule:
-    - cron: '0 5-17 * * 1-4'
+    - cron: '0 * * * 1-5'
 
 jobs:
   ci:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,11 +1,14 @@
-name: Continuous integration
+name: Deploy
 on:
-  push:
-    branches:
-      - master
+  # Adds a 'Run Workflow' button to the GitHub Actions UI so the team can
+  # manually deploy the site.
+  workflow_dispatch:
+  
+  # Automatically build and deploy the site hourly,
+  # between the hours of 5am and 5pm
+  # every day-of-week from Monday through Thursday.
   schedule:
-    # At 15:00 UTC / 7:00 PST on every day-of-week from Monday through Friday.
-    - cron: '0 15 * * 1-5'
+    - cron: '0 5-17 * * 1-4'
 
 jobs:
   ci:


### PR DESCRIPTION
Moves the site to an hourly deploy cadence (Mon-Fri), instead of deploying every time we merge something into master. Also adds a 'Run Workflow' button so folks can manually deploy the site on-demand.

**Why do this?**
We've recently been seeing issues with App Engine failing our builds. The App Engine team is still debugging why this is happening, but one likely culprit is when we queue multiple builds to run at the same time. This is pretty easy to do if we merge two PRs close to one another. It's also wasteful to enqueue so many builds. This change will essentially bucket our builds, so if we merge 10 PRs in an hour, it'll only do 1 deploy. The addition of the manual trigger also means folks can deploy the site immediately if they need to.

Changes proposed in this pull request:

- Merging to master will no longer deploy the site. This is because we often see folks going through and merging several PRs at once, which queues up a number of builds that begin to race one another and seem to be breaking App Engine.
- Adds [a manual trigger](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to the Action. This will add a button to the Actions tab so folks on the team can easily manually deploy the site.
- Updates the schedule so the site does an automated build every hour, Mon-Fri.
- Renames 'Continuous Integration' task to 'Deploy' so it's easier for folks to grok at a glance.
