### PR TITLE
Use event.target for connect/disconnect serial events

### DIFF
--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -4,7 +4,7 @@ subhead: The Serial API allows websites to communicate with serial devices.
 authors:
   - beaufortfrancois
 date: 2020-08-12
-updated: 2020-11-24
+updated: 2020-12-02
 hero: hero.jpg
 thumbnail: thumbnail.jpg
 alt: |
@@ -405,7 +405,8 @@ navigator.serial.addEventListener("disconnect", (event) => {
 {% Aside %}
 Prior to Chrome 89 the `connect` and `disconnect` events fired a custom
 `SerialConnectionEvent` object with the affected `SerialPort` interface
-available as the `port` attribute.
+available as the `port` attribute. You may want to use `event.port ||
+event.target` to handle the transition.
 {% endAside %}
 
 ### Handle signals {: #signals }

--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -4,7 +4,7 @@ subhead: The Serial API allows websites to communicate with serial devices.
 authors:
   - beaufortfrancois
 date: 2020-08-12
-updated: 2020-09-29
+updated: 2020-11-24
 hero: hero.jpg
 thumbnail: thumbnail.jpg
 alt: |
@@ -393,14 +393,20 @@ access a serial port, it should monitor the `connect` and `disconnect` events.
 
 ```js
 navigator.serial.addEventListener("connect", (event) => {
-  // TODO: Automatically open event.port or warn user a port is available.
+  // TODO: Automatically open event.target or warn user a port is available.
 });
 
 navigator.serial.addEventListener("disconnect", (event) => {
-  // TODO: Remove |event.port| from the UI.
+  // TODO: Remove |event.target| from the UI.
   // If the serial port was opened, a stream error would be observed as well.
 });
 ```
+
+{% Aside %}
+Prior to Chrome 89 the `connect` and `disconnect` events fired a custom
+`SerialConnectionEvent` object with the affected `SerialPort` interface
+available as the `port` attribute.
+{% endAside %}
 
 ### Handle signals {: #signals }
 


### PR DESCRIPTION
This PR updates the serial article to document changes to the events fired when a serial port is connected or disconnected that are implemented in Chrome 89.
Spec: https://github.com/WICG/serial/commit/32dfe36cf081dd26f41681159a11863f5167bb91

Live preview: https://deploy-preview-4290--web-dev-staging.netlify.app/serial/#connection-disconnection