### PR TITLE
fix missing 'v'

### DIFF
--- a/.github/workflows/cleanup-versions-workflow.yml
+++ b/.github/workflows/cleanup-versions-workflow.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@0.2.0
+        uses: google-github-actions/setup-gcloud@v0.2.0
         with:
           version: '290.0.1'
           service_account_email: ${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
       
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@0.2.0
+        uses: google-github-actions/setup-gcloud@v0.2.0
         with:
           version: '290.0.1'
           service_account_email: ${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/snapshot-firestore-workflow.yml
+++ b/.github/workflows/snapshot-firestore-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@0.2.0
+        uses: google-github-actions/setup-gcloud@v0.2.0
         with:
           version: '290.0.1'
           service_account_email: ${{ secrets.GCLOUD_EMAIL }}


### PR DESCRIPTION
This tries to fix #4298. We cannot test unless we submit as there's no PR-triggered tasks that deploy to Gcloud.