### PR TITLE
Change wording around Android zoom support.

### DIFF
--- a/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
+++ b/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
@@ -33,7 +33,7 @@ The presence of `"pan"`, `"tilt"`, and `"zoom"` constraint names in
 `navigator.mediaDevices.getSupportedConstraints()` tells you that the browser
 supports the API to control camera PTZ, but not whether the camera hardware
 supports it. As of Chrome&nbsp;87, controlling camera PTZ is supported on
-on desktop, while Android supports zoom only.
+desktop, while Android still supports zoom only.
 
 ```js
 const supports = navigator.mediaDevices.getSupportedConstraints();

--- a/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
+++ b/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
@@ -5,6 +5,7 @@ subhead:
 authors:
   - beaufortfrancois
 date: 2020-10-05
+updated: 2020-11-18
 hero: hero.jpg
 thumbnail: thumbnail.jpg
 alt: Five persons in a conference room photo.


### PR DESCRIPTION
This PR is about making it clear that Android used to support zoom before, but still no pan and tilt.