### PR TITLE
Update COOP/COEP article

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -13,6 +13,7 @@ description: >
 authors:
   - agektmr
 hero: hero.jpg
+alt: An illustration of a person browsing a website that has a popup, an iframe, and an image.
 date: 2020-04-13
 updated: 2020-10-15
 tags:
@@ -23,6 +24,7 @@ origin_trial:
 feedback:
   - api
 ---
+
 {% Banner 'caution', 'body' %}
 
 **Updates**
@@ -33,8 +35,8 @@ returns `true`. `performance.measureMemory` is ending its origin trial and is
 planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
-**September 1st, 2020**: COOP Reporting is behind the `#cross-origin-isolated` flag
-in Chrome 86.
+**September 1st, 2020**: COOP Reporting is behind flags in Chrome 86. See
+[Enable Chrome flags](#flags).
 
 {% endBanner %}
 
@@ -245,22 +247,21 @@ API](https://bugzilla.mozilla.org/show_bug.cgi?id=1620573). You may want to use
 both APIs during the transition.
 {% endAside %}
 
-{% Details %}
+#### Enable the Reporting API
 
-{% DetailsSummary %}
-The COOP Reporting API in Chrome is available after version 86 with one of two conditions:
+You can try the COOP Reporting API in Chrome 86 and later by doing one of the following:
 
-1. Enable 2 flags at `chrome://flags`
-2. Register an orign trial
-{% endDetailsSummary %}
+1. Enabling Chrome flags
+2. Registering for an origin trial
 
-#### Enable 2 flags at `chrome://flags`
+##### Enable via Chrome flags {: #flags }
 
-* Cross Origin Opener Policy reporting (`#cross-origin-opener-policy-reporting`)
-* Cross Origin Opener Policy access reporting
-  (`#cross-origin-opener-policy-access-reporting`)
+1. Go to `chrome://flags`
+1. Enable **Cross Origin Opener Policy reporting** (`chrome://flags/#cross-origin-opener-policy-reporting`)
+1. Enable **Cross Origin Opener Policy access reporting**
+   (`chrome://flags/#cross-origin-opener-policy-access-reporting`)
 
-#### Register an origin trial
+##### Register for an origin trial
 
 {% include 'content/origin-trials.njk' %}
 
@@ -271,7 +272,7 @@ To use COOP Reporting API, the token must be served as an HTTP header instead of
 a `<meta>` tag.
 {% endAside %}
 
-{% endDetails %}
+#### `Report-To`
 
 To specify where the browser should send reports, append the `Report-To` HTTP
 header to any document that is served with a COEP or COOP HTTP header. The

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -27,8 +27,9 @@ feedback:
 
 **[15th Oct. 2020]**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureMemory` in on origin trial from Chrome 87.
-Shared Array Buffer on Android Chrome is available from Chrome 88.
+returns `true`. `performance.measureMemory` ending its origin trial and will be
+enabled by default in Chrome 88. Shared Array Buffer on Android Chrome will be
+available from Chrome 88.
 
 **[1st Sep. 2020]**: COOP Reporting is behind the `#cross-origin-isolated` flag
 in Chrome 86. Added instructions.
@@ -46,8 +47,8 @@ able to use privileged features including:
   Isolation](https://www.chromium.org/Home/chromium-security/site-isolation),
   but will require the cross-origin isolated state and will be disabled by
   default.)
-* [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Available
-  behind a flag from Chrome 87)
+* [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Ends its
+  origin trial and will be enabled by default in Chrome 88)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
   available yet in Chrome)
 

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -27,9 +27,9 @@ feedback:
 
 **[15th Oct. 2020]**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureMemory` ending its origin trial and will be
-enabled by default in Chrome 88. Shared Array Buffer on Android Chrome will be
-available from Chrome 88.
+returns `true`. `performance.measureMemory` ending its origin trial and is
+planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
+Chrome will be available from Chrome 88.
 
 **[1st Sep. 2020]**: COOP Reporting is behind the `#cross-origin-isolated` flag
 in Chrome 86. Added instructions.
@@ -48,7 +48,7 @@ able to use privileged features including:
   but will require the cross-origin isolated state and will be disabled by
   default.)
 * [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Ends its
-  origin trial and will be enabled by default in Chrome 88)
+  origin trial and is planned to be enabled by default in Chrome 88)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
   available yet in Chrome)
 

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -23,13 +23,15 @@ origin_trial:
 feedback:
   - api
 ---
