### PR TITLE
Move alex to a dedicated workflow.

### DIFF
--- a/.github/workflows/alex-workflow.yml
+++ b/.github/workflows/alex-workflow.yml
@@ -1,0 +1,21 @@
+# Check PRs for inclusive language.
+# This Action runs separately from our other linters because it requires the
+# pull_request_target GitHub event in order to get elevated permissions so it
+# can write to our comment fields.
+
+name: Alex
+
+# By default, runs when a pull request is opened, synchronized, or reopened.
+# We use the pull_request_target hook to enable proper permissions for
+# pull requests coming from forks.
+# https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
+on: pull_request_target
+
+jobs:
+  alex:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: brown-ccv/alex-recommends@v1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          profanity_sureness: 2

--- a/.github/workflows/lint-and-test-workflow.yml
+++ b/.github/workflows/lint-and-test-workflow.yml
@@ -1,10 +1,7 @@
 name: Lint and test
 
 # By default, runs when a pull request is opened, synchronized, or reopened.
-# We use the pull_request_target hook to enable proper permissions for
-# pull requests coming from forks.
-# https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
-on: pull_request_target
+on: pull_request
 
 jobs:
   lint_and_test:
@@ -56,13 +53,6 @@ jobs:
       - name: Lint Markdown
         if: ${{ steps.filter.outputs.md == 'true' }}
         run: npm run lint:md
-
-      - name: Lint Language
-        if: ${{ steps.filter.outputs.md == 'true' }}
-        uses: brown-ccv/alex-recommends@v1.0.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          profanity_sureness: 2
 
       - name: Lint JavaScript
         if: ${{ steps.filter.outputs.js == 'true' || steps.filter.outputs.json == 'true' }}


### PR DESCRIPTION
See this discussion: https://github.com/GoogleChrome/web.dev/issues/3705#issuecomment-675439002
Because we switched to the pull_request_target event, the files in our PRs were not being tested by our GH Actions. Instead, only the current contents of master were being tested. Alex was working around this because it uses a GH token to fetch the contents of the PR from the GitHub API.

Changes proposed in this pull request:

- Move Alex into its own workflow so we can go back to using the pull_request event for our other linting and testing tasks.