### PR TITLE
fix measuring what we delete

### DIFF
--- a/tools/cleanup-versions/index.js
+++ b/tools/cleanup-versions/index.js
@@ -113,7 +113,7 @@ function deleteVersions(project, versions, service = 'default') {
     const next = versions.splice(0, deleteAtMost);
     log('Enacting deletion for versions:', next.join(' '));
 
-    const {status, stdout} = childProcess.spawnSync(
+    const {status, stdout, stderr} = childProcess.spawnSync(
       'gcloud',
       [
         'app',
@@ -131,11 +131,12 @@ function deleteVersions(project, versions, service = 'default') {
         timeout: 60 * 1000,
       },
     );
+    process.stderr.write(stderr);
     if (status !== 0) {
       log('Could not delete versions:', status);
       break;
     }
-    done += versions.length;
+    done += next.length;
     console.info(JSON.parse(stdout));
   }
   return done;


### PR DESCRIPTION
Fixes #3759.

The action itself wasn't broken. I was just incorrectly recording the number of versions we successfully deleted to be _after_ we did a first deletion. So if there was fewer than 4 invalid versions, then this appeared if this was failing.