### PR TITLE
cls: add link to ad-specific mitigation guidance

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2020-06-23
+updated: 2020-10-09
 description: |
   This post introduces the Cumulative Layout Shift (CLS) metric and explains
   how to measure it
@@ -383,6 +383,8 @@ few guiding principles:
 
 For a deep dive on how to improve CLS, see [Optimize
 CLS](https://web.dev/optimize-cls/).
+
+Also, consider this guide specific to [minimizing CLS when working with Google Publisher Tags (GPT)](https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift).
 
 ## Additional resources
 

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -384,12 +384,10 @@ few guiding principles:
 For a deep dive on how to improve CLS, see [Optimize
 CLS](https://web.dev/optimize-cls/).
 
-### Google Publisher Tags
-
-See the official Google Publisher Tag guide on [Minimizing layout shift](https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift).
-
 ## Additional resources
 
+- Google Publisher Tag's guidance on
+  [minimizing layout shift](https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift)
 - [Understanding Cumulative Layout Shift](https://youtu.be/zIJuY-JCjqw) by
   [Annie Sullivan](https://anniesullie.com/) and [Steve
   Kobes](https://kobes.ca/) at [#PerfMatters](https://perfmattersconf.com/)

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -384,7 +384,9 @@ few guiding principles:
 For a deep dive on how to improve CLS, see [Optimize
 CLS](https://web.dev/optimize-cls/).
 
-Also, consider this guide specific to [minimizing CLS when working with Google Publisher Tags (GPT)](https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift).
+### Google Publisher Tags
+
+See the official Google Publisher Tag guide on [Minimizing layout shift](https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift).
 
 ## Additional resources
 


### PR DESCRIPTION

Changes proposed in this pull request:

- add a link from the CLS doc to https://developers.google.com/doubleclick-gpt/guides/minimize-layout-shift
