### PR TITLE
Use thumbnail ID

### DIFF
--- a/src/site/content/en/blog/devices-introduction/index.md
+++ b/src/site/content/en/blog/devices-introduction/index.md
@@ -9,7 +9,7 @@ authors:
 date: 2021-02-12
 updated: 2021-02-12
 hero: hero.jpg
-thumbnail: thumbnail.jpg
+thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/B1fq4VnPfJT6X4oN7tAv.jpg
 alt: A woman sitting in front of a wooden desk photo.
 tags:
   - blog # blog is a required tag for the article to show up in the blog.


### PR DESCRIPTION
This PR fixes a temporary glitch with thumbnails by using its ID instead of the path for the "Accessing hardware devices on the web" article.

Note that I'm not sure if this PR fixes it for real until it's deployed sadly ;(