### PR TITLE
Add description and screenshots to manifest article

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
   - beaufortfrancois
 date: 2018-11-05
-updated: 2021-01-21
+updated: 2021-01-22
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile
@@ -231,16 +231,19 @@ The `description` property describes the purpose of your app.
 
 #### `categories` {: #categories }
 
-The `categories` property is an array of lowercase strings that describes the
-application categories your app belongs to.
+The `categories` property is an array of lowercase strings that indicates the
+categories that best describe your app.
 
-The current list of known categories includes books, business, donations,
-education, entertainment, finance, fitness, food, fundraising, games,
-government, health, kids, lifestyle, magazines, medical, music, navigation,
-news, personalization, photo, politics, productivity, security, shopping,
-social, sports, travel, utilities, and weather. To add more categories, file a
-bug to the [manifest-app-info
-repository](https://github.com/w3c/manifest-app-info/issues/new).
+The list of categories is defined in the [Web App Manifest - Application
+Information](https://w3c.github.io/manifest-app-info/#categories-member) spec,
+and include: books, business, donations, education, entertainment, finance,
+fitness, food, fundraising, games, government, health, kids, lifestyle,
+magazines, medical, music, navigation, news, personalization, photo, politics,
+productivity, security, shopping, social, sports, travel, utilities, and
+weather.
+
+To suggest the addition of new categories, file a bug in the [manifest-app-info
+GitHub repository](https://github.com/w3c/manifest-app-info/issues/new).
 
 #### `screenshots` {: #screenshots }
 
@@ -248,12 +251,15 @@ The `screenshots` property is an array of image objects, representing your app
 in common usage scenarios. Each object must include the `src`, a `sizes`
 property, and the `type` of image.
 
-In Chrome, the image dimensions must be at least 320px, and only JPEG and PNG
-image formats are supported.
+In Chrome, the image dimensions (width and height) must be at least 320px, and
+only JPEG and PNG image formats are supported.
 
 {% Aside 'gotchas' %}
-The `categories`, `description` and `screenshots` properties are for now used
-only on Android when a user wants to install your app.
+The `categories`, `description` and `screenshots` properties are currently used
+only in Chrome for Android when a user wants to install your app. The
+experimental flag `chrome://flags/#mobile-pwa-install-use-bottom-sheet` flag
+must be enabled in Chrome 89.
+
 {% endAside %}
 
 ## Add the web app manifest to your pages {: #link-manifest }

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -252,8 +252,8 @@ In Chrome, the image dimensions must be at least 320px, and only JPEG and PNG
 image formats are supported.
 
 {% Aside 'gotchas' %}
-The `categories`, `description` and `screenshots` properties are for now used only on
-Android when a user wants to install your app.
+The `categories`, `description` and `screenshots` properties are for now used
+only on Android when a user wants to install your app.
 {% endAside %}
 
 ## Add the web app manifest to your pages {: #link-manifest }

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
   - beaufortfrancois
 date: 2018-11-05
-updated: 2020-05-28
+updated: 2021-01-21
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile
@@ -35,7 +35,6 @@ directory).
 {
   "short_name": "Weather",
   "name": "Weather: Do I need an umbrella?",
-  "description": "Weather forecast information",
   "icons": [
     {
       "src": "/images/icons-192.png",
@@ -67,6 +66,20 @@ directory).
       "description": "View weather information for tomorrow",
       "url": "/tomorrow?source=pwa",
       "icons": [{ "src": "/images/tomorrow.png", "sizes": "192x192" }]
+    }
+  ],
+  "description": "Weather forecast information",
+  "categories": ["weather", "news"],
+  "screenshots": [
+    {
+      "src": "/images/screenshot1.png",
+      "type": "image/png",
+      "sizes": "540x720"
+    },
+    {
+      "src": "/images/screenshot2.jpg",
+      "type": "image/jpg",
+      "sizes": "540x720"
     }
   ]
 }
@@ -211,6 +224,37 @@ the app's preview in task switchers. The `theme_color` should match the
 The `shortcuts` property is an array of [app shortcut](/app-shortcuts) objects
 whose goal is to provide quick access to key tasks within your app. Each member
 is a dictionary that contains at least a `name` and a `url`.
+
+#### `description` {: #description }
+
+The `description` property describes the purpose of your app.
+
+#### `categories` {: #categories }
+
+The `categories` property is an array of lowercase strings that describes the
+application categories to which your app belongs.
+
+The current list of known categories includes books, business, donations,
+education, entertainment, finance, fitness, food, fundraising, games,
+government, health, kids, lifestyle, magazines, medical, music, navigation,
+news, personalization, photo, politics, productivity, security, shopping,
+social, sports, travel, utilities, and weather. To add more categories, file a
+bug to the [manifest-app-info
+repository](https://github.com/w3c/manifest-app-info/issues/new).
+
+#### `screenshots` {: #screenshots }
+
+The `screenshots` property is an array of image objects, representing your app
+in common usage scenarios. Each object must include the `src`, a `sizes`
+property, and the `type` of image.
+
+In Chrome, the image dimensions must be at least 320px, and only JPEG and PNG
+image formats are supported.
+
+{% Aside 'gotchas' %}
+The `categories`, `description` and `screenshots` properties are used only on
+Android for now when a user wants to install your app.
+{% endAside %}
 
 ## Add the web app manifest to your pages {: #link-manifest }
 

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -232,7 +232,7 @@ The `description` property describes the purpose of your app.
 #### `categories` {: #categories }
 
 The `categories` property is an array of lowercase strings that describes the
-application categories to which your app belongs.
+application categories your app belongs to.
 
 The current list of known categories includes books, business, donations,
 education, entertainment, finance, fitness, food, fundraising, games,
@@ -252,8 +252,8 @@ In Chrome, the image dimensions must be at least 320px, and only JPEG and PNG
 image formats are supported.
 
 {% Aside 'gotchas' %}
-The `categories`, `description` and `screenshots` properties are used only on
-Android for now when a user wants to install your app.
+The `categories`, `description` and `screenshots` properties are for now used only on
+Android when a user wants to install your app.
 {% endAside %}
 
 ## Add the web app manifest to your pages {: #link-manifest }

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
   - beaufortfrancois
 date: 2018-11-05
-updated: 2021-01-22
+updated: 2021-01-28
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile
@@ -69,7 +69,6 @@ directory).
     }
   ],
   "description": "Weather forecast information",
