### PR TITLE
Fix LCP fast threshold in LH doc

### DIFF
--- a/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
@@ -44,7 +44,7 @@ The table below shows how to interpret your LCP score:
     </thead>
     <tbody>
       <tr>
-        <td>0-2</td>
+        <td>0-2.5</td>
         <td>Green (fast)</td>
       </tr>
       <tr>


### PR DESCRIPTION
LCP fast threshold was 2 even though the mid threshold starts at 2.5. This change makes the threshold consistently 2.5, which is how it's documented at web.dev/lcp.