### PR TITLE
fix typo

### DIFF
--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -75,7 +75,7 @@ before painting a single pixel on the screen.
 ## Optimize
 
 To optimize this page, you need to know which classes are considered "critical".
-You'll use the the [Coverage Tool](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) for that:
+You'll use the [Coverage Tool](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) for that:
 
 1. In DevTools, open the [Command Menu](https://developers.google.com/web/tools/chrome-devtools/command-menu), by pressing `Control+Shift+P` or `Command+Shift+P` (Mac).
 1. Type "Coverage" and select **Show Coverage**.


### PR DESCRIPTION
Remove extra redundant repeated extraneous word in 'Optimize' paragraph of 'defer-non-critical-css':
`the the` -> `the`
