### PR TITLE
Add `screenshots` criteria

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -5,7 +5,7 @@ authors:
   - petelepage
   - beaufortfrancois
 date: 2018-11-05
-updated: 2021-01-28
+updated: 2021-01-29
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile
@@ -234,8 +234,12 @@ The `screenshots` property is an array of image objects, representing your app
 in common usage scenarios. Each object must include the `src`, a `sizes`
 property, and the `type` of image.
 
-In Chrome, the image dimensions (width and height) must be at least 320px, and
-only JPEG and PNG image formats are supported.
+In Chrome, the image dimensions must respond to certain criteria:
+
+* Width and height must be at least 320px.
+* The max dimension can't be twice larger than the min dimension.
+* Screenshots must have the same dimensions.
+* Only JPEG and PNG image formats are supported. 
 
 {% Aside 'gotchas' %}
 The `description` and `screenshots` properties are currently used only in Chrome

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -237,7 +237,7 @@ property, and the `type` of image.
 In Chrome, the image dimensions must respond to certain criteria:
 
 * Width and height must be at least 320px.
-* The max dimension can't be twice larger than the min dimension.
+* The maximum dimension can't be twice larger than the minimum dimension.
 * Screenshots must have the same dimensions.
 * Only JPEG and PNG image formats are supported. 
 


### PR DESCRIPTION
This PR updates the "Add a web app manifest" article with new criteria for the `screenshots` web app manifest property.

@petele FYI