### PR TITLE
Don't show lastmod if we don't have a date or updated.

### DIFF
--- a/src/site/content/sitemap.xml.njk
+++ b/src/site/content/sitemap.xml.njk
@@ -13,10 +13,12 @@ permalink: "/sitemap.xml"
   {% set fullUrl %}{{ site.url }}{{ page.url }}{% endset %}
   <url>
     <loc>{{ fullUrl }}</loc>
-    {%- if page.data.updated %}
-    <lastmod>{{ page.data.updated | htmlDateString }}</lastmod>
-    {%- else %}
-    <lastmod>{{ page.data.date | htmlDateString }}</lastmod>
+    {%- set lastMod = page.data.date -%}
+    {%- if page.data.updated -%}
+      {%- set lastMod = page.data.updated -%}
+    {%- endif -%}
+    {%- if lastMod %}
+    <lastmod>{{ lastMod | htmlDateString }}</lastmod>
     {%- endif %}
   </url>
   {%- endif %}


### PR DESCRIPTION
I noticed we had a few sitemap errors in search console because we were doing `<lastmod></lastmod>`

Because `lastmod` is optional, this just removes it if we don't have a confident date or updated date for a page. Search says that they generally ignore lastmod anyway but I figure it's good to not have sitemap errors.