### PR TITLE
Don't index algolia if a build fails.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,12 +42,6 @@ jobs:
           ELEVENTY_ENV: prod
         run: npm run build
       
-      - name: Index algolia
-        env:
-          ALGOLIA_APP: ${{ secrets.ALGOLIA_APP }}
-          ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
-        run: node index-algolia.js
-
       - name: Setup gcloud
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.1
         with:
@@ -65,3 +59,9 @@ jobs:
       
       - name: Deploy to production
         run: gcloud app deploy --project web-dev-production-1
+      
+      - name: Index algolia
+        env:
+          ALGOLIA_APP: ${{ secrets.ALGOLIA_APP }}
+          ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
+        run: node index-algolia.js


### PR DESCRIPTION
Fixes #3703 

Changes proposed in this pull request:

- Index algolia _after_ a deploy succeeds