### PR TITLE
Link to lazysizes library

### DIFF
--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -300,7 +300,7 @@ library only when `loading` isn't supported. This works as follows:
 </script>
 ```
 
-Here's a [demo](https://lazy-loading.firebaseapp.com/lazy_loading_native.html) of this pattern. Try
+Here's a [demo](https://lazy-loading.firebaseapp.com/lazy_loading_lib.html) of this pattern. Try
 it out in a browser like Firefox or Safari to see the fallback in action.
 
 {% Aside %}


### PR DESCRIPTION
This PR make sure the demo points to the one that uses lazysizes library, not the native one.

Fixes #https://github.com/GoogleChrome/web.dev/issues/3944