### PR TITLE
Force express to no-store our html.

### DIFF
--- a/server.js
+++ b/server.js
@@ -119,12 +119,22 @@ const safetyHandler = (req, res, next) => {
   return next();
 };
 
+// Express' static middleware uses weak etags which will sometimes serve
+// stale html (which then requests the wrong versioned js resources).
+// This handler forces express to not allow any caching of the html
+// whatsoever.
+const staticHandler = (res, path) => {
+  if (path.endsWith('.html')) {
+    res.setHeader('Cache-Control', 'no-store');
+  }
+};
+
 const handlers = [
   safetyHandler,
   buildSafetyAssetHandler(),
   localeHandler,
-  express.static('dist'),
-  express.static('dist/en'),
+  express.static('dist', {setHeaders: staticHandler}),
+  express.static('dist/en', {setHeaders: staticHandler}),
   redirectHandler,
   notFoundHandler,
 ];


### PR DESCRIPTION
Fixes #3911 

Changes proposed in this pull request:

- Add express handler that forces html to not be cached at all. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Directives for more info.

@jeffposnick mentioned that we might be able to get away with disabling etags in express.static() and relying on Last-Modified:

```
app.use(express.static('dist', {
  etag: false,
  lastModified: true,  // Just being explicit about the default.
}));
```

I'd like to land this no-store change as a quick fix to see if it unbreaks the site. Then we can see if using the `etag:false` approach works.