### PR TITLE
Update the PR template to mention the proposal form and draft mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,8 @@
-<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
-     to merge this PR immediately after approving it. -->
+<!-- Googlers: Please complete go/web.dev-content-proposal before
+     submitting PRs that create new pages of content. -->
+
+<!-- If you're PR isn't ready for review yet, please set it to draft mode:
+     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
 
 Fixes #SOME_ISSUE_NUMBER
 


### PR DESCRIPTION
@robdodson this updates the PR template to mention that people should fill out our content proposal form before submitting pull requests that create new content. It also mentions PR draft mode.

Fixes #3356 