### PR TITLE
Add YouTube video to paths landing pages

### DIFF
--- a/src/site/_data/paths/devices.json
+++ b/src/site/_data/paths/devices.json
@@ -5,6 +5,7 @@
   "updated": "November 17, 2020",
   "description": "Connecting hardware devices to the web",
   "overview": "Learn to communicate with hardware devices over Bluetooth, USB, NFC, Serial, and HID from a website.",
+  "youtubeId": "ZIZqmXfrRLI",
   "topics": [
     {
       "title": "API guides",

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -50,4 +50,10 @@ layout: layout
       {% include 'partials/topic.njk' %}
     {% endfor %}
   </section>
+
+  {% if path.youtubeId %}
+    <section class="w-layout-container">
+      {% YouTube path.youtubeId %}
+    </section>
+  {% endif %}
 </div>


### PR DESCRIPTION
This PR is about giving possibility to add a YouTube video to path landing pages and using this for web.dev/devices with YouTube video released at Chrome Dev Summit 2020.

Live preview: https://deploy-preview-4366--web-dev-staging.netlify.app/devices

Time to merge: 11:00AM