### PR TITLE
feat(search): add highlighting

### DIFF
--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -348,8 +348,8 @@ class Search extends BaseElement {
         hitsPerPage: 10,
         attributesToHighlight: ['title'],
         attributesToRetrieve: ['url'],
-        highlightPreTag: '<mark>',
-        highlightPostTag: '</mark>',
+        highlightPreTag: '<strong>',
+        highlightPostTag: '</strong>',
       });
       if (this.query === query) {
         this.hits = hits;

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -344,6 +344,7 @@ class Search extends BaseElement {
       const {hits} = await index.search(query, {
         hitsPerPage: 10,
         attributesToHighlight: ['title'],
+        attributesToRetrieve: ['url'],
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',
       });

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -3,6 +3,7 @@
  */
 
 import {html} from 'lit-element';
+import {unsafeHTML} from 'lit-html/directives/unsafe-html';
 import {BaseElement} from '../BaseElement';
 import {store} from '../../store';
 import * as router from '../../utils/router';
@@ -233,7 +234,9 @@ class Search extends BaseElement {
             aria-selected="${idx === this.cursor}"
             tabindex="-1"
             href="${hit.url}"
-            >${html`hit._highlightResult.title.value`}</a
+            >${unsafeHTML(
+              hit._highlightResult.title && hit._highlightResult.title.value,
+            )}</a
           >
         </li>
       `,

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -233,7 +233,7 @@ class Search extends BaseElement {
             aria-selected="${idx === this.cursor}"
             tabindex="-1"
             href="${hit.url}"
-            >${hit.title}</a
+            >${html`hit._highlightResult.title.value`}</a
           >
         </li>
       `,
@@ -341,7 +341,12 @@ class Search extends BaseElement {
     }
     try {
       const index = await loadAlgoliaLibrary();
-      const {hits} = await index.search(query, {hitsPerPage: 10});
+      const {hits} = await index.search(query, {
+        hitsPerPage: 10,
+        attributesToHighlight: ['title'],
+        highlightPreTag: '<mark>',
+        highlightPostTag: '</mark>',
+      });
       if (this.query === query) {
         this.hits = hits;
       }


### PR DESCRIPTION
Changes proposed in this pull request:

- adds highlighting to the search 
- adds attributes to retrieve to the search (only request what's shown, makes the search a bit faster)

some questions that I need to check before it should be merged (but the main idea can already been reviewed)

- [ ] should the highlight tag be mark, or strong
- [x] is the code correctly indented (I committed from GitHub, didn't run prettier)
- [x] does every hit have a title (aka should ?. be used)
