### PR TITLE
Update Notification Triggers status

### DIFF
--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -54,6 +54,20 @@ change.<a name="shape-face-text"></a>
           <em>Updated April 14, 2020</em>
         </td>
       </tr>
+      <tr>
+        <td>
+          <a href="/notification-triggers/">
+            Notification Triggers
+          </a>
+        </td>
+        <td>
+          Notification Triggers let you schedule notifications in advance, so
+          that the operating system will deliver the notification at the right
+          time - even if there is no network connectivity, or the device is in
+          battery saver mode.<br>
+          <em>Updated August 23, 2020</em>
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -107,20 +121,6 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
           allows web apps to read or save changes directly to files and folders
           on the user's device.<br>
           <em>Updated April 13, 2020</em>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="/notification-triggers/">
-            Notification Triggers
-          </a>
-        </td>
-        <td>
-          Notification Triggers let you schedule notifications in advance, so
-          that the operating system will deliver the notification at the right
-          time - even if there is no network connectivity, or the device is in
-          battery saver mode.<br>
-          <em>Updated December 12, 2019</em>
         </td>
       </tr>
       <tr>

--- a/src/site/content/en/blog/notification-triggers/index.md
+++ b/src/site/content/en/blog/notification-triggers/index.md
@@ -9,7 +9,7 @@ description:
   The Notification Triggers API allows developers to schedule local notifications that don't require
   a network connection, which makes them ideal for use cases like calendar apps.
 date: 2019-10-24
-updated: 2020-07-31
+updated: 2020-08-23
 hero: hero.jpg
 hero_position: center
 tags:
@@ -20,9 +20,9 @@ tags:
 ---
 
 {% Aside %}
-  The Notification Triggers API, part of Google's
+  The development of Notification Triggers API, part of Google's
   [capabilities project](https://developers.google.com/web/updates/capabilities),
-  is currently in development. This post will be updated as the
+  is currently on hold. This post will be updated as the
   implementation progresses.
 {% endAside %}
 


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

- In the Fugu status list, move Notification Triggers from origin trial back to "behind a flag"
- More prominently state that Notification Triggers are currently on hold
