### PR TITLE
[File System Access article] showFileOpenPicker -> showOpenFilePicker

### DIFF
--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -12,7 +12,7 @@ description:
   user grants a web app access, this API allows them to read or save changes directly to files and
   folders on the user's device.
 date: 2019-08-20
-updated: 2020-10-07
+updated: 2020-10-28
 tags:
   - blog
   - capabilities

--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -347,8 +347,8 @@ await root.removeEntry('Old Stuff', { recursive: true });
 
 It is not possible to completely polyfill the File System Access API methods.
 
-- The `showFileOpenPicker()` method can be approximated with an `<input type="file">` element.
-- The `showFileSavePicker()` method can be simulated with a `<a download="file_name">` element,
+- The `showOpenFilePicker()` method can be approximated with an `<input type="file">` element.
+- The `showSaveFilePicker()` method can be simulated with a `<a download="file_name">` element,
   albeit this will trigger a programmatic download and not allow for overwriting existing files.
 - The `showDirectoryPicker()` method can be somewhat emulated with the non-standard
   `<input type="file" webkitdirectory>` element.


### PR DESCRIPTION
Corrected mispelling of "showFileOpenPicker / showFileSavePicker" which should be "showOpenFilePicker / showSaveFilePicker" in the Polyfilling section.

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
