### PR TITLE
Don't fetch hero image if small screens

### DIFF
--- a/src/site/_includes/components/Hero.js
+++ b/src/site/_includes/components/Hero.js
@@ -32,6 +32,7 @@ module.exports = ({hero, alt, heroPosition, heroFit = 'cover'}) => {
       `)}"
       src="${hero}"
       alt="${alt}"
+      loading="lazy"
     />
   `;
 };


### PR DESCRIPTION
This PR make sure the hero image is not fetched on small screen devices. It is done by simply adding `loading=lazy` to the hero image element.

Without this fix, the hero image is always downloaded but never shown in the page on small screen devices.