### PR TITLE
Make browser compatibility info up to date

### DIFF
--- a/src/site/content/en/fast/preload-critical-assets/index.md
+++ b/src/site/content/en/fast/preload-critical-assets/index.md
@@ -61,7 +61,7 @@ Unused preloads trigger a Console warning in Chrome, approximately 3 seconds aft
 <img class="w-screenshot" src="./console-warning.png" alt="Chrome DevTools Console warning about unused preloaded resources.">
 
 {% Aside %}
-[`preload` is supported](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#Browser_compatibility) in all modern browsers except Firefox.
+[`preload` is supported](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#Browser_compatibility) in all modern browsers.
 {% endAside %}
 
 ## Use cases


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#browser_compatibility preload is already supported by Firefox (since version 85)

Changes proposed in this pull request:

- Remove information about Firefox not supporting preload
