### PR TITLE
Temporarily disable content indexing.

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -8,14 +8,16 @@
 
 import './webcomponents-config'; // must go before -loader below
 import '@webcomponents/webcomponentsjs/webcomponents-loader.js';
-import {trackError} from './analytics'; // side effects & named export
 import {swapContent, getHTML} from './loader';
 import * as router from './utils/router';
 import {checkUserPreferredLanguage} from './actions';
 import {store} from './store';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
-import {syncContentIndex} from './content-indexing';
+// TODO: Enable this when #3836 is fixed.
+// // https://github.com/GoogleChrome/web.dev/issues/3836
+// import {trackError} from './analytics'; // side effects & named export
+// import {syncContentIndex} from './content-indexing';
 
 window.WebComponents.waitFor(async () => {
   // TODO(samthor): This isn't quite the right class name because not all Web Components are ready
@@ -65,9 +67,11 @@ onGlobalStateChanged(store.getState());
 // never happen here unless the valid domains change, but left in for safety).
 if (serviceWorkerIsSupported(window.location.hostname)) {
   ensureServiceWorker();
-  syncContentIndex().catch((error) => {
-    trackError(error, 'Content Indexing error');
-  });
+  // TODO: Re-enable this when #3836 is fixed.
+  // https://github.com/GoogleChrome/web.dev/issues/3836
+  // syncContentIndex().catch((error) => {
+  //   trackError(error, 'Content Indexing error');
+  // });
 } else {
   removeServiceWorkers();
 }

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -14,9 +14,9 @@ import {checkUserPreferredLanguage} from './actions';
 import {store} from './store';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
+import './analytics'; // side effects & named export
 // TODO: Enable this when #3836 is fixed.
 // // https://github.com/GoogleChrome/web.dev/issues/3836
-// import {trackError} from './analytics'; // side effects & named export
 // import {syncContentIndex} from './content-indexing';
 
 window.WebComponents.waitFor(async () => {


### PR DESCRIPTION
Related to #3836 

Changes proposed in this pull request:

- Temporarily disable content indexing API. We should turn this back on when the underlying bug is fixed in the API itself.