### PR TITLE
Corrected syntax error in code example

### DIFF
--- a/src/site/content/en/blog/trusted-types/index.md
+++ b/src/site/content/en/blog/trusted-types/index.md
@@ -260,7 +260,7 @@ Sometimes you can't change the offending code. For example, this is the case if 
 ```javascript
 if (window.trustedTypes && trustedTypes.createPolicy) { // Feature testing
   trustedTypes.createPolicy('default', {
-    createHTML: (string, sink) => DOMPurify.sanitize(string, {RETURN_TRUSTED_TYPE: true});
+    createHTML: (string, sink) => DOMPurify.sanitize(string, {RETURN_TRUSTED_TYPE: true})
   });
 }
 ```


### PR DESCRIPTION
Corrected syntax error caused by an unnecessary and ill-placed semi-colon

This code has an unnecessary and wrong semi-colon at the end of the line that defines the `createHTML` property on the object:

```javascript
if (window.trustedTypes && trustedTypes.createPolicy) { // Feature testing
    trustedTypes.createPolicy('default', {
        createHTML: (string, sink) => DOMPurify.sanitize(string, {RETURN_TRUSTED_TYPE: true});
    });
}
```

My PR only removes that semi-colon.