### PR TITLE
Note that Chrome 88 will disavow opener for target=_blank links

### DIFF
--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -309,9 +309,9 @@ onAllChangesSaved(() => {
 
 ### Avoid window.opener references
 
-In some browsers (including Chrome) if a page was opened using
+In some browsers (including Chromium-based browsers) if a page was opened using
 <code>[window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open)</code>
-or (in Chrome [prior to version 88](https://crbug.com/898942)) from a link with
+or (in [Chromium-based browsers prior to version 88](https://crbug.com/898942)) from a link with
 <code>[target=_blank](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)</code>—without
 specifying
 <code>[rel="noopener"](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener)</code>—then

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -309,9 +309,9 @@ onAllChangesSaved(() => {
 
 ### Avoid window.opener references
 
-In some browsers (including Chrome, as of version 86) if a page was opened using
+In some browsers (including Chrome) if a page was opened using
 <code>[window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open)</code>
-or from a link with
+or (in Chrome [prior to version 88](https://crbug.com/898942)) from a link with
 <code>[target=_blank](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)</code>—without
 specifying
 <code>[rel="noopener"](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener)</code>—then


### PR DESCRIPTION
<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

- Note that Chrome 88+ will disavow opener for target=_blank hyperlinks
- 
- 
