### PR TITLE
remove extra slashes when normalizing URL

### DIFF
--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -5,6 +5,8 @@ import lang from './utils/language';
  * @return {string} normalized URL
  */
 export function normalizeUrl(url) {
+  url = url.replace(/\/+/g, '/'); // replace any occurance of "////" with "/"
+
   const u = new URL(url, window.location.toString());
   let pathname = u.pathname;
 

--- a/test/unit/src/lib/urls.js
+++ b/test/unit/src/lib/urls.js
@@ -31,5 +31,13 @@ describe('urls', function () {
         'ignores non-index.html HTML pages',
       );
     });
+
+    it('should remove extra slashes', function () {
+      assert(normalizeUrl('///foo') === '/foo/', 'removes extra slashes');
+      assert(
+        normalizeUrl('/foo///bar//') === '/foo/bar/',
+        'removes extra slashes',
+      );
+    });
   });
 });

--- a/test/unit/src/lib/urls.js
+++ b/test/unit/src/lib/urls.js
@@ -39,5 +39,22 @@ describe('urls', function () {
         'removes extra slashes',
       );
     });
+
+    it('should do nothing to valid URLs', function () {
+      assert(
+        normalizeUrl('/foo/?query=123&other') === '/foo/?query=123&other',
+        'retains query string',
+      );
+      assert(normalizeUrl('/foo/') === '/foo/', 'does nothing');
+      assert(
+        normalizeUrl('/foo/page.html') === '/foo/page.html',
+        'does nothing to non-index.html',
+      );
+      assert(normalizeUrl('/') === '/', 'does nothing');
+      assert(
+        normalizeUrl('/foo/bar/hello/') === '/foo/bar/hello/',
+        'does nothing to long path',
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #3969.

We were constructing a new URL from the pathname, which when it was "//foo", was treated as an origin. (This is an interesting bug and I wonder how often normalizing code doesn't look for this.)