### PR TITLE
Fix layout shift in hamburger button

### DIFF
--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -39,7 +39,7 @@ web-header {
 
     // sass-lint:disable class-name-format
     &.unresolved {
-      display: inline-block;  // override default .unresolved behavior
+      display: flex;  // override default .unresolved behavior
       visibility: hidden;
     }
     // sass-lint:enable class-name-format


### PR DESCRIPTION
This PR is part of the many PRs (to be expected) to fix CLS regression raised at https://github.com/GoogleChrome/web.dev/issues/4263

This one is specifically about the hamburger button that once resolved causes a tiny layout shift. 

![image](https://user-images.githubusercontent.com/634478/99807079-3d851d00-2b3f-11eb-8f61-8971736aa325.png)
