### PR TITLE
[requestVideoFrameCallback article] Improve title

### DIFF
--- a/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
+++ b/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
@@ -1,12 +1,12 @@
 ---
 title: |
-  Perform efficient per-video-frame operations on video
+  Perform efficient per-video-frame operations on video with `requestVideoFrameCallback()`
 subhead: |
   Learn how to use the `requestVideoFrameCallback()` to work more efficiently with videos in the browser.
 authors:
   - thomassteiner
 date: 2020-06-29
-updated: 2020-08-14
+updated: 2020-08-17
 hero: hero.jpg
 alt: Film roll.
 description: |

--- a/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
+++ b/src/site/content/en/blog/requestvideoframecallback-rvfc/index.md
@@ -1,12 +1,12 @@
 ---
 title: |
-  The `requestVideoFrameCallback()` method
+  Perform efficient per-video-frame operations on video
 subhead: |
-  Perform efficient per-video-frame operations on video.
+  Learn how to use the `requestVideoFrameCallback()` to work more efficiently with videos in the browser.
 authors:
   - thomassteiner
 date: 2020-06-29
-updated: 2020-06-29
+updated: 2020-08-14
 hero: hero.jpg
 alt: Film roll.
 description: |


### PR DESCRIPTION
Changes proposed in this pull request:

- Improve the title. The current one wraps very unfortunately:
  <img width="415" alt="Screen Shot 2020-08-14 at 11 43 20" src="https://user-images.githubusercontent.com/145676/90236689-5fc21d00-de23-11ea-91ba-9a191aac79f5.png">

