### PR TITLE
Synchronize LanguageSelect element state with real language of the page

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -3,7 +3,6 @@ import {saveUserUrl} from './fb';
 import {runLighthouse, fetchReports} from './lighthouse-service';
 import lang from './utils/language';
 import {localStorage} from './utils/storage';
-import {getCanonicalPath} from './urls';
 import cookies from 'js-cookie';
 import {trackEvent} from './analytics';
 
@@ -191,35 +190,20 @@ export const setUserAcceptsCookies = store.action(() => {
   };
 });
 
-export const checkUserPreferredLanguage = store.action(
-  ({userPreferredLanguage}) => {
-    userPreferredLanguage =
-      // Use currently set language.
-      userPreferredLanguage ||
-      // Or check in the url.
-      lang.getLanguageFromPath(location.pathname) ||
-      // Or check in a cookie.
-      cookies.get('firebase-language-override') ||
-      // Or check in the browser setting.
-      navigator.language.split('-')[0];
-    if (!lang.isValidLanguage(userPreferredLanguage)) {
-      userPreferredLanguage = '';
-    }
-    return {userPreferredLanguage};
-  },
-);
-
-export const setLanguage = store.action((state, preferredLanguage) => {
+export const setLanguage = store.action((state, language) => {
+  if (!lang.isValidLanguage(language)) {
+    return state;
+  }
   const options = {
     expires: 10 * 365, // 10 years
     samesite: 'strict',
   };
-  cookies.set('firebase-language-override', preferredLanguage, options);
-  if (preferredLanguage !== state.userPreferredLanguage) {
-    location.pathname = getCanonicalPath(location.pathname);
+  cookies.set('firebase-language-override', language, options);
+  if (language !== state.currentLanguage) {
+    location.reload();
   }
   return {
-    userPreferredLanguage: preferredLanguage,
+    currentLanguage: language,
   };
 });
 

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -5,7 +5,6 @@
  * sw cleanup code.
  */
 
-import {checkUserPreferredLanguage} from './actions';
 import {store} from './store';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
@@ -13,9 +12,6 @@ import removeServiceWorkers from './utils/sw-remove';
 // This hides a legacy browser warning that can appear on the /measure page
 // See .unsupported-notice in _page-header.scss
 document.body.classList.remove('unresolved');
-
-// Read preferred language from the url, a cookie or browser settings.
-checkUserPreferredLanguage();
 
 // Configures global page state (loading, signed in).
 function onGlobalStateChanged({isSignedIn}) {

--- a/src/lib/components/LanguageSelect/index.js
+++ b/src/lib/components/LanguageSelect/index.js
@@ -26,12 +26,12 @@ import lang from '../../utils/language';
 class LanguageSelect extends BaseStateElement {
   static get properties() {
     return {
-      currentLanguage: {type: String},
+      current: {type: String},
     };
   }
 
-  onStateChanged({userPreferredLanguage}) {
-    this.currentLanguage = userPreferredLanguage;
+  onStateChanged({currentLanguage}) {
+    this.current = currentLanguage;
   }
 
   onChange(e) {
@@ -44,7 +44,7 @@ class LanguageSelect extends BaseStateElement {
       return '';
     }
     languageName = languageName.toUpperCase();
-    return this.currentLanguage === language
+    return this.current === language
       ? html`
           <option value="${language}" selected>
             ${languageName} (${language})

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,5 +1,3 @@
-import lang from './utils/language';
-
 /**
  * @param {string} url containing pathname and search only
  * @return {string} normalized URL
@@ -21,12 +19,4 @@ export function normalizeUrl(url) {
   }
 
   return pathname + u.search;
-}
-
-export function getCanonicalPath(path) {
-  const parts = path.split('/');
-  if (parts[1] && lang.isValidLanguage(parts[1])) {
-    parts.splice(1, 1);
-  }
-  return parts.join('/');
 }

--- a/src/lib/utils/language.js
+++ b/src/lib/utils/language.js
@@ -34,15 +34,9 @@ function isValidLanguage(lang) {
   return supportedLanguages.indexOf(lang) > -1;
 }
 
-function getLanguageFromPath(path) {
-  const parts = path.split('/');
-  return isValidLanguage(parts[1]) && parts[1];
-}
-
 export default {
   languageNames,
   defaultLanguage,
   isValidLanguage,
   supportedLanguages,
-  getLanguageFromPath,
 };

--- a/src/site/_includes/partials/footer.njk
+++ b/src/site/_includes/partials/footer.njk
@@ -106,7 +106,7 @@
           </a>
         </li>
       </ul>
-      <web-language-select></web-language-select>
+      <web-language-select current="{{ lang }}"></web-language-select>
     </nav>
     <nav class="w-footer__utility-nav">
       <ul class="w-footer__utility-list">


### PR DESCRIPTION
Fixes #4640

It removes also `getLanguageFromPath` and `getCanonicalPath` as we don't do language paths anymore.