### PR TITLE
Clarify rel=preload tag use

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
@@ -59,7 +59,8 @@ should be downloaded as soon as possible.
 ## Declare your preload links
 
 Declare preload links in your HTML to instruct the browser to download key resources
-as soon as possible.
+as soon as possible.  Note that these tags are added *in addition to* the existing
+`link` or `script` tags, not replacing them.
 
 ```html
 <head>


### PR DESCRIPTION
Changes proposed in this pull request:

This updates the wording in the page describing the usage of `rel="preload"`. At a glance, the current wording implies that the rel=preload tags replace the existing ones, rather than supplementing them.