### PR TITLE
Fix undefined codelab paths

### DIFF
--- a/src/site/_filters/get-paths.js
+++ b/src/site/_filters/get-paths.js
@@ -14,7 +14,24 @@
  * limitations under the License.
  */
 const postToPathsMap = require('../_data/postToPaths.js');
+const paths = require('../_data/paths');
 
 module.exports = (post) => {
-  return postToPathsMap[post.fileSlug];
+  const out = postToPathsMap[post.fileSlug];
+  if (out) {
+    return out;
+  }
+
+  // Not all posts are correctly attributed to a path (they're not linked to in the path JSON).
+  // However, guess based on their filename. This is only needed for some "return" links.
+  const parts = post.filePathStem.split('/');
+
+  if (parts.length > 2) {
+    const pathFolder = parts[2];
+    if (pathFolder in paths) {
+      return [pathFolder]; // callers use this key to look up in paths again
+    }
+  }
+
+  return [];
 };

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -5,6 +5,11 @@ show_banner: false
 ---
 
 <div class="codelab-landing-page">
+  {% if path === undefined  %}
+    {% set postPaths = page | getPaths %}
+    {# Use first found path as a default path. #}
+    {% set path = paths[postPaths[0]] %}
+  {% endif %}
   <web-codelab glitch="{{ glitch }}" {% if glitch_path %}path="{{ glitch_path }}"{% endif %} {% if site.env === 'test' %}testmode{% endif %}>
     <div class="web-codelab__instructions">
       <h1 class="w-headline w-headline--two web-codelab__headline">{{ title }}</h1>
@@ -40,10 +45,11 @@ show_banner: false
           back: '/' + related_post,
           backLabel: 'Return to article'
         } %}
-      {% else %}
+      {% elif path %}
         {% ArticleNavigation {
           back: '/' + path.slug,
-          backLabel: 'Return to all articles'
+          backLabel: 'Return to all articles',
+          path: page
         } %}
       {% endif %}
     </div>

--- a/test/unit/src/site/_filters/getPaths.js
+++ b/test/unit/src/site/_filters/getPaths.js
@@ -5,17 +5,29 @@ describe('getPaths', function () {
   it('returns a list of path names the post belongs to', function () {
     const post = {
       fileSlug: 'what-is-accessibility',
+      filePathStem: '/en/blog/what-is-accessibility',
     };
     const expected = ['accessible'];
     const actual = getPaths(post);
     assert.deepStrictEqual(actual, expected);
   });
 
-  it('returns undefined for a non-existent post', function () {
+  it('returns empty for a non-existent post', function () {
     const post = {
       fileSlug: 'non-existent-post',
+      filePathStem: '/en/not-a-valid-path/non-existent-post',
     };
-    const expected = undefined;
+    const expected = [];
+    const actual = getPaths(post);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it('returns a guess for a valid but not recorded post', function () {
+    const post = {
+      fileSlug: 'inferred-post-does-not-exist',
+      filePathStem: '/en/fast/inferred-post-does-not-exist',
+    };
+    const expected = ['fast'];
     const actual = getPaths(post);
     assert.deepStrictEqual(actual, expected);
   });


### PR DESCRIPTION
Fixes #3939.

Having said that, I wonder if we should just simplify the `getPaths` function: we only use it literally for one reason, to get the default path for "back" URLs.

(We use `postToPathsMap` for a bunch of things, but that's more on the _discovery_ angle, things we explicitly want to list in certain places.)