### PR TITLE
Fix minimum bar for LCP

### DIFF
--- a/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
@@ -48,7 +48,7 @@ The table below shows how to interpret your LCP score:
         <td>Green (fast)</td>
       </tr>
       <tr>
-        <td>2-4</td>
+        <td>2.5-4</td>
         <td>Orange (moderate)</td>
       </tr>
       <tr>


### PR DESCRIPTION
I think this is an inconsistency to the rest of the documentation. PageSpeedInsights and https://web.dev/lighthouse-largest-contentful-paint/ use 2.5-4 as moderate range.

