### PR TITLE
Move experimental-web-platform-features flag section

### DIFF
--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -34,6 +34,11 @@ Maybe you can think of a much more exciting use-case for request streaming.
 
 ## Try out request streams
 
+### Enabling via chrome://flags {: #enable-flags }
+
+Try out request streams in Chrome 85 by flipping an experimental flag:
+`enable-experimental-web-platform-features`.
+
 ### Enabling support during the origin trial phase
 
 Fetch request streams are available in an origin trial as of Chrome 85. The
@@ -44,11 +49,6 @@ origin trial is expected to end in Chrome 87.
 ### Register for the origin trial {: #register-for-ot }
 
 {% include 'content/origin-trial-register.njk' %}
-
-### Enabling via chrome://flags {: #enable-flags }
-
-Try out request streams in Chrome 85 by flipping an experimental flag:
-`enable-experimental-web-platform-features`.
 
 ## Demo {: #demo }
 

--- a/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
+++ b/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
@@ -128,6 +128,11 @@ results for the same browser.
 
 ## Using `performance.measureMemory()` {: use }
 
+### Enabling via chrome://flags
+
+To experiment with `performance.measureMemory()` without an origin trial
+token, enable the `#experimental-web-platform-features` flag in `chrome://flags`.
+
 ### Enabling support during the origin trial phase
 
 The `performance.measureMemory()` API is available as an origin trial starting in
@@ -138,11 +143,6 @@ Chrome 83. The origin trial is expected to end in Chrome 86, in early November 2
 ### Register for the origin trial {: #register-for-ot }
 
 {% include 'content/origin-trial-register.njk' %}
-
-### Enabling via chrome://flags
-
-To experiment with `performance.measureMemory()` without an origin trial
-token, enable the `#experimental-web-platform-features` flag in `chrome://flags`.
 
 ### Feature detection
 

--- a/src/site/content/en/blog/nfc/index.md
+++ b/src/site/content/en/blog/nfc/index.md
@@ -78,6 +78,16 @@ Examples of sites that may use Web NFC include:
 
 ## Using Web NFC {: #use }
 
+### Enabling via chrome://flags
+
+To experiment with Web NFC locally on Android, without an origin trial token,
+enable the `#experimental-web-platform-features` flag in `chrome://flags`.
+
+<figure class="w-figure">
+  <img src="./chrome-flag.jpg" alt="Screenshot of the chrome://flags internal page to enable for Web NFC on Android">
+  <figcaption class="w-figcaption">Experimental flag for Web NFC on Android</figcaption>
+</figure>
+
 ### Enabling support during the origin trial phase
 
 Web NFC will be available on Android as an origin trial in Chrome 81. The origin
@@ -88,16 +98,6 @@ trial is expected to end in Chrome 84.
 ### Register for the origin trial {: #register-for-ot }
 
 {% include 'content/origin-trial-register.njk' %}
-
-### Enabling via chrome://flags
-
-To experiment with Web NFC locally on Android, without an origin trial token,
-enable the `#experimental-web-platform-features` flag in `chrome://flags`.
-
-<figure class="w-figure">
-  <img src="./chrome-flag.jpg" alt="Screenshot of the chrome://flags internal page to enable for Web NFC on Android">
-  <figcaption class="w-figcaption">Experimental flag for Web NFC on Android</figcaption>
-</figure>
 
 ### Feature detection {: #feature-detection }
 

--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -85,6 +85,12 @@ communication between the website and the device that it is controlling.
 
 ## Using the Serial API {: #use }
 
+### Enabling via chrome://flags
+
+To experiment with the Serial API locally on all desktop platforms, without an
+origin trial token, enable the `#experimental-web-platform-features` flag in
+`chrome://flags`.
+
 ### Enabling support during the origin trial phase
 
 The Serial API is available on all desktop platforms (Chrome OS, Linux, macOS,
@@ -97,12 +103,6 @@ be enabled using a flag.
 ### Register for the origin trial {: #ot }
 
 {% include 'content/origin-trial-register.njk' %}
-
-### Enabling via chrome://flags
-
-To experiment with the Serial API locally on all desktop platforms, without an
-origin trial token, enable the `#experimental-web-platform-features` flag in
-`chrome://flags`.
 
 ### Feature detection {: #feature-detection }
 


### PR DESCRIPTION
As discussed in https://github.com/GoogleChrome/web.dev/pull/3860/#discussion_r487340601 and https://github.com/GoogleChrome/web.dev/pull/3860/#discussion_r488021594, the "experimental-web-platform-features flag" section should be moved before the origin trial section for all web.dev articles.

This PR addresses this.

Note that I intentionally didn't update the "updated" article tag as the content doesn't change, only the layout.