-{% Aside %}
-- 15th Oct. 2020: `self.crossOriginIsolated` and Shared Array Buffer on Android
-  Chrome are now available in Chrome 87. `document.domain` is now immutable when
-  `self.crossOriginIsolated` return `true`. `performance.measureMemory` in on
-  origin trial.
-- 1st Sep. 2020: COOP Reporting is now available behind a flag in Chrome 86.
-  Added instructions.
+{% Aside 'gotchas' %}
+**[15th Oct. 2020]**: `self.crossOriginIsolated` and Shared Array Buffer on Android
+Chrome are now available in Chrome 87. `document.domain` is now immutable when
+`self.crossOriginIsolated` returns `true`. `performance.measureMemory` in on
+origin trial from Chrome 87.
+
+**[1st Sep. 2020]**: COOP Reporting is now available behind a flag in Chrome 86.
+Added instructions.
+
 {% endAside %}
 
 Some web APIs increase the risk of side-channel attacks like Spectre. To
@@ -45,9 +47,9 @@ able to use privileged features including:
   available yet in Chrome)
 
 The cross-origin isolated state also prevents modifications of
-`document.domain`. (This is  from Chrome 87. Being able to alter
-`document.domain` allows communication between same-site documents and has been
-considered a loophole in the same-origin policy.)
+`document.domain`. (Being able to alter `document.domain` allows communication
+between same-site documents and has been considered a loophole in the
+same-origin policy.)
 
 To opt in to a cross-origin isolated state, you need to send the following
 HTTP headers on the main document:

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -29,7 +29,7 @@ feedback:
 
 **October 15th, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureMemory` ending its origin trial and is
+returns `true`. `performance.measureMemory` is ending its origin trial and is
 planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
@@ -178,7 +178,7 @@ parameters](https://first-party-test.glitch.me/coep).
 {% endAside %}
 
 {% Aside %}
-[squoosh.app](https://squoosh.app) [now uses COOP /
+[Squoosh](https://squoosh.app) (an image optimization PWA) [now uses COOP /
 COEP](https://github.com/GoogleChromeLabs/squoosh/pull/829/files#diff-316f969413f2d9a065fcc08c7a5589c088dd1e21deebadccfc5a4372ac5e0cbbR22-R23)
 to gain access to Wasm Threads (and Shared Array Buffer) as well on Android
 Chrome.

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -25,19 +25,15 @@ feedback:
 ---
 {% Banner 'caution', 'body' %}
 
-## Updates
+**Updates**
 
-### October 15th, 2020
-
-`self.crossOriginIsolated` is available from Chrome 87.
+**October 15th, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
 returns `true`. `performance.measureMemory` ending its origin trial and is
 planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
-### September 1st, 2020
-
-COOP Reporting is behind the `#cross-origin-isolated` flag
+**September 1st, 2020**: COOP Reporting is behind the `#cross-origin-isolated` flag
 in Chrome 86.
 
 {% endBanner %}

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -14,7 +14,7 @@ authors:
   - agektmr
 hero: hero.jpg
 date: 2020-04-13
-updated: 2020-09-01
+updated: 2020-10-15
 tags:
   - blog
   - security
@@ -23,26 +23,31 @@ origin_trial:
 feedback:
   - api
 ---
