### PR TITLE
Remove no longer maintained Medium channel from footer

### DIFF
--- a/src/site/_includes/devsite/devsite-footer.njk
+++ b/src/site/_includes/devsite/devsite-footer.njk
@@ -107,17 +107,6 @@
               YouTube
             </a>
           </li>
-          <li class="devsite-footer-linkbox-item">
-            <a
-              href="https://medium.com/dev-channel"
-              class="devsite-footer-linkbox-link
-            gc-analytics-event"
-              data-category="Site-Wide Custom Events"
-              data-label="Footer Link (index 3)"
-            >
-              Medium
-            </a>
-          </li>
         </ul>
       </li>
     </ul>

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -68,12 +68,6 @@
               YouTube
             </a>
           </li>
-          <li class="w-footer__linkbox-item">
-            <a href="https://medium.com/dev-channel" class="w-footer__linkbox-link"
-              data-category="Site-Wide Custom Events" data-label="Footer Link (index 3)">
-              Medium
-            </a>
-          </li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove no longer maintained Medium channel from footer. 
