### PR TITLE
Fix Lighthouse link text audit for cds 2020 site banner

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -33,7 +33,7 @@ module.exports = {
   thumbnail: '/images/social.png',
   isBannerEnabled: true,
   banner:
-    'Chrome Dev Summit 2020 is back & going virtual on December 9-10. [Learn more](https://developer.chrome.com/devsummit/?utm_source=webdevbanner&utm_medium=website).',
+    '[Chrome Dev Summit 2020](https://developer.chrome.com/devsummit/?utm_source=webdevbanner&utm_medium=website) is back & going virtual on December 9-10.',
   // Note that the imageCdn value is only used when we do a production build
   // of the site. Otherwise all image paths are local. This means you can
   // develop locally without having to mess with the CDN at all.


### PR DESCRIPTION
This CL makes sure web.dev passes the "[link-text](https://web.dev/link-text)" Lighthouse audit by removing the "learn more" link in the cds 2020 site banner text.


![image](https://user-images.githubusercontent.com/634478/97674334-a7a12980-1a8d-11eb-840d-cc71904201b2.png)
