### PR TITLE
Update performance.measureMemory after renaming

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -2,14 +2,14 @@
 title: Making your website "cross-origin isolated" using COOP and COEP
 subhead: >
   Use COOP and COEP to set up a cross-origin isolated environment and enable
-  powerful features like `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`, and
+  powerful features like `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`, and
   the JS Self-Profiling API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Use COOP and COEP to set up such an environment and
   enable powerful features like `SharedArrayBuffer`,
-  `performance.measureUserAgentSpecificMemoryMemory()` or the JS Self-Profiling API.
+  `performance.measureUserAgentSpecificMemory()` or the JS Self-Profiling API.
 authors:
   - agektmr
 hero: hero.jpg
@@ -31,7 +31,7 @@ feedback:
 
 **October 15th, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureUserAgentSpecificMemoryMemory()` is ending its origin trial and is
+returns `true`. `performance.measureUserAgentSpecificMemory()` is ending its origin trial and is
 enabled by default in Chrome 89. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
@@ -51,7 +51,7 @@ able to use privileged features including:
   Isolation](https://www.chromium.org/Home/chromium-security/site-isolation),
   but will require the cross-origin isolated state and will be disabled by
   default.)
-* [`performance.measureUserAgentSpecificMemoryMemory()`](/monitor-total-page-memory-usage/) (Ends its
+* [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/) (Ends its
   origin trial and is planned to be enabled by default in Chrome 88)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
   available yet in Chrome)
@@ -83,7 +83,7 @@ article](/why-coop-coep) I will provide more background and context.
 
 {% Aside %}
 This article is aimed at those who would like to get their websites ready for
-using `SharedArrayBuffer`, WebAssembly Threads, `performance.measureUserAgentSpecificMemoryMemory()`
+using `SharedArrayBuffer`, WebAssembly Threads, `performance.measureUserAgentSpecificMemory()`
 or the JS Self-Profiling API in a more robust manner across browser
 platforms.
 {% endAside %}
@@ -192,7 +192,7 @@ The `self.crossOriginIsolated` property returns `true` when the web page is in a
 cross-origin isolated state and all resources and windows are isolated within
 the same browsing context group. You can use this API to determine whether you
 have successfully isolated the browsing context group and gained access to
-powerful features like `performance.measureUserAgentSpecificMemoryMemory()`.
+powerful features like `performance.measureUserAgentSpecificMemory()`.
 
 {% Aside 'caution' %}
 The
@@ -424,7 +424,7 @@ In upcoming releases of Chrome, this cross-origin isolated state will prevent
 `document.domain`](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Changing_origin)
 and will give access to powerful features such as:
 
-* [`performance.measureUserAgentSpecificMemoryMemory()`](/monitor-total-page-memory-usage/)
+* [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) and more.
 
 We'll keep this post updated as new features are made available to this

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -31,8 +31,8 @@ feedback:
 
 **October 15th, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureUserAgentSpecificMemoryMemory` is ending its origin trial and is
-planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
+returns `true`. `performance.measureUserAgentSpecificMemoryMemory()` is ending its origin trial and is
+enabled by default in Chrome 89. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
 **September 1st, 2020**: COOP Reporting is behind flags in Chrome 86. See

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -2,14 +2,14 @@
 title: Making your website "cross-origin isolated" using COOP and COEP
 subhead: >
   Use COOP and COEP to set up a cross-origin isolated environment and enable
-  powerful features like `SharedArrayBuffer`, `performance.measureMemory()`, and
+  powerful features like `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`, and
   the JS Self-Profiling API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Use COOP and COEP to set up such an environment and
   enable powerful features like `SharedArrayBuffer`,
-  `performance.measureMemory()` or the JS Self-Profiling API.
+  `performance.measureUserAgentSpecificMemoryMemory()` or the JS Self-Profiling API.
 authors:
   - agektmr
 hero: hero.jpg
@@ -31,7 +31,7 @@ feedback:
 
 **October 15th, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
 Reflecting that, `document.domain` is immutable when `self.crossOriginIsolated`