+{% Aside %}
+- 15th Oct. 2020: `self.crossOriginIsolated` and Shared Array Buffer on Android
+  Chrome are now available in Chrome 87. `document.domain` is now immutable when
+  `self.crossOriginIsolated` return `true`. `performance.measureMemory` in on
+  origin trial.
+- 1st Sep. 2020: COOP Reporting is now available behind a flag in Chrome 86.
+  Added instructions.
+{% endAside %}
+
 Some web APIs increase the risk of side-channel attacks like Spectre. To
 mitigate that risk, browsers offer an opt-in-based isolated environment called
 cross-origin isolated. With a cross-origin isolated state, the webpage will be
 able to use privileged features including:
 
 * [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
-  (required for WebAssembly Threads)
-* [`performance.measureMemory()`](/monitor-total-page-memory-usage/)
-* [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/)
+  (required for WebAssembly Threads) (Available from Chrome 87)
+* [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Available
+  behind a flag from Chrome 87)
+* [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
+  available yet in Chrome)
 
 The cross-origin isolated state also prevents modifications of
-`document.domain`. (Being able to alter `document.domain` allows communication
-between same-site documents and has been considered a loophole in the
-same-origin policy.)
-
-{% Aside 'caution' %}
-These powerful features and the prevention of `document.domain` modification
-are not yet enabled in Chrome as of version 83. We'll update this post as they
-become available.
-{% endAside %}
+`document.domain`. (This is  from Chrome 87. Being able to alter
+`document.domain` allows communication between same-site documents and has been
+considered a loophole in the same-origin policy.)
 
 To opt in to a cross-origin isolated state, you need to send the following
 HTTP headers on the main document:
@@ -174,8 +179,7 @@ powerful features like `performance.measureMemory()`.
 {% Aside 'caution' %}
 The
 [`self.crossOriginIsolated`](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/crossOriginIsolated)
-property is still under development and not available yet in Chrome as of
-version 83.
+property is available in Chrome from version 87.
 {% endAside %}
 
 ### Debug issues using Chrome DevTools

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -177,6 +177,12 @@ header to all documents including those that are embedded via iframes.
 parameters](https://first-party-test.glitch.me/coep).
 {% endAside %}
 
+{% Aside %}
+[squoosh.app](https://squoosh.app) [now uses COOP /
+COEP](https://github.com/GoogleChromeLabs/squoosh/pull/829/files#diff-316f969413f2d9a065fcc08c7a5589c088dd1e21deebadccfc5a4372ac5e0cbbR22-R23)
+to leverage Shared Array Buffer on Android Chrome.
+{% endAside %}
+
 ### Determine whether isolation succeeded with `self.crossOriginIsolated`
 
 The `self.crossOriginIsolated` property returns `true` when the web page is in a

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -24,13 +24,14 @@ feedback:
   - api
 ---
 {% Aside 'gotchas' %}
-**[15th Oct. 2020]**: `self.crossOriginIsolated` and Shared Array Buffer on Android
-Chrome are now available in Chrome 87. `document.domain` is now immutable when
-`self.crossOriginIsolated` returns `true`. `performance.measureMemory` in on
-origin trial from Chrome 87.
 
-**[1st Sep. 2020]**: COOP Reporting is now available behind a flag in Chrome 86.
-Added instructions.
+**[15th Oct. 2020]**: `self.crossOriginIsolated` is available from Chrome 87.
+Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
+returns `true`. `performance.measureMemory` in on origin trial from Chrome 87.
+Shared Array Buffer on Android Chrome is available from Chrome 88.
+
+**[1st Sep. 2020]**: COOP Reporting is behind the `#cross-origin-isolated` flag
+in Chrome 86. Added instructions.
 
 {% endAside %}
 
@@ -40,7 +41,11 @@ cross-origin isolated. With a cross-origin isolated state, the webpage will be
 able to use privileged features including:
 
 * [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
-  (required for WebAssembly Threads) (Available from Chrome 87)
+  (required for WebAssembly Threads. This is available from Android Chrome 88.
+  Desktop version is currently enabled by default with the help of [Site
+  Isolation](https://www.chromium.org/Home/chromium-security/site-isolation),
+  but will require the cross-origin isolated state and will be disabled by
+  default.)
 * [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Available
   behind a flag from Chrome 87)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
@@ -67,7 +72,6 @@ means those resources being loaded cross-origin require opt-ins.
 You can determine whether a web page is in a cross-origin isolated state by
 examining
 [`self.crossOriginIsolated`](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/crossOriginIsolated).
-(This works on Firefox but has yet to be implemented in Chrome).
 
 This article shows how to use these new headers. In [a follow-up
 article](/why-coop-coep) I will provide more background and context.

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -23,18 +23,24 @@ origin_trial:
 feedback:
   - api
 ---
-{% Aside 'gotchas' %}
+{% Banner 'caution', 'body' %}
 
-**[15th Oct. 2020]**: `self.crossOriginIsolated` is available from Chrome 87.
+## Updates
+
+### October 15th, 2020
+
+`self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
 returns `true`. `performance.measureMemory` ending its origin trial and is
 planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
-**[1st Sep. 2020]**: COOP Reporting is behind the `#cross-origin-isolated` flag
-in Chrome 86. Added instructions.
+### September 1st, 2020
 
-{% endAside %}
+COOP Reporting is behind the `#cross-origin-isolated` flag
+in Chrome 86.
+
+{% endBanner %}
 
 Some web APIs increase the risk of side-channel attacks like Spectre. To
 mitigate that risk, browsers offer an opt-in-based isolated environment called

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -180,7 +180,8 @@ parameters](https://first-party-test.glitch.me/coep).
 {% Aside %}
 [squoosh.app](https://squoosh.app) [now uses COOP /
 COEP](https://github.com/GoogleChromeLabs/squoosh/pull/829/files#diff-316f969413f2d9a065fcc08c7a5589c088dd1e21deebadccfc5a4372ac5e0cbbR22-R23)
-to leverage Shared Array Buffer on Android Chrome.
+to gain access to Wasm Threads (and Shared Array Buffer) as well on Android
+Chrome.
 {% endAside %}
 
 ### Determine whether isolation succeeded with `self.crossOriginIsolated`


### PR DESCRIPTION
Reflect changes in Chrome 87
- `self.crossOriginIsolated` is now available
- Shared Array Buffers is available in Android Chrome
- `document.domain` is now immutable
- `performance.measureMemory()` is now an origin trial
