### PR TITLE
Revert "prefer redirect"

### DIFF
--- a/redirect-handler.js
+++ b/redirect-handler.js
@@ -118,8 +118,6 @@ function prepareHandler(yamlSource, baseUrlPrefix) {
  * Builds HTTP middleware that serves redirects for web.dev's _redirects.yaml
  * configuration file, originally from DevSite.
  *
- * This code does NOT consider language whatsoever.
- *
  * @param {string} filename to load configuration from
  * @param {number=} code to use (DevSite uses 301)
  * @return {!Function}

--- a/server.js
+++ b/server.js
@@ -133,9 +133,9 @@ const handlers = [
   safetyHandler,
   buildSafetyAssetHandler(),
   localeHandler,
-  redirectHandler,
   express.static('dist', {setHeaders: staticHandler}),
   express.static('dist/en', {setHeaders: staticHandler}),
+  redirectHandler,
   notFoundHandler,
 ];
 


### PR DESCRIPTION
This reverts #4087.

Fixes #4156.

Turns out our `_redirects.yaml` contains an entry which redirects "/fast/..." to "/...". We still have the top-level "/fast/" page, which was being redirected.

I actually can't remember why y'all wanted to prefer redirects. If we have a file on disk then it should probably win—it's easier for us to remove files, but a catch-all redirect feels more dangerous...

Anyway, I'm going to submit this since our major landing pages are currently broken.