### PR TITLE
[Img component] Prevent markup bloat

### DIFF
--- a/src/site/_includes/components/Img.js
+++ b/src/site/_includes/components/Img.js
@@ -54,8 +54,10 @@ const Img = function (args) {
   params = {auto: 'format', ...params};
   // https://github.com/imgix/imgix-core-js#imgixclientbuildsrcsetpath-params-options
   options = {
-    minWidth: 200,
-    maxWidth: 1600,
+    // Use the image width as the lower bound, or 200px.
+    minWidth: Math.min(200, widthAsNumber),
+    // Use image width as the upper bound, maxed out at 1,600px.
+    maxWidth: Math.min(1600, widthAsNumber),
     widthTolerance: 0.07,
     ...options,
   };


### PR DESCRIPTION
For images that are capped at 300px, don't create sizes up to 1,600px.

<img width="583" alt="Screen Shot 2021-02-12 at 17 47 53" src="https://user-images.githubusercontent.com/145676/107796982-b40a7300-6d5a-11eb-9eda-6e95aa140262.png">

If the image is smaller than 200px, use the image width as the lower limit as to not scale up small images.