### PR TITLE
Indicate that noopener behavior is now default

### DIFF
--- a/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
+++ b/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
@@ -21,7 +21,13 @@ you can expose your site to performance and security issues:
 Adding `rel="noopener"` or `rel="noreferrer"`
 to your `target="_blank"` links avoids these issues.
 
-**Update** As of Chromium version 88, anchors with `target="_blank"` automatically get `noopener` behavior [by default](https://crbug.com?id=898942). Explicit specification of  `rel="noopener"` helps protect users of legacy browsers including Edge Legacy and Internet Explorer.
+{% Aside %}
+As of Chromium version 88, anchors with `target="_blank"` automatically get
+[`noopener` behavior by
+default](https://www.chromestatus.com/feature/6140064063029248). Explicit
+specification of  `rel="noopener"` helps protect users of legacy browsers
+including Edge Legacy and Internet Explorer.
+{% endAside %}
 
 ## How the Lighthouse cross-origin destination audit fails
 

--- a/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
+++ b/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
@@ -21,6 +21,8 @@ you can expose your site to performance and security issues:
 Adding `rel="noopener"` or `rel="noreferrer"`
 to your `target="_blank"` links avoids these issues.
 
+**Update** As of Chromium version 88, anchors with `target="_blank"` automatically get `noopener` behavior [by default](https://crbug.com?id=898942). Explicit specification of  `rel="noopener"` helps protect users of legacy browsers including Edge Legacy and Internet Explorer.
+
 ## How the Lighthouse cross-origin destination audit fails
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags unsafe links to cross-origin destinations:


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

- Update lighthouse audit info page with mention that noopener behavior is now the default in M88+.