### PR TITLE
Respect screenshot image widths from markup

### DIFF
--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -51,7 +51,12 @@
 .w-figure--screenshot > img {
   border: 1px solid $GREY_300;
   padding: 4px;
+  
+  // This ensures images are scaled to the exact size specified by the
+  // width attribute, preventing HiDPI screenshots from being blurry:
+  //  <img src="800x500.png" width="400" class="w-screenshot">
   box-sizing: content-box;
+  margin-left: -5px;
 }
 
 .w-screenshot--filled,

--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -51,7 +51,7 @@
 .w-figure--screenshot > img {
   border: 1px solid $GREY_300;
   padding: 4px;
-  
+
   // This ensures images are scaled to the exact size specified by the
   // width attribute, preventing HiDPI screenshots from being blurry:
   //  <img src="800x500.png" width="400" class="w-screenshot">

--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -51,6 +51,7 @@
 .w-figure--screenshot > img {
   border: 1px solid $GREY_300;
   padding: 4px;
+  box-sizing: content-box;
 }
 
 .w-screenshot--filled,


### PR DESCRIPTION
Web.dev's CSS uses `*{box-sizing:border-box}`. However, for `.w-screenshot` images/videos that supply a `width=".."` attribute, this means that images are rendered 10 pixels smaller than the markup's specified width. With this PR, the width attribute value for `.w-screenshot` images/videos is taken to be the _content_ width, so that images are not slightly scaled. This only affects `.w-screenshot` because it applies a border and padding.

You can see the blurry effect in the before & after images below:

## Before: (current)
<img width="636" alt="Screen Shot 2020-09-24 at 7 09 33 PM" src="https://user-images.githubusercontent.com/105127/94209304-f7db0980-fe99-11ea-987a-34063626bf83.png">

## After: (with this change)
<img width="649" alt="Screen Shot 2020-09-24 at 7 09 39 PM" src="https://user-images.githubusercontent.com/105127/94209313-fad5fa00-fe99-11ea-8aa9-2b170942da0a.png">

Here's a live example image you can use to compare the deploy preview's sizing VS what's on stable:

https://web.dev/text-fragments/#mixing-element-and-text-fragments
https://deploy-preview-3943--web-dev-staging.netlify.app/text-fragments/#mixing-element-and-text-fragments

<img width="378" src="https://user-images.githubusercontent.com/105127/94216364-31694000-fead-11ea-850e-b237c8182361.gif">