### PR TITLE
Link to Cache API guide from web.dev/reliable

### DIFF
--- a/src/site/_data/paths/reliable.json
+++ b/src/site/_data/paths/reliable.json
@@ -17,7 +17,7 @@
       "title": "The options in your caching toolbox",
       "pathItems": [
         "http-cache",
-        "/cache-api-quick-guide/",
+        "cache-api-quick-guide",
         "service-workers-cache-storage",
         "workbox",
         "service-worker-caching-and-http-caching"

--- a/src/site/_data/paths/reliable.json
+++ b/src/site/_data/paths/reliable.json
@@ -17,6 +17,7 @@
       "title": "The options in your caching toolbox",
       "pathItems": [
         "http-cache",
+        "/cache-api-quick-guide/",
         "service-workers-cache-storage",
         "workbox",
         "service-worker-caching-and-http-caching"


### PR DESCRIPTION
Adds a link to the [The Cache API: A Quick Guide](https://web.dev/cache-api-quick-guide) from https://web.dev/reliable