### PR TITLE
Update example from makeRequest() to handle()

### DIFF
--- a/src/site/content/en/reliable/app-shell-ux-with-service-workers/index.md
+++ b/src/site/content/en/reliable/app-shell-ux-with-service-workers/index.md
@@ -149,15 +149,21 @@ Next, tell Workbox how to use the strategies to construct a complete, streaming 
 
 ```javascript
 workbox.streams.strategy([
-  () => cacheStrategy.makeRequest({request: '/head.html'}),
-  () => cacheStrategy.makeRequest({request: '/navbar.html'}),
+  () => cacheStrategy.handle({
+      request: new Request(getCacheKeyForURL("/head.html")),
+    }),
+  () => cacheStrategy.handle({
+      request: new Request(getCacheKeyForURL("/navbar.html")),
+    }),
   async ({event, url}) => {
     const tag = url.searchParams.get('tag') || DEFAULT_TAG;
-    const listResponse = await apiStrategy.makeRequest(…);
+    const listResponse = await apiStrategy.handle(…);
     const data = await listResponse.json();
     return templates.index(tag, data.items);
   },
-  () => cacheStrategy.makeRequest({request: '/foot.html'}),
+  () => cacheStrategy.handle({
+      request: new Request(getCacheKeyForURL("/foot.html")),
+    }),
 ]);
 ```
 


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

This PR updates a code example in the post https://web.dev/app-shell-ux-with-service-workers/ to use `handle` rather than `makeRequest`.

Based on https://github.com/GoogleChrome/workbox/pull/2123 `makeRequest` has been removed and `handle` is what should be used instead.

I followed https://philipwalton.com/articles/smaller-html-payloads-with-service-workers/ for an example of how `handle` should be used.