### PR TITLE
Fix wording re: LCP calcuation for video elements

### DIFF
--- a/src/site/content/en/blog/optimize-lcp/index.md
+++ b/src/site/content/en/blog/optimize-lcp/index.md
@@ -291,7 +291,7 @@ elements that affect LCP are:
 
 +   `<img>` elements
 +   `<image>` elements inside an `<svg>` element
-+   `<video>` elements (if specified, the
++   `<video>` elements (the
     [poster](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-poster) image is
     used to measure LCP)
 +   An element with a background image loaded via the


### PR DESCRIPTION
This wording now matches https://web.dev/lcp/

(IMO the existing wording could be misinterpreted to mean that it falls back to using the `<video>` element if the video placeholder is not specified.)

cc @philipwalton 