### PR TITLE
Add a guard in the example with a message passing

### DIFF
--- a/src/site/content/en/blog/detached-window-memory-leaks/index.md
+++ b/src/site/content/en/blog/detached-window-memory-leaks/index.md
@@ -500,10 +500,11 @@ function showNotes() {
 }
 let slide = 1;
 function nextSlide() {
-  if (!updateNotes) return;
   slide += 1;
-  // tell the popup to update without directly referencing it:
-  updateNotes(['setSlide', slide]);
+  // if the popup is open, tell it to update without referencing it:
+  if (updateNotes) {
+    updateNotes(['setSlide', slide]);
+  }
 }
 document.body.onclick = nextSlide;
 ```

--- a/src/site/content/en/blog/detached-window-memory-leaks/index.md
+++ b/src/site/content/en/blog/detached-window-memory-leaks/index.md
@@ -500,6 +500,7 @@ function showNotes() {
 }
 let slide = 1;
 function nextSlide() {
+  if (!updateNotes) return;
   slide += 1;
   // tell the popup to update without directly referencing it:
   updateNotes(['setSlide', slide]);


### PR DESCRIPTION
This fix handles the case when nextSlide() is called before showNotes();

P.S. JFYI I don't participate in hacktoberfest :)