### PR TITLE
Fix fluid typography example in min-max-clamp blog post

### DIFF
--- a/src/site/content/en/blog/min-max-clamp/index.md
+++ b/src/site/content/en/blog/min-max-clamp/index.md
@@ -228,7 +228,7 @@ code:
 
 ```css
 p {
-  clamp(1.5rem, 5vw, 3rem);
+  font-size: clamp(1.5rem, 5vw, 3rem);
 }
 ```
 


### PR DESCRIPTION
Fixes the fluid typography example in the [min(), max(), and clamp(): three logical CSS functions to use today](https://web.dev/min-max-clamp/) blog post.

```diff
p {
-  clamp(1.5rem, 5vw, 3rem);
+  font-size: clamp(1.5rem, 5vw, 3rem);
}
```