### PR TITLE
Trivial update to Web OTP

### DIFF
--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -4,7 +4,7 @@ subhead: Help users with OTPs received through SMS
 authors:
   - agektmr
 date: 2019-10-07
-updated: 2020-10-23
+updated: 2020-10-27
 hero: hero.png
 alt: A drawing of a woman using OTP to log in to a web app.
 
@@ -365,7 +365,7 @@ know before using it. The message must be sent after
 where `get()` was called. Finally, the message must adhere to the following
 formatting:
 
-* The message begins with (optional) human-readable text that contains a three to ten
+* The message begins with (optional) human-readable text that contains a four to ten
   character alphanumeric string with at least one number leaving the last line
   for the URL and the OTP.
 * The domain part of the URL of the website that invoked the API must be preceded


### PR DESCRIPTION
Change `three` to `four` in the explanation about User Consent API constraint.