### PR TITLE
Note on WCAG risk for fluid type

### DIFF
--- a/src/site/content/en/blog/min-max-clamp/index.md
+++ b/src/site/content/en/blog/min-max-clamp/index.md
@@ -232,6 +232,8 @@ p {
 }
 ```
 
+When you use `vw` units or limit how large text can get with `clamp()`, there is a chance a user may be unable to scale the text to 200% of its original size. If that happens, it is WCAG failure under [1.4.4 Resize text (AA)](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=144#resize-text) so be certain to [test the results with zoom](https://adrianroselli.com/2019/12/responsive-type-and-zoom.html).
+
 
 ## Conclusion
 The CSS math functions, `min()`, `max()`, and `clamp()` are very powerful, well


### PR DESCRIPTION
Added two sentences with two links total noting the risk with `clamp()` and `vw` for WCAG 1.4.4.
