### PR TITLE
Mark font-display:optional for Material Icons font

### DIFF
--- a/src/styles/fonts/_material-icons.scss
+++ b/src/styles/fonts/_material-icons.scss
@@ -3,4 +3,5 @@
   font-style: normal;
   font-weight: 400;
   src: url('/fonts/material-icons/regular.woff2') format('woff2');
+  font-display: optional;
 }


### PR DESCRIPTION
Following https://web.dev/preload-optional-fonts/ recommandations, marking Material Icons font as `font-display:optional` should improve greatly the CLS that has jumped recently with https://github.com/GoogleChrome/web.dev/pull/4218

![image](https://user-images.githubusercontent.com/634478/99669256-13642a00-2a6f-11eb-94b2-2eac3403be3e.png)
Source: https://webpagetest.org/result/201119_DiJN_70db15a47be0291dfa7149a3beb4ad6c/

FIX: https://github.com/GoogleChrome/web.dev/issues/4263