### PR TITLE
Always link to /feature instead of /features

### DIFF
--- a/src/site/content/en/blog/keyboard-lock/index.md
+++ b/src/site/content/en/blog/keyboard-lock/index.md
@@ -118,7 +118,7 @@ One concern with this API is that it could be used to grab all of the keys and (
 
 - [Specification draft](https://wicg.github.io/keyboard-lock/)
 - [GitHub repository](https://github.com/WICG/keyboard-lock)
-- [ChromeStatus entry](https://chromestatus.com/features/5642959835889664)
+- [ChromeStatus entry](https://chromestatus.com/feature/5642959835889664)
 - [Chrome tracking bug](https://crbug.com/677559)
 - [Key codes for standard keyboards](https://www.w3.org/TR/uievents-code/#keyboard-key-codes)
 

--- a/src/site/content/en/blog/text-fragments/index.md
+++ b/src/site/content/en/blog/text-fragments/index.md
@@ -491,7 +491,7 @@ browser extension.
 ## Related links
 
 - [TAG Review](https://github.com/w3ctag/design-reviews/issues/392)
-- [Chrome Platform Status entry](https://chromestatus.com/features/4733392803332096)
+- [Chrome Platform Status entry](https://chromestatus.com/feature/4733392803332096)
 - [Chrome tracking bug](https://crbug.com/919204)
 - [Intent to Ship thread](https://groups.google.com/a/chromium.org/d/topic/blink-dev/zlLSxQ9BA8Y/discussion)
 - [WebKit-Dev thread](https://lists.webkit.org/pipermail/webkit-dev/2019-December/030978.html)


### PR DESCRIPTION
URLs with /features links to a list view and the identified item is supposed to expand and scroll into view. This is broken in the current iteration of Chrome Status.

@tomayac FYI