### PR TITLE
Don't compute image sizes if there's already a dimension.

### DIFF
--- a/src/site/_transforms/responsive-images/index.js
+++ b/src/site/_transforms/responsive-images/index.js
@@ -40,13 +40,23 @@ const responsiveImages = (content, outputPath) => {
       return;
     }
 
-    const isLocal = !RegExp('^(https?://|/)').test(originalSrc);
-    if (isLocal) {
-      const distSrc = path.join(path.dirname(outputPath), originalSrc);
-      if (fs.existsSync(distSrc)) {
-        const {width, height} = sizeOf(distSrc);
-        $elem.attr('width', width);
-        $elem.attr('height', height);
+    // If the author has not specified a width or height on the image then
+    // one will be provided.
+    // nb. If the author has only specified a single dimension,
+    // like a width without a height, then only that dimensions will be used.
+    // We don't compute the other dimension because the author may be
+    // purposefully displaying the image smaller than its original size and
+    // for a high res image we could end up with a very tall height that doesn't
+    // match the width (i.e. width=200 height=3000 for a 2x image).
+    if (!$elem.attr('width') && !$elem.attr('height')) {
+      const isLocal = !RegExp('^(https?://|/)').test(originalSrc);
+      if (isLocal) {
+        const distSrc = path.join(path.dirname(outputPath), originalSrc);
+        if (fs.existsSync(distSrc)) {
+          const {width, height} = sizeOf(distSrc);
+          $elem.attr('width', width);
+          $elem.attr('height', height);
+        }
       }
     }
 


### PR DESCRIPTION
This fixes an issue that is already live in production 😅

#4300 added automatic image dimensions to improve our CLS (yay!) but, if an author has already provided a width and height (or in many cases, just a width) then #4300 was overriding their dimensions and forcing some images to be quite large (because it was using their high res dimensions).

You can see an example on this page https://web.dev/workers-overview/ where the screenshot of Proxx is huge
![image](https://user-images.githubusercontent.com/1066253/102831608-166d7580-43a1-11eb-943e-040543a3ff75.png)

After this patch is applied the screenshot looks like this:
![image](https://user-images.githubusercontent.com/1066253/102831637-271deb80-43a1-11eb-85b3-b4625444a7b7.png)

Changes proposed in this pull request:

- Only compute image size if the author has not specified a width or a height.
