### PR TITLE
Fix a mistake in the CLS code sample

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -353,11 +353,9 @@ changes to hidden:
   // page's lifecycle state changes to hidden.
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
-      // Force any pending records to be dispatched and disconnect the observer.
+      // Include any pending records not yet dispatched,
+      // and send the CLS value to an analytics endpoint.
       po.takeRecords().forEach((entry) => onLayoutShiftEntry(entry, po));
-      po.disconnect();
-
-      // Report the CLS value to an analytics endpoint.
       sendToAnalytics({cls});
     }
   });


### PR DESCRIPTION
I thought this was fixed a while ago, but @npm1 noticed today the `disconnect()` method was still being called. We need CLS to be observed for the entire page lifecycle, so we shouldn't ever disconnect the observer.