### PR TITLE
Remove redundant `=== true`

### DIFF
--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -152,7 +152,7 @@ to distinguish regular page loads from bfcache restores. For example:
 
 ```js
 window.addEventListener('pageshow', function(event) {
-  if (event.persisted === true) {
+  if (event.persisted) {
     console.log('This page was restored from the bfcache.');
   } else {
     console.log('This page was loaded normally.');


### PR DESCRIPTION
This jumped out while reading the article. The prose already explains the value is either `true` or `false`, so I think we can just write the code as one usually would without losing clarity.
