### PR TITLE
Adding vanilla-lazyload to the scripts at the end of the page

### DIFF
--- a/src/site/content/en/fast/lazy-loading-images/index.md
+++ b/src/site/content/en/fast/lazy-loading-images/index.md
@@ -275,7 +275,7 @@ Observer (which you can polyfill), and can be extended with [a number of
 plugins](https://github.com/aFarkas/lazysizes#available-plugins-in-this-repo) to
 do things like lazy-load video. [Find out more about using lazysizes](/use-lazysizes-to-lazyload-images/).
 - [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) is a 
-lightweight option for lazy loading images, background images, videos, iframes, 
+lightweight option for lazy-loading images, background images, videos, iframes, 
 and scripts. It leverages Intersection Observer, supports responsive images, and 
 enables native lazy loading.
 - [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a another lightweight

--- a/src/site/content/en/fast/lazy-loading-images/index.md
+++ b/src/site/content/en/fast/lazy-loading-images/index.md
@@ -274,9 +274,9 @@ into `src` and/or `srcset` attributes, respectively. It uses Intersection
 Observer (which you can polyfill), and can be extended with [a number of
 plugins](https://github.com/aFarkas/lazysizes#available-plugins-in-this-repo) to
 do things like lazy-load video. [Find out more about using lazysizes](/use-lazysizes-to-lazyload-images/).
-- [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) is a super 
-lightweight option for lazy loading images, background images, videos, iframes 
-and scripts. It leverages IntersectionObserver, supports responsive images and 
+- [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) is a 
+lightweight option for lazy loading images, background images, videos, iframes, 
+and scripts. It leverages Intersection Observer, supports responsive images, and 
 enables native lazy loading.
 - [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a another lightweight
 option that uses Intersection Observer only. As such, it's highly performant,

--- a/src/site/content/en/fast/lazy-loading-images/index.md
+++ b/src/site/content/en/fast/lazy-loading-images/index.md
@@ -275,9 +275,9 @@ Observer (which you can polyfill), and can be extended with [a number of
 plugins](https://github.com/aFarkas/lazysizes#available-plugins-in-this-repo) to
 do things like lazy-load video. [Find out more about using lazysizes](/use-lazysizes-to-lazyload-images/).
 - [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) is a 
-lightweight option for lazy-loading images, background images, videos, iframes, 
-and scripts. It leverages Intersection Observer, supports responsive images, and 
-enables native lazy loading.
+  lightweight option for lazy-loading images, background images, videos, iframes, 
+  and scripts. It leverages Intersection Observer, supports responsive images, and 
+  enables native lazy loading.
 - [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a another lightweight
 option that uses Intersection Observer only. As such, it's highly performant,
 but will need to be polyfilled before you can use it on older browsers.

--- a/src/site/content/en/fast/lazy-loading-images/index.md
+++ b/src/site/content/en/fast/lazy-loading-images/index.md
@@ -274,7 +274,11 @@ into `src` and/or `srcset` attributes, respectively. It uses Intersection
 Observer (which you can polyfill), and can be extended with [a number of
 plugins](https://github.com/aFarkas/lazysizes#available-plugins-in-this-repo) to
 do things like lazy-load video. [Find out more about using lazysizes](/use-lazysizes-to-lazyload-images/).
-- [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a super lightweight
+- [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) is a super 
+lightweight option for lazy loading images, background images, videos, iframes 
+and scripts. It leverages IntersectionObserver, supports responsive images and 
+enables native lazy loading.
+- [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a another lightweight
 option that uses Intersection Observer only. As such, it's highly performant,
 but will need to be polyfilled before you can use it on older browsers.
 - [yall.js](https://github.com/malchata/yall.js) is a library that uses


### PR DESCRIPTION
Proposing the addition of vanilla-lazyload

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Changes proposed in this pull request:

- Added vanilla-lazyload to the list of scripts at the end of the article