### PR TITLE
Update web-vitals package to 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25524,9 +25524,9 @@
       }
     },
     "web-vitals": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.3.tgz",
-      "integrity": "sha512-6idlbUoL38El+QS320Qz6h4QSZLaWw3CHiJWBtQDmFGs72ro+fnukfavTxTdQSlsaoaBuNL/0bqlIhfdtlrx4A=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
     },
     "websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rollup-plugin-virtual": "^1.0.1",
     "terser": "^4.6.4",
     "unistore": "^3.4.1",
-    "web-vitals": "^0.2.3",
+    "web-vitals": "^0.2.4",
     "wicg-inert": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This CL makes sure web.dev passes the Lighthouse audit "[no-unload-listener](https://github.com/GoogleChrome/lighthouse/pull/11085)"  by simply updating web-vitals package to 0.2.4.

See https://github.com/GoogleChrome/web-vitals/blob/master/CHANGELOG.md#v024-2020-07-23 

![image](https://user-images.githubusercontent.com/634478/97673352-f221a680-1a8b-11eb-904c-1af1a0f1e668.png)
