### PR TITLE
Minor updates to installable PWA codelab

### DIFF
--- a/src/site/content/en/progressive-web-apps/codelab-make-installable/index.md
+++ b/src/site/content/en/progressive-web-apps/codelab-make-installable/index.md
@@ -4,11 +4,11 @@ title: Make it installable
 authors:
   - petelepage
 date: 2018-11-05
-updated: 2020-02-28
+updated: 2021-02-11
 description: |
   In this codelab, learn how to make a site installable using the
   beforeinstallprompt event.
-glitch: make-it-installable
+glitch: make-it-installable?path=script.js
 related_post: customize-install
 tags:
   - progressive-web-apps
@@ -25,8 +25,8 @@ It also has an install button that is hidden by default.
 
 When the browser fires the `beforeinstallprompt` event, that's the indication
 that the Progressive Web App can be installed and an install button can be shown
-to the user. The `beforeinstallprompt` event is fired when the PWA meets the
-criteria for installability.
+to the user. The `beforeinstallprompt` event is fired when the PWA meets [the
+criteria for installability](/install-criteria/).
 
 {% Instruction 'remix', 'ol' %}
 1. Add a `beforeinstallprompt` event handler to the `window` object.
@@ -61,7 +61,7 @@ event. Calling `prompt()` is done in the install button click handler because
 Code:
 
 ```js
-butInstall.addEventListener('click', () => {
+butInstall.addEventListener('click', async () => {
   console.log('👍', 'butInstall-clicked');
   const promptEvent = window.deferredPrompt;
   if (!promptEvent) {
@@ -71,14 +71,13 @@ butInstall.addEventListener('click', () => {
   // Show the install prompt.
   promptEvent.prompt();
   // Log the result
-  promptEvent.userChoice.then((result) => {
-    console.log('👍', 'userChoice', result);
-    // Reset the deferred prompt variable, since
-    // prompt() can only be called once.
-    window.deferredPrompt = null;
-    // Hide the install button.
-    divInstall.classList.toggle('hidden', true);
-  });
+  const result = await promptEvent.userChoice;
+  console.log('👍', 'userChoice', result);
+  // Reset the deferred prompt variable, since
+  // prompt() can only be called once.
+  window.deferredPrompt = null;
+  // Hide the install button.
+  divInstall.classList.toggle('hidden', true);
 });
 ```
 
@@ -98,6 +97,8 @@ Code:
 ```js
 window.addEventListener('appinstalled', (event) => {
   console.log('👍', 'appinstalled', event);
+  // Clear the deferredPrompt so it can be garbage collected
+  window.deferredPrompt = null;
 });
 ```
 
@@ -107,5 +108,5 @@ Congratulations, you app is now installable!
 
 Here are some additional things that you can do:
 
-+  [Detecting if your app is launched from the home screen](https://developers.google.com/web/fundamentals/app-install-banners/#detect-mode)
++  [Detecting if your app is launched from the home screen](/customize-install/#detect-mode)
 +  [How to show the native app install prompt instead](https://developers.google.com/web/fundamentals/app-install-banners/native)

--- a/src/site/content/en/progressive-web-apps/codelab-make-installable/index.md
+++ b/src/site/content/en/progressive-web-apps/codelab-make-installable/index.md
@@ -4,7 +4,7 @@ title: Make it installable
 authors:
   - petelepage
 date: 2018-11-05
-updated: 2021-02-11
+updated: 2021-02-12
 description: |
   In this codelab, learn how to make a site installable using the
   beforeinstallprompt event.
@@ -26,7 +26,7 @@ It also has an install button that is hidden by default.
 When the browser fires the `beforeinstallprompt` event, that's the indication
 that the Progressive Web App can be installed and an install button can be shown
 to the user. The `beforeinstallprompt` event is fired when the PWA meets [the
-criteria for installability](/install-criteria/).
+installability criteria](/install-criteria/).
 
 {% Instruction 'remix', 'ol' %}
 1. Add a `beforeinstallprompt` event handler to the `window` object.
@@ -108,5 +108,5 @@ Congratulations, you app is now installable!
 
 Here are some additional things that you can do:
 
-+  [Detecting if your app is launched from the home screen](/customize-install/#detect-mode)
-+  [How to show the native app install prompt instead](https://developers.google.com/web/fundamentals/app-install-banners/native)
++  [Detect if your app is launched from the home screen](/customize-install/#detect-mode)
++  [Show the native app install prompt instead](https://developers.google.com/web/fundamentals/app-install-banners/native)


### PR DESCRIPTION
This PR makes sure changes made in https://github.com/GoogleChrome/web.dev/pull/4622 are reflected in the associated codelab article.

Note that the codelab was also updated:
- I've asked Glitch support folks to restore it as it was [broken/empty previously](https://github.com/GoogleChrome/web.dev/issues/4632).
- A new service worker offline page logic was added to address [upcoming changes](https://developer.chrome.com/blog/improved-pwa-offline-detection/).
- Links have been fixed.

@petele Can you review/merge?