### PR TITLE
Add macOS and Chrome OS support for barcode detection

### DIFF
--- a/src/site/content/en/blog/shape-detection/index.md
+++ b/src/site/content/en/blog/shape-detection/index.md
@@ -261,7 +261,7 @@ const supported = await (async () => 'FaceDetector' in window &&
 
 Barcode detection is available on macOS, Chrome OS, and Android. [Google Play
 Services](https://play.google.com/store/apps/details?id=com.google.android.gms)
-are required on Chrome OS and Android.
+are required on Android.
 
 ## Best practices {: #bestpractices}
 

--- a/src/site/content/en/blog/shape-detection/index.md
+++ b/src/site/content/en/blog/shape-detection/index.md
@@ -5,7 +5,7 @@ authors:
   - thomassteiner
 description: The Shape Detection API detects faces, barcodes, and text in images.
 date: 2019-01-07
-updated: 2020-08-10
+updated: 2020-11-30
 tags:
   - blog
   - capabilities
@@ -24,10 +24,7 @@ feedback:
 {% Aside %}
   This API is part of the new
   [capabilities project](https://developers.google.com/web/updates/capabilities).
-  Barcode detection has launched in Chrome 83
-  on certified devices with
-  [Google Play Services](https://play.google.com/store/apps/details?id=com.google.android.gms)
-  installed.
+  Barcode detection has launched in Chrome 83.
   Face and text detection are available behind a flag. This post will be updated as
   the Shape Detection API evolves.
 {% endAside %}
@@ -128,10 +125,7 @@ of use cases for all three features.
 ## How to use the Shape Detection API {: #use }
 
 {% Aside 'warning' %}
-  So far only barcode detection is available by default, starting in Chrome 83
-  on certified devices with
-  [Google Play Services](https://play.google.com/store/apps/details?id=com.google.android.gms)
-  installed,
+  So far only barcode detection is available by default, starting in Chrome 83,
   but face and text detection are available behind a flag.
   You can always use the Shape Detection API for local experiments by enabling the
   `#enable-experimental-web-platform-features` flag.
@@ -262,6 +256,12 @@ const supported = await (async () => 'FaceDetector' in window &&
     .then(_ => true)
     .catch(e => e.name === 'NotSupportedError' ? false : true))();
 ```
+
+## Operating system support {: #os-support}
+
+Barcode detection is available on macOS, Chrome OS, and Android. [Google Play
+Services](https://play.google.com/store/apps/details?id=com.google.android.gms)
+are required on Chrome OS and Android.
 
 ## Best practices {: #bestpractices}
 


### PR DESCRIPTION
This PR makes sure macOS and Chrome OS support are mentioned for barcode detection. 