### PR TITLE
Update capabilities status

### DIFF
--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -3,9 +3,9 @@ title: Indexing your offline-capable pages with the Content Indexing API
 subhead: Enabling service workers to tell browsers which pages work offline
 authors:
   - jeffposnick
-description: Your PWA might cache articles and media files, but how will your users know that your pages work while offline? The Content Indexing API is one answer to this question currently in an origin trial. Once the index is populated with content from your PWA, as well as any other installed PWAs, it will show up in dedicated areas of supported browsers.
+description: Your PWA might cache articles and media files, but how will your users know that your pages work while offline? The Content Indexing API is one answer to this question. Once the index is populated with content from your PWA, as well as any other installed PWAs, it will show up in dedicated areas of supported browsers.
 date: 2019-12-12
-updated: 2020-05-26
+updated: 2021-01-21
 tags:
   - blog
   - capabilities
@@ -18,6 +18,11 @@ alt: Index cards in a filing cabinet.
 feedback:
   - api
 ---
+
+{% Aside 'success' %}
+The Content Indexing API, part of the [capabilities project](/fugu-status/),
+launched in Chrome&nbsp;84 for Android.
+{% endAside %}
 
 ## What is the Content Indexing API? {: #what }
 
@@ -168,9 +173,7 @@ await registration.index.add({
   id: 'article-123',
 
   // Required; url needs to be an offline-capable HTML page.
-  // For compatibility during the Origin Trial, include launchUrl as well.
   url: '/articles/123',
-  launchUrl: '/articles/123',
 
   // Required; used in user-visible lists of content.
   title: 'Article title',

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -259,7 +259,7 @@ latest version of Chrome, and in many cases other Chromium based browsers.
       </tr>
       <tr>
         <td>
-          <a href="/wakelock/">Wake Lock API</a>
+          <a href="/wake-lock/">Wake Lock API</a>
         </td>
         <td>
           To avoid draining the battery, most devices will quickly fall asleep

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -101,7 +101,7 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
         <td>
           Notification Triggers let you schedule notifications in advance, so
           that the operating system will deliver the notification at the right
-          time - even if there is no network connectivity, or the device is in
+          time-even if there is no network connectivity, or the device is in
           battery saver mode.<br>
           <em>Updated September 28, 2020</em>
         </td>
@@ -212,7 +212,7 @@ latest version of Chrome, and in many cases other Chromium based browsers.
         </td>
         <td>
           The Get Installed Related Apps API is a web platform API
-          that allows your web app to check to see if your iOS/Android app is
+          that allows your web app to check to see if your iOS or Android app is
           installed on the users device, and vice versa.<br>
           <em>Updated December 18, 2019</em>
         </td>

--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -54,20 +54,6 @@ change.<a name="shape-face-text"></a>
           <em>Updated April 14, 2020</em>
         </td>
       </tr>
-      <tr>
-        <td>
-          <a href="/notification-triggers/">
-            Notification Triggers
-          </a>
-        </td>
-        <td>
-          Notification Triggers let you schedule notifications in advance, so
-          that the operating system will deliver the notification at the right
-          time - even if there is no network connectivity, or the device is in
-          battery saver mode.<br>
-          <em>Updated August 23, 2020</em>
-        </td>
-      </tr>
     </tbody>
   </table>
 </div>
@@ -95,20 +81,6 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
     <tbody>
       <tr>
         <td>
-          <a href="/content-indexing-api/">Content Indexing API</a>
-        </td>
-        <td>
-          Your PWA might cache articles and media files, but how will your users
-          know that your pages work while offline? The Content Indexing API is
-          one answer to this question currently in an origin trial. Once the
-          index is populated with content from your PWA, as well as any other
-          installed PWAs, it will show up in dedicated areas of supported
-          browsers.<br>
-          <em>Updated December 12, 2019</em>
-        </td>
-      </tr>
-      <tr>
-        <td>
           <a href="/idle-detection/">Idle Detection API</a>
         </td>
         <td>
@@ -118,6 +90,20 @@ trials in the [Origin Trials Guide for Web Developers][ot-guide].
           moving to a different screen. A developer-defined threshold triggers
           the notification.<br>
           <em>Updated August 11, 2020</em>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/notification-triggers/">
+            Notification Triggers
+          </a>
+        </td>
+        <td>
+          Notification Triggers let you schedule notifications in advance, so
+          that the operating system will deliver the notification at the right
+          time - even if there is no network connectivity, or the device is in
+          battery saver mode.<br>
+          <em>Updated September 28, 2020</em>
         </td>
       </tr>
     </tbody>
@@ -140,17 +126,15 @@ latest version of Chrome, and in many cases other Chromium based browsers.
     <tbody>
       <tr>
         <td>
-          <a href="/wakelock/">Wake Lock API</a>
+          <a href="/image-support-for-async-clipboard/">
+            Async&nbsp;Clipboard API (images)
+          </a>
         </td>
         <td>
-          To avoid draining the battery, most devices will quickly fall asleep
-          when left idle. While this is fine most of the time, there are
-          some applications that need to keep the screen or the device awake in
-          order to complete some work. The Wake Lock API provides a way to
-          prevent the device from dimming or locking the screen or prevent
-          the device from going to sleep when an application needs to keep
-          running.<br>
-          <em>Updated June 24, 2020</em>
+          The Asynchronous Clipboard API makes it possible to read and write
+          text or image data to the clipboard, without blocking the main
+          thread.<br>
+          <em>Updated February 26, 2020</em>
         </td>
       </tr>
       <tr>
@@ -164,24 +148,17 @@ latest version of Chrome, and in many cases other Chromium based browsers.
           to subtly notify the user that there is some new activity that might
           require their attention, or it can be used to indicate a small
           amount of information, such as an unread count.<br/>
-          <div class="w-aside w-aside--note">
-          Despite a stable version of the spec shipping in Chrome 81, an origin
-          trial is running in Chrome 79 and Chrome 81 until September 15, 2020.
-          </div>
           <em>Updated March 16, 2020</em>
         </td>
       </tr>
       <tr>
         <td>
-          <a href="/image-support-for-async-clipboard/">
-            Async&nbsp;Clipboard API (images)
-          </a>
+          <a href="/camera-pan-tilt-zoom/">Camera pan, tilt, and zoom</a>
         </td>
         <td>
-          The Asynchronous Clipboard API makes it possible to read and write
-          text or image data to the clipboard, without blocking the main
-          thread.<br>
-          <em>Updated February 26, 2020</em>
+          Pan, tilt, and zoom features on cameras are accessible on the
+          web, after requesting proper user permissions.<br>
+          <em>Updated October 5, 2020</em>
         </td>
       </tr>
       <tr>
@@ -199,15 +176,15 @@ latest version of Chrome, and in many cases other Chromium based browsers.
       </tr>
       <tr>
         <td>
-          <a href="/get-installed-related-apps/">
-            Get Installed Related Apps API
-          </a>
+          <a href="/content-indexing-api/">Content Indexing API</a>
         </td>
         <td>
-          The Get Installed Related Apps API is a web platform API
-          that allows your web app to check to see if your iOS/Android app is
-          installed on the users device, and vice versa.<br>
-          <em>Updated December 18, 2019</em>
+          Your PWA might cache articles and media files, but how will your users
+          know that your pages work while offline? The Content Indexing API is
+          one answer to this question. Once the index is populated with content
+          from your PWA, as well as any other installed PWAs, it will show up in
+          dedicated areas of supported browsers.<br>
+          <em>Updated January 21, 2021</em>
         </td>
       </tr>
       <tr>
@@ -225,6 +202,19 @@ latest version of Chrome, and in many cases other Chromium based browsers.
           allows web apps to read or save changes directly to files and folders
           on the user's device.<br>
           <em>Updated September 23, 2020</em>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/get-installed-related-apps/">
+            Get Installed Related Apps API
+          </a>
+        </td>
+        <td>
+          The Get Installed Related Apps API is a web platform API
+          that allows your web app to check to see if your iOS/Android app is
+          installed on the users device, and vice versa.<br>
+          <em>Updated December 18, 2019</em>
         </td>
       </tr>
       <tr>
@@ -265,6 +255,21 @@ latest version of Chrome, and in many cases other Chromium based browsers.
           for information on other shape detection APIs that are under
           development.<br>
           <em>Updated April 14, 2020</em>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/wakelock/">Wake Lock API</a>
+        </td>
+        <td>
+          To avoid draining the battery, most devices will quickly fall asleep
+          when left idle. While this is fine most of the time, there are
+          some applications that need to keep the screen or the device awake in
+          order to complete some work. The Wake Lock API provides a way to
+          prevent the device from dimming or locking the screen or prevent
+          the device from going to sleep when an application needs to keep
+          running.<br>
+          <em>Updated June 24, 2020</em>
         </td>
       </tr>
       <tr>
@@ -328,16 +333,6 @@ latest version of Chrome, and in many cases other Chromium based browsers.
           either the Web Share API or system events, like the OS-level share
           button.<br>
           <em>Updated November 8, 2019</em>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="/camera-pan-tilt-zoom/">Camera pan, tilt, and zoom</a>
-        </td>
-        <td>
-          Pan, tilt, and zoom features on cameras are accessible on the
-          web, after requesting proper user permissions.<br>
-          <em>Updated October 5, 2020</em>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
This PR makes sure the "New capabilities status" page matches latest articles status:
- Move "Content Indexing API" from OT to Stable
- Move "Notification Triggers" from behind a flag to OT
- Order alphabetically capabilities in tables
- Remove Badging API outdated note
- Update "Content Indexing API" article to reflect shipped status

@petele @tomayac Can you review?

Live preview:
- https://deploy-preview-4503--web-dev-staging.netlify.app/fugu-status/
- https://deploy-preview-4503--web-dev-staging.netlify.app/content-indexing-api/