### PR TITLE
add stack pack guidance into each LH audit guide

### DIFF
--- a/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
+++ b/src/site/content/en/lighthouse-performance/critical-request-chains/index.md
@@ -49,6 +49,14 @@ Learn more about optimizing your
 [CSS](/defer-non-critical-css), and
 [web fonts](/avoid-invisible-text).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Magento
+
+If you are not bundling your JavaScript assets, consider using [baler](https://github.com/magento/baler).
+
 ## Resources
 
 [Source code for **Minimize critical request depth** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/critical-request-chains.js)

--- a/src/site/content/en/lighthouse-performance/dom-size/index.md
+++ b/src/site/content/en/lighthouse-performance/dom-size/index.md
@@ -76,7 +76,8 @@ If you use any of these CMS's, libraries or frameworks, consider the following s
 
 ### Angular
 
-Consider virtual scrolling with the Component Dev Kit (CDK) if very large lists are being rendered. [Learn more](https://web.dev/virtualize-lists-with-angular-cdk/).
+Consider [virtual scrolling](/virtualize-lists-with-angular-cdk/) with the
+Component Dev Kit (CDK) if very large lists are being rendered.
 
 ### React
 

--- a/src/site/content/en/lighthouse-performance/dom-size/index.md
+++ b/src/site/content/en/lighthouse-performance/dom-size/index.md
@@ -70,6 +70,18 @@ another approach for improving rendering performance is simplifying your CSS sel
 See Google's [Reduce the Scope and Complexity of Style Calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)
 for more information.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Angular
+
+Consider virtual scrolling with the Component Dev Kit (CDK) if very large lists are being rendered. [Learn more](https://web.dev/virtualize-lists-with-angular-cdk/).
+
+### React
+
+Consider using a "windowing" library like `react-window` to minimize the number of DOM nodes created if you are rendering many repeated elements on the page. [Learn more](https://web.dev/virtualize-long-lists-react-window/). Also, minimize unnecessary re-renders using [`shouldComponentUpdate`](https://reactjs.org/docs/optimizing-performance.html#shouldcomponentupdate-in-action), [`PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent), or [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) and [skip effects](https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects) only until certain dependencies have changed if you are using the `Effect` hook to improve runtime performance.
+
 ## Resources
 
 - [Source code for **Avoid an excessive DOM size** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/dom-size.js)

--- a/src/site/content/en/lighthouse-performance/efficient-animated-content/index.md
+++ b/src/site/content/en/lighthouse-performance/efficient-animated-content/index.md
@@ -64,6 +64,26 @@ Luckily, you can recreate these behaviors using the `<video>` element.
 </video>  
 ```
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+For animated content, use [`amp-anim`](https://amp.dev/documentation/components/amp-anim/) to minimize CPU usage when the content is offscreen.
+
+### Drupal
+
+Consider uploading your GIF to a service which will make it available to embed as an HTML5 video.
+
+### Joomla
+
+Consider uploading your GIF to a service which will make it available to embed as an HTML5 video.
+
+### WordPress
+
+Consider uploading your GIF to a service which will make it available to embed as an HTML5 video.
+
 ## Resources
 
 - [Source code for **Use video formats for animated content** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/efficient-animated-content.js)

--- a/src/site/content/en/lighthouse-performance/font-display/index.md
+++ b/src/site/content/en/lighthouse-performance/font-display/index.md
@@ -73,6 +73,18 @@ so you may need to do a bit more work to fix the invisible text problem.
   to learn how to avoid FOIT across all browsers.
 {% endAside %}
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Specify `@font-display` when defining custom fonts in your theme.
+
+### Magento
+
+Specify `@font-display` when [defining custom fonts](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/using-fonts.html).
+
 ## Resources
 
 * [Source code for **Ensure text remains visible during webfont load** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/font-display.js)

--- a/src/site/content/en/lighthouse-performance/offscreen-images/index.md
+++ b/src/site/content/en/lighthouse-performance/offscreen-images/index.md
@@ -22,6 +22,30 @@ to lower [Time to Interactive](/interactive):
 
 See also [Lazy load offscreen images with lazysizes codelab](/codelab-use-lazysizes-to-lazyload-images).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+Ensure that you are using [`amp-img`](https://amp.dev/documentation/components/amp-img/?format=websites) for images to automatically lazy-load. [Learn more](https://amp.dev/documentation/guides-and-tutorials/develop/media_iframes_3p/?format=websites#images).
+
+### Drupal
+
+Install [a Drupal module](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A67&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=%22lazy+load%22&solrsort=iss_project_release_usage+desc&op=Search) that can lazy load images. Such modules provide the ability to defer any offscreen images to improve performance.
+
+### Joomla
+
+Install a [lazy-load Joomla plugin](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=lazy%20loading) that provides the ability to defer any offscreen images, or switch to a template that provides that functionality. Starting with Joomla 4.0, a dedicated lazy-loading plugin can be enabled by using the "Content - Lazy Loading Images" plugin. Also consider using [an AMP plugin](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=amp).
+
+### Magento
+
+Consider modifying your product and catalog templates to make use of the web platform's [lazy loading](https://web.dev/native-lazy-loading) feature.
+
+### WordPress
+
+Install a [lazy-load WordPress plugin](https://wordpress.org/plugins/search/lazy+load/) that provides the ability to defer any offscreen images, or switch to a theme that provides that functionality. Also consider using [the AMP plugin](https://wordpress.org/plugins/amp/).
+
 ## Resources
 
 - [Source code for **Defer offscreen images** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/offscreen-images.js)

--- a/src/site/content/en/lighthouse-performance/redirects/index.md
+++ b/src/site/content/en/lighthouse-performance/redirects/index.md
@@ -46,6 +46,14 @@ If you're using redirects to divert mobile users to the mobile version of your p
 consider redesigning your site to use
 [Responsive Design](https://developers.google.com/web/fundamentals/design-and-ux/responsive/).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### React
+
+If you are using React Router, minimize usage of the `<Redirect>` component for [route navigations](https://reacttraining.com/react-router/web/api/Redirect).
+
 ## Resources
 
 - [Source code for **Avoid multiple page redirects** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/redirects.js)

--- a/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
+++ b/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
@@ -95,6 +95,26 @@ Finally, you'll want to minify your CSS to remove any extra whitespace or
 characters (see [Minify CSS](/minify-css)).
 This ensures that you're sending the smallest possible bundle to your users.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+Use tools such as [AMP Optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer) to [server-side render AMP layouts](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/server-side-rendering/).
+
+### Drupal
+
+Consider using a module to inline critical CSS and JavaScript, or potentially load assets asynchronously via JavaScript such as the [Advanced CSS/JS Aggregation](https://www.drupal.org/project/advagg) module. Beware that optimizations provided by this module may break your site, so you will likely need to make code changes.
+
+### Joomla
+
+There are a number of Joomla plugins that can help you [inline critical assets](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=performance) or [defer less important resources](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=performance). Beware that optimizations provided by these plugins may break features of your templates or plugins, so you will need to test these thoroughly.
+
+### WordPress
+
+There are a number of WordPress plugins that can help you [inline critical assets](https://wordpress.org/plugins/search/critical+css/) or [defer less important resources](https://wordpress.org/plugins/search/defer+css+javascript/). Beware that optimizations provided by these plugins may break features of your theme or plugins, so you will likely need to make code changes.
+
 ## Resources
 
 - [Source code for **Eliminate render-blocking resources** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js)

--- a/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
+++ b/src/site/content/en/lighthouse-performance/time-to-first-byte/index.md
@@ -45,6 +45,26 @@ There are many possible causes of slow server responses, and therefore many poss
 - Optimize how your server queries databases, or migrate to faster database systems.
 - Upgrade your server hardware to have more memory or CPU.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Themes, modules, and server specifications all contribute to server response time. Consider finding a more optimized theme, carefully selecting an optimization module, and/or upgrading your server. Your hosting servers should make use of PHP opcode caching, memory-caching to reduce database query times such as Redis or Memcached, as well as optimized application logic to prepare pages faster.
+
+### Magento
+
+Use Magento's [Varnish integration](https://devdocs.magento.com/guides/v2.3/config-guide/varnish/config-varnish.html).
+
+### React
+
+If you are server-side rendering any React components, consider using `renderToNodeStream()` or `renderToStaticNodeStream()` to allow the client to receive and hydrate different parts of the markup instead of all at once. [Learn more](https://reactjs.org/docs/react-dom-server.html#rendertonodestream).
+
+### WordPress
+
+Themes, plugins, and server specifications all contribute to server response time. Consider finding a more optimized theme, carefully selecting an optimization plugin, and/or upgrading your server.
+
 ## Resources
 
 - [Source code for **Reduce server response times (TTFB)** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/server-response-time.js)

--- a/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
+++ b/src/site/content/en/lighthouse-performance/total-byte-weight/index.md
@@ -57,6 +57,26 @@ Here are some ways to keep payload size down:
   on repeat visits. (See the [Network reliability landing page](/reliable)
   to learn how caching works and how to implement it.)
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Angular
+
+Apply [route-level code splitting](https://web.dev/route-level-code-splitting-in-angular/) to minimize the size of your JavaScript bundles. Also, consider precaching assets with the [Angular service worker](https://web.dev/precaching-with-the-angular-service-worker/).
+
+### Drupal
+
+Consider using [Responsive Image Styles](https://www.drupal.org/docs/8/mobile-guide/responsive-images-in-drupal-8) to reduce the size of images loaded on your page. If you are using Views to show multiple content items on a page, consider implementing pagination to limit the number of content items shown on a given page.
+
+### Joomla
+
+Consider showing excerpts in your article categories (e.g. via the read more link), reducing the number of articles shown on a given page, breaking your long posts into multiple pages, or using a plugin to lazy-load comments.
+
+### WordPress
+
+Consider showing excerpts in your post lists (e.g. via the more tag), reducing the number of posts shown on a given page, breaking your long posts into multiple pages, or using a plugin to lazy-load comments.
+
 ## Resources
 
 [Source code for **Avoid enormous network payloads** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/total-byte-weight.js)

--- a/src/site/content/en/lighthouse-performance/unminified-css/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-css/index.md
@@ -75,6 +75,34 @@ This is usually accomplished with a build tool like Gulp or Webpack.
 
 Learn how to minify your CSS code in [Minify CSS](/minify-css).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+Refer to the [AMP documentation](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/) to ensure all styles are supported.
+
+### Drupal
+
+Ensure you have enabled "Aggregate CSS files" in the "Administration » Configuration » Development" page. You can also configure more advanced aggregation options through [additional modules](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A123&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=css+aggregation&solrsort=iss_project_release_usage+desc&op=Search) to speed up your site by concatenating, minifying, and compressing your CSS styles.
+
+### Joomla
+
+A number of [Joomla extensions](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=performance) can speed up your site by concatenating, minifying, and compressing your css styles. There are also templates that provide this functionality.
+
+### Magento
+
+Enable the "Minify CSS Files" option in your store's Developer settings. [Learn more](https://devdocs.magento.com/guides/v2.3/performance-best-practices/configuration.html?itm_source=devdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=minify%20css%20files).
+
+### React
+
+If your build system minifies CSS files automatically, ensure that you are deploying the production build of your application. You can check this with the React Developer Tools extension. [Learn more](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build).
+
+### WordPress
+
+A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+css/) can speed up your site by concatenating, minifying, and compressing your styles. You may also want to use a build process to do this minification up-front if possible.
+
 ## Resources
 
 - [Source code for **Minify CSS** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/unminified-css.js)

--- a/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unminified-javascript/index.md
@@ -26,6 +26,30 @@ to create a smaller but perfectly valid code file.
 [Terser](https://github.com/terser-js/terser) is a popular JavaScript compression tool.
 webpack v4 includes a plugin for this library by default to create minified build files.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Ensure you have enabled "Aggregate JavaScript files" in the "Administration » Configuration » Development" page. You can also configure more advanced aggregation options through [additional modules](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A123&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=javascript+aggregation&solrsort=iss_project_release_usage+desc&op=Search) to speed up your site by concatenating, minifying, and compressing your JavaScript assets.
+
+### Joomla
+
+A number of [Joomla extensions](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=performance) can speed up your site by concatenating, minifying, and compressing your scripts. There are also templates that provide this functionality.
+
+### Magento
+
+Use [Terser](https://www.npmjs.com/package/terser) to minify all JavaScript assets from static content deployment, and disable the built-in minification feature.
+
+### React
+
+If your build system minifies JS files automatically, ensure that you are deploying the production build of your application. You can check this with the React Developer Tools extension. [Learn more](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build).
+
+### WordPress
+
+A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+javascript/) can speed up your site by concatenating, minifying, and compressing your scripts. You may also want to use a build process to do this minification up front if possible.
+
 ## Resources
 
 - [Source code for **Minify JavaScript** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/unminified-javascript.js)

--- a/src/site/content/en/lighthouse-performance/unused-css-rules/index.md
+++ b/src/site/content/en/lighthouse-performance/unused-css-rules/index.md
@@ -78,6 +78,22 @@ using the [Critical tool](https://github.com/addyosmani/critical/blob/master/REA
 
 Learn more in [Defer non-critical CSS](/defer-non-critical-css).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Consider removing unused CSS rules and only attach the needed Drupal libraries to the relevant page or component in a page. See the [Drupal documentation link](https://www.drupal.org/docs/8/creating-custom-modules/adding-stylesheets-css-and-javascript-js-to-a-drupal-8-module#library) for details. To identify attached libraries that are adding extraneous CSS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/module responsible from the URL of the stylesheet when CSS aggregation is disabled in your Drupal site. Look out for themes/modules that have many stylesheets in the list which have a lot of red in code coverage. A theme/module should only enqueue a stylesheet if it is actually used on the page.
+
+### Joomla
+
+Consider reducing, or switching, the number of [Joomla extensions](https://extensions.joomla.org/) loading unused CSS in your page. To identify extensions that are adding extraneous CSS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the stylesheet. Look out for plugins that have many stylesheets in the list which have a lot of red in code coverage. A plugin should only enqueue a stylesheet if it is actually used on the page.
+
+### WordPress
+
+Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused CSS in your page. To identify plugins that are adding extraneous CSS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the stylesheet. Look out for plugins that have many stylesheets in the list which have a lot of red in code coverage. A plugin should only enqueue a stylesheet if it is actually used on the page.
+
 ## Resources
 
 - [Source code for **Remove unused CSS** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/unused-css-rules.js)

--- a/src/site/content/en/lighthouse-performance/unused-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unused-javascript/index.md
@@ -56,6 +56,34 @@ supports features that make it easier to avoid or remove unused code:
 * [Unused Code Elimination][eliminate]
 * [Unused Imported Code][import]
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Angular
+
+If you are using Angular CLI, include source maps in your production build to inspect your bundles. [Learn more](https://angular.io/guide/deployment#inspect-the-bundles).
+
+### Drupal
+
+Consider removing unused JavaScript assets and only attach the needed Drupal libraries to the relevant page or component in a page. See the [Drupal documentation link](https://www.drupal.org/docs/8/creating-custom-modules/adding-stylesheets-css-and-javascript-js-to-a-drupal-8-module#library) for details. To identify attached libraries that are adding extraneous JavaScript, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/module responsible from the URL of the script when JavaScript aggregation is disabled in your Drupal site. Look out for themes/modules that have many scripts in the list which have a lot of red in code coverage. A theme/module should only enqueue a script if it is actually used on the page.
+
+### Joomla
+
+Consider reducing, or switching, the number of [Joomla extensions](https://extensions.joomla.org/) loading unused JavaScript in your page. To identify plugins that are adding extraneous JS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the extension responsible from the URL of the script. Look out for extensions that have many scripts in the list which have a lot of red in code coverage. An extension should only enqueue a script if it is actually used on the page.
+
+### Magento
+
+Disable Magento's built-in [JavaScript bundling](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/js-bundling.html).
+
+### React
+
+If you are not server-side rendering, [split your JavaScript bundles](https://web.dev/code-splitting-suspense/) with `React.lazy()`. Otherwise, code-split using a third-party library such as [loadable-components](https://www.smooth-code.com/open-source/loadable-components/docs/getting-started/).
+
+### WordPress
+
+Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused JavaScript in your page. To identify plugins that are adding extraneous JS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the script. Look out for plugins that have many scripts in the list which have a lot of red in code coverage. A plugin should only enqueue a script if it is actually used on the page.
+
 ## Resources
 
 * [Source code for the **Remove unused code** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/unused-javascript.js)

--- a/src/site/content/en/lighthouse-performance/user-timings/index.md
+++ b/src/site/content/en/lighthouse-performance/user-timings/index.md
@@ -44,6 +44,14 @@ It's just an opportunity to discover a useful API that can help you measure your
 
 {% include 'content/lighthouse-performance/scoring.njk' %}
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### React
+
+Use the React DevTools Profiler, which makes use of the Profiler API, to measure the rendering performance of your components. [Learn more.](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html)
+
 ## Resources
 
 - [Source code for **User Timing marks and measures** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/user-timings.js)

--- a/src/site/content/en/lighthouse-performance/uses-long-cache-ttl/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-long-cache-ttl/index.md
@@ -125,6 +125,22 @@ check its HTTP header data:
   </figcaption>
 </figure>
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Set the "Browser and proxy cache maximum age" in the "Administration » Configuration » Development" page. Read about [Drupal cache and optimizing for performance](https://www.drupal.org/docs/7/managing-site-performance-and-scalability/caching-to-improve-performance/caching-overview#s-drupal-performance-resources).
+
+### Joomla
+
+Read about [Browser Caching in Joomla](https://docs.joomla.org/Cache).
+
+### WordPress
+
+Read about [Browser Caching in WordPress](https://wordpress.org/support/article/optimization/#browser-caching).
+
 ## Resources
 
 - [Source code for **Serve static assets with an efficient cache policy** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js)

--- a/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
@@ -50,6 +50,26 @@ this option is probably good enough.
 [Squoosh](https://squoosh.app/) is another option.
 Squoosh is maintained by the Google Web DevRel team.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Consider using [a module](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A123&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=optimize+images&solrsort=iss_project_release_usage+desc&op=Search) that automatically optimizes and reduces the size of images uploaded through the site while retaining quality. Also, ensure you are using the native [Responsive Image Styles](https://www.drupal.org/docs/8/mobile-guide/responsive-images-in-drupal-8) provided from Drupal (available in Drupal 8 and above) for all images rendered on the site.
+
+### Joomla
+
+Consider using an [image optimization plugin](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=performance) that compresses your images while retaining quality.
+
+### Magento
+
+Consider searching the [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=optimize%20image) for a variety of third party extensions to optimize images.
+
+### WordPress
+
+Consider using an [image optimization WordPress plugin](https://wordpress.org/plugins/search/optimize+images/) that compresses your images while retaining quality.
+
 ## Resources
 
 - [Source code for **Efficiently encode images** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js)

--- a/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
@@ -67,6 +67,18 @@ You use it the exact same way:
 <link rel="dns-prefetch" href="https://example.com">.
 ```
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Drupal
+
+Preconnect or dns-prefetch resource hints can be added by installing and configuring [a module](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=dns-prefetch&solrsort=iss_project_release_usage+desc&op=Search) that provides facilities for user agent resource hints.
+
+### Magento
+
+Preconnect or dns-prefetch resource hints can be added by [modifying a themes's layout](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html).
+
 ## Resources
 
 - [Source code for **Preconnect to required origins** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/uses-rel-preconnect.js)

--- a/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preload/index.md
@@ -94,6 +94,18 @@ for updates.
 See [Tooling.Report's Preloading Assets](https://bundlers.tooling.report/non-js-resources/html/preload-assets/?utm_source=web.dev&utm_campaign=lighthouse&utm_medium=uses-rel-preload)
 page.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Angular
+
+Preload routes ahead of time to speed up navigation. [Learn more](https://web.dev/route-preloading-in-angular/).
+
+### Magento
+
+`<link rel=preload>` tags can be added by [modifying a themes's layout](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html).
+
 ## Resources
 
 - [Source code for **Preload key requests** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/uses-rel-preload.js)

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -52,6 +52,30 @@ can help automate the process of converting an image into multiple formats.
 There are also image CDNs which let you generate multiple versions,
 either when you upload an image, or request it from your page.
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+The [`amp-img`](https://amp.dev/documentation/components/amp-img/?format=websites) component supports the [`srcset`](https://web.dev/use-srcset-to-automatically-choose-the-right-image/) attribute to specify which image assets to use based on the screen size. [Learn more](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction/).
+
+### Angular
+
+Consider using the `BreakpointObserver` utility in the Component Dev Kit (CDK) to manage image breakpoints. [Learn more](https://material.angular.io/cdk/layout/overview).
+
+### Drupal
+
+Ensure that you are using the native [Responsive Image Styles](https://www.drupal.org/docs/8/mobile-guide/responsive-images-in-drupal-8) provided from Drupal (available in Drupal 8 and above). Use the Responsive Image Styles when rendering image fields through view modes, views, or images uploaded through the WYSIWYG editor.
+
+### Joomla
+
+Consider using a [responsive images plugin](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=responsive%20images) to use responsive images in your content.
+
+### WordPress
+
+Upload images directly through the [media library](https://wordpress.org/support/article/media-library-screen/) to ensure that the required image sizes are available, and then insert them from the media library or use the image widget to ensure the optimal image sizes are used (including those for the responsive breakpoints). Avoid using `Full Size` images unless the dimensions are adequate for their usage. [Learn More](https://wordpress.org/support/article/inserting-images-into-posts-and-pages/).
+
 ## Resources
 
 - [Source code for **Properly size images** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js)

--- a/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-text-compression/index.md
@@ -100,6 +100,18 @@ See [Use large request rows](https://developers.google.com/web/tools/chrome-devt
 
 See also [Minify and compress network payloads](/reduce-network-payloads-using-text-compression).
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### Joomla
+
+You can enable text compression by enabling Gzip Page Compression in Joomla (System > Global configuration > Server).
+
+### WordPress
+
+You can enable text compression in your web server configuration.
+
 ## Resources
 
 - [Source code for **Enable text compression** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-text-compression.js)

--- a/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-webp-images/index.md
@@ -52,6 +52,30 @@ To see the current browser support for each next-gen format, check out the entri
 - [JPEG 2000](https://caniuse.com/#feat=jpeg2000)
 - [JPEG XR](https://caniuse.com/#feat=jpegxr)
 
+## Stack-specific guidance
+
+If you use any of these CMS's, libraries or frameworks, consider the following suggestions:
+
+### AMP
+
+Consider displaying all [`amp-img`](https://amp.dev/documentation/components/amp-img/?format=websites) components in WebP formats while specifying an appropriate fallback for other browsers. [Learn more](https://amp.dev/documentation/components/amp-img/#example:-specifying-a-fallback-image).
+
+### Drupal
+
+Consider installing and configuring [a module to leverage WebP image formats](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=webp&solrsort=iss_project_release_usage+desc&op=Search) in your site. Such modules automatically generate a WebP version of your uploaded images to optimize loading times.
+
+### Joomla
+
+Consider using a [plugin](https://extensions.joomla.org/instant-search/?jed_live%5Bquery%5D=webp) or service that will automatically convert your uploaded images to the optimal formats.
+
+### Magento
+
+Consider searching the [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=webp) for a variety of third-party extensions to leverage newer image formats.
+
+### WordPress
+
+Consider using a [plugin](https://wordpress.org/plugins/search/convert+webp/) or service that will automatically convert your uploaded images to the optimal formats.
+
 ## Resources
 
 - [Source code for **Serve images in next-gen formats** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-webp-images.js)


### PR DESCRIPTION
Fixes #3674

Changes proposed in this pull request:

- Add each LH audit's stack pack content into the documentation.


Built via https://github.com/GoogleChrome/lighthouse/compare/updatewebdevwstackpack