### PR TITLE
Add vanity url for scale on web case studies

### DIFF
--- a/src/site/content/_redirects.yaml
+++ b/src/site/content/_redirects.yaml
@@ -229,3 +229,7 @@ redirects:
 
 - from: /native-lazy-loading
   to: /browser-level-image-lazy-loading
+
+# Redirects for vanity URLs
+- from: /scale-on-web
+  to: /tags/scale-on-web


### PR DESCRIPTION
Adds a vanity url redirect for web.dev/scale-on-web

Changes proposed in this pull request:

- redirect web.dev/scale-on-web to web.dev/tags/scale-on-web