### PR TITLE
Remove unused percy paths. Make others more specific.

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -7,16 +7,16 @@ on:
     branches:
       - master
     paths:
-      - '**.js'
-      - '!src/site/_data/contributors.js'
+      - 'src/**.js'
+      - 'shared/**.js'
       - '!src/site/_data/countries.js'
       - 'package.json'
       - '**.njk'
       - '**.scss'
   pull_request:
     paths:
-      - '**.js'
-      - '!src/site/_data/contributors.js'
+      - 'src/**.js'
+      - 'shared/**.js'
       - '!src/site/_data/countries.js'
       - 'package.json'
       - '**.njk'


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes the ignore for contributors.js because we don't use it anymore
- Tells percy to only snapshot if js files in src/ or shared/ are changed