### PR TITLE
fix(authors): add fallback images in `prod` if authors don't have them, fixes #3318

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -125,7 +125,7 @@ module.exports = (collections) => {
         console.warn(
           `No 2x image was found for ${author.title} (${author.key}), replacing with placeholder.`,
         );
-        authorsImage = path.join('/images', 'authors', 'no-photo@2x.jpg');
+        authorsImage = path.join('/images', 'authors', 'no-photo.svg');
       }
     }
     author.data.hero = authorsImage;

--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const fs = require('fs');
 const path = require('path');
 const authorsData = require('../_data/authorsData');
 const {livePosts} = require('../_filters/live-posts');
@@ -117,7 +118,16 @@ module.exports = (collections) => {
       invalidAuthors.push(key);
     }
 
-    const authorsImage = path.join('/images', 'authors', `${key}@2x.jpg`);
+    let authorsImage = path.join('/images', 'authors', `${key}@2x.jpg`);
+    if (process.env.ELEVENTY_ENV === 'prod') {
+      const authorsImageExists = fs.existsSync(path.join('src', authorsImage));
+      if (!authorsImageExists) {
+        console.warn(
+          `No 2x image was found for ${author.title} (${author.key}), replacing with placeholder.`,
+        );
+        authorsImage = path.join('/images', 'authors', 'no-photo@2x.jpg');
+      }
+    }
     author.data.hero = authorsImage;
     author.data.alt = author.title;
 


### PR DESCRIPTION
Fixes #3318

When in `prod` mode the authors collection will check if the author has a profile picture. If they do not it'll log a warning in the console and swap in `no-photo@2x.jpg`.