### PR TITLE
Add crop filter to GIF -> video FFMPEG commands

### DIFF
--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -54,7 +54,9 @@ ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
 `-i` flag, and to convert it to a video called `my-animation.mp4`.
 
-The libx264 encoder only works with files that have even dimensions, like 320px by 240px. If the input GIF has odd dimensions you can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
+The libx264 encoder only works with files that have even dimensions, like 320px
+by 240px. If the input GIF has odd dimensions you can include a crop filter to
+avoid FFmpeg throwing a 'height/width not divisible by 2' error:
 
 ```bash
 ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -54,7 +54,7 @@ ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
 `-i` flag, and to convert it to a video called `my-animation.mp4`.
 
-The libx264 encoder only works with files that have even dimensions, like 320x240px. If the input GIF has odd dimensions we can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
+The libx264 encoder only works with files that have even dimensions, like 320px by 240px. If the input GIF has odd dimensions you can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
 
 ```bash
 ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -54,7 +54,7 @@ ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
 `-i` flag, and to convert it to a video called `my-animation.mp4`.
 
-The libx264 encoder only works with files that have even dimensions, like 320x240px. If the input GIF has odd dimenions we can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
+The libx264 encoder only works with files that have even dimensions, like 320x240px. If the input GIF has odd dimensions we can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
 
 ```bash
 ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -48,7 +48,7 @@ To use FFmpeg to convert the GIF, `my-animation.gif` to an MP4 video, run the
 following command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
+ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
 ```
 
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
@@ -64,7 +64,7 @@ To use FFmpeg to convert `my-animation.gif` to a WebM video, run the following
 command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif -c vp9 -b:v 0 -crf 41 my-animation.webm
+ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -c vp9 -b:v 0 -crf 41 my-animation.webm
 ```
 
 ## Compare the difference

--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -48,11 +48,17 @@ To use FFmpeg to convert the GIF, `my-animation.gif` to an MP4 video, run the
 following command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
+ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
 ```
 
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
 `-i` flag, and to convert it to a video called `my-animation.mp4`.
+
+The libx264 encoder only works with files that have even dimensions, like 320x240px. If the input GIF has odd dimenions we can include a crop filter to avoid FFmpeg throwing a 'height/width not divisible by 2' error:
+
+```bash
+ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
+```
 
 ## Create WebM videos
 
@@ -64,7 +70,7 @@ To use FFmpeg to convert `my-animation.gif` to a WebM video, run the following
 command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -c vp9 -b:v 0 -crf 41 my-animation.webm
+ffmpeg -i my-animation.gif -c vp9 -b:v 0 -crf 41 my-animation.webm
 ```
 
 ## Compare the difference


### PR DESCRIPTION
This prevents the common 'height not divisible by 2' error when working with GIFs of odd dimensions

Solution taken from https://stackoverflow.com/a/29582287

Changes proposed in this pull request:

- Updates example FFMPEG commands to include a crop filter to make the commands more resilient when used with GIFs that may have odd (in a numerical sense) dimensions