### PR TITLE
Update end date for AppCache origin trial

### DIFF
--- a/src/site/content/en/blog/appcache-removal/index.md
+++ b/src/site/content/en/blog/appcache-removal/index.md
@@ -5,7 +5,7 @@ authors:
   - jeffposnick
 description: Details of Chrome's and other browsers' plans to remove AppCache.
 date: 2020-05-18
-updated: 2020-05-18
+updated: 2020-02-01
 scheduled: true
 tags:
   - appcache
@@ -74,7 +74,7 @@ A "deprecated" feature still exists, but logs warning messages discouraging use.
     <tr>
     <td>Complete removal from secure contexts for everyone, with completion of origin trial
     </td>
-    <td>Chrome 90 (<a href="https://chromiumdash.appspot.com/schedule">estimated April 2021</a>)
+    <td>Chrome 93 (<a href="https://chromiumdash.appspot.com/schedule">estimated October 2021</a>)
     </td>
     </tr>
   </table>

--- a/src/site/content/en/blog/appcache-removal/index.md
+++ b/src/site/content/en/blog/appcache-removal/index.md
@@ -5,7 +5,7 @@ authors:
   - jeffposnick
 description: Details of Chrome's and other browsers' plans to remove AppCache.
 date: 2020-05-18
-updated: 2020-02-01
+updated: 2021-02-01
 scheduled: true
 tags:
   - appcache


### PR DESCRIPTION
The end date of the [AppCache OT](https://developer.chrome.com/origintrials/#/view_trial/1776670052997660673) has been updated. It will now end with Chrome 93.