### PR TITLE
Move youtube video under overview in path landing pages.

### DIFF
--- a/src/site/_data/paths/devices.json
+++ b/src/site/_data/paths/devices.json
@@ -5,6 +5,7 @@
   "updated": "November 17, 2020",
   "description": "Connecting hardware devices to the web",
   "overview": "Learn to communicate with hardware devices over Bluetooth, USB, NFC, Serial, and HID from a website.",
+  "youtubeId": "ZIZqmXfrRLI",
   "topics": [
     {
       "title": "API guides",

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -50,4 +50,10 @@ layout: layout
       {% include 'partials/topic.njk' %}
     {% endfor %}
   </section>
+
+  {% if path.youtubeId %}
+    <section class="w-layout-container">
+      {% YouTube path.youtubeId %}
+    </section>
+  {% endif %}
 </div>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -30,6 +30,11 @@ layout: layout
     <div class="w-path-intro__overview">
       <h2 class="w-headline--three no-link">Overview</h2>
       <div>{{path.overview}}</div>
+      {% if path.youtubeId %}
+        <figure class="w-figure">
+          {% YouTube path.youtubeId %}
+        </figure>
+      {% endif %}
     </div>
     <div class="w-path-intro__learn">
       <h2 class="w-headline--three no-link">What you'll learn</h2>
@@ -50,10 +55,4 @@ layout: layout
       {% include 'partials/topic.njk' %}
     {% endfor %}
   </section>
-
-  {% if path.youtubeId %}
-    <section class="w-layout-container">
-      {% YouTube path.youtubeId %}
-    </section>
-  {% endif %}
 </div>


### PR DESCRIPTION
Following https://github.com/GoogleChrome/web.dev/pull/4366#issuecomment-742689784 suggestion, this PR moves youtube video under overview in path landing pages