### PR TITLE
Fix debugging npm command to debug eleventy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ teams:
 If you need to debug the site's build process:
 
 1. Add a `debugger` statement to `.eleventy.js`
-1. Run `npm run debug`
+1. Run `npm run debug:eleventy`
 1. Go to `chrome://inspect` to attach to the running process.
 
 <img


### PR DESCRIPTION
As I was looking into debugging eleventy, I've noticed command in the README was outdated. This PR fixes it.