### PR TITLE
Updated encoding and conversiondestination definition

### DIFF
--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -154,10 +154,9 @@ timing](#report-timing)).
 
 The Event Conversion Measurement API can be supported:
 
-- As an [origin trial](/origin-trials/), from Chrome 86 beta and Chrome 87 (stable from mid-November
-  2020), to Chrome 88 (February 2021). Origin trials enable the API for **all visitors** of a given
+- As an [origin trial](/origin-trials/). Origin trials enable the API for **all visitors** of a given
   [origin](/same-site-same-origin/#origin). **You need to register your origin for the origin trial
-  in order to try the API with end users**.
+  in order to try the API with end users**. See [Using the conversion measurement API](/using-conversion-measurement) for details about the origin trial.
 - By turning on flags, in Chrome 86 and later. Flags enable the API on a **single user**'s browser.
   **Flags are useful when developing locally**.
 
@@ -390,7 +389,7 @@ attributes:
 ```html
 <a
   id="ad"
-  impressiondata="776f09351f5809c5"
+  impressiondata="200400600"
   conversiondestination="https://advertiser.example"
   reportingorigin="https://adtech.example"
   impressionexpiry="864000000"
@@ -417,7 +416,7 @@ This code specifies the following:
         <td><code>impressiondata</code> (required): a <b>64-bit</b> identifier to attach to an ad click.</td>
         <td>(no default)</td>
         <td>A dynamically generated click ID  such as a 64-bit integer:
-          <code>776f09351f5809c5</code>
+          <code>200400600</code>
         </td>
       </tr>
       <tr>
@@ -471,7 +470,7 @@ committed, the browser stores an object that includes `impressiondata`, `convers
 
 ```json
 {
-  "impression-data": "776f09351f5809c5",
+  "impression-data": "200400600",
   "conversion-destination": "https://advertiser.example",
   "reporting-origin": "https://adtech.example",
   "impression-expiry": 864000000
@@ -553,7 +552,7 @@ Once the scheduled time to send the report is reached, the browser sends the **c
 it sends an HTTP POST to the reporting origin that was specified in the `<a>` element
 (`adtech.example`). For example:
 
-`https://adtech.example/.well-known/register-conversion?impression-data=776f09351f5809c5&conversion-data=2&credit=100`
+`https://adtech.example/.well-known/register-conversion?impression-data=200400600&conversion-data=2&credit=100`
 
 Included as parameters are:
 
@@ -567,7 +566,7 @@ As the adtech server receives this request, it can pull the `impression-data` an
 from it, i.e. the conversion report:
 
 ```json
-{"impression-data": "776f09351f5809c5", "conversion-data": 3, "credit": 100}
+{"impression-data": "200400600", "conversion-data": 3, "credit": 100}
 ```
 
 ### Subsequent conversions and expiry

--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -416,14 +416,15 @@ This code specifies the following:
       <tr>
         <td><code>impressiondata</code> (required): a <b>64-bit</b> identifier to attach to an ad click.</td>
         <td>(no default)</td>
-        <td>A dynamically generated click ID  such as a hex-encoded 64-bit integer:
+        <td>A dynamically generated click ID  such as a 64-bit integer:
           <code>776f09351f5809c5</code>
         </td>
       </tr>
       <tr>
-        <td><code>conversiondestination</code> (required): the <b>origin</b> where a conversion is expected for this ad.</td>
+        <td><code>conversiondestination</code> (required): the <b><a href="https://web.dev/same-site-same-origin/#site" noopener>eTLD+1</a></b> where a conversion is expected for this ad.</td>
         <td>(no default)</td>
-        <td><code>https://advertiser.example</code></td>
+        <td><code>https://advertiser.example</code>.<br/>If the <code>conversiondestination</code> is <code>https://advertiser.example</code>, conversions on both <code>https://advertiser.example</code> and <code>https://shop.advertiser.example</code> will be attributed.<br/>The same happens if the <code>conversiondestination</code> is <code>https://shop.advertiser.example</code>: conversions on both <code>https://advertiser.example</code> and <code>https://shop.advertiser.example</code> will be attributed. 
+        </td>
       </tr>
       <tr>
         <td><code>impressionexpiry</code> (optional): in milliseconds, the cutoff time for when conversions can be attributed to this ad.</td>
@@ -453,9 +454,9 @@ Some notes about the example:
 
 - You will find the term "impression" used in the attributes of the API or in the API proposal, even
   though only clicks are supported for now. Names may be updated in future iterations of the API.
-- The conversion destination is an [origin](/same-site-same-origin/#origin). This may change in the
-  future to specify just an [eTLD+1](/same-site-same-origin/#site).
-- The ad doesn't have to be in an iframe, but this is what this example is based on. {% endAside %}
+- The ad doesn't have to be in an iframe, but this is what this example is based on.
+
+{% endAside %}
 
 {% Aside 'gotchas' %}
 
@@ -476,9 +477,6 @@ committed, the browser stores an object that includes `impressiondata`, `convers
   "impression-expiry": 864000000
 }
 ```
-
-{% Aside %} In the demo and in this example, the 64-bit impression data (click ID) is encoded as a
-hexadecimal string. {% endAside %}
 
 ### Conversion and report scheduling (steps 6 to 9)
 
@@ -627,8 +625,6 @@ it](#share-your-feedback). {% endAside %}
 - API and attribute naming may evolve.
 - Click data and conversion data may not require encoding.
 - The 3-bit limit for conversion data may be increased or decreased.
-- The conversion destination may become an eTLD+1; right now, it's an
-  [origin](/same-site-same-origin/#origin).
 - [More features may be added](#what-is-not-supported-yet), and **more privacy protections** (noise / fewer bits /
   other limitations) if needed to support these new features.
 

--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -349,7 +349,7 @@ In Chrome, report scheduling works as follows:
       <tr>
         <td><code>impressionexpiry</code> is under 2 days</td>
         <td>
-            2 days after ad click
+          <li>2 days after ad click</li>
         </td>
         <td>1</td>
       </tr>

--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -7,7 +7,7 @@ authors:
   - samdutton
 hero: hero.jpg
 date: 2020-10-06
-updated: 2020-10-06
+updated: 2020-02-10
 tags:
   - blog
   - privacy


### PR DESCRIPTION
Fixes #4630

Changes proposed in this pull request:

- Removed mentions of hexa encoding
- Updated conversiondestination definition

`DO NOT MERGE` yet: the article update should ideally happen shortly before comms go out to OT participants (should be some time next week).
