### PR TITLE
Lighthouse no longer utilizing [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte) as a metric

### DIFF
--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists
 all offscreen or hidden images in your page
-along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
+along with the potential savings in [kilobytes (KB)].
 Consider lazy-loading these images
 after all critical resources have finished loading
 to lower [Time to Interactive](/interactive):

--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists
 all offscreen or hidden images in your page
-along with the potential savings in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte).
+along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
 Consider lazy-loading these images
 after all critical resources have finished loading
 to lower [Time to Interactive](/interactive):

--- a/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
+++ b/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
@@ -25,7 +25,7 @@ You can adjust the results to factor in purchasing power.
 ## How the Lighthouse network payload audit fails
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/)
-shows the total size in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte) of all resources requested by your page.
+shows the total size in [kilobytes (KB)] of all resources requested by your page.
 The largest requests are presented first:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
+++ b/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
@@ -25,7 +25,7 @@ You can adjust the results to factor in purchasing power.
 ## How the Lighthouse network payload audit fails
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/)
-shows the total size in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte) of all resources requested by your page.
+shows the total size in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte) of all resources requested by your page.
 The largest requests are presented first:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/unminified-css/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-css/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists
 all unminified CSS files,
-along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte)
+along with the potential savings in [kilobytes (KB)]
 when these files are minified:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/unminified-css/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-css/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists
 all unminified CSS files,
-along with the potential savings in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte)
+along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte)
 when these files are minified:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
@@ -12,7 +12,7 @@ web_lighthouse:
 Minifying JavaScript files can reduce payload sizes and script parse time.
 The Opportunities section of your Lighthouse report lists
 all unminified JavaScript files,
-along with the potential savings in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte)
+along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte)
 when these files are minified:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
@@ -12,7 +12,7 @@ web_lighthouse:
 Minifying JavaScript files can reduce payload sizes and script parse time.
 The Opportunities section of your Lighthouse report lists
 all unminified JavaScript files,
-along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte)
+along with the potential savings in [kilobytes (KB)]
 when these files are minified:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/unused-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unused-javascript/index.md
@@ -23,7 +23,7 @@ Unused JavaScript can slow down your page load speed:
 ## How the unused JavaScript audit fails
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/)
-flags every JavaScript file with more than 20 kibibytes of unused code:
+flags every JavaScript file with more than 20 kilobytes of unused code:
 
 <figure class="w-figure">
   <img class="w-screenshot" src="remove-unused-javascript.jpg"

--- a/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
@@ -10,7 +10,7 @@ web_lighthouse:
 ---
 
 The Opportunities section of your Lighthouse report lists
-all unoptimized images, with potential savings in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte).
+all unoptimized images, with potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
 Optimize these images so that the page loads faster and consumes less data:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
@@ -10,7 +10,7 @@ web_lighthouse:
 ---
 
 The Opportunities section of your Lighthouse report lists
-all unoptimized images, with potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
+all unoptimized images, with potential savings in [kilobytes (KB)].
 Optimize these images so that the page loads faster and consumes less data:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists all images in your page
 that aren't appropriately sized,
-along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
+along with the potential savings in [kilobytes (KB)].
 Resize these images to save data and improve page load time:
 
 <figure class="w-figure">

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -11,7 +11,7 @@ web_lighthouse:
 
 The Opportunities section of your Lighthouse report lists all images in your page
 that aren't appropriately sized,
-along with the potential savings in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte).
+along with the potential savings in [kilobytes (KB)](https://en.wikipedia.org/wiki/Kibibyte).
 Resize these images to save data and improve page load time:
 
 <figure class="w-figure">


### PR DESCRIPTION
Fixes  #3877

Name used on Individual CLA: Cody Wirth codyrwirth@gmail.com

Changes proposed in this pull request:

- Remove reference from the outdated metric and replace it with kilobytes.

