### PR TITLE
question - What is "DOM Storage"?

### DIFF
--- a/src/site/content/en/blog/persistent-storage/index.md
+++ b/src/site/content/en/blog/persistent-storage/index.md
@@ -134,7 +134,7 @@ data stored in:
 
 - Cache API
 - Cookies
-- DOM Storage
+- DOM Storage (Local Storage)
 - File System API (browser-provided and sandboxed file system)
 - IndexedDB
 - Service workers


### PR DESCRIPTION
What is "DOM Storage"? Does persist protect "Local Storage"?

This change could help clarify.

(I don't even know whether this is correct. I tried googling "DOM Storage", and some results make it look like it does include Local Storage, and other results make it look like it doesn't include Local Storage. If it doesn't, then reject this pull request, and instead add a note to say that Local Storage is not protected.)