### PR TITLE
Trust Tokens docs: clean up a few syntax errors, and add context to a…

### DIFF
--- a/src/site/content/en/blog/trust-tokens/index.md
+++ b/src/site/content/en/blog/trust-tokens/index.md
@@ -113,7 +113,7 @@ The following is adapted from
 [sample code in the API explainer](https://github.com/WICG/trust-token-api#sample-api-usage).
 
 {% Aside 'caution' %}
-The code in this post uses version 2 of the API.
+The code in this post uses updated syntax available since Chrome 88.
 {% endAside %}
 
 Imagine that a user visits a news website (`publisher.example`) which embeds
@@ -165,7 +165,7 @@ document:
 fetch('foo.example/get-content', {
   trustToken: {
     type: 'send-redemption-record',
-    issuer: 'https://issuer.example'
+    issuers: ['https://issuer.example']
   }
 });
 ```
@@ -197,8 +197,7 @@ If the user is deemed to be trustworthy by a trust token issuer such as
 ```js
 fetch('issuer.example/.well-known/trust-token', {
   trustToken: {
-    type: 'token-request',
-    issuer: <issuer>
+    type: 'token-request'
   }
 }).then(...)
 ```
@@ -235,7 +234,6 @@ fetch('issuer.example/.well-known/trust-token', {
   ...
   trustToken: {
     type: 'token-redemption',
-    issuer: 'issuer.example',
     refreshPolicy: 'none'
   }
   ...
@@ -250,7 +248,7 @@ fetch('<url>', {
   ...
   trustToken: {
     type: 'send-redemption-record',
-    issuer: <issuer>,
+    issuers: [<issuer>, ...]
   }
   ...
 }).then(...);

--- a/src/site/content/en/blog/trust-tokens/index.md
+++ b/src/site/content/en/blog/trust-tokens/index.md
@@ -112,7 +112,7 @@ websites from tracking users through them.</p>
 The following is adapted from
 [sample code in the API explainer](https://github.com/WICG/trust-token-api#sample-api-usage).
 
-{% Aside 'caution' %}
+{% Aside %}
 The code in this post uses updated syntax available since Chrome 88.
 {% endAside %}
 


### PR DESCRIPTION
… callout

This change makes two small changes to web.dev/trust-tokens:

* It updates examples' syntax to no longer use the `issuer` argument in issuance and redemption operations (it's not used in these operations), and to swap it out for `issuers`, a list, in signing operations.
* It replaces a reference to "version 2 of the API" in a "Caution" callout with "updated syntax available since Chrome 88"; the reference to "version 2" seems hard to interpret since we don't give the reader any definition of the different versions.

**Reviewer**: It struck me that the "Caution" callout style is a little alarming and might be better suited for some kind of security-relevant usage warning than for a notification about a minimum version necessary for compatibility with an update to the API's syntax. Is there a more appropriate parameter I could provide to the {%aside%} tag?
