### PR TITLE
Escape HTML titles/descriptions when displaying them as search results

### DIFF
--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -9,6 +9,7 @@ import {store} from '../../store';
 import * as router from '../../utils/router';
 import {debounce} from '../../utils/debounce';
 import {trackError} from '../../analytics';
+import {allowHtml, escapeHtml} from '../../../lib/utils/escape-html';
 import 'focus-visible';
 import './_styles.scss';
 
@@ -223,8 +224,19 @@ class Search extends BaseElement {
     // This is intentional because focus needs to stay in the input field.
     // When the user is pressing arrow keys, we use a virtual cursor and
     // aria-activedescendant to indicate the active anchor.
-    return this.hits.map(
-      (hit, idx) => html`
+    return this.hits.map((hit, idx) => {
+      if (!hit._highlightResult.title || !hit._highlightResult.title.value) {
+        return html``;
+      }
+
+      let title = hit._highlightResult.title.value;
+      // Escape any html entities in the title except for <strong> tags.
+      // Algolia sends back <strong> tags in the title which help highlight
+      // the characters that match what the user has typed.
+      title = allowHtml(escapeHtml(title), 'strong');
+      // Strip backticks as they look a bit ugly in the results.
+      title = title.replace(/`/g, '');
+      return html`
         <li class="web-search-popout__item">
           <a
             id="web-search-popout__link--${idx}"
@@ -234,13 +246,11 @@ class Search extends BaseElement {
             aria-selected="${idx === this.cursor}"
             tabindex="-1"
             href="${hit.url}"
-            >${unsafeHTML(
-              hit._highlightResult.title && hit._highlightResult.title.value,
-            )}</a
+            >${unsafeHTML(title)}</a
           >
         </li>
-      `,
-    );
+      `;
+    });
   }
   /* eslint-enable indent */
 

--- a/src/lib/utils/escape-html.js
+++ b/src/lib/utils/escape-html.js
@@ -1,0 +1,20 @@
+/**
+ * Sanitize an HTML string by escaping < and > characters.
+ * @param {string} str A string to sanitize
+ * @return {string}
+ */
+export const escapeHtml = (str) => {
+  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+};
+
+/**
+ * Allow a specific tag to be unescaped.
+ * @param {string} str A string which has already been escaped
+ * @param {string} tag The html tag to allow. E.g. "strong"
+ * @return {string}
+ */
+export const allowHtml = (str, tag) => {
+  const open = new RegExp(`&lt;${tag}&gt;`, 'g');
+  const close = new RegExp(`&lt;/${tag}&gt;`, 'g');
+  return str.replace(open, `<${tag}>`).replace(close, `</${tag}>`);
+};


### PR DESCRIPTION
Fixes #4575

Changes proposed in this pull request:

- Escape html entities (but allow `<strong>` tags) in search results. We allow strong tags because Algolia sends them back in the results to indicate which letters in the title match what the user was typing. The effect is really subtle and hard to see on the current site, but more noticeable on d.c.c.