### PR TITLE
fix: image is cut off on mobile device when specifying .w-screenshot--filled

### DIFF
--- a/src/styles/components/_images.scss
+++ b/src/styles/components/_images.scss
@@ -63,6 +63,11 @@
 .w-figure--screenshot > img {
   background-color: $GREY_50;
   padding: 16px;
+
+  // This ensures image size fits to content width with padding(16 * 2)
+  // while specifying `box-sizing: content-box;` in .w-screenshot
+  max-width: calc(100% - 32px);
+  margin-left: 0;
 }
 
 .w-screenshot + .w-screenshot,


### PR DESCRIPTION
Fixes #4416

Changes proposed in this pull request:

- added max-width for `.w-screenshot--filled` in order not to overflow

![Group 49](https://user-images.githubusercontent.com/6080698/103215397-93c35800-4956-11eb-9711-6b823456965e.png)

this styling depends on another css class `.w-screenshot` so it may not be a good solution to solve the issue.
Please give any advice if there are other ideas🙏