### PR TITLE
Add a note about `registrationStrategy`

### DIFF
--- a/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
+++ b/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
@@ -44,6 +44,17 @@ This command will:
 * Add the [`theme-color`](/themed-omnibox) `<meta>` tag to `index.html`.
 * Create app icons in the `src/assets` directory.
 
+## Register the service worker at startup
+
+In `app.module.ts`, make sure the service worker starts immediately so it can serve pages when offline:
+
+```typescript
+ServiceWorkerModule.register('ngsw-worker.js', {
+  enabled: environment.production,
+  registrationStrategy: 'registerImmediately',
+}),
+```
+
 ## Customize your PWA
 
 The [Precaching with the Angular service worker](/precaching-with-the-angular-service-worker) post explains how to configure the Angular service worker. There you can find how to specify which resources you want the service worker to cache and what strategy it should use to do so.

--- a/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
+++ b/src/site/content/en/angular/creating-pwa-with-angular-cli/index.md
@@ -44,16 +44,7 @@ This command will:
 * Add the [`theme-color`](/themed-omnibox) `<meta>` tag to `index.html`.
 * Create app icons in the `src/assets` directory.
 
-## Register the service worker at startup
-
-In `app.module.ts`, make sure the service worker starts immediately so it can serve pages when offline:
-
-```typescript
-ServiceWorkerModule.register('ngsw-worker.js', {
-  enabled: environment.production,
-  registrationStrategy: 'registerImmediately',
-}),
-```
+By default, your service worker should be registered within a few seconds of the first page load. If it isn't, consider modifying the [`registrationStrategy`](https://angular.io/api/service-worker/SwRegistrationOptions).
 
 ## Customize your PWA
 


### PR DESCRIPTION
I was following this guide to add PWA functionality to an Angular 11 app, but the Lighthouse tool was claiming I [still had no service worker](https://web.dev/service-worker/?utm_source=lighthouse&utm_medium=devtools) despite the fact that it was there. I also noticed that the service worker would take a long time to be installed.

Lo and behold, the default strategy can [take up to 30 seconds](https://stackoverflow.com/a/61152966/587091) to install the service worker. I don't know if you want this article to recommend `registerImmediately`, but at least the `registrationStrategy` property should be discussed.
