### PR TITLE
[Async Clipboard article] Fix iframe permissions policy attributes, add explanation

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -6,7 +6,7 @@ authors:
   - thomassteiner
 description: Async Clipboard API simplifies permissions-friendly copy and paste.
 date: 2020-07-31
-updated: 2020-07-31
+updated: 2020-10-21
 tags:
   - blog
   - capabilities
@@ -311,6 +311,21 @@ setTimeout(async () => {
 }, 2000);
 ```
 
+## Permissions policy integration
+
+In order to use the API in iframes, you need to enable it by making use of the
+[Permissions Policy](https://w3c.github.io/webappsec-permissions-policy/),
+which defines a mechanism that allows developers to selectively enable and
+disable various browser features and APIs. Concretely, you need to pass either
+or both of `clipboard-read` or `clipboard-write`, depending on the needs of your app.
+
+```html/2
+<iframe
+    src="index.html"
+    allow="clipboard-read; clipboard-write"
+</iframe>
+```
+
 ## Feature detection
 
 To use the Async Clipboard API while supporting all browsers, test for
@@ -358,11 +373,8 @@ event—part of asking permission responsibly—no permissions prompt is shown.
 
 ## Demos
 
-You can play with the Async Clipboard API in the demos below. You might get a
-`NotAllowedError` if running in an iframe, that is caused by the newly implemented
-[`clipboard` Feature Policy](https://www.chromestatus.com/feature/5767075295395840).
-In this case
-just run the demo [directly on Glitch](https://async-clipboard-api.glitch.me/).
+You can play with the Async Clipboard API in the demos below or
+[directly on Glitch](https://async-clipboard-api.glitch.me/).
 
 The first example demonstrates moving text on and off the clipboard.
 
@@ -370,8 +382,7 @@ The first example demonstrates moving text on and off the clipboard.
   <iframe
     src="https://glitch.com/embed/#!/embed/async-clipboard-text?previewSize=100"
     title="async-clipboard-text on Glitch"
-    allow="geolocation; microphone; camera; midi; vr; encrypted-media;
-clipboard; clipboard-read; clipboard-write"
+    allow="geolocation; microphone; camera; midi; vr; encrypted-media; clipboard-read; clipboard-write"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>
@@ -384,8 +395,7 @@ and only in
   <iframe
     src="https://glitch.com/embed/#!/embed/async-clipboard-api?previewSize=100"
     title="async-clipboard-api on Glitch"
-    allow="geolocation; microphone; camera; midi; vr; encrypted-media;
-clipboard; clipboard-read; clipboard-write"
+    allow="geolocation; microphone; camera; midi; vr; encrypted-media; clipboard-read; clipboard-write"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>

--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -308,10 +308,10 @@ setTimeout(async () => {
 
 ## Permissions policy integration
 
-In order to use the API in iframes, you need to enable it by making use of the
+To use the API in iframes, you need to enable it with
 [Permissions Policy](https://w3c.github.io/webappsec-permissions-policy/),
-which defines a mechanism that allows developers to selectively enable and
-disable various browser features and APIs. Concretely, you need to pass either
+which defines a mechanism that allows for selectively enabling and
+disabling various browser features and APIs. Concretely, you need to pass either
 or both of `clipboard-read` or `clipboard-write`, depending on the needs of your app.
 
 ```html/2

--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -45,11 +45,6 @@ the API,
 [consult a browser support table](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#Browser_compatibility)
 before proceeding.
 
-This article explains how to write both text and images to, and read them from
-the clipboard. This article does not cover [Feature Policy for the
-clipboard](https://www.chromestatus.com/features/5767075295395840) which landed
-in Chrome&nbsp;85.
-
 {% Aside %}
 The Async Clipboard API is limited to handling text and images. Chrome&nbsp;84
 introduces an experimental feature that allows the clipboard to handle any


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes the attributes that had an unfortunate line break.
- Add explanation about permissions policy.

CC: @dway123
