### PR TITLE
Change RSS updated field to build date

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -25,6 +25,7 @@ module.exports = {
   titleVariation: 'Home',
   defaultLocale: locale.defaultLocale,
   url: 'https://web.dev',
+  buildDate: new Date(),
   repo: 'https://github.com/GoogleChrome/web.dev',
   subscribe: 'https://web.dev/newsletter',
   subscribeForm:

--- a/src/site/_includes/feed.njk
+++ b/src/site/_includes/feed.njk
@@ -4,7 +4,7 @@
   <subtitle>{{ metadata.feed.subtitle }}</subtitle>
   <link href="{{ metadata.feed.url }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
-  <updated>{{ collections.blogPosts | reverse | rssLastUpdatedDate }}</updated>
+  <updated>{{ site.buildDate | rssDate }}</updated>
   <id>{{ metadata.feed.id }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>

--- a/src/site/content/en/authors/feed.njk
+++ b/src/site/content/en/authors/feed.njk
@@ -20,7 +20,7 @@ pagination:
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id>{{ renderData.metadata.id }}</id>
   <title>{{ renderData.metadata.title }}</title>
-  <updated>{{ paged.elements | reverse | rssLastUpdatedDate }}</updated>
+  <updated>{{ site.buildDate | rssDate }}</updated>
   <author>
     <name>{{ renderData.metadata.author }}</name>
   </author>

--- a/src/site/content/en/tags/feed.njk
+++ b/src/site/content/en/tags/feed.njk
@@ -21,7 +21,7 @@ pagination:
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id>{{ renderData.metadata.id }}</id>
   <title>{{ renderData.metadata.title }}</title>
-  <updated>{{ paged.elements | reverse | rssLastUpdatedDate }}</updated>
+  <updated>{{ site.buildDate | rssDate }}</updated>
   <author>
     <name>{{ renderData.metadata.author }}</name>
   </author>


### PR DESCRIPTION
This PR make sure the `<updated>` feed date is the build date so that when an article is removed, RSS readers will fetch new information and will remove a previous cached article.

Fixes #3949
