### PR TITLE
Add authors to algolia posts

### DIFF
--- a/src/site/_collections/algolia-posts.js
+++ b/src/site/_collections/algolia-posts.js
@@ -16,6 +16,7 @@
 
 const {livePosts} = require('../_filters/live-posts');
 const removeMarkdown = require('remove-markdown');
+const authorsCollectionFn = require('../_collections/authors');
 
 /**
  * Shrink the size of the given fulltext to fit within a certain limit, at the
@@ -57,6 +58,8 @@ module.exports = (collection) => {
   // For now, hard-code language to English.
   const lang = 'en';
 
+  const authorsCollection = authorsCollectionFn();
+
   // Convert 11ty-posts to a flat, indexable format.
   return eleventyPosts.map(({data, template}) => {
     const fulltext = removeMarkdown(template.frontMatter.content);
@@ -67,6 +70,10 @@ module.exports = (collection) => {
     // https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size
     const limited = limitText(fulltext);
 
+    const authors = (data.authors || []).map(
+      (author) => authorsCollection[author].title,
+    );
+
     return {
       objectID: data.page.url + '#' + lang,
       lang,
@@ -74,6 +81,7 @@ module.exports = (collection) => {
       url: data.canonicalUrl,
       description: data.description,
       fulltext: limited,
+      authors: authors,
       _tags: data.tags,
     };
   });


### PR DESCRIPTION
This PR adds authors to algolia posts so that users who search for authors in web.dev can see posts they've published.
Once it's live, I'll add `authors` to the list of `searchableAttributes` in algolia admin interface.