### PR TITLE
A tiny typo fix.

### DIFF
--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -132,7 +132,7 @@ that version of the API be aware of the changes made to it. Improvements from
 SMS Receiver API include:
 
 * The SMS message format is now aligned with WebKit's.
-* The web page only recives an OTP code regardless of whatever else is in the
+* The web page only receives an OTP code regardless of whatever else is in the
   message.
 * The browser's application hash code is no longer required in the message.
 


### PR DESCRIPTION
A tiny typo fix. `recives` -> `receives` in Web TOP article.