### PR TITLE
Get latest version of alex recommends

### DIFF
--- a/.github/workflows/alex-workflow.yml
+++ b/.github/workflows/alex-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - uses: brown-ccv/alex-recommends@v1.0.0
+      - uses: brown-ccv/alex-recommends@v1.1.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           profanity_sureness: 2


### PR DESCRIPTION
Changes proposed in this pull request:

- alex-recommends wasn't using the latest version of alex, which was failing to detect singular uses of 'master' and 'slave'. Previously it would only flag these if they were used in the same phrase, i.e. "master and slave".