### PR TITLE
Web share updates for M89

### DIFF
--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -261,7 +261,7 @@ the `text` field, or occasionally in the `title` field.
 As of early 2021, the Web Share Target API is supported by:
 
 - Chrome and Edge 76 or later on Android.
-- Chrome 89+ on Chrome OS.
+- Chrome 89 or later on Chrome OS.
 
 On all platforms, your web app has to be [installed][installability] before it will show up as a
 potential target for receiving shared data.

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -221,19 +221,19 @@ a request, the page passes it to the service worker, where you can intercept it 
 page using `postMessage()` or pass it on to the server:
 
 ```js
-self.addEventListener('fetch', event   => {
-  // If this isn't an incoming POST request, this
-  // fetch handler doesn't need to respond.
-  if (event.request.method !== 'POST') {
-    return;
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  // If this is an incoming POST request for the
+  // registered "action" URL, respond to it.
+  if (event.request.method === 'POST' &&
+      url.pathname === '/bookmark') {
+    event.respondWith((async () => {
+      const formData = await event.request.formData();
+      const link = formData.get('link') || '';
+      const responseUrl = await saveBookmark(link);
+      return Response.redirect(responseUrl, 303);
+    })());
   }
-
-  event.respondWith((async () => {
-    const formData = await event.request.formData();
-    const link = formData.get('link') || '';
-    const responseUrl = await saveBookmark(link);
-    return Response.redirect(responseUrl, 303);
-  })());
 });
 ```
 

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -205,8 +205,10 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-Be sure to use a service worker to [precache](https://web.dev/precache-with-workbox/) the `action`
+Be sure to use a service worker to [precache](https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker) the `action`
 page so that it will load quickly and work reliably, even if the user is offline.
+[Workbox](https://developers.google.com/web/tools/workbox/) is a tool that can help you
+[implement precaching](https://web.dev/precache-with-workbox/) in your service worker.
 
 ### Processing POST shares
 

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
   - joemedley
 date: 2019-11-08
-updated: 2020-08-05
+updated: 2020-01-26
 hero: hero.png
 alt: An illustration demonstrating that platform-specific apps can now share content with web apps.
 description: |
@@ -29,8 +29,6 @@ In the past, only platform-specific apps could register with the operating syste
 receive shares from other installed apps. But with the Web Share Target API,
 installed web apps can register with the underlying operating system
 as a share target to receive shared content.
-Support for text and data was added in Chrome 71, and
-support for files was added in Chrome 76.
 
 {% Aside %}
 The Web Share Target API is only half of the magic. Web apps can share data,
@@ -47,7 +45,8 @@ files, links, or text using the Web Share API. See
 
 ## See Web Share Target in action
 
-1. Using Chrome 76 or later (Android only), open the [Web Share Target demo][demo].
+1. Using Chrome 76 or later (on Android), or Chrome 89 or later (on Chrome OS) open the
+   [Web Share Target demo][demo].
 2. When prompted, click **Install** to add the app to your home screen, or
    use the Chrome menu to add it to your home screen.
 3. Open any app that supports sharing, or use the Share button
@@ -206,8 +205,8 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-Be sure to use a service worker to precache the `action` page so that it will
-load quickly and work reliably, even if the user is offline.
+Be sure to use a service worker to [precache](https://web.dev/precache-with-workbox/) the `action`
+page so that it will load quickly and work reliably, even if the user is offline.
 
 ### Processing POST shares
 
@@ -222,9 +221,10 @@ a request, the page passes it to the service worker, where you can intercept it 
 page using `postMessage()` or pass it on to the server:
 
 ```js
-self.addEventListener('fetch', event => {
+self.addEventListener('fetch', event   => {
+  // If this isn't an incoming POST request, this
+  // fetch handler doesn't need to respond.
   if (event.request.method !== 'POST') {
-    event.respondWith(fetch(event.request));
     return;
   }
 
@@ -255,6 +255,22 @@ it's not supported in Android's share system. Instead, URLs will often appear in
 the `text` field, or occasionally in the `title` field.
 
 <div class="w-clearfix"></div>
+
+## Browser support
+
+As of early 2021, the Web Share Target API is supported by:
+
+- Chrome and Edge 76+ on Android.
+- Chrome 89+ on Chrome OS.
+
+On all platforms, your web app has to be [installed][installability] before it will show up as a
+potential target for receiving shared data.
+
+## Sample applications
+
+- [Squoosh](https://github.com/GoogleChromeLabs/squoosh)
+- [Scrapbook PWA](https://github.com/GoogleChrome/samples/blob/gh-pages/web-share/README.md#web-share-demo)
+
 
 [spec]: https://wicg.github.io/web-share-target/
 [demo]: https://web-share.glitch.me/

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -20,7 +20,7 @@ feedback:
   - api
 ---
 
-On a mobile device, sharing should be as simple as clicking the **Share** button,
+On a mobile device, sharing should be as straightforward as clicking the **Share** button,
 choosing an app, and choosing who to share with. For example, you may want to
 share an interesting article, either by emailing it to friends or tweeting it to
 the world.

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -260,7 +260,7 @@ the `text` field, or occasionally in the `title` field.
 
 As of early 2021, the Web Share Target API is supported by:
 
-- Chrome and Edge 76+ on Android.
+- Chrome and Edge 76 or later on Android.
 - Chrome 89+ on Chrome OS.
 
 On all platforms, your web app has to be [installed][installability] before it will show up as a

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -136,10 +136,10 @@ with games and educational experiences.
 
 In 2016, the Santa Tracker team used the Web Share API on Android.
 This API was a perfect fit for mobile.
-In previous years, the team disabled share buttons on mobile because space is
+In previous years, the team removed share buttons on mobile because space is
 at a premium, and they couldn't justify having several share targets.
 
-But with the Web Share API, they were able to present just one button,
+But with the Web Share API, they were able to present one button,
 saving precious pixels.
 They also found that users shared with Web Share around 20% more than
 users without the API enabled. Head to

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -155,13 +155,12 @@ supported.
 
 As of early 2021, using the API to share title, text, and URL is supported by:
 
-- Safari 12+ on macOS and iOS.
-- Chrome 75+ on Android, and 89+ on Chrome OS and Windows.
+- Safari 12 or later on macOS and iOS.
+- Chrome 75 or later on Android, and 89 or later on Chrome OS and Windows.
 
 Using the API to share files is supported by:
 
-- Chrome 75 or later on Android
-- 89 or later on Chrome OS and Windows.
+- Chrome 75 or later on Android, and 89 or later on Chrome OS and Windows.
 
 (Most Chromium-based browsers, like Edge, have the same support for this feature as the
 corresponding version of Chrome.)

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -4,7 +4,7 @@ subhead: Web apps can use the same system-provided share capabilities as platfor
 authors:
   - joemedley
 date: 2019-11-08
-updated: 2020-05-12
+updated: 2020-01-26
 hero: hero.png
 alt: An illustration demonstrating that web apps can use the system-provided sharing UI.
 description: |
@@ -43,14 +43,12 @@ way as platform-specific apps.
 ### Capabilities and limitations
 
 Web share has the following capabilities and limitations:
-* It can only be used on a site that supports HTTPS.
+* It can only be used on a site that is [accessed via HTTPS](https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features).
 * It must be invoked in response to a user action such as a click. Invoking it
-  through the `onload` handler is impossible.
-* It can share, URLs, text, or files.
-* As of mid 2020, it is only available on Safari and on Android in Chromium
-  forks. See
-  [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#Browser_compatibility)
-  for details.
+  through the `onload` handler is not allowed.
+* It can share URLs, text, and in some browsers, files.
+* Some features are only available on specific combinations of browsers and platforms. Please see
+  the [browser support](#browser-support) section for more details.
 
 <div class="w-clearfix"></div>
 
@@ -94,7 +92,7 @@ const canonicalElement = document.querySelector('link[rel=canonical]');
 if (canonicalElement !== null) {
     url = canonicalElement.href;
 }
-navigator.share({url: url});
+navigator.share({url});
 ```
 
 ### Sharing files
@@ -102,7 +100,7 @@ navigator.share({url: url});
 To share files, first test for and call `navigator.canShare()`. Then include an
 array of files in the call to `navigator.share()`:
 
-```js/0-4
+```js/0-5
 if (navigator.canShare && navigator.canShare({ files: filesArray })) {
   navigator.share({
     files: filesArray,
@@ -149,6 +147,25 @@ users without the API enabled. Head to
 
 <div class="w-clearfix"></div>
 
+## Browser support
+
+Browser support for the Web Share API is nuanced, and it's recommended that you use feature
+detection (as described in the earlier code samples) instead of assuming that a particular method is
+supported.
+
+As of early 2021, using the API to share title, text, and URL is supported by:
+
+- Safari 12+ on macOS and iOS.
+- Chrome 75+ on Android, and 89+ on Chrome OS and Windows.
+
+Using the API to share files is supported by:
+
+- Chrome 75+ on Android, and 89+ on Chrome OS and Windows.
+
+(Most Chromium-based browsers, like Edge, have the same support for this feature as the
+corresponding version of Chrome.)
+
 ## Helpful Links
 
-[Web Share Demos](https://w3c.github.io/web-share/demos/share-files.html)
+- [Web Share Demos](https://w3c.github.io/web-share/demos/share-files.html)
+- [Scrapbook PWA](https://github.com/GoogleChrome/samples/blob/gh-pages/web-share/README.md#web-share-demo)

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -48,7 +48,7 @@ Web share has the following capabilities and limitations:
   through the `onload` handler is not allowed.
 * It can share URLs, text, and in some browsers, files.
 * Some features are only available on specific combinations of browsers and platforms. Please see
-  the [browser support](#browser-support) section for more details.
+  the [browser support](#browser-support) section for details.
 
 <div class="w-clearfix"></div>
 

--- a/src/site/content/en/blog/web-share/index.md
+++ b/src/site/content/en/blog/web-share/index.md
@@ -160,7 +160,8 @@ As of early 2021, using the API to share title, text, and URL is supported by:
 
 Using the API to share files is supported by:
 
-- Chrome 75+ on Android, and 89+ on Chrome OS and Windows.
+- Chrome 75 or later on Android
+- 89 or later on Chrome OS and Windows.
 
 (Most Chromium-based browsers, like Edge, have the same support for this feature as the
 corresponding version of Chrome.)


### PR DESCRIPTION
This updates the Web Share and Web Share Target blog posts to account for changes in Chrome 89, and to make the browser-support story more accurate in general.

R: @jpmedley @petele 