### PR TITLE
Add stale close comment.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,5 +14,6 @@ markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed in 7 days if no further activity occurs.
   To prevent this from happening, leave a comment.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Closing this issue because it has been marked as stale for more than 7 days.


### PR DESCRIPTION
Changes proposed in this pull request:

- Makes the stalebot leave a comment when it closes issues. This will make it easier to tally up how many items it closed each month.