### PR TITLE
[CSS] Add table scroll hint shadow

### DIFF
--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -15,18 +15,18 @@
   margin: 32px 0;
   overflow: auto;
   background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
-              linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
-              radial-gradient(
-                farthest-side at 0% 50%,
-                rgba(0, 0, 0, 0.2),
-                rgba(0, 0, 0, 0)
-              ),
-              radial-gradient(
-                  farthest-side at 100% 50%,
-                  rgba(0, 0, 0, 0.2),
-                  rgba(0, 0, 0, 0)
-                )
-                0 100%;
+    linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
+    radial-gradient(
+      farthest-side at 0% 50%,
+      rgba(0, 0, 0, 0.2),
+      rgba(0, 0, 0, 0)
+    ),
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0)
+      )
+      0 100%;
   background-repeat: no-repeat;
   background-color: #fff;
   background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;

--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -14,6 +14,24 @@
 .w-table-wrapper {
   margin: 32px 0;
   overflow: auto;
+  background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
+    radial-gradient(
+      farthest-side at 0% 50%,
+      rgba(0, 0, 0, 0.2),
+      rgba(0, 0, 0, 0)
+    ),
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0)
+      )
+      0 100%;
+  background-repeat: no-repeat;
+  background-color: #fff;
+  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+  background-position: 0 0, 100%, 0 0, 100%;
+  background-attachment: local, local, scroll, scroll;
 }
 
 .w-table-wrapper::-webkit-scrollbar {

--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -15,18 +15,18 @@
   margin: 32px 0;
   overflow: auto;
   background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
-    linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
-    radial-gradient(
-      farthest-side at 0% 50%,
-      rgba(0, 0, 0, 0.2),
-      rgba(0, 0, 0, 0)
-    ),
-    radial-gradient(
-        farthest-side at 100% 50%,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0)
-      )
-      0 100%;
+              linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
+              radial-gradient(
+                farthest-side at 0% 50%,
+                rgba(0, 0, 0, 0.2),
+                rgba(0, 0, 0, 0)
+              ),
+              radial-gradient(
+                  farthest-side at 100% 50%,
+                  rgba(0, 0, 0, 0.2),
+                  rgba(0, 0, 0, 0)
+                )
+                0 100%;
   background-repeat: no-repeat;
   background-color: #fff;
   background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;

--- a/src/styles/generic/_tables.scss
+++ b/src/styles/generic/_tables.scss
@@ -15,18 +15,18 @@
   margin: 32px 0;
   overflow: auto;
   background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
-    linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
-    radial-gradient(
-      farthest-side at 0% 50%,
-      rgba(0, 0, 0, 0.2),
-      rgba(0, 0, 0, 0)
-    ),
-    radial-gradient(
-        farthest-side at 100% 50%,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0)
-      )
-      0 100%;
+  linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
+  radial-gradient(
+    farthest-side at 0% 50%,
+    rgba(0, 0, 0, .2),
+    rgba(0, 0, 0, 0)
+  ),
+  radial-gradient(
+    farthest-side at 100% 50%,
+    rgba(0, 0, 0, .2),
+    rgba(0, 0, 0, 0)
+  )
+  0 100%;
   background-repeat: no-repeat;
   background-color: #fff;
   background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds visual scroll hint for wide tables ([demo](https://deploy-preview-4258--web-dev-staging.netlify.app/handbook/web-dev-components/#tables:~:text=Tables%20scroll%20when%20their%20width%20is%20larger%20than%20that%20of%20the%20content%20column%3A)):
<img width="872" alt="Screen Shot 2020-11-18 at 09 47 37" src="https://user-images.githubusercontent.com/145676/99507130-47fab780-2983-11eb-8bab-7937e59957b6.png">
<img width="860" alt="Screen Shot 2020-11-18 at 09 47 45" src="https://user-images.githubusercontent.com/145676/99507141-492be480-2983-11eb-9ff6-a50da9ba0e6e.png">
<img width="849" alt="Screen Shot 2020-11-18 at 09 47 53" src="https://user-images.githubusercontent.com/145676/99507144-49c47b00-2983-11eb-8c16-42972fa7f8e9.png">
