### PR TITLE
Clarifying scrolling as non-excluded input

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -242,6 +242,11 @@ Layout shifts that occur within 500 milliseconds of user input will have the
 [`hadRecentInput`](https://wicg.github.io/layout-instability/#dom-layoutshift-hadrecentinput)
 flag set, so they can be excluded from calculations.
 
+{% Aside 'caution' %}
+  Please note: scrolling input is not given a 500 ms buffer, as per the 
+  [Layout Instability Spec](https://github.com/WICG/layout-instability#recent-input-exclusion)
+{% endAside %}
+
 #### Animations and transitions
 
 Animations and transitions, when done well, are a great way to update content on

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -250,7 +250,6 @@ flag set, so they can be excluded from calculations.
   for more details.
 {% endAside %}
 
-The hadRecentInput flag will only be true for discrete input events like tap, click, or keypress. Continuous interactions such as scrolls, drags, or pinch and zoom gestures are not considered "recent input". See the Layout Instability spec for more details.
 
 #### Animations and transitions
 

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -243,7 +243,7 @@ Layout shifts that occur within 500 milliseconds of user input will have the
 flag set, so they can be excluded from calculations.
 
 {% Aside 'caution' %}
-  The hadRecentInput flag will only be true for discrete input events like tap,
+  The `hadRecentInput` flag will only be true for discrete input events like tap,
   click, or keypress. Continuous interactions such as scrolls, drags, or pinch
   and zoom gestures are not considered "recent input". See the
   [Layout Instability Spec](https://github.com/WICG/layout-instability#recent-input-exclusion)

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -243,9 +243,14 @@ Layout shifts that occur within 500 milliseconds of user input will have the
 flag set, so they can be excluded from calculations.
 
 {% Aside 'caution' %}
-  Please note: scrolling input is not given a 500 ms buffer, as per the 
+  The hadRecentInput flag will only be true for discrete input events like tap,
+  click, or keypress. Continuous interactions such as scrolls, drags, or pinch
+  and zoom gestures are not considered "recent input". See the
   [Layout Instability Spec](https://github.com/WICG/layout-instability#recent-input-exclusion)
+  for more details.
 {% endAside %}
+
+The hadRecentInput flag will only be true for discrete input events like tap, click, or keypress. Continuous interactions such as scrolls, drags, or pinch and zoom gestures are not considered "recent input". See the Layout Instability spec for more details.
 
 #### Animations and transitions
 


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #3835

There's generally confusion around whether or not scrolling is incorporated in CLS calculations. While the spec is clear, this article doesn't mention that scrolling is not excluded input.

Changes proposed in this pull request:

- Adding a 'caution' aside to web.dev/cls on scrolling input not being given a 500 ms buffer 
