### PR TITLE
Remove self-referencing tag from /tags/* page

### DIFF
--- a/src/site/content/en/metrics/index.njk
+++ b/src/site/content/en/metrics/index.njk
@@ -3,6 +3,4 @@ layout: path
 override:tags: []
 date: 2019-11-07
 pathName: metrics
-tags:
-  - metrics
 ---

--- a/src/site/content/en/notifications/index.njk
+++ b/src/site/content/en/notifications/index.njk
@@ -1,6 +1,4 @@
 ---
 layout: path
 pathName: notifications
-tags:
-  - notifications
 ---

--- a/src/site/content/en/payments/index.njk
+++ b/src/site/content/en/payments/index.njk
@@ -3,6 +3,4 @@ layout: path
 override:tags: []
 date: 2018-11-05
 pathName: payments
-tags:
-  - payments
 ---

--- a/src/site/content/en/progressive-web-apps/index.njk
+++ b/src/site/content/en/progressive-web-apps/index.njk
@@ -3,6 +3,4 @@ layout: path
 override:tags: []
 date: 2020-02-24
 pathName: progressive-web-apps
-tags:
-  - progressive-web-apps
 ---


### PR DESCRIPTION
Changes proposed in this pull request:

As title described, I noticed that there are empty card/post on certain tags page (`/tags/*`). Including:
- https://web.dev/tags/metrics/
- https://web.dev/tags/notifications/
- https://web.dev/tags/payments/
- https://web.dev/tags/progressive-web-apps/

It looks like this:
<img width="1552" alt="Screen Shot 2020-09-25 at 1 28 46 AM" src="https://user-images.githubusercontent.com/12913401/94179213-c6306580-fece-11ea-9f1c-18b877562f74.png">

I think it's because there are `tags` been defined which is exactly the same as `pathName`. And sort of created a self-referencing that resulted in the page been curated under itself.

Removing them should fix this.