### PR TITLE
a bunch of misc tsc fixes

### DIFF
--- a/src/build/minify-js.js
+++ b/src/build/minify-js.js
@@ -22,9 +22,13 @@ async function compressOutput(generated) {
     const raw = await fs.readFile(target, 'utf8');
     inputSize += raw.length;
 
+    const sourceMapContent = JSON.parse(
+      await fs.readFile(target + '.map', 'utf8'),
+    );
+
     const result = terser.minify(raw, {
       sourceMap: {
-        content: await fs.readFile(target + '.map', 'utf8'),
+        content: sourceMapContent,
         url: fileName + '.map',
       },
     });

--- a/src/build/virtual-json.js
+++ b/src/build/virtual-json.js
@@ -7,6 +7,10 @@
 
 const validJSName = /^[\w_$][\w\d_$]*$/;
 
+/**
+ * @param {any} object to serialize
+ * @return {string}
+ */
 function createVirtualExport(object) {
   const parts = [`export default ${JSON.stringify(object)};`];
 
@@ -25,8 +29,12 @@ function createVirtualExport(object) {
   return parts.join('\n');
 }
 
+/**
+ * @param {!Object<string, any>} all
+ * @return {!Object<string, string>}
+ */
 module.exports = (all) => {
-  const out = {};
+  const out = /** @type {!Object<string, string>} } */ ({});
   Object.keys(all).forEach((key) => {
     out[key] = createVirtualExport(all[key]);
   });

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -136,7 +136,9 @@ export const collapseSideNav = store.action(() => {
 
 export const openModal = store.action(() => {
   const main = document.querySelector('main');
+  /** @type import('./components/Header').Header */
   const header = document.querySelector('web-header');
+  /** @type {HTMLElement} */
   const footer = document.querySelector('.w-footer');
 
   document.documentElement.classList.add('web-modal__overflow-hidden');
@@ -150,6 +152,7 @@ export const closeModal = store.action(() => {
   const main = document.querySelector('main');
   /** @type import('./components/Header').Header */
   const header = document.querySelector('web-header');
+  /** @type {HTMLElement} */
   const footer = document.querySelector('.w-footer');
 
   document.documentElement.classList.remove('web-modal__overflow-hidden');

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -6,7 +6,6 @@
  * Worker initialization, component loading for routes, et al.
  */
 
-/* global WebComponents */
 import './webcomponents-config'; // must go before -loader below
 import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
 import './analytics'; // side effects
@@ -17,7 +16,7 @@ import {store} from './store';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
 
-WebComponents.waitFor(async () => {
+window.WebComponents.waitFor(async () => {
   // TODO(samthor): This isn't quite the right class name because not all Web Components are ready
   // at this point due to code-splitting.
   document.body.classList.remove('unresolved');

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -19,6 +19,7 @@ import entrypoint from 'webdev_entrypoint';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
 
+// @ts-ignore
 window.ga =
   window.ga ||
   function () {

--- a/src/lib/components/AssessmentQuestion/index.js
+++ b/src/lib/components/AssessmentQuestion/index.js
@@ -66,7 +66,8 @@ export class AssessmentQuestion extends BaseElement {
 
     // Listen to contained option selections.
     this.addEventListener('question-option-select', (e) => {
-      const {detail: optionIndex, target} = e;
+      const ce = /** @type {!CustomEvent} */ (e);
+      const {detail: optionIndex, target} = ce;
 
       // This event comes from the final option that the user selects.
       // Find the index of the response that this input is contained within.
@@ -77,7 +78,7 @@ export class AssessmentQuestion extends BaseElement {
         this.querySelectorAll('[data-role=response]'),
       );
       for (let i = 0; i < responseComponents.length; ++i) {
-        if (responseComponents[i].contains(target)) {
+        if (responseComponents[i].contains(/** @type {Element} */ (target))) {
           responseIndex = i;
           break;
         }

--- a/src/lib/components/BaseElement/index.js
+++ b/src/lib/components/BaseElement/index.js
@@ -7,7 +7,7 @@ export class BaseElement extends LitElement {
   }
 
   /**
-   * @param {Map<string | number | symbol, unknown>} changedProperties
+   * @param {PropertyValues} changedProperties
    */
   firstUpdated(changedProperties) {
     this.classList.remove('unresolved');

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -21,6 +21,7 @@ export class Tabs extends BaseElement {
 
   constructor() {
     super();
+    this.label = '';
     this.activeTab = 0;
     this.overflow = false;
     this.prerenderedChildren = null;
@@ -118,8 +119,8 @@ export class Tabs extends BaseElement {
     `;
   }
 
-  firstUpdated() {
-    super.firstUpdated();
+  firstUpdated(changedProperties) {
+    super.firstUpdated(changedProperties);
 
     this.activeTab = 0;
     this.onResize();

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -5,7 +5,7 @@ import lang from './utils/language';
  * @return {string} normalized URL
  */
 export function normalizeUrl(url) {
-  const u = new URL(url, window.location);
+  const u = new URL(url, window.location.toString());
   let pathname = u.pathname;
 
   if (pathname.endsWith('/index.html')) {

--- a/src/lib/utils/generate-salt.js
+++ b/src/lib/utils/generate-salt.js
@@ -5,7 +5,7 @@
  *     Used to check the uniqueness of the outcome id (prefix + salt).
  * @return {string} Id salt.
  */
-export const generateIdSalt = (idPrefix) => {
+export const generateIdSalt = (/** @type {string} */ idPrefix) => {
   const salt = Math.random().toString(36).substr(2, 9);
   return document.getElementById(idPrefix + salt)
     ? generateIdSalt(idPrefix)

--- a/src/lib/utils/router.js
+++ b/src/lib/utils/router.js
@@ -71,9 +71,13 @@ function onClick(e) {
     return;
   }
 
+  if (!(e.target instanceof HTMLElement)) {
+    return;
+  }
+
   // nb. If this ever supports Shadow DOM, we can use .composedPath to find
   // the nearest link inside an open Shadow Root.
-  const link = e.target.closest('a[href]');
+  const link = /** @type {!HTMLAnchorElement} */ (e.target.closest('a[href]'));
   if (
     !link ||
     link.target ||
@@ -89,16 +93,23 @@ function onClick(e) {
 }
 
 /**
- * @TODO how is listen being reassigned as a function?
+ * Exports the 'default' listener function. This is a let so we can change it
+ * after it has been called once.
+ *
+ * @param {function(!Object): ?} handler which returns an optional Promise
+ */
+export let listen = defaultListen;
+
+/**
  * Adds global page listeners for SPA routing.
  *
  * @param {function(!Object): ?} handler which returns an optional Promise
  */
-export function listen(handler) {
+function defaultListen(handler) {
   if (!handler) {
     throw new Error('need handler');
   }
-  listen = () => { // eslint-disable-line
+  listen = () => {
     throw new Error('listen can only be called once');
   };
 
@@ -186,7 +197,7 @@ export function route(url) {
   if (!globalHandler) {
     throw new Error('listen() not called');
   }
-  const u = new URL(url, window.location);
+  const u = new URL(url, window.location.toString());
 
   // Check if this is the same URL, but has a hash. If so, allow the *browser*
   // to move to the correct target on the page.

--- a/src/lib/utils/time-offset.js
+++ b/src/lib/utils/time-offset.js
@@ -40,7 +40,7 @@ export function getTimeOffset(raw) {
   if (+d) {
     const now = new Date();
     console.warn('debug time start at', d);
-    return d - now;
+    return +d - +now;
   }
   return 0;
 }

--- a/src/lib/utils/underscore-import-polyfill.js
+++ b/src/lib/utils/underscore-import-polyfill.js
@@ -8,7 +8,7 @@ const seen = {};
  * @param {string} src
  * @return {!Promise<?>}
  */
-window._import = (src) => {
+window['_import'] = (src) => {
   // Rollup generates relative paths, but they're all relative to top level.
   if (src.startsWith('./')) {
     src = src.substr(2);

--- a/src/lib/utils/web-share.js
+++ b/src/lib/utils/web-share.js
@@ -2,7 +2,7 @@
  * @return {boolean} whether Web Share is supported on this browser
  */
 export function isWebShareSupported() {
-  if (!('share' in navigator)) {
+  if (!('share' in window.navigator)) {
     return false;
   }
 
@@ -11,7 +11,7 @@ export function isWebShareSupported() {
   // https://bugs.chromium.org/p/chromium/issues/detail?id=903010
   if ('canShare' in navigator) {
     const url = `https://${window.location.hostname}`;
-    return navigator.canShare({url});
+    return window.navigator.canShare({url});
   }
 
   return true;

--- a/types/utils/global.d.ts
+++ b/types/utils/global.d.ts
@@ -16,15 +16,16 @@
 
 import * as firebase from 'firebase';
 
+interface WebComponentsType {
+  root?: string;
+  waitFor?: (arg: () => any) => void;
+}
+
 declare global {
-  export interface Window extends Window {
-    firebase: firebase.app.App;
+  interface Window extends Window {
     inert: boolean;
   }
 
+  var WebComponents: WebComponentsType;
   var firebase: firebase.app.App;
 }
-
-
-// empty export to keep file a module
-export {};

--- a/types/utils/navigator.d.ts
+++ b/types/utils/navigator.d.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-declare global {
-  export interface HTMLElement extends HTMLElement {
-    inert: boolean;
-  }
+interface Navigator {
+  canShare(data: ShareData): boolean;
 }
-
-// empty export to keep file a module
-export {};

--- a/types/utils/npm-dependencies.d.ts
+++ b/types/utils/npm-dependencies.d.ts
@@ -15,7 +15,7 @@
  */
 
 declare global {
-  export {TemplateResult} from 'lit-element';
+  export {TemplateResult, PropertyValues} from 'lit-element';
 }
 
 // empty export to keep file a module


### PR DESCRIPTION
Fixes a bunch of small TSC typing issues.

We still have 78 errors, according to my local TSC. This is mostly in three categories:
* assuming a `Node` or `Element` can be used as a `HTMLElement` (just needs lots of casting), especially in component code
* we have untyped virtual imports for config
* no included types for SW code (the default DOM code doesn't seem to know about e.g., `ServiceWorkerGlobalScope`)