### PR TITLE
Improve body banner and list styles

### DIFF
--- a/src/site/content/en/blog/how-to-use-local-https/index.md
+++ b/src/site/content/en/blog/how-to-use-local-https/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-{% Banner 'caution' %}
+{% Banner 'caution', 'body' %}
 Most of the time, `http://localhost` does what you need: in browsers, it mostly behaves like HTTPS 🔒. That's why some APIs that won't work on a deployed HTTP site, will work on `http://localhost`.
 
 What this means is that you need to use HTTPS locally **only in special cases** (see [When to use HTTPS for local development](/when-to-use-local-https)), like custom hostnames or Secure cookies across browsers. Keep reading if that's you!
@@ -72,7 +72,7 @@ The mkcert we're interested in in this post is [this one](https://github.com/Fil
 
 ### Caution
 
-{% Banner 'caution' %}
+{% Banner 'caution', 'body' %}
 
 - Never export or share the file `rootCA-key.pem` mkcert creates automatically when you run `mkcert -install`. **An attacker getting hold of this file can create on-path attacks for any site you may be visiting**. They could intercept secure requests from your machine to any site—your bank, healthcare provider, or social networks. If you need to know where `rootCA-key.pem` is located to make sure it's safe, run `mkcert -CAROOT`.
 - Only use mkcert for **development purposes**—and by extension, never ask end-users to run mkcert commands.
@@ -236,7 +236,7 @@ To run your local development site with HTTPS:
 3.  Configure your development server to use HTTPS and the certificate you've created in Step 2.
 4.  ✨ You're done! You can now access `https://{YOUR HOSTNAME}` in your browser, without warnings
 
-{% Banner 'caution' %}
+{% Banner 'caution', 'body' %}
 
 Do this only for **development purposes** and **never export or share** the file `rootCA-key.pem` (if you need to know where this file is located to make sure it's safe, run `mkcert -CAROOT`).
 

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -56,5 +56,18 @@
 .w-banner--body {
   display: block;
   font: inherit;
-  padding: 24px;
+  padding: 8px;
+
+  > * {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  > * + * {
+    margin-top: 24px;
+  }
+
+  @include bp(md) {
+    padding: 24px;
+  }
 }

--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -13,7 +13,7 @@ ol:not([class]) {
   counter-reset: ol-step-counter;
   list-style: none;
   margin: 32px 0;
-  padding-left: 48px;
+  padding-left: 32px;
   position: relative;
 }
 
@@ -51,7 +51,7 @@ ol:not([class]) > li::before {
 ul:not([class]) {
   list-style: none;
   margin: 32px 0;
-  padding-left: 48px;
+  padding-left: 24px;
   position: relative;
 }
 


### PR DESCRIPTION
Fixes #4597

Changes proposed in this pull request:

- Improve the look of the Banner shortcode when it's used as a body banner.
- Improves the look of lists (reduces the space between the bullet and the list content).

cc @maudnals @kaycebasques if y'all are using the `Banner` shortcode, make sure to include the `'body'` argument, otherwise it gets hidden on mobile.