### PR TITLE
More accurate storage info for Firefox

### DIFF
--- a/src/site/content/en/blog/storage-for-the-web/index.md
+++ b/src/site/content/en/blog/storage-for-the-web/index.md
@@ -95,7 +95,8 @@ device.
   Chromium-based browsers may allow the browser to use more storage.
 * Internet Explorer 10 and later can store up to 250MB and will prompt the
   user when more than 10MB has been used.
-* Firefox allows the browser to use up to 50% of free disk space. An eTLD+1
+* Firefox allows the browser to use up to 50% of free disk space. An 
+  [eTLD+1](https://godoc.org/golang.org/x/net/publicsuffix)
   group (e.g., `example.com`, `www.example.com` and `foo.bar.example.com`)
   [may use up to 2GB][ff-usage-limits]. You can use the
   [StorageManager API](#check-available) to determine how much space is still

--- a/src/site/content/en/blog/storage-for-the-web/index.md
+++ b/src/site/content/en/blog/storage-for-the-web/index.md
@@ -95,9 +95,11 @@ device.
   Chromium-based browsers may allow the browser to use more storage.
 * Internet Explorer 10 and later can store up to 250MB and will prompt the
   user when more than 10MB has been used.
-* Firefox allows an [origin to use up to 2GB][ff-usage-limits]. You can use
-  the [StorageManager API](#check-available) to determine how much space is
-  still available.
+* Firefox allows the browser to use up to 50% of free disk space. An eTLD+1
+  group (e.g., `example.com`, `www.example.com` and `foo.bar.example.com`)
+  [may use up to 2GB][ff-usage-limits]. You can use the
+  [StorageManager API](#check-available) to determine how much space is still
+  available.
 * Safari (both desktop and mobile) appears to allow up to 1GB. When the limit
   is reached, Safari will prompt the user, increasing the limit in 200MB
   increments. I was unable to find any official documentation on this.


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

Add more accurate maximum storage info for Firefox based on the already cited article: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria#Storage_limits