-  "categories": ["weather", "news"],
   "screenshots": [
     {
       "src": "/images/screenshot1.png",
@@ -229,22 +228,6 @@ is a dictionary that contains at least a `name` and a `url`.
 
 The `description` property describes the purpose of your app.
 
-#### `categories` {: #categories }
-
-The `categories` property is an array of lowercase strings that indicates the
-categories that best describe your app.
-
-The list of categories is defined in the [Web App Manifest - Application
-Information](https://w3c.github.io/manifest-app-info/#categories-member) spec,
-and include: books, business, donations, education, entertainment, finance,
-fitness, food, fundraising, games, government, health, kids, lifestyle,
-magazines, medical, music, navigation, news, personalization, photo, politics,
-productivity, security, shopping, social, sports, travel, utilities, and
-weather.
-
-To suggest the addition of new categories, file a bug in the [manifest-app-info
-GitHub repository](https://github.com/w3c/manifest-app-info/issues/new).
-
 #### `screenshots` {: #screenshots }
 
 The `screenshots` property is an array of image objects, representing your app
@@ -255,11 +238,10 @@ In Chrome, the image dimensions (width and height) must be at least 320px, and
 only JPEG and PNG image formats are supported.
 
 {% Aside 'gotchas' %}
-The `categories`, `description` and `screenshots` properties are currently used
-only in Chrome for Android when a user wants to install your app. The
-experimental flag `chrome://flags/#mobile-pwa-install-use-bottom-sheet` flag
-must be enabled in Chrome 89.
-
+The `description` and `screenshots` properties are currently used only in Chrome
+for Android when a user wants to install your app. The experimental flag
+`chrome://flags/#mobile-pwa-install-use-bottom-sheet` flag must be enabled in
+Chrome 90.
 {% endAside %}
 
 ## Add the web app manifest to your pages {: #link-manifest }


### PR DESCRIPTION
This PR adds standardized`description` ~, `categories`,~ and `screenshots` properties to the manifest article so that web developers interested in playing with the PWA install bottom sheet have some documentation.

Note that it currently requires `chrome://flags/#mobile-pwa-install-use-bottom-sheet` flag in Chrome Canary on Android.

Live preview: https://deploy-preview-4502--web-dev-staging.netlify.app/add-manifest/

@petele Can you review?