### PR TITLE
[Post Template] Correct hero image dimensions

### DIFF
--- a/src/site/_drafts/_template-post/index.md
+++ b/src/site/_drafts/_template-post/index.md
@@ -21,7 +21,7 @@ date: 2019-10-31
 
 # !!! IMPORTANT: If your post does not contain a hero image it will not appear
 # on the homepage.
-# Hero images should be 3200 x 920.
+# Hero images should be 3200 x 960.
 hero: hero.jpg
 # You can adjust the fit of your hero image with this property.
 # Values: contain | cover (default)


### PR DESCRIPTION
They should be 3200x960, according to the [handbook](https://web.dev/handbook/markup-media/#hero:~:text=homepage.-,Hero%20images%20should%20be%203200px%20wide%20and%20960px%20tall.).
