### PR TITLE
Code snippets pass contrast accessibility scores

### DIFF
--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -17,8 +17,8 @@ $CODE_COLORS: (
   bright-blue: #007aa2,
   black: $PRIMARY_TEXT_COLOR,
   purple: #a71d5d,
-  maroon: #a71d5d,
-  green: #63a35c,
+  maroon:#9f1c59,
+  green:#385d34,
   light-gray: #f7f7f7,
   dimgrey: #696969
 );


### PR DESCRIPTION
Changes proposed in this pull request:
- darker green
- slightly darker red

<details>

<summary>After <-> Before Screenshot Comparison</summary>

![image](https://user-images.githubusercontent.com/1134620/98165824-6351c700-1e9b-11eb-8138-cdefd5c4cba1.png)

</details>
