### PR TITLE
Preload app.css

### DIFF
--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -27,6 +27,7 @@ eleventyComputed:
     <link rel="preconnect" href="//firebaseinstallations.googleapis.com" crossorigin="" />
     <link rel="preconnect" href="//webdev.imgix.net" crossorigin="" />
 
+    <link rel="preload" as="style" href="{{ resourceCSS.path | stripQueryParamsDev }}" />
     {# We only preload Material Icons because the site can't render properly without them. #}
     {# For Google Sans we use font-display: swap because preloading too many fonts can hurt performance. #}
     {# https://www.zachleat.com/web/preload/ #}


### PR DESCRIPTION
This PR makes sure `app.css` file is preloaded before Material Icons font (43KB font blocking any layout) to improve rendering performance due to [chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=788757).

**TLDR;**

Time to start render: 1.1s faster
Web Vitals: 4.6 -> 3.5 
Time to interactive: 40 -> 18

**Without app.css preload**
![webpagetest org_result_201113_Di8C_9b8ea21c0df163a2f4642f48feba819f_1_details_](https://user-images.githubusercontent.com/634478/99066487-59217e00-25a9-11eb-9765-8cc1b3ccd307.png)
![webpagetest org_result_201113_Di8C_9b8ea21c0df163a2f4642f48feba819f_1_details_ (1)](https://user-images.githubusercontent.com/634478/99066507-5faff580-25a9-11eb-8b64-a2504dc1c278.png)

**With app.css preload**
![webpagetest org_result_201113_DiW6_b1a4559458aefb7524df621a3e91064e_2_details_](https://user-images.githubusercontent.com/634478/99066365-25465880-25a9-11eb-9b0e-f239570585e2.png)
![webpagetest org_result_201113_DiW6_b1a4559458aefb7524df621a3e91064e_2_details_ (1)](https://user-images.githubusercontent.com/634478/99066417-38f1bf00-25a9-11eb-9e1d-6cdb61d0d171.png)



Full details https://webpagetest.org/video/compare.php?tests=201113_DiW6_b1a4559458aefb7524df621a3e91064e%2C201113_Di8C_9b8ea21c0df163a2f4642f48feba819f&thumbSize=100&ival=100&end=visual



