### PR TITLE
Fixes #3800. Label should not overlap glitch embeds.

### DIFF
--- a/src/styles/components/_label.scss
+++ b/src/styles/components/_label.scss
@@ -5,6 +5,23 @@
 // =============================================================================
 
 .w-label {
-  margin-bottom: -28px;
   opacity: .7;
+  margin-bottom: 4px;
+}
+
+// This is a bit gross.
+// Because components define their own margins the pre tag inside of code blocks
+// has a 32px top/bottom margin that pushes the label away. The pre tag is
+// wrapped inside of a web-copy-code button, so we use a sibling selector
+// to negate this margin.
+// We need the display: block property because we lazy load the CSS for our
+// custom elements so if we don't have this then the element will be inline
+// and the margin-top will not take affect.
+// Fixes https://github.com/GoogleChrome/web.dev/issues/3800
+// Longer term fix: Components shouldn't define their own margins, instead the
+// page layout should define those margins using a + * + selector.
+// https://every-layout.dev/layouts/stack/#the-solution
+.w-label + web-copy-code {
+  display: block;
+  margin-top: -28px;
 }


### PR DESCRIPTION
Fixes #3800

Changes proposed in this pull request:

- Fix broken margin on `.w-label` element when it's next to a Glitch embed