### PR TITLE
Fix hidden caution on mobile

### DIFF
--- a/src/site/content/en/blog/how-to-use-local-https/index.md
+++ b/src/site/content/en/blog/how-to-use-local-https/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-{% Banner 'caution' %}
+{% Banner 'caution', 'body' %}
 Most of the time, `http://localhost` does what you need: in browsers, it mostly behaves like HTTPS 🔒. That's why some APIs that won't work on a deployed HTTP site, will work on `http://localhost`.
 
 What this means is that you need to use HTTPS locally **only in special cases** (see [When to use HTTPS for local development](/when-to-use-local-https)), like custom hostnames or Secure cookies across browsers. Keep reading if that's you!

--- a/src/site/content/en/blog/how-to-use-local-https/index.md
+++ b/src/site/content/en/blog/how-to-use-local-https/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-{% Banner 'caution', 'body' %}
+{% Banner 'caution' %}
 Most of the time, `http://localhost` does what you need: in browsers, it mostly behaves like HTTPS 🔒. That's why some APIs that won't work on a deployed HTTP site, will work on `http://localhost`.
 
 What this means is that you need to use HTTPS locally **only in special cases** (see [When to use HTTPS for local development](/when-to-use-local-https)), like custom hostnames or Secure cookies across browsers. Keep reading if that's you!
@@ -72,7 +72,7 @@ The mkcert we're interested in in this post is [this one](https://github.com/Fil
 
 ### Caution
 
-{% Banner 'caution' %}
+{% Banner 'caution', 'body' %}
 
 - Never export or share the file `rootCA-key.pem` mkcert creates automatically when you run `mkcert -install`. **An attacker getting hold of this file can create on-path attacks for any site you may be visiting**. They could intercept secure requests from your machine to any site—your bank, healthcare provider, or social networks. If you need to know where `rootCA-key.pem` is located to make sure it's safe, run `mkcert -CAROOT`.
 - Only use mkcert for **development purposes**—and by extension, never ask end-users to run mkcert commands.


### PR DESCRIPTION
This image is https://web.dev/how-to-use-local-https/ on mobile emulation. The caution is not visible. I've fixed it by adding body class.

![image](https://user-images.githubusercontent.com/446352/106924827-d432a480-6752-11eb-9d67-30ef68570c51.png)
