### PR TITLE
Temporary redirect for CORS-RFC1918 guidance

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -246,3 +246,8 @@ redirects:
   destination: /aria-name
 - source: /aria-input-field-name
   destination: /aria-name
+
+# Temporary redirect for CORS-RFC1918 guidance on DevTools.
+# Remove once the actual article is published.
+- source: /cors-rfc1918-guide
+  destination: /cors-rfc1918-feedback


### PR DESCRIPTION
Add a temporary redirect for a placeholder URL: https://web.dev/cors-rfc1918-guide

There will be two new articles:

* https://web.dev/cors-rfc1918 : The canonical article about CORS-RFC1918
* https://web.dev/cors-rfc1918-guide : A brief guidance on CORS-RFC1918 primarily as a destination for DevTools.

Until they emerge, we'll redirect traffic to https://web.dev/cors-rfc1918-guide to https://web.dev/cors-rfc1918-feedback.
