### PR TITLE
Remove "clipboard" and "vr" from default iframes allow

### DIFF
--- a/compile-css.js
+++ b/compile-css.js
@@ -109,6 +109,8 @@ function renderTo(result, fileName) {
 
   let out = result.css.toString('utf-8');
   if (!isProd) {
+    console.log('Adding sourceMappingURL...');
+
     result.map['file'] = base;
 
     out += `\n/*# sourceMappingURL=${base}.map */`;

--- a/compile-css.js
+++ b/compile-css.js
@@ -109,8 +109,6 @@ function renderTo(result, fileName) {
 
   let out = result.css.toString('utf-8');
   if (!isProd) {
-    console.log('Adding sourceMappingURL...');
-
     result.map['file'] = base;
 
     out += `\n/*# sourceMappingURL=${base}.map */`;

--- a/src/site/_includes/components/Glitch.js
+++ b/src/site/_includes/components/Glitch.js
@@ -40,14 +40,12 @@ function expandAllowSource(s) {
 module.exports = (param) => {
   const defaultAllow = [
     'camera',
-    'clipboard',
     'clipboard-read',
     'clipboard-write',
     'encrypted-media',
     'geolocation',
     'microphone',
     'midi',
-    'vr',
   ];
 
   /** @type GlitchParam */

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -683,7 +683,7 @@ if you need more or less space.
 Shortcode object fields allow for modifying how the embed is presented:
 
 * {`string | string[]`} `allow?` List of feature policies of an IFrame either as an array of strings, or as a `;` separated list. By default the following policies are enabled:
-  * `'camera', 'clipboard', 'clipboard-read', 'clipboard-write', 'geolocation', 'encrypted-media', 'microphone', 'midi', 'vr'`
+  * `'camera', 'clipboard-read', 'clipboard-write', 'encrypted-media', 'geolocation', 'microphone', 'midi'`
 * {`string`} `id` ID of Glitch project.
 * {`string`} `path?` Lets you specify which source code file to show.
 * {`number`} `previewSize?` Defines what percentage of the embed should be dedicated to the preview, default is 100.


### PR DESCRIPTION
This PR makes sure "clipboard" and "vr" unrecognized features are not set by default in iframes. For info, the complete list of
feature names allowed is available at https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/web_tests/webexposed/feature-policy-features-expected.txt and https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/feature_policy/feature_policy_features.json5.

![image](https://user-images.githubusercontent.com/634478/97995719-2deba180-1de7-11eb-8dad-171c9b997be1.png)
 