### PR TITLE
Update third-party facades audit doc

### DIFF
--- a/src/site/content/en/lighthouse-performance/third-party-facades/index.md
+++ b/src/site/content/en/lighthouse-performance/third-party-facades/index.md
@@ -88,8 +88,8 @@ There are some tradeoffs when lazily loading third-parties with facades as they 
 
 You may choose to [build a custom facade solution](https://wildbit.com/blog/2020/09/30/getting-postmark-lighthouse-performance-score-to-100#:~:text=What%20if%20we%20could%20replace%20the%20real%20widget) which employs the interaction pattern outlined above. The facade should be significantly smaller in comparison to the deferred third-party product and only include enough code to mimic the appearance of the product.
 
-If you would like your solution to be included in the list above, check out our [submissions process](https://github.com/patrickhulce/third-party-web/blob/master/facades.md).
+If you would like your solution to be included in the list above, check out the [submissions process](https://github.com/patrickhulce/third-party-web/blob/master/facades.md).
 
 ## Resources
 
-Source code for [Lazy load third-party resources with facades audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/third-party-facades.js)
+Source code for [Lazy load third-party resources with facades audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/third-party-facades.js).

--- a/src/site/content/en/lighthouse-performance/third-party-facades/index.md
+++ b/src/site/content/en/lighthouse-performance/third-party-facades/index.md
@@ -12,7 +12,7 @@ web_lighthouse:
 
 [Third-party resources](/third-party-javascript/) are often used for displaying ads or videos and integrating with social media. The default approach is to load third-party resources as soon as the page loads, but this can unnecessarily slow the page load. If the third-party content is not critical, this performance cost can be reduced by [lazy loading](/fast/#lazy-load-images-and-video) it.
 
-This audit highlights third-party embeds which can be lazily loaded on interaction. In that case, a *facade* is used in place of the third-party content until the user interacts with it. 
+This audit highlights third-party embeds which can be lazily loaded on interaction. In that case, a *facade* is used in place of the third-party content until the user interacts with it.
 
 {% Aside 'key-term' %}
 
@@ -21,7 +21,7 @@ A *facade* is a static element which looks similar to the actual embedded third-
 {% endAside %}
 
 <figure class="w-figure">
-  <img src="./loadYouTube.jpg" 
+  <img src="./loadYouTube.jpg"
        alt="An example of loading YouTube embedded player with a facade. The facade weighs 3 KB and the player weighing 540 KB is loaded on interaction.">
   <figcaption class="w-figcaption">
     Loading YouTube embedded player with a facade.
@@ -31,7 +31,7 @@ A *facade* is a static element which looks similar to the actual embedded third-
 
 ## How Lighthouse detects deferrable third-party embeds
 
-Lighthouse looks for third-party products which can be deferred, such as social button widgets or video embeds (for example, YouTube embedded player). 
+Lighthouse looks for third-party products which can be deferred, such as social button widgets or video embeds (for example, YouTube embedded player).
 
 The data about deferrable products and available facades is [maintained in third-party-web](https://github.com/patrickhulce/third-party-web/).
 
@@ -39,7 +39,7 @@ The audit fails if the page loads resources belonging to one of these third-part
 
 
 <figure class="w-figure">
-  <img class="w-screenshot" src="./audit.jpg" 
+  <img class="w-screenshot" src="./audit.jpg"
        alt="Lighthouse third-party facade audit highlighting Vimeo embedded player and Drift live chat.">
   <figcaption class="w-figcaption">
     Lighthouse third-party facade audit.
@@ -58,7 +58,7 @@ Instead of adding a third-party embed directly to your HTML, load the page with 
 
 ## Recommended facades
 
-In general, video embeds, social button widgets, and chat widgets can all employ the facade pattern. The list below offers our recommendations of open-source facades. When choosing a facade, take into account the balance between the size and feature set.
+In general, video embeds, social button widgets, and chat widgets can all employ the facade pattern. The list below offers our recommendations of open-source facades. When choosing a facade, take into account the balance between the size and feature set. You can also use a lazy iframe loader such as [vb/lazyframe](https://github.com/vb/lazyframe).
 
 ### YouTube embedded player
 
@@ -78,10 +78,6 @@ In general, video embeds, social button widgets, and chat widgets can all employ
 
 * [calibreapp/react-live-chat-loader](https://github.com/calibreapp/react-live-chat-loader) ([blog post](https://calibreapp.com/blog/fast-live-chat))
 
-### Iframes
-
-* [vb/lazyframe](https://github.com/vb/lazyframe)
-
 {% Aside 'caution' %}
 
 There are some tradeoffs when lazily loading third-parties with facades as they do not have the full range of functionality of the actual embeds. For example, the Drift Live Chat bubble has a badge indicating the number of new messages. If the live chat bubble is deferred with a facade, users will not see the badge until after first interaction. For video embeds, autoplay may not work consistently if it's loaded lazily.
@@ -91,3 +87,9 @@ There are some tradeoffs when lazily loading third-parties with facades as they 
 ## Writing your own facade
 
 You may choose to [build a custom facade solution](https://wildbit.com/blog/2020/09/30/getting-postmark-lighthouse-performance-score-to-100#:~:text=What%20if%20we%20could%20replace%20the%20real%20widget) which employs the interaction pattern outlined above. The facade should be significantly smaller in comparison to the deferred third-party product and only include enough code to mimic the appearance of the product.
+
+If you would like your solution to be included in the list above, check out our [submissions process](https://github.com/patrickhulce/third-party-web/blob/master/facades.md).
+
+## Resources
+
+Source code for [Lazy load third-party resources with facades audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/third-party-facades.js)


### PR DESCRIPTION
Fixes #4334.

Changes:
> - The audit was recently merged in LH, we can add a link to the [source code](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/third-party-facades.js)  as per https://github.com/GoogleChrome/web.dev/pull/4316#discussion_r532528310
> - We still need to add the facade additions process link (https://github.com/GoogleChrome/web.dev/pull/4316#discussion_r533717049)
> - Instead of having a specific section for a general iframes facade, call out generic iframe loaders in the paragraph above.
