### PR TITLE
Incorrect MDN link for Clipboard API

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -412,7 +412,7 @@ Happy copying and pasting!
 
 ## Related links
 
-* [MDN]([https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API))
+* [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
 * [Raw Clipboard Access Design Doc](https://docs.google.com/document/d/1XDOtTv8DtwTi4GaszwRFIJCOuzAEA4g9Tk0HrasQAdE/edit?usp=sharing)
 
 ## Acknowledgements


### PR DESCRIPTION
Noticed a bad link at https://web.dev/async-clipboard/#related-links
