### PR TITLE
Fix shadowed SW variable names.

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -47,15 +47,15 @@ self.addEventListener('install', (event) => {
   event.waitUntil(self.skipWaiting());
 });
 
-self.addEventListener('activate', () => {
+self.addEventListener('activate', (event) => {
   // Define a list of allowed caches.
   // If a cache does not appear in the list then it will be deleted.
   const p = Promise.resolve().then(async () => {
     const allowedCaches = new Set(Object.values(cacheNames));
-    const cacheNames = await caches.keys();
-    for (const cacheName of cacheNames) {
-      if (!allowedCaches.has(cacheName)) {
-        await caches.delete(cacheName);
+    const cacheKeys = await caches.keys();
+    for (const cacheKey of cacheKeys) {
+      if (!allowedCaches.has(cacheKey)) {
+        await caches.delete(cacheKey);
       }
     }
   });


### PR DESCRIPTION
I noticed the SW was throwing in incognito windows. Turns out I accidentally used the same variable name in two places. The new typescript linting helped catch it 👍 

However, it looks like the SW is still throwing in incognito windows but now it's for a different issue:

```
Uncaught (in promise) TypeError: Failed to execute 'fetch' on 'WorkerGlobalScope': 'only-if-cached' can be set only with 'same-origin' mode
```

It's blowing up on [this line](https://github.com/GoogleChrome/web.dev/blob/master/src/lib/sw.js#L283)

Changes proposed in this pull request:

- `cacheNames` was being defined on line 15 and line 55. This renames the variable on line 55 to `cacheKeys`.
- adds `event` argument, otherwise line 62 will blow up because it calls `event.waitUntil()`