### PR TITLE
Improve cross-origin isolation related documents

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -160,6 +160,12 @@ Here is what you need to do depending on the nature of the resource:
   `Cross-Origin-Resource-Policy: same-origin` (or `same-site`, `cross-origin`
   depending on the context) and `Cross-Origin-Embedder-Policy: require-corp`.
 
+{% Aside 'gotchas' %}
+You can enable cross-origin isolation on a document embedded within an iframe by
+applying `allow="cross-origin-isolated"` feature policy to the `<iframe>` tag
+and meeting the same conditions described in this document.
+{% endAside %}
+
 {% Aside 'key-term' %}
 It's important that you understand the difference between "same-site" and
 "same-origin". Learn about the difference at [Understanding same-site and
@@ -228,6 +234,22 @@ You can then click the entry to see more details.
 
 <figure class="w-figure">
   <img class="w-screenshot w-screenshot-filled" src="devtools2.jpg" alt="Details of the COEP issue are shown in the Headers tab after clicking a network resource in the Network panel.">
+</figure>
+
+You can also determine the status of iframes and popup windows through the
+**Application** panel. Go to the "Frames" section on the left hand side and
+expand "top" to see the breakdown of the resource structure.
+
+You can check the iframe's status such as availability of SharedArrayBuffer, etc.
+
+<figure class="w-figure">
+{% Img src="image/YLflGBAPWecgtKJLqCJHSzHqe2J2/9titfaieIs0gwSKnkL3S.png", alt="Chrome DevTools iframe inspector", width="800", height="480", className="w-screenshot w-screenshot-filled" %}
+</figure>
+
+You can also check the popup windows's status such as whether it's cross-origin isolated.
+
+<figure class="w-figure">
+{% Img src="image/YLflGBAPWecgtKJLqCJHSzHqe2J2/kKvPUo2ZODZu8byK7gTB.png", alt="Chrome DevTools popup window inspector", width="800", height="480", className="w-screenshot w-screenshot-filled" %}
 </figure>
 
 {% Aside %}

--- a/src/site/content/en/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/en/secure/cross-origin-isolation-guide/index.md
@@ -66,7 +66,9 @@ cross-origin resources:
    impact analysis.
 2. On cross-origin resources such as images, scripts, stylesheets, iframes, and
    others, set the [`Cross-Origin-Resource-Policy:
-   cross-origin`](https://resourcepolicy.fyi) header.
+   cross-origin`](https://resourcepolicy.fyi/#cross-origin) header. On same-site
+   resources, set [`Cross-Origin-Resource-Policy:
+   same-site`](https://resourcepolicy.fyi/#same-origin) header.
 3. Set the `crossorigin` attribute in the HTML tag on top-level document if the
    resource is served with [CORS](/cross-origin-resource-sharing/) (for example,
    `<img src="example.jpg" crossorigin>`).

--- a/src/site/content/en/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/en/secure/cross-origin-isolation-guide/index.md
@@ -61,15 +61,22 @@ After you have determined which resources will be affected by cross-origin
 isolation, here are general guidelines for how you actually opt-in those
 cross-origin resources:
 
-1. Set the `Cross-Origin-Embedder-Policy: require-corp` header on cross-origin
-   resources loaded into iframes.
-2. Set the [`Cross-Origin-Resource-Policy:
-   cross-origin`](https://resourcepolicy.fyi) header on cross-origin resources :
-   images, scripts, stylesheets, iframes, and other.
+1. On cross-origin resources loaded into iframes, set the
+   `Cross-Origin-Embedder-Policy-Report-Only: require-corp` header to do an
+   impact analysis.
+2. On cross-origin resources such as images, scripts, stylesheets, iframes, and
+   others, set the [`Cross-Origin-Resource-Policy:
+   cross-origin`](https://resourcepolicy.fyi) header.
 3. Set the `crossorigin` attribute in the HTML tag on top-level document if the
    resource is served with [CORS](/cross-origin-resource-sharing/) (for example,
    `<img src="example.jpg" crossorigin>`).
-4. Make sure there are no cross-origin popup windows that require communication
+4. If cross-origin resources loaded into iframes involve another layer of
+   iframes, recursively apply steps described in this section before moving
+   forward.
+5. Once you confirm that all cross-origin resources are opt-in, set the
+   `Cross-Origin-Embedder-Policy: require-corp` header on the cross-origin
+   resources loaded into iframes.
+6. Make sure there are no cross-origin popup windows that require communication
    through `postMessage()`. There's no way to keep them working when
    cross-origin isolation is enabled. You can move the communication to another
    document that isn't cross-origin isolated, or use a different communication

--- a/src/site/content/en/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/en/secure/cross-origin-isolation-guide/index.md
@@ -75,7 +75,7 @@ cross-origin resources:
 4. If cross-origin resources loaded into iframes involve another layer of
    iframes, recursively apply steps described in this section before moving
    forward.
-5. Once you confirm that all cross-origin resources are opt-in, set the
+5. Once you confirm that all cross-origin resources are opted-in, set the
    `Cross-Origin-Embedder-Policy: require-corp` header on the cross-origin
    resources loaded into iframes.
 6. Make sure there are no cross-origin popup windows that require communication


### PR DESCRIPTION
Improves cross-origin isolation related documents

- https://web.dev/coop-coep
- https://web.dev/cross-origin-isolation-guide

Here's list of changes:

- Add report only mode step in the guide to recursively apply COEP to iframes.
- Add explanation about `allow="cross-origin-isolated"` to enable SharedArrayBuffer etc within an iframe.
- Add instructions how to check iframe and popup window's status of cross-origin isolation on DevTools.