### PR TITLE
Make code blocks larger on small screens

### DIFF
--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -49,10 +49,20 @@ pre {
 pre,
 pre[class*='language-'] {
   @include scrollbars();
-  margin: 32px 0;
+  margin: 32px -24px;
+  border-width: 1px 0;
   overflow: auto;
   padding: 16px;
   white-space: pre;
+
+  @include bp(sm) {
+    margin: 32px -32px;
+  }
+
+  @include bp(md) {
+    margin: 32px 0;
+    border-width: 1px;
+  }
 }
 
 pre code,


### PR DESCRIPTION
This PR makes sure code blocks takes all available horizontal space on small(er) screens.


<p align="center">before vs. after</p>

<img style="border: 1px" width="50%" src="https://user-images.githubusercontent.com/634478/94559908-3558e180-0262-11eb-8d16-693f358568f1.png"><img width="50%" src="https://user-images.githubusercontent.com/634478/94559895-2f630080-0262-11eb-8dd2-365a356fe848.png">

