### PR TITLE
Fix Netlify CDN reference link

### DIFF
--- a/src/site/content/en/blog/love-your-cache/index.md
+++ b/src/site/content/en/blog/love-your-cache/index.md
@@ -130,7 +130,7 @@ great coverage, but not for those folks who might be on slower mobile
 connections or using poor infrastructure.
 
 Regardless, this is a modern approach that
-[is the default on a popular CDN, Netlify](https://www.netlify.com/blog/2017/02/23/better-living-through-caching/https://www.netlify.com/blog/2017/02/23/better-living-through-caching/),
+[is the default on a popular CDN, Netlify](https://www.netlify.com/blog/2017/02/23/better-living-through-caching/),
 but can be configured on nearly any CDN. For Firebase Hosting, you can include
 this header
 [in the hosting section](https://firebase.google.com/docs/hosting/full-config#headers)


### PR DESCRIPTION
Changes proposed in this pull request:
* 🔗 URL was doubled in the README markdown

