### PR TITLE
Remove references to index.html

### DIFF
--- a/src/site/content/en/blog/link-prefetch/index.md
+++ b/src/site/content/en/blog/link-prefetch/index.md
@@ -24,7 +24,7 @@ This guide explains how to achieve that with `<link rel=prefetch>`, a [resource 
 Adding `<link rel=prefetch>` to a web page tells the browser to download entire pages, or some of the resources (like scripts or CSS files), that the user might need in the future. This can improve metrics like [First Contentful Paint](/first-contentful-paint) and [Time to Interactive](/interactive/) and can often make subsequent navigations appear to load instantly.
 
 ```html
-<link rel="prefetch" href="index.html" as="document">
+<link rel="prefetch" href="/articles/" as="document">
 ```
 
 ![A diagram showing how link prefetch works.](prefetch.png)
@@ -68,7 +68,7 @@ The simplest way to implement `prefetch` is adding a `<link>` tag to the `<head>
 ```html
 <head>
 	...
-	<link rel="prefetch" href="index.html" as="document">
+	<link rel="prefetch" href="/articles/" as="document">
 	...
 </head>
 


### PR DESCRIPTION
It's considered bad practice to navigate to `index.html`. Usually servers make it the default resource for a 'directory'. However, this is just convention, there's nothing that requires `/foo/` and `/foo/index.html` to be the same content.

If you prefetch `/foo/index.html` then navigate to `/foo/`, it will be a cache miss.

I've changes these references to `/articles/` to avoid this confusion.