### PR TITLE
Fix copy button, hide ToC for now.

### DIFF
--- a/src/lib/components/CopyCode/_styles.scss
+++ b/src/lib/components/CopyCode/_styles.scss
@@ -9,6 +9,11 @@
   right: 0;
   width: 48px;
 
+  &::before {
+    @include font-material-icon();
+    content: 'content_copy';
+  }
+
   &:focus,
   &:hover {
     background-color: rgba($WEB_SECONDARY_COLOR, 0.2);

--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -24,7 +24,6 @@ class CopyCode extends BaseElement {
       this.copyButton = document.createElement('button');
       this.copyButton.className =
         'w-button--icon w-button--round web-copy-code__button';
-      this.copyButton.setAttribute('data-icon', 'file_copy');
       // Set aria-label because title isn't accessible to sighted keyboard users
       // and the tooltip is only visible on focus,
       // which means it isn't read reliably by screen readers.

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -17,7 +17,7 @@
     } %}
   {% endif %}
 
-  <web-table-of-contents>
+  {# <web-table-of-contents>
     <h2 class="w-toc__header">
       <a href="#{{ safeTitle | slugify }}" class="w-toc__header--link">
         {{ safeTitle }}
@@ -25,7 +25,7 @@
     </h2>
     {{ content | toc | safe }}
   </web-table-of-contents>
-  <web-table-of-contents-button></web-table-of-contents-button>
+  <web-table-of-contents-button></web-table-of-contents-button> #}
 
   {# Make sure Actions are first in the tab order. #}
   <div class="w-actions">


### PR DESCRIPTION
Partial fix for #3783 

Changes proposed in this pull request:

- Fixes the broken font on the copy code button.
- Hides the ToC for now as the `web-table-of-contents` seems to cause a bit of horizontal overflow on mobile.