-returns `true`. `performance.measureMemory` is ending its origin trial and is
+returns `true`. `performance.measureUserAgentSpecificMemoryMemory` is ending its origin trial and is
 planned to be enabled by default in Chrome 88. Shared Array Buffer on Android
 Chrome will be available from Chrome 88.
 
@@ -51,7 +51,7 @@ able to use privileged features including:
   Isolation](https://www.chromium.org/Home/chromium-security/site-isolation),
   but will require the cross-origin isolated state and will be disabled by
   default.)
-* [`performance.measureMemory()`](/monitor-total-page-memory-usage/) (Ends its
+* [`performance.measureUserAgentSpecificMemoryMemory()`](/monitor-total-page-memory-usage/) (Ends its
   origin trial and is planned to be enabled by default in Chrome 88)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (Not
   available yet in Chrome)
@@ -83,7 +83,7 @@ article](/why-coop-coep) I will provide more background and context.
 
 {% Aside %}
 This article is aimed at those who would like to get their websites ready for
-using `SharedArrayBuffer`, WebAssembly Threads, `performance.measureMemory()`
+using `SharedArrayBuffer`, WebAssembly Threads, `performance.measureUserAgentSpecificMemoryMemory()`
 or the JS Self-Profiling API in a more robust manner across browser
 platforms.
 {% endAside %}
@@ -192,7 +192,7 @@ The `self.crossOriginIsolated` property returns `true` when the web page is in a
 cross-origin isolated state and all resources and windows are isolated within
 the same browsing context group. You can use this API to determine whether you
 have successfully isolated the browsing context group and gained access to
-powerful features like `performance.measureMemory()`.
+powerful features like `performance.measureUserAgentSpecificMemoryMemory()`.
 
 {% Aside 'caution' %}
 The
@@ -424,7 +424,7 @@ In upcoming releases of Chrome, this cross-origin isolated state will prevent
 `document.domain`](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Changing_origin)
 and will give access to powerful features such as:
 
-* [`performance.measureMemory()`](/monitor-total-page-memory-usage/)
+* [`performance.measureUserAgentSpecificMemoryMemory()`](/monitor-total-page-memory-usage/)
 * [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) and more.
 
 We'll keep this post updated as new features are made available to this

