### PR TITLE
fix(Glitch): assign default `previewSize` value, fixes #3633

### DIFF
--- a/src/site/_includes/components/Glitch.js
+++ b/src/site/_includes/components/Glitch.js
@@ -29,7 +29,7 @@ module.exports = (param) => {
   let glitchProps = {
     id: null,
     path: '',
-    previewSize: null,
+    previewSize: 100,
     height: 420,
   };
 

--- a/src/site/content/en/accessible/accessible-tap-targets/index.md
+++ b/src/site/content/en/accessible/accessible-tap-targets/index.md
@@ -32,8 +32,7 @@ In the demo, I have added padding to all of the links in order to make sure they
 
 {% Glitch {
   id: 'tap-targets',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 Touch targets should also be spaced about 8 pixels apart,
@@ -48,8 +47,7 @@ In the example below I am using `em` for my text and padding.
 
 {% Glitch {
   id: 'tap-targets-2',
-  path: 'style.css',
-  previewSize: 100
+  path: 'style.css'
 } %}
 
 Inspect the `a` of the link,

--- a/src/site/content/en/accessible/content-reordering/index.md
+++ b/src/site/content/en/accessible/content-reordering/index.md
@@ -32,8 +32,7 @@ the order that we read in English.
 
 {% Glitch {
   id: 'flex-nav-source-ordered',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 If you have created this sort of pattern and then were asked to move **Contact Us**,
@@ -42,8 +41,7 @@ Try tabbing through the items in the example below, which has used the `order` p
 
 {% Glitch {
   id: 'flex-nav-ordered',
-  path: 'style.css',
-  previewSize: 100
+  path: 'style.css'
 } %}
 
 The focus jumps to the final item and then back again.
@@ -70,8 +68,7 @@ using line numbers, without considering where they are in the source.
 
 {% Glitch {
   id: 'grid-mixed-up-order',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 Try tabbing around this example, and see how the focus jumps about.

--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -51,7 +51,6 @@ To focus an element, press the `Tab` key or call the element's `focus()` method.
 {% Glitch {
   id: 'tabindex-zero',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -69,7 +68,6 @@ focused by calling its `focus()` method.
 {% Glitch {
   id: 'tabindex-negative-one',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -140,7 +138,6 @@ method on it.
 {% Glitch {
   id: 'roving-tabindex',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/accessible/keyboard-access/index.md
+++ b/src/site/content/en/accessible/keyboard-access/index.md
@@ -64,7 +64,6 @@ order versus an illogical tab order:
 {% Glitch {
   id: 'logical-tab-order',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -73,7 +72,6 @@ order versus an illogical tab order:
 {% Glitch {
   id: 'illogical-tab-order',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/accessible/style-focus/index.md
+++ b/src/site/content/en/accessible/style-focus/index.md
@@ -38,7 +38,6 @@ the `<div>` will _always_ look the same.
 {% Glitch {
   id: 'focus-style',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -63,7 +62,6 @@ Firefox and Safari the element does not receive focus when you click on it.
 {% Glitch {
   id: 'focus-style2',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -106,7 +104,6 @@ button:focus-visible {
 {% Glitch {
   id: 'focus-visible-style',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -131,7 +128,6 @@ form:focus-within {
 {% Glitch {
   id: 'focus-within-style',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -196,6 +192,5 @@ the polyfill to change the focus indicator on a button.
 {% Glitch {
   id: 'focus-visible',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}

--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -39,7 +39,6 @@ TAB`) to move between controls, and you can use the arrow keys and keys like
 {% Glitch {
   id: 'interactive-elements',
   path: 'index.html',
-  previewSize: 100,
   height: 450
 } %}
 
@@ -76,7 +75,6 @@ and `SPACE` to attempt to click on them.
 {% Glitch {
   id: 'synthetic-click',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/blog/drag-and-drop/index.md
+++ b/src/site/content/en/blog/drag-and-drop/index.md
@@ -118,8 +118,7 @@ although the drop functionality is not in place,
 
 {% Glitch {
   id: 'simple-drag-and-drop-1',
-  path: 'style.css',
-  previewSize: 100
+  path: 'style.css'
 } %}
 
 ## Add additional visual cues with `dragenter`, `dragover`, and `dragleave`
@@ -185,8 +184,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 {% Glitch {
   id: 'simple-drag-drop2',
-  path: 'dnd.js',
-  previewSize: 100
+  path: 'dnd.js'
 } %}
 
 There are a couple of points worth covering in this code:
@@ -272,8 +270,7 @@ Drag and release the A column on top of the B column and notice how they change 
 
 {% Glitch {
   id: 'simple-drag-drop',
-  path: 'dnd.js',
-  previewSize: 100
+  path: 'dnd.js'
 } %}
 
 ## More dragging properties

--- a/src/site/content/en/blog/image-support-for-async-clipboard/index.md
+++ b/src/site/content/en/blog/image-support-for-async-clipboard/index.md
@@ -245,7 +245,6 @@ In this case just run the demo
 {% Glitch {
   id: 'async-clipboard-api',
   path: 'README.md',
-  previewSize: 100,
   height: 500
 } %}
 

--- a/src/site/content/en/blog/keyboard-lock/index.md
+++ b/src/site/content/en/blog/keyboard-lock/index.md
@@ -107,8 +107,7 @@ You can test the Keyboard Lock API by running the [demo](https://keyboard-lock.g
 
 {% Glitch {
   id: 'keyboard-lock',
-  path: 'script.js',
-  previewSize: 100
+  path: 'script.js'
 } %}
 
 ## Security Considerations

--- a/src/site/content/en/blog/module-workers/index.md
+++ b/src/site/content/en/blog/module-workers/index.md
@@ -194,7 +194,6 @@ to avoid worker instantiation having to wait to download the worker script. Howe
 
 {% Glitch {
   id: 'worker-preloading',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/one-line-layouts/index.md
+++ b/src/site/content/en/blog/one-line-layouts/index.md
@@ -21,7 +21,6 @@ Modern CSS layouts enable developers to write really meaningful and robust styli
 {% Glitch {
   id: '1linelayouts',
   path: 'README.md',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/promises/index.md
+++ b/src/site/content/en/blog/promises/index.md
@@ -681,7 +681,6 @@ document.querySelector('.spinner').style.display = 'none'
 
 {% Glitch {
   id: 'promises-sync-example',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -806,7 +805,6 @@ getJSON('story.json').then(function(story) {
 
 {% Glitch {
   id: 'promises-async-example',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -863,7 +861,6 @@ getJSON('story.json').then(function(story) {
 
 {% Glitch {
   id: 'promises-async-all-example',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -920,7 +917,6 @@ getJSON('story.json')
 
 {% Glitch {
   id: 'promises-async-best-example',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -1045,7 +1041,6 @@ spawn(function *() {
 
 {% Glitch {
   id: 'promises-async-generator-example',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/read-files/index.md
+++ b/src/site/content/en/blog/read-files/index.md
@@ -58,7 +58,6 @@ built-in file selection UI and then logs each selected file to the console.
 
 {% Glitch {
   id: 'input-type-file',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -218,7 +217,6 @@ verify that the user has selected an image file.
 
 {% Glitch {
   id: 'read-image-file',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
+++ b/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
@@ -185,7 +185,6 @@ video.requestVideoFrameCallback(updateCanvas);
 {% Glitch {
   id: 'requestvideoframecallback',
   path: 'script.js',
-  previewSize: 100,
   height: 1200
 } %}
 

--- a/src/site/content/en/blog/responsive-web-design-basics/index.md
+++ b/src/site/content/en/blog/responsive-web-design-basics/index.md
@@ -175,8 +175,7 @@ This means that the columns become narrower, rather than creating a scrollbar.
 
 {% Glitch {
   id: 'layout-floats-percent',
-  path: 'README.md',
-  previewSize: 100
+  path: 'README.md'
 } %}
 
 Modern CSS layout techniques such as Flexbox, Grid Layout, and Multicol
@@ -200,7 +199,6 @@ or wrapped onto multiple rows as the available space decreases.
 
 {% Glitch {
   id: 'responsive-flexbox',
-  previewSize: 100,
   height: 220
 } %}
 
@@ -221,10 +219,7 @@ which represents a portion of the available space in the container.
 }
 ```
 
-{% Glitch {
-  id: 'two-column-grid',
-  previewSize: 100
-} %}
+{% Glitch 'two-column-grid' %}
 
 Grid can also be used to create regular grid layouts,
 with as many items as will fit.
@@ -232,10 +227,7 @@ The number of available tracks will be reduced as the screen size shrinks.
 In the below demo, we have as many cards as will fit on each row,
 with a minimum size of `200px`.
 
-{% Glitch {
-  id: 'grid-as-many-as-fit',
-  previewSize: 100
-} %}
+{% Glitch 'grid-as-many-as-fit' %}
 
 [Read more about CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Grids)
 
@@ -247,8 +239,7 @@ In the demo below, you can see that columns are added if there is room for anoth
 
 {% Glitch {
   id: 'responsive-multicol',
-  path: 'style.css',
-  previewSize: 100
+  path: 'style.css'
 } %}
 
 [Read more about Multicol](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
@@ -309,8 +300,7 @@ and we can test for the following things.
 
 {% Glitch {
   id: 'media-queries-size',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 All of these features have excellent browser support,
@@ -343,10 +333,7 @@ and whether the user can hover over elements.
 Try viewing this demo on different devices,
 such as a regular desktop computer and a phone or tablet.
 
-{% Glitch {
-  id: 'media-query-pointer',
-  previewSize: 100
-} %}
+{% Glitch 'media-query-pointer' %}
 
 These newer features have good support in all modern browsers. Find out more on the MDN pages for
 [hover](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover),
@@ -468,8 +455,7 @@ so it doesn't consume the whole screen width.
 
 {% Glitch {
   id: 'responsive-forecast',
-  path: 'style.css',
-  previewSize: 100
+  path: 'style.css'
 } %}
 
 ### Optimize text for reading
@@ -510,8 +496,7 @@ In this case, if the browser width is greater than `575px`, the ideal content wi
 
 {% Glitch {
   id: 'rwd-reading',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 ### Avoid simply hiding content

--- a/src/site/content/en/blog/sign-in-form-best-practices/index.md
+++ b/src/site/content/en/blog/sign-in-form-best-practices/index.md
@@ -38,7 +38,6 @@ Here is an example of a simple sign-in form that demonstrates all of the best pr
 {% Glitch {
   id: 'sign-in-form',
   path: 'index.html',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -631,7 +630,6 @@ You can see both ARIA features in action in the following Glitch:
 {% Glitch {
   id: 'signin-form',
   path: 'index.html',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/stale-while-revalidate/index.md
+++ b/src/site/content/en/blog/stale-while-revalidate/index.md
@@ -74,7 +74,6 @@ specifically, the current number of minutes past the hour.
 {% Glitch {
   id: 's-w-r-demo',
   path: 'server.js:20:15',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/blog/user-agent-client-hints/index.md
+++ b/src/site/content/en/blog/user-agent-client-hints/index.md
@@ -302,7 +302,6 @@ You can try out both the headers and the JavaScript API on your own device at
 {% Glitch {
   id: 'user-agent-client-hints',
   path: 'README.md',
-  previewSize: 100,
   height: 600
 } %}
 

--- a/src/site/content/en/blog/variable-fonts/index.md
+++ b/src/site/content/en/blog/variable-fonts/index.md
@@ -180,7 +180,6 @@ that primary colors can be mixed to create any other color.
 
 {% Glitch {
   id: 'variable-font-experiments',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/web-animations/index.md
+++ b/src/site/content/en/blog/web-animations/index.md
@@ -88,7 +88,6 @@ However, with the update, the Web Animations API is no longer restricted to anim
 {% Glitch {
   id: 'waapi-getanimations',
   path: 'index.html',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -139,7 +138,6 @@ You can take the above animation, and give it a smooth, reversed animation when 
 {% Glitch {
   id: 'waapi-promises',
   path: 'script.js',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/blog/websocketstream/index.md
+++ b/src/site/content/en/blog/websocketstream/index.md
@@ -261,8 +261,7 @@ or [directly on Glitch](https://websocketstream-demo.glitch.me/).
 
 {% Glitch {
   id: 'websocketstream-demo',
-  path: 'public/index.html',
-  previewSize: 100
+  path: 'public/index.html'
 } %}
 
 ## Feedback {: #feedback }

--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -24,8 +24,7 @@ The following example contains an accordion with three hidden paragraphs of text
 
 {% Glitch {
   id: 'defer-css-unoptimized',
-  path: 'index.html',
-  previewSize: 100
+  path: 'index.html'
 } %}
 
 This page requests a CSS file with eight classes, but not all of them are

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -683,7 +683,7 @@ Shortcode object fields allow for modifying how the embed is presented:
 
 * {`string`} `id` ID of Glitch project.
 * {`string`} `path?` Lets you specify which source code file to show.
-* {`number`} `previewSize?` Displays the app, rather than the source code.
+* {`number`} `previewSize?` Defines what percentage of the embed should be dedicated to the preview, default is 100.
 * {`number`} `height?` Height, in pixels, of the Glitch wrapper element.
 
 <!-- https://support.glitch.com/t/more-flexible-embeds/2925 -->

--- a/src/site/content/en/lighthouse-accessibility/custom-controls-labels/index.md
+++ b/src/site/content/en/lighthouse-accessibility/custom-controls-labels/index.md
@@ -24,7 +24,6 @@ press the `TAB` key to navigate through the site:
 {% Glitch {
   id: 'tabindex-zero',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/lighthouse-accessibility/focusable-controls/index.md
+++ b/src/site/content/en/lighthouse-accessibility/focusable-controls/index.md
@@ -29,7 +29,6 @@ TAB`) to move between controls, and use the arrow keys and
 {% Glitch {
   id: 'interactive-elements',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -62,7 +61,6 @@ the button's focus indicator always looks the same
 {% Glitch {
   id: 'focus-style',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 

--- a/src/site/content/en/react/code-splitting-suspense/index.md
+++ b/src/site/content/en/react/code-splitting-suspense/index.md
@@ -83,7 +83,6 @@ In the meantime, the fallback loading component is shown.
 {% Glitch {
   id: 'react-lazy-suspense',
   path: 'src/index.css',
-  previewSize: 100,
   height: 480
 } %}
 
@@ -148,7 +147,6 @@ You can see this with the following embed:
 {% Glitch {
   id: 'react-lazy-suspense-multiple',
   path: 'src/index.css',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/react/precache-with-workbox-react/index.md
+++ b/src/site/content/en/react/precache-with-workbox-react/index.md
@@ -60,7 +60,6 @@ Here is an example of a React app built with CRA that has a service worker enabl
 {% Glitch {
   id: 'react-sw-example',
   path: 'src/index.css',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/en/react/virtualize-long-lists-react-window/index.md
+++ b/src/site/content/en/react/virtualize-long-lists-react-window/index.md
@@ -21,7 +21,6 @@ Here's an example of a list that contains 1000 rows being rendered with
 {% Glitch {
   id: 'react-window-fixed',
   path: 'src/App.js',
-  previewSize: 100,
   height: 750
 } %}
 
@@ -145,7 +144,6 @@ The following embed shows an example of this component.
 {% Glitch {
   id: 'react-window-variable',
   path: 'src/ListComponent.js',
-  previewSize: 100,
   height: 750
 } %}
 
@@ -324,7 +322,6 @@ list.
 {% Glitch {
   id: 'react-window-infinite',
   path: 'src/ListComponent.js',
-  previewSize: 100,
   height: 750
 } %}
 

--- a/src/site/content/en/reliable/service-worker-caching-and-http-caching/index.md
+++ b/src/site/content/en/reliable/service-worker-caching-and-http-caching/index.md
@@ -195,7 +195,6 @@ different scenarios:
 
 {% Glitch {
   id: 'compare-sw-and-http-caching',
-  previewSize: 100,
   height: 480
 } %}
 

--- a/src/site/content/pl/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/pl/accessible/control-focus-with-tabindex/index.md
@@ -52,7 +52,6 @@ To focus an element, press the `Tab` key or call the element's `focus()` method.
 {% Glitch {
   id: 'tabindex-zero',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -70,7 +69,6 @@ focused by calling its `focus()` method.
 {% Glitch {
   id: 'tabindex-negative-one',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 
@@ -141,7 +139,6 @@ method on it.
 {% Glitch {
   id: 'roving-tabindex',
   path: 'index.html',
-  previewSize: 100,
   height: 346
 } %}
 


### PR DESCRIPTION
Fixes #3633

Assigns default value for previewSize and removes value from embeds that use default size