### PR TITLE
refactor(collections): save processed 11ty collections, fixes #3532

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -19,6 +19,8 @@ const authorsData = require('../_data/authorsData');
 const {livePosts} = require('../_filters/live-posts');
 const setdefault = require('../_utils/setdefault');
 
+let processedCollection;
+
 /**
  * Generate map the posts by author's username/key
  *
@@ -68,6 +70,10 @@ const maybeUpdateAuthorHref = (author, allAuthorPosts) => {
  * @return {Object.<string, Author>}
  */
 module.exports = (collections) => {
+  if (processedCollection) {
+    return processedCollection;
+  }
+
   let allPosts = [];
 
   if (collections) {
@@ -144,6 +150,10 @@ module.exports = (collections) => {
   if (isRegularBuild && invalidAuthors.length) {
     const s = invalidAuthors.join(',');
     throw new Error(`authors [${s}] have no posts and/or Twitter information`);
+  }
+
+  if (collections) {
+    processedCollection = authors;
   }
 
   return authors;

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -16,6 +16,8 @@
 const tagsData = require('../_data/tagsData');
 const {livePosts} = require('../_filters/live-posts');
 
+let processedCollection;
+
 /**
  * Returns all tags with posts.
  *
@@ -23,6 +25,10 @@ const {livePosts} = require('../_filters/live-posts');
  * @return {Array<{ title: string, key: string, description: string, href: string, url: string, data: { title: string, subhead: string }, elements: Array<object> }>} An array where each element is a paged tag with some meta data and n posts for the page.
  */
 module.exports = (collections) => {
+  if (processedCollection) {
+    return processedCollection;
+  }
+
   const tags = {};
 
   Object.keys(tagsData).forEach((key) => {
@@ -51,6 +57,10 @@ module.exports = (collections) => {
       tags[tag.key] = tag;
     }
   });
+
+  if (collections) {
+    processedCollection = tags;
+  }
 
   return tags;
 };


### PR DESCRIPTION
Fixes #3532

The first time the collections get called is by 11ty when it passes the 11ty collection object into it. Every time we call it after, elsewhere, we are unable to pass in the 11ty collection object, which means that if we call it to process authors posts it'll think there are no authors posts and provide a twitter link instead of a link to the authors page.

By storing the result of the authors and tags, we can return the collection object with the posts and the correct links. (And we don't need to process it again)

Memoization FTW!(?)