--- a/src/site/content/en/blog/detached-window-memory-leaks/index.md
+++ b/src/site/content/en/blog/detached-window-memory-leaks/index.md
@@ -274,7 +274,7 @@ the currently used JavaScript heap size from the [`performance.memory` API][perf
 
 The `performance.memory` API only provides information about the JavaScript heap size, which means
 it doesn't include memory used by the popup's document and resources. To get the full picture, we'd
-need to use the new [`performance.measureMemory()` API][performance-measurememory] currently being
+need to use the new [`performance.measureUserAgentSpecificMemoryMemory()` API][performance-measurememory] currently being
 trialled in Chrome.
 
 ## Solutions for avoiding detached window leaks {: #solutions }

--- a/src/site/content/en/blog/detached-window-memory-leaks/index.md
+++ b/src/site/content/en/blog/detached-window-memory-leaks/index.md
@@ -274,7 +274,7 @@ the currently used JavaScript heap size from the [`performance.memory` API][perf
 
 The `performance.memory` API only provides information about the JavaScript heap size, which means
 it doesn't include memory used by the popup's document and resources. To get the full picture, we'd
-need to use the new [`performance.measureUserAgentSpecificMemoryMemory()` API][performance-measurememory] currently being
+need to use the new [`performance.measureUserAgentSpecificMemory()` API][performance-measurememory] currently being
 trialled in Chrome.
 
 ## Solutions for avoiding detached window leaks {: #solutions }

--- a/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
+++ b/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
@@ -21,6 +21,16 @@ feedback:
   - api
 ---
 
+{% Banner 'caution', 'body' %}
+
+**Updates**
+
+**January 20th, 2020**: `performance.measureUserAgentSpecificMemoryMemory` is renamed to `performance.measureUserAgentSpecificMemory`
+and enabled by default in Chrome 89 for [cross-origin isolated](/coop-coep) web pages.
+The format of the result also [has changed](https://github.com/WICG/performance-measure-memory/blob/master/ORIGIN_TRIAL.md#result-differences)
+slightly compared to the Origin Trial version.
+{% endBanner %}
+
 Browsers manage the memory of web pages automatically. Whenever a web page
 creates an object, the browser allocates a chunk of memory "under the hood" to
 store the object. Since memory is a finite resource, the browser performs
@@ -50,11 +60,11 @@ then its memory usage grows over time and the web page appears slow and
 bloated to the users.
 
 The first step in solving this problem is measuring it. The new
-[`performance.measureMemory()` API][explainer] allows developers to
+[`performance.measureUserAgentSpecificMemoryMemory()` API][explainer] allows developers to
 measure memory usage of their web pages in production and thus detect memory
 leaks that slip through local testing.
 
-## How is `performance.measureMemory()` different from the legacy `performance.memory` API? {: #legacy-api }
+## How is `performance.measureUserAgentSpecificMemoryMemory()` different from the legacy `performance.memory` API? {: #legacy-api }
 
 If you are familiar with the existing non-standard `performance.memory` API,
 you might be wondering how the new API differs from it. The main difference is
@@ -128,16 +138,16 @@ results for the same browser.
 </table>
 </div>
 
-## Using `performance.measureMemory()` {: use }
+## Using `performance.measureUserAgentSpecificMemoryMemory()` {: use }
 
 ### Enabling via chrome://flags
 
-To experiment with `performance.measureMemory()` without an origin trial
+To experiment with `performance.measureUserAgentSpecificMemoryMemory()` without an origin trial
 token, enable the `#experimental-web-platform-features` flag in `chrome://flags`.
 
 ### Enabling support during the origin trial phase
 
-The `performance.measureMemory()` API is available as an origin trial starting in
+The `performance.measureUserAgentSpecificMemoryMemory()` API is available as an origin trial starting in
 Chrome 83. The origin trial is expected to end in Chrome 86, in early November 2020.
 
 {% include 'content/origin-trials.njk' %}
@@ -148,7 +158,7 @@ Chrome 83. The origin trial is expected to end in Chrome 86, in early November 2
 
 ### Feature detection
 
-The `performance.measureMemory()` function may fail with a
+The `performance.measureUserAgentSpecificMemoryMemory()` function may fail with a
 [SecurityError][security-error] if the execution environment does not fulfil
 the security requirements for preventing cross-origin information leaks.
 During the origin trial in Chrome, the API requires that [Site
@@ -157,10 +167,10 @@ Isolation][site-isolation] is enabled. When the API ships, it will rely on
 cross-origin isolation by setting [COOP+COEP headers][coop-coep].
 
 ```javascript
-if (performance.measureMemory) {
+if (performance.measureUserAgentSpecificMemoryMemory) {
   let result;
   try {
-    result = await performance.measureMemory();
+    result = await performance.measureUserAgentSpecificMemoryMemory();
   } catch (error) {
     if (error instanceof DOMException &&
         error.name === "SecurityError") {
@@ -199,8 +209,8 @@ page load on the main window.
 
 ```javascript
 function scheduleMeasurement() {
-  if (!performance.measureMemory) {
-    console.log("performance.measureMemory() is not available.");
+  if (!performance.measureUserAgentSpecificMemoryMemory) {
+    console.log("performance.measureUserAgentSpecificMemoryMemory() is not available.");
     return;
   }
   const interval = measurementInterval();
@@ -231,10 +241,10 @@ the result, and schedules the next measurement.
 
 ```javascript
 async function performMeasurement() {
-  // 1. Invoke performance.measureMemory().
+  // 1. Invoke performance.measureUserAgentSpecificMemoryMemory().
   let result;
   try {
-    result = await performance.measureMemory();
+    result = await performance.measureUserAgentSpecificMemoryMemory();
   } catch (error) {
     if (error instanceof DOMException &&
         error.name === "SecurityError") {
@@ -259,14 +269,32 @@ The result may look as follows:
   breakdown: [
     {
       bytes: 40_000_000,
-      attribution: ["https://foo.com"],
-      userAgentSpecificTypes: ["Window", "JS"]
+      attribution: [
+        {
+          url: "https://foo.com",
+          scope: "Window",
+        },
+      ]
+      types: ["JS"]
+    },
+    {
+      bytes: 0,
+      attribution: [],
+      types: []
     },
     {
       bytes: 20_000_000,
-      attribution: ["https://foo.com/iframe"],
-      userAgentSpecificTypes: ["Window", "JS"]
-    }
+      attribution: [
+        {
+          url: "https://foo.com/iframe",
+          container: {
+            id: "iframe-id-attribute",
+            src: "redirect.html?target=iframe.html",
+          },
+        },
+      ],
+      types: ["JS"]
+    },
   ]
 }
 ```
@@ -278,31 +306,30 @@ even change between different versions of the same browser. During the origin
 trial the value includes JavaScript memory usage of the main window and all
 **same-site** iframes and related windows. When the API ships, the value will
 account for JavaScript and DOM memory of all iframes, related windows, and web
-workers.
+workers in the current process.
 
 The `breakdown` list provides further information about the used memory. Each
 entry describes some portion of the memory and attributes it to a set of
-windows, iframes, and workers identified by URLs. The `userAgentSpecificTypes`
-field  lists the implementation-specific memory types associated with the
-memory.
+windows, iframes, and workers identified by URLs. The `types` field lists
+the implementation-specific memory types associated with the memory.
 
 It is important to treat all lists in a generic way and to not hardcode
 assumptions based on a particular browser. For example, some browsers may
 return an empty `breakdown` or an empty `attribution`. Other browsers may
-return multiple URLs in `attribution` indicating they could not distinguish
-which of these URLs owns the memory.
+return multiple entries in `attribution` indicating they could not distinguish
+which of these entries owns the memory.
 
 ## Feedback {: #feedback }
 
 The [Web Performance Community Group][webperfs] and the Chrome team would love
 to hear about your thoughts and experiences with
-`performance.measureMemory()`.
+`performance.measureUserAgentSpecificMemoryMemory()`.
 
 ### Tell us about the API design
 
 Is there something about the API that doesn't work as expected? Or are there
 missing properties that you need to implement your idea? File a spec issue on
-the [performance.measureMemory() GitHub repo][issues] or add your thoughts to an
+the [performance.measureUserAgentSpecificMemoryMemory() GitHub repo][issues] or add your thoughts to an
 existing issue.
 
 ### Report a problem with the implementation
@@ -315,7 +342,7 @@ the bug, and have **Components** set to `Blink>PerformanceAPIs`.
 
 ### Show support
 
-Are you planning to use `performance.measureMemory()`? Your public support
+Are you planning to use `performance.measureUserAgentSpecificMemoryMemory()`? Your public support
 helps the Chrome team prioritize features and shows other browser vendors how
 critical it is to support them. Send a tweet to [@ChromiumDev](https://twitter.com/chromiumdev) and let us know
 where and how you're using it.

--- a/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
+++ b/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
@@ -25,7 +25,7 @@ feedback:
 
 **Updates**
 
-**January 20th, 2020**: `performance.measureUserAgentSpecificMemoryMemory` is renamed to `performance.measureUserAgentSpecificMemory`
+**January 20th, 2020**: `performance.measureMemory` is renamed to `performance.measureUserAgentSpecificMemory`
 and enabled by default in Chrome 89 for [cross-origin isolated](/coop-coep) web pages.
 The format of the result also [has changed](https://github.com/WICG/performance-measure-memory/blob/master/ORIGIN_TRIAL.md#result-differences)
 slightly compared to the Origin Trial version.

--- a/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
+++ b/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
@@ -60,11 +60,11 @@ then its memory usage grows over time and the web page appears slow and
 bloated to the users.
 
 The first step in solving this problem is measuring it. The new
-[`performance.measureUserAgentSpecificMemoryMemory()` API][explainer] allows developers to
+[`performance.measureUserAgentSpecificMemory()` API][explainer] allows developers to
 measure memory usage of their web pages in production and thus detect memory
 leaks that slip through local testing.
 
-## How is `performance.measureUserAgentSpecificMemoryMemory()` different from the legacy `performance.memory` API? {: #legacy-api }
+## How is `performance.measureUserAgentSpecificMemory()` different from the legacy `performance.memory` API? {: #legacy-api }
 
 If you are familiar with the existing non-standard `performance.memory` API,
 you might be wondering how the new API differs from it. The main difference is
@@ -138,16 +138,16 @@ results for the same browser.
 </table>
 </div>
 
-## Using `performance.measureUserAgentSpecificMemoryMemory()` {: use }
+## Using `performance.measureUserAgentSpecificMemory()` {: use }
 
 ### Enabling via chrome://flags
 
-To experiment with `performance.measureUserAgentSpecificMemoryMemory()` without an origin trial
+To experiment with `performance.measureUserAgentSpecificMemory()` without an origin trial
 token, enable the `#experimental-web-platform-features` flag in `chrome://flags`.
 
 ### Enabling support during the origin trial phase
 
-The `performance.measureUserAgentSpecificMemoryMemory()` API is available as an origin trial starting in
+The `performance.measureUserAgentSpecificMemory()` API is available as an origin trial starting in
 Chrome 83. The origin trial is expected to end in Chrome 86, in early November 2020.
 
 {% include 'content/origin-trials.njk' %}
@@ -158,7 +158,7 @@ Chrome 83. The origin trial is expected to end in Chrome 86, in early November 2
 
 ### Feature detection
 
-The `performance.measureUserAgentSpecificMemoryMemory()` function may fail with a
+The `performance.measureUserAgentSpecificMemory()` function may fail with a
 [SecurityError][security-error] if the execution environment does not fulfil
 the security requirements for preventing cross-origin information leaks.
 During the origin trial in Chrome, the API requires that [Site
@@ -167,10 +167,10 @@ Isolation][site-isolation] is enabled. When the API ships, it will rely on
 cross-origin isolation by setting [COOP+COEP headers][coop-coep].
 
 ```javascript
-if (performance.measureUserAgentSpecificMemoryMemory) {
+if (performance.measureUserAgentSpecificMemory) {
   let result;
   try {
-    result = await performance.measureUserAgentSpecificMemoryMemory();
+    result = await performance.measureUserAgentSpecificMemory();
   } catch (error) {
     if (error instanceof DOMException &&
         error.name === "SecurityError") {
@@ -209,8 +209,8 @@ page load on the main window.
 
 ```javascript
 function scheduleMeasurement() {
-  if (!performance.measureUserAgentSpecificMemoryMemory) {
-    console.log("performance.measureUserAgentSpecificMemoryMemory() is not available.");
+  if (!performance.measureUserAgentSpecificMemory) {
+    console.log("performance.measureUserAgentSpecificMemory() is not available.");
     return;
   }
   const interval = measurementInterval();
@@ -241,10 +241,10 @@ the result, and schedules the next measurement.
 
 ```javascript
 async function performMeasurement() {
-  // 1. Invoke performance.measureUserAgentSpecificMemoryMemory().
+  // 1. Invoke performance.measureUserAgentSpecificMemory().
   let result;
   try {
-    result = await performance.measureUserAgentSpecificMemoryMemory();
+    result = await performance.measureUserAgentSpecificMemory();
   } catch (error) {
     if (error instanceof DOMException &&
         error.name === "SecurityError") {
@@ -323,13 +323,13 @@ which of these entries owns the memory.
 
 The [Web Performance Community Group][webperfs] and the Chrome team would love
 to hear about your thoughts and experiences with
-`performance.measureUserAgentSpecificMemoryMemory()`.
+`performance.measureUserAgentSpecificMemory()`.
 
 ### Tell us about the API design
 
 Is there something about the API that doesn't work as expected? Or are there
 missing properties that you need to implement your idea? File a spec issue on
-the [performance.measureUserAgentSpecificMemoryMemory() GitHub repo][issues] or add your thoughts to an
+the [performance.measureUserAgentSpecificMemory() GitHub repo][issues] or add your thoughts to an
 existing issue.
 
 ### Report a problem with the implementation
@@ -342,7 +342,7 @@ the bug, and have **Components** set to `Blink>PerformanceAPIs`.
 
 ### Show support
 
-Are you planning to use `performance.measureUserAgentSpecificMemoryMemory()`? Your public support
+Are you planning to use `performance.measureUserAgentSpecificMemory()`? Your public support
 helps the Chrome team prioritize features and shows other browser vendors how
 critical it is to support them. Send a tweet to [@ChromiumDev](https://twitter.com/chromiumdev) and let us know
 where and how you're using it.

--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -2,13 +2,13 @@
 title: Why you need "cross-origin isolated" for powerful features
 subhead: >
   Learn why cross-origin isolation is needed to use powerful features such as
-  `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`, and the JS Self-Profiling
+  `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`, and the JS Self-Profiling
   API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Learn why cross-origin isolation is needed to use
-  powerful features such as `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`,
+  powerful features such as `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`,
   and the JS Self-Profiling API.
 authors:
   - agektmr
@@ -101,7 +101,7 @@ This is exactly what COOP+COEP is about.
 
 Under a cross-origin isolated state, the requesting site is considered less
 dangerous and this unlocks powerful features such as `SharedArrayBuffer`,
-`performance.measureUserAgentSpecificMemoryMemory()` and the JS Self-Profiling API which could otherwise be
+`performance.measureUserAgentSpecificMemory()` and the JS Self-Profiling API which could otherwise be
 used for Spectre-like attacks. It also prevents modifying `document.domain`.
 
 ### Cross Origin Embedder Policy {: #coep }
@@ -239,7 +239,7 @@ protect your website in browsers that don't support COOP.
 ## Summary {: #summary }
 
 If you want guaranteed access to powerful features like `SharedArrayBuffer`,
-`performance.measureUserAgentSpecificMemoryMemory()` or JS Self-Profiling API, just remember that your
+`performance.measureUserAgentSpecificMemory()` or JS Self-Profiling API, just remember that your
 document needs to use both COEP with the value of `require-corp` and COOP with
 the value of `same-origin`. In the absence of either, the browser will not
 guarantee sufficient isolation to safely enable those powerful features. You can

--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -2,13 +2,13 @@
 title: Why you need "cross-origin isolated" for powerful features
 subhead: >
   Learn why cross-origin isolation is needed to use powerful features such as
-  `SharedArrayBuffer`, `performance.measureMemory()`, and the JS Self-Profiling
+  `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`, and the JS Self-Profiling
   API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Learn why cross-origin isolation is needed to use
-  powerful features such as `SharedArrayBuffer`, `performance.measureMemory()`,
+  powerful features such as `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemoryMemory()`,
   and the JS Self-Profiling API.
 authors:
   - agektmr
@@ -101,7 +101,7 @@ This is exactly what COOP+COEP is about.
 
 Under a cross-origin isolated state, the requesting site is considered less
 dangerous and this unlocks powerful features such as `SharedArrayBuffer`,
-`performance.measureMemory()` and the JS Self-Profiling API which could otherwise be
+`performance.measureUserAgentSpecificMemoryMemory()` and the JS Self-Profiling API which could otherwise be
 used for Spectre-like attacks. It also prevents modifying `document.domain`.
 
 ### Cross Origin Embedder Policy {: #coep }
@@ -239,7 +239,7 @@ protect your website in browsers that don't support COOP.
 ## Summary {: #summary }
 
 If you want guaranteed access to powerful features like `SharedArrayBuffer`,
-`performance.measureMemory()` or JS Self-Profiling API, just remember that your
+`performance.measureUserAgentSpecificMemoryMemory()` or JS Self-Profiling API, just remember that your
 document needs to use both COEP with the value of `require-corp` and COOP with
 the value of `same-origin`. In the absence of either, the browser will not
 guarantee sufficient isolation to safely enable those powerful features. You can


### PR DESCRIPTION
The new name is performance.measureUserAgentSpecificMemory.

This also updates the examples to the new result format.

