### PR TITLE
Correct cli command to start angular application

### DIFF
--- a/src/site/content/en/angular/get-started-optimize-angular/index.md
+++ b/src/site/content/en/angular/get-started-optimize-angular/index.md
@@ -70,7 +70,7 @@ Once the setup process completes successfully, start your application by running
 
 ```bash
 cd my-app
-ng start
+ng serve
 ```
 
 You should now be able to access your application at [http://localhost:4200](http://localhost:4200).


### PR DESCRIPTION
"ng start" command is not available in Angular CLI.
"ng serve"  command is used to start Angular applications.
Reference: https://angular.io/cli

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #3644

