### PR TITLE
Changes color-scheme meta tag link URL from W3C draft to Whatwg

### DIFF
--- a/src/site/content/en/blog/color-scheme/index.md
+++ b/src/site/content/en/blog/color-scheme/index.md
@@ -187,7 +187,7 @@ Honoring the `color-scheme` CSS property requires the CSS to be first downloaded
 (if it is referenced via `<link rel="stylesheet">`) and to be parsed.
 To aid user agents in rendering the page background with the desired color scheme *immediately*,
 a `color-scheme` value can also be provided in a
-[`<meta name="color-scheme">`](https://drafts.csswg.org/css-color-adjust/#color-scheme-meta)
+[`<meta name="color-scheme">`](https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme)
 element.
 
 ```html


### PR DESCRIPTION
**This PR**

_TL;DR; Changes https://drafts.csswg.org/css-color-adjust/#color-scheme-meta to https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme_

Changes the URL for link of for more information about the `color-scheme` meta from a hash that no longer exists on the W3C draft page to a working link on the Whatwg spec.

**Why?**

The current URL https://drafts.csswg.org/css-color-adjust/#color-scheme-meta goes to the top of the document because there is no longer an element with the `color-scheme-meta` id in the page.

The only mention of the `color-scheme` meta tag in that draft does not have an `id` to link to it. The note reads:

> Note: [HTML] specifies a color-scheme meta tag which can be used to set the color-scheme on the root element as a non-CSS presentational hint.

In that note there is a link to the `color-scheme` meta tag docs in the Whatwg spec https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme

When I was reading the post, I was confused why the link just went to the top of the W3C draft and not to relevant info about the `color-scheme` meta tag.
