### PR TITLE
Don't let bugs get closed as stale.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ exemptLabels:
   - pinned
   - accepted
   - Epic
+  - bug
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Exempts the `bug` label from being marked as stale and closed by the stalebot.

We originally added the stalebot because content PRs were going stale and it should continue to serve that function. But we want to avoid legitimate bugs from being closed, especially when we're heads down working on a different project (like we recently were with developer.chrome.com).