### PR TITLE
Add a link to COOP/COEP guide, embed two videos

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -135,7 +135,7 @@ in separate browsing context groups.
 
 {% Aside 'codelab' %}
 [See the impact of different COOP
-params](https://first-party-test.glitch.me/coop).
+parameters](https://first-party-test.glitch.me/coop).
 {% endAside %}
 
 #### 2. Ensure resources have CORP or CORS enabled

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -106,7 +106,7 @@ clearer, let's define them first:
 
 ## Deploy COOP and COEP to make your website cross-origin isolated
 
-{% Aside 'gotchas' %}
+{% Aside %}
 Learn practical steps to enable cross-origin isolation at [A guide to
 enable cross-origin isolation](/cross-origin-isolation-guide/).
 {% endAside %}

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -38,6 +38,8 @@ Chrome will be available from Chrome 88.
 - **September 1, 2020**: COOP Reporting is behind flags in Chrome 86. See
 [Enable Chrome flags](#flags).
 
+{% YouTube 'XLNJYhjA-0c' %}
+
 Some web APIs increase the risk of side-channel attacks like Spectre. To
 mitigate that risk, browsers offer an opt-in-based isolated environment called
 cross-origin isolated. With a cross-origin isolated state, the webpage will be
@@ -103,6 +105,11 @@ clearer, let's define them first:
 {% endAside %}
 
 ## Deploy COOP and COEP to make your website cross-origin isolated
+
+{% Aside 'gotchas' %}
+Learn practical steps to enable cross-origin isolation at [A guide to
+enable cross-origin isolation](/cross-origin-isolation-guide/).
+{% endAside %}
 
 ### Integrate COOP and COEP
 
@@ -201,6 +208,8 @@ property is available in Chrome from version 87.
 {% endAside %}
 
 ### Debug issues using Chrome DevTools
+
+{% YouTube 'D5DLVo_TlEA' %}
 
 For resources that are rendered on the screen such as images, it's fairly easy
 to detect COEP issues because the request will be blocked and the page will


### PR DESCRIPTION
- Adds a link to [A guide to enable cross-origin isolation](https://web.dev/cross-origin-isolation-guide/).
- Embeds two video about COOP/COEP from web.dev live and CDS.