### PR TITLE
Trust Token V2 changes to blog post.

### DIFF
--- a/src/site/content/en/blog/trust-tokens/index.md
+++ b/src/site/content/en/blog/trust-tokens/index.md
@@ -21,10 +21,10 @@ feedback:
 ## Summary
 
 Trust tokens enable an origin to issue cryptographic tokens to a user it trusts.
-The tokens are stored by the user's browser. The browser can then use the tokens 
-in other contexts to evaluate the user's authenticity.   
+The tokens are stored by the user's browser. The browser can then use the tokens
+in other contexts to evaluate the user's authenticity.
 
-The Trust Token API enables trust of a user in one context to be conveyed to another context without 
+The Trust Token API enables trust of a user in one context to be conveyed to another context without
 identifying the user or linking the two identities.
 
 You can try out Trust Tokens with our [demo](https://trust-token-demo.glitch.me).
@@ -45,40 +45,40 @@ explainer](https://github.com/WICG/trust-token-api) repository.
 The web needs ways to establish trust signals which show that a user is who they
 say they are, and not a bot pretending to be a human, or a malicious third-party
 defrauding a real person or service. Fraud protection is particularly important
-for advertisers, ad providers, and CDNs.   
-  
+for advertisers, ad providers, and CDNs.
+
 Unfortunately, many existing mechanisms to gauge and propagate
-trustworthiness—to work out if an interaction with a site is from a real human, 
+trustworthiness—to work out if an interaction with a site is from a real human,
 for example—take advantage of techniques that can also be used for
 fingerprinting.
 
-{% Aside 'key-term' %}  
+{% Aside 'key-term' %}
 **Fingerprinting** enables sites to identify and track individual users by
 getting data about their device, operating system, and browser setup (such as
 language preferences,
-[user agent](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/userAgent), and 
+[user agent](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/userAgent), and
 available fonts) or changes in device state. This may be done on the server
 by checking request headers or on the client with JavaScript.
 
 Fingerprinting uses mechanisms that users aren't aware of and can't control.
 Sites such as [Panopticlick](https://panopticlick.eff.org/) and
 [amiunique.org](https://amiunique.org/) show how fingerprint data can be
-combined to identify you as an individual.  
-{% endAside %} 
+combined to identify you as an individual.
+{% endAside %}
 
-The API must preserve privacy, enabling trust to be propagated across sites 
+The API must preserve privacy, enabling trust to be propagated across sites
 without individual user tracking.
 
 ## What's in the Trust Tokens proposal?
 
 The web relies on building trust signals to detect fraud and spamming. One way
 to do this is by tracking browsing with global, cross-site per-user identifiers.
-For a privacy-preserving API, that's not acceptable.  
+For a privacy-preserving API, that's not acceptable.
 
 From the proposal
-[**explainer**](https://github.com/WICG/trust-token-api#overview): 
-  
-<blockquote>  
+[**explainer**](https://github.com/WICG/trust-token-api#overview):
+
+<blockquote>
 <p>This API proposes a new per-origin storage area for "Privacy Pass" style
 cryptographic tokens, which are accessible in third party contexts. These
 tokens are non-personalized and cannot be used to track users, but are
@@ -89,21 +89,21 @@ context where the user would otherwise be unknown or less trusted.
 Crucially, the tokens are indistinguishable from one another, preventing
 websites from tracking users through them.</p>
 <p>We further propose an extension mechanism for the browser to sign outgoing
-  requests with keys bound to a particular token redemption.</p>  
+  requests with keys bound to a particular token redemption.</p>
 </blockquote>
 
 
 ## Sample API usage
 
 The following is adapted from
-[sample code in the API explainer](https://github.com/WICG/trust-token-api#sample-api-usage).  
+[sample code in the API explainer](https://github.com/WICG/trust-token-api#sample-api-usage).
 
 {% Aside 'caution' %}
 The code in this post uses version 2 of the API.
 {% endAside %}
 
-Imagine that a user visits a news website (`publisher.example`) which embeds 
-advertising from a third party ad network (`foo.example`). The user has 
+Imagine that a user visits a news website (`publisher.example`) which embeds
+advertising from a third party ad network (`foo.example`). The user has
 previously used a social media site that issues trust tokens (`issuer.example`).
 
 The sequence below shows how trust tokens work.
@@ -111,12 +111,12 @@ The sequence below shows how trust tokens work.
 1.&nbsp;The user visits `issuer.example`.
 
 2.&nbsp;`issuer.example` verifies the user is a human, and runs the following
-JavaScript:  
+JavaScript:
 
 ```js
-fetch('https://issuer.example/issue', {  
-  trustToken: {  
-    type: 'token-request'  
+fetch('https://issuer.example/issue', {
+  trustToken: {
+    type: 'token-request'
   }
 });
 ```
@@ -125,52 +125,52 @@ fetch('https://issuer.example/issue', {
 
 4.&nbsp;Some time later, the user visits `publisher.example`.
 
-5.&nbsp;`publisher.example` wants to know if the user is a human, so they ask 
-`issuer.example` by running the following JavaScript:  
-  
+5.&nbsp;`publisher.example` wants to know if the user is a human, so they ask
+`issuer.example` by running the following JavaScript:
+
  ```js
  fetch('https://issuer.example/redeem', {
    trustToken: {
      type: 'token-redemption'
-   }  
- });    
+   }
+ });
 ```
 
 With this code:
 
  1. The browser requests a redemption.
- 1. The issuer returns a Signed Redemption Record (SRR) which indicates
+ 1. The issuer returns a Redemption Record (RR) which indicates
     that at some point they issued a valid token to this browser.
- 1. When the promise returned resolves, the SRR can be used in
+ 1. When the promise returned resolves, the RR can be used in
     subsequent resource requests.
 
 6.&nbsp;`publisher.example` can then run the following JavaScript in a top-level
-document:  
+document:
 
-```js  
-fetch('foo.example/get-content', {  
-  trustToken: {  
-    type: 'send-redemption-record',   
-    issuer: 'https://issuer.example'  
-  }  
-});  
+```js
+fetch('foo.example/get-content', {
+  trustToken: {
+    type: 'send-redemption-record',
+    issuer: 'https://issuer.example'
+  }
+});
 ```
 
 With this code:
 
-1. `foo.example`  receives the SRR, and now has some indication that
+1. `foo.example`  receives the RR and can parse the record to determine whether
   `issuer.example` thought this user was a human.
 1. `foo.example` responds accordingly.
 
 {% Details %}
-{% DetailsSummary %}  
-How can a website work out whether to trust you?  
-{% endDetailsSummary %}  
+{% DetailsSummary %}
+How can a website work out whether to trust you?
+{% endDetailsSummary %}
 You might have shopping history with an ecommerce site, checkins on a location
 platform, or account history at a bank. Issuers might also look at other factors
 such as how long you've had an account, or other interactions (such as CAPTCHAs
 or form submission) that increase the issuer's trust in the likelihood that
-you're a real human.  
+you're a real human.
 {% endDetails %}
 
 ### Trust token issuance
@@ -193,13 +193,13 @@ This invokes an extension of the [Privacy Pass](https://privacypass.github.io/) 
 protocol using a [new cryptographic primitive](https://eprint.iacr.org/2020/072.pdf):
 
 1. Generate a set of pseudo-random numbers known as _nonces_.
- 
-1. Blind the nonces (encode them so the issuer can't view their contents) and attach them to the 
+
+1. Blind the nonces (encode them so the issuer can't view their contents) and attach them to the
 request in a `Sec-Trust-Token` header.
- 
+
 1. Send a POST request to the endpoint provided.
- 
-The endpoint responds with blinded tokens (signatures on the blind nonces), then the tokens are 
+
+The endpoint responds with blinded tokens (signatures on the blind nonces), then the tokens are
 unblinded and stored internally together with the associated nonces by the browser as trust tokens.
 
 
@@ -214,7 +214,7 @@ const userHasTokens = await document.hasTrustToken(<issuer>);
 ````
 
 If there are tokens available, the publisher site can redeem them to get a
-signed redemption record:
+redemption record:
 
 ```js
 fetch('issuer.example/.well-known/trust-token', {
@@ -228,9 +228,9 @@ fetch('issuer.example/.well-known/trust-token', {
 }).then(...)
 ```
 
-Then the publisher site can send the SRR to requests it makes using the
+Then the publisher site can send the RR to requests it makes using the
 following API:
- 
+
 ```js
 fetch('<url>', {
   ...
@@ -242,13 +242,13 @@ fetch('<url>', {
 }).then(...);
 ```
 
-The publisher should include the SRR in requests that will require a trust
-token, such as posting a comment, liking a page, or voting in a poll.  
-  
-{% Aside %}  
+The publisher should include the RR in requests that will require a trust
+token, such as posting a comment, liking a page, or voting in a poll.
+
+{% Aside %}
 Trust tokens are only accessible through options to Fetch, XHR, and the HTML
-`<iframe>` element: they cannot be accessed directly.  
-{% endAside%}  
+`<iframe>` element: they cannot be accessed directly.
+{% endAside%}
 
 ### Privacy considerations
 
@@ -268,8 +268,8 @@ Privacy Sandbox APIs, so not discussed further here.
 supply of tokens from a particular issuer. There are several mitigations against
 this kind of attack, such as enabling issuers to provide many tokens at once, so
 users have an adequate supply of ensuring browsers only ever redeem one token
-per top-level page view.  
-  
+per top-level page view.
+
 **Double-spend prevention:** malware might attempt to access all of a user's
 trust tokens. However, tokens will run out over time, since every redemption is
 sent to the same token issuer, which can verify that each token is used only
@@ -277,7 +277,7 @@ once. To mitigate risk, issuers could also sign fewer tokens.
 
 ### Request mechanisms
 
-It might be possible to allow for sending SRRs outside of `fetch()`, for example
+It might be possible to allow for sending RRs outside of `fetch()`, for example
 with navigation requests. Sites might also be able to include issuer data in
 HTTP response headers to enable token redemption in parallel with page
 loading.
@@ -298,7 +298,7 @@ Trust Token [explainer repository](https://github.com/WICG/trust-token-api).
 
 ---
 
-Thanks to Kayce Basques, David Van Cleve, Steven Valdez, Tancrède Lepoint and Marshall Vale for 
+Thanks to Kayce Basques, David Van Cleve, Steven Valdez, Tancrède Lepoint and Marshall Vale for
 their help with writing and reviewing this post.
 
 Photo by [ZSun Fu](https://unsplash.com/photos/b4D7FKAghoE) on [Unsplash](https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText).


### PR DESCRIPTION
Changes proposed in this pull request:

- Update Trust Token blogpost to use the correct terminology.
- Specify redeemer should parse Redemption Record.
- 
