### PR TITLE
Inline sw manifest to avoid weirdness with etags.

### DIFF
--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -18,22 +18,13 @@ const cacheNames = {
   ...workboxCacheNames,
 };
 
-// This import defines self['_manifest'], used below. This is the workbox precache manifest, and
-// we fetch it this way as this allows us to build sw.js early, but build the manifest itself after
-// all other build scripts have run.
-try {
-  self.importScripts('/sw-manifest.js');
-} catch (e) {
-  // ignore, possible in dev
-}
-
 /**
  * Configure default cache for some common web.dev assets: images, CSS, JS, offline page.
  *
  * This must occur first, as we cache images that are also matched by runtime handlers below. See
  * this workbox issue for updates: https://github.com/GoogleChrome/workbox/issues/2402
  */
-precacheAndRoute(self['_manifest'] || [], {
+precacheAndRoute(self.__WB_MANIFEST, {
   cleanURLs: false, // don't allow "foo" for "foo.html"
 });
 

--- a/sw-manifest.js
+++ b/sw-manifest.js
@@ -61,6 +61,9 @@ async function buildCacheManifest() {
   }
 
   const toplevelManifest = await injectManifest(config);
+  log(
+    `Building the Service Worker manifest, caching: ${toplevelManifest.count} files`,
+  );
   if (toplevelManifest.warnings.length) {
     if (isProd) {
       throw new Error(`toplevel manifest: ${toplevelManifest.warnings}`);

--- a/sw-manifest.js
+++ b/sw-manifest.js
@@ -18,8 +18,7 @@ require('dotenv').config();
 const isProd = process.env.ELEVENTY_ENV === 'prod';
 
 const log = require('fancy-log');
-const {promises: fs} = require('fs');
-const {getManifest} = require('workbox-build');
+const {injectManifest} = require('workbox-build');
 const resourcePath = require('./src/build/resource-path');
 
 process.on('unhandledRejection', (reason, p) => {
@@ -33,6 +32,8 @@ process.on('unhandledRejection', (reason, p) => {
  */
 async function buildCacheManifest() {
   const config = {
+    swSrc: 'dist/sw.js',
+    swDest: 'dist/sw.js',
     // JS or CSS files that include hashes don't need their own revision fields.
     dontCacheBustURLsMatching: /-[0-9a-f]{8}\.(css|js)/,
     globDirectory: 'dist',
@@ -59,20 +60,15 @@ async function buildCacheManifest() {
     config.globPatterns.push('bootstrap.js', 'app.css');
   }
 
-  const toplevelManifest = await getManifest(config);
+  const toplevelManifest = await injectManifest(config);
   if (toplevelManifest.warnings.length) {
     if (isProd) {
       throw new Error(`toplevel manifest: ${toplevelManifest.warnings}`);
     }
     toplevelManifest.warnings.forEach((warning) => log(warning));
   }
-
-  return toplevelManifest.manifestEntries;
 }
 
 (async function () {
-  const manifest = await buildCacheManifest();
-  const src = `self['_manifest']=${JSON.stringify(manifest)};`;
-  await fs.writeFile('dist/sw-manifest.js', src);
-  log(`Build the Service Worker manifest, ${manifest.length} files`);
+  await buildCacheManifest();
 })();


### PR DESCRIPTION
Fixes #3879

Changes proposed in this pull request:

- Inline the sw manifest to avoid etags getting out of sync.