### PR TITLE
Remove the threshold recommendation for FCP

### DIFF
--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -130,13 +130,6 @@ for a complete example of how to measure FCP in JavaScript.
   of the `web-vitals` library for details.
 {% endAside %}
 
-## What is a good FCP score?
-
-To provide a good user experience, sites should strive to have First Contentful
-Paint occur within **1 second** of the page starting to load. To ensure you're
-hitting this target for most of your users, a good threshold to measure is the
-**75th percentile** of page loads, segmented across mobile and desktop devices.
-
 ## How to improve FCP
 
 To learn how to improve FCP for a specific site, you can run a Lighthouse


### PR DESCRIPTION
Fixes #4128

We decided several months ago that any Web Vitals metrics that aren't part of the set of Core Web Vitals should not suggest a threshold in their web.dev guidance. In some cases tools like Lighthouse or PSI may still give a score, but we're not going to be suggesting a threshold for field data in our web.dev metric guidance.