### PR TITLE
Update Audit tab to Lighthouse tab

### DIFF
--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -167,9 +167,9 @@ module.exports = (type, listStyle = 'ul') => {
       // prettier-ignore
       instruction = html`
         ${shared.devtools}
-        ${bullet}Click the **Audits** tab.
-        ${bullet}Select the **${substitution}** checkbox.
-        ${bullet}Click **Run audits**.
+        ${bullet}Click the **Lighthouse** tab.
+        ${bullet}Make sure the **${substitution}** checkbox is selected in the *Categories* list.
+        ${bullet}Click the **Generate report** button.
       `;
       break;
 


### PR DESCRIPTION
As of DevTools (Chrome 83), the Audits panel is now the Lighthouse panel

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 'Audit tab' changed to 'Lighthouse tab'
- Instruction of selecting the right 'selection' checkbox is made more clear
- Button name updated to 'Generate report'
