### PR TITLE
Fix broken Glitch and nextjs.org links

### DIFF
--- a/src/site/content/en/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/en/react/route-prefetching-in-nextjs/index.md
@@ -23,7 +23,7 @@ inside the `./pages/` directory:
 </figure>
 
 To link to different pages, use the
-[`<Link>`](https://nextjs.org/docs#with-link) component, similarly to how you'd
+[`<Link>`](https://nextjs.org/docs/api-reference/next/link) component, similarly to how you'd
 use the good old `<a>` element:
 
 ```js
@@ -34,8 +34,7 @@ use the good old `<a>` element:
 
 When you use the `<Link>` component for navigation, Next.js does a little bit
 more for you. Normally, a page is downloaded when you follow a link to it, but
-[Next.js automatically prefetches](https://nextjs.org/docs#prefetching-pages)
-the JavaScript needed to render the page.
+Next.js automatically prefetches the JavaScript needed to render the page.
 
 When you load a page with a few links, odds are that by the time you follow
 a link, the component behind it has already been fetched. This improves
@@ -120,8 +119,8 @@ downloaded, but `pineapple-pizza.js` is not:
 
 The `<Link>` component is suitable for most use cases, but you can also build
 your own component to do routing. Next.js makes this easy for you with the
-router API available in [`next/router`](https://nextjs.org/docs#userouter). If
-you want to do something (for example, submit a form) before navigating to a new
+router API available in [`next/router`](https://nextjs.org/docs/api-reference/next/router#userouter). 
+If you want to do something (for example, submit a form) before navigating to a new
 route, you can define that in your custom routing code.
 
 When you use custom components for routing, you can add prefetching to them too.
@@ -131,7 +130,7 @@ To implement prefetching in your routing code, use the `prefetch` method from
 Take a look at `components/MyLink.js` in this example app:
 
 {% Glitch {
-  id: 'nextjs-routing',
+  id: 'custom-routing-nextjs',
   path: 'components/MyLink.js',
   height: 480
 } %}


### PR DESCRIPTION
Fixes #3818 and links broken due to changes in the URL scheme on nextjs.org. 