### PR TITLE
[Video component] The `autoplay` attribute needs to go along with `playsinline` for iOS

### DIFF
--- a/src/site/_includes/components/Video.js
+++ b/src/site/_includes/components/Video.js
@@ -42,7 +42,7 @@ const Video = (args) => {
   } = args;
 
   return html`<video
-    ${autoplay ? 'autoplay' : ''}
+    ${autoplay ? 'autoplay playsinline' : ''}
     ${autoPictureInPicture ? 'autoPictureInPicture' : ''}
     ${className ? `class="${className}"` : ''}
     controls


### PR DESCRIPTION
Changes proposed in this pull request:

- The `autoplay` attribute needs to go along with `playsinline` for iOS (see [blog post](https://webkit.org/blog/6784/new-video-policies-for-ios/#post-6784:~:text=%3Cvideo-,playsinline,-%3E))