### PR TITLE
Remove link to Raw Clipboard design doc

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -6,7 +6,7 @@ authors:
   - thomassteiner
 description: Async Clipboard API simplifies permissions-friendly copy and paste.
 date: 2020-07-31
-updated: 2020-11-16
+updated: 2021-02-08
 tags:
   - blog
   - capabilities
@@ -413,7 +413,6 @@ Happy copying and pasting!
 ## Related links
 
 * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
-* [Raw Clipboard Access Design Doc](https://docs.google.com/document/d/1XDOtTv8DtwTi4GaszwRFIJCOuzAEA4g9Tk0HrasQAdE/edit?usp=sharing)
 
 ## Acknowledgements
 


### PR DESCRIPTION
The Raw Clipboard API proposal is no longer being pursued for security reasons.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
