### PR TITLE
margin-inline isn't a potential physical cruft

### DIFF
--- a/src/site/content/en/blog/logical-property-shorthands/index.md
+++ b/src/site/content/en/blog/logical-property-shorthands/index.md
@@ -439,7 +439,7 @@ p {
 /* and unsupporting browsers to ignore #TheCascade */
 p {
   /* remove any potential physical cruft.. */
-  margin-inline: 0;
+  margin: 0;
   /* explicitly set logical value */
   margin-block: 1ch 2ch;
 }


### PR DESCRIPTION
Replace margin-inline with margin, because context is about physical property

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
