### PR TITLE
Issue #3606 : <heading> should be <header> in Lighthouse docs

### DIFF
--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -27,7 +27,7 @@ Lighthouse flags pages that don't provide a way to skip repetitive content:
 </figure>
 
 Lighthouse checks that the page contains at least one of the following:
-- A `<heading>` element
+- A `<header>` element
 - A [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links)
 - A [landmark](/headings-and-landmarks/#use-landmarks-to-aid-navigation)
 


### PR DESCRIPTION
Fixes #3606

Changes proposed in this pull request:
- `<heading>` changed to `<header>` in lighthouse checks.
