### PR TITLE
Feat/courses basic

### DIFF
--- a/src/site/_includes/base.njk
+++ b/src/site/_includes/base.njk
@@ -15,17 +15,9 @@ tags: []
       snackbar will be the first stop for the screen reader / focus.
     #}
     <web-snackbar-container></web-snackbar-container>
-    {% include 'partials/header.njk' %}
-    {% include 'partials/side-nav.njk' %}
-    <main>
-      <div id="content">
-        {% if show_banner %}
-          {% include 'partials/banner.njk' %}
-        {% endif %}
-        {% include 'partials/translation-disclaimer.njk' %}
-        {{ content | safe }}
-      </div>
-    </main>
+
+    {{ content | safe }}
+
     {% include 'partials/footer.njk' %}
     {% include 'partials/analytics.njk' %}
   </body>

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
 show_banner: false
 pageScripts:

--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -1,0 +1,3 @@
+---
+layout: layout
+---

--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -1,3 +1,9 @@
 ---
-layout: layout
+layout: base
+# This flag tells the parent layout not to include all of the site navigation.
+course: true
 ---
+
+<div>
+  {{ content | safe }}
+</div>

--- a/src/site/_includes/default.njk
+++ b/src/site/_includes/default.njk
@@ -1,0 +1,16 @@
+---
+layout: base
+---
+
+{# This is the standard layout that most pages will use. #}
+{% include 'partials/header.njk' %}
+{% include 'partials/side-nav.njk' %}
+<main>
+  <div id="content">
+    {% if show_banner %}
+      {% include 'partials/banner.njk' %}
+    {% endif %}
+    {% include 'partials/translation-disclaimer.njk' %}
+    {{ content | safe }}
+  </div>
+</main>

--- a/src/site/_includes/handbook.njk
+++ b/src/site/_includes/handbook.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 noindex: true
 permalink: "/{{lang}}/handbook/{{page.fileSlug}}/index.html"
 pageScripts:

--- a/src/site/_includes/homepage.njk
+++ b/src/site/_includes/homepage.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: web.dev
 show_banner: false
 ---

--- a/src/site/_includes/layout.njk
+++ b/src/site/_includes/layout.njk
@@ -6,51 +6,7 @@ tags: []
 <!DOCTYPE html>
 <html lang="{{lang}}">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    {% if process.env.ELEVENTY_ENV === 'prod' %}
-      {# CSS will be injected by purify-css transform. #}
-      <!-- __PURGECSS_INJECT -->
-    {% else %}
-      <link rel="stylesheet" href="/css/main.css">
-    {% endif %}
-
-    {# We only preload Material Icons because the site can't render properly without them. #}
-    {# For Google Sans we use font-display: swap because preloading too many fonts can hurt performance. #}
-    {# https://www.zachleat.com/web/preload/ #}
-    <link rel="preload" as="font" crossorigin href="/fonts/material-icons/regular.woff2">
-
-    <meta name="theme-color" content="#fff"/>
-
-    {% if noindex or draft -%}
-      <meta name="robots" content="noindex" />
-    {%- endif %}
-    {% if offline %}
-      <meta name="offline" content="true" />
-    {%- endif %}
-
-    {% Meta locale, page, collections, renderData %}
-
-    <link rel="manifest" href="/manifest.webmanifest" />
-    {# Include default icon even though we have a manifest #}
-    <link rel="shortcut icon" href="/images/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
-    <link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
-    <script type="module" src="{{ helpers.hashForProd('/js/app.js') }}"></script>
-    {# Add a facility for pages to declare an array of script paths. #}
-    {# If no scripts are declared we will use the default page script. #}
-    {# default.js loads the basic set of custom elements that all pages need. #}
-    {% for item in pageScripts %}
-      <script type="module" src="{{ helpers.hashForProd(item) }}"></script>
-    {% else %}
-      <script type="module" src="{{ helpers.hashForProd('/js/default.js') }}"></script>
-    {% endfor %}
-    {% if process.env.ELEVENTY_ENV === 'prod' %}
-      <script async src="https://www.google-analytics.com/analytics.js"></script>
-    {% endif %}
+    {% include 'partials/head.njk' %}
   </head>
   <body class="unresolved">
     {#
@@ -59,107 +15,8 @@ tags: []
       snackbar will be the first stop for the screen reader / focus.
     #}
     <web-snackbar-container></web-snackbar-container>
-    <div class="w-loading-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" hidden></div>
-    <web-header role="navigation">
-      <button class="w-button--icon w-button--round web-header__hamburger-btn unresolved" aria-label="Open menu">
-        <span class="w-tooltip w-tooltip--left">Open menu</span>
-      </button>
-
-      <a
-        href="/"
-        class="web-header__logo-link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="Site logo"
-      >
-        <img class="web-header__logo" src="/images/lockup.svg" alt="web.dev" />
-      </a>
-
-      <div class="web-header__middle">
-        <div class="web-header__links">
-          <a
-            href="/learn/"
-            class="web-header__link gc-analytics-event"
-            data-category="Site-Wide Custom Events"
-            data-label="Tab: Learn"
-          >
-            Learn
-          </a>
-
-          <a
-            href="/measure/"
-            class="web-header__link gc-analytics-event"
-            data-category="Site-Wide Custom Events"
-            data-label="Tab: Measure"
-          >
-            Measure
-          </a>
-
-          <a
-            href="/blog/"
-            class="web-header__link gc-analytics-event"
-            data-category="Site-Wide Custom Events"
-            data-label="Tab: Blog"
-          >
-            Blog
-          </a>
-
-          <a
-            href="/about/"
-            class="web-header__link gc-analytics-event"
-            data-category="Site-Wide Custom Events"
-            data-label="Tab: About"
-          >
-            About
-          </a>
-        </div>
-        <web-search></web-search>
-      </div>
-
-      <web-profile-switcher-container></web-profile-switcher-container>
-    </web-header>
-
-    <web-side-nav class="unresolved" logo="/images/lockup.svg">
-      <a
-        href="/learn/"
-        class="web-side-nav__link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="SideNav: Learn"
-      >
-        Learn
-      </a>
-      <a
-        href="/measure/"
-        class="web-side-nav__link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="SideNav: Measure"
-      >
-        Measure
-      </a>
-      <a
-        href="/blog/"
-        class="web-side-nav__link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="SideNav: Blog"
-      >
-        Blog
-      </a>
-      <a
-        href="/live/"
-        class="web-side-nav__link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="SideNav: Live"
-      >
-        Live
-      </a>
-      <a
-        href="/about/"
-        class="web-side-nav__link gc-analytics-event"
-        data-category="Site-Wide Custom Events"
-        data-label="SideNav: About"
-      >
-        About
-      </a>
-    </web-side-nav>
+    {% include 'partials/header.njk' %}
+    {% include 'partials/side-nav.njk' %}
     <main>
       <div id="content">
         {% if show_banner %}

--- a/src/site/_includes/newsletter.njk
+++ b/src/site/_includes/newsletter.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 pageScripts:
   - '/js/newsletter.js'
 ---

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -1,0 +1,45 @@
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+{% if process.env.ELEVENTY_ENV === 'prod' %}
+  {# CSS will be injected by purify-css transform. #}
+  <!-- __PURGECSS_INJECT -->
+{% else %}
+  <link rel="stylesheet" href="/css/main.css">
+{% endif %}
+
+{# We only preload Material Icons because the site can't render properly without them. #}
+{# For Google Sans we use font-display: swap because preloading too many fonts can hurt performance. #}
+{# https://www.zachleat.com/web/preload/ #}
+<link rel="preload" as="font" crossorigin href="/fonts/material-icons/regular.woff2">
+
+<meta name="theme-color" content="#fff"/>
+
+{% if noindex or draft -%}
+  <meta name="robots" content="noindex" />
+{%- endif %}
+{% if offline %}
+  <meta name="offline" content="true" />
+{%- endif %}
+
+{% Meta locale, page, collections, renderData %}
+
+<link rel="manifest" href="/manifest.webmanifest" />
+{# Include default icon even though we have a manifest #}
+<link rel="shortcut icon" href="/images/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
+<link rel="mask-icon" color="#0054ff" href="/images/safari-pinned-tab.svg">
+<script type="module" src="{{ helpers.hashForProd('/js/app.js') }}"></script>
+{# Add a facility for pages to declare an array of script paths. #}
+{# If no scripts are declared we will use the default page script. #}
+{# default.js loads the basic set of custom elements that all pages need. #}
+{% for item in pageScripts %}
+  <script type="module" src="{{ helpers.hashForProd(item) }}"></script>
+{% else %}
+  <script type="module" src="{{ helpers.hashForProd('/js/default.js') }}"></script>
+{% endfor %}
+{% if process.env.ELEVENTY_ENV === 'prod' %}
+  <script async src="https://www.google-analytics.com/analytics.js"></script>
+{% endif %}

--- a/src/site/_includes/partials/header.njk
+++ b/src/site/_includes/partials/header.njk
@@ -1,0 +1,57 @@
+<web-header role="navigation">
+  <button class="w-button--icon w-button--round web-header__hamburger-btn unresolved" aria-label="Open menu">
+    <span class="w-tooltip w-tooltip--left">Open menu</span>
+  </button>
+
+  <a
+    href="/"
+    class="web-header__logo-link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="Site logo"
+  >
+    <img class="web-header__logo" src="/images/lockup.svg" alt="web.dev" />
+  </a>
+
+  <div class="web-header__middle">
+    <div class="web-header__links">
+      <a
+        href="/learn/"
+        class="web-header__link gc-analytics-event"
+        data-category="Site-Wide Custom Events"
+        data-label="Tab: Learn"
+      >
+        Learn
+      </a>
+
+      <a
+        href="/measure/"
+        class="web-header__link gc-analytics-event"
+        data-category="Site-Wide Custom Events"
+        data-label="Tab: Measure"
+      >
+        Measure
+      </a>
+
+      <a
+        href="/blog/"
+        class="web-header__link gc-analytics-event"
+        data-category="Site-Wide Custom Events"
+        data-label="Tab: Blog"
+      >
+        Blog
+      </a>
+
+      <a
+        href="/about/"
+        class="web-header__link gc-analytics-event"
+        data-category="Site-Wide Custom Events"
+        data-label="Tab: About"
+      >
+        About
+      </a>
+    </div>
+    <web-search></web-search>
+  </div>
+
+  <web-profile-switcher-container></web-profile-switcher-container>
+</web-header>

--- a/src/site/_includes/partials/side-nav.njk
+++ b/src/site/_includes/partials/side-nav.njk
@@ -1,0 +1,42 @@
+<web-side-nav class="unresolved" logo="/images/lockup.svg">
+  <a
+    href="/learn/"
+    class="web-side-nav__link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="SideNav: Learn"
+  >
+    Learn
+  </a>
+  <a
+    href="/measure/"
+    class="web-side-nav__link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="SideNav: Measure"
+  >
+    Measure
+  </a>
+  <a
+    href="/blog/"
+    class="web-side-nav__link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="SideNav: Blog"
+  >
+    Blog
+  </a>
+  <a
+    href="/live/"
+    class="web-side-nav__link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="SideNav: Live"
+  >
+    Live
+  </a>
+  <a
+    href="/about/"
+    class="web-side-nav__link gc-analytics-event"
+    data-category="Site-Wide Custom Events"
+    data-label="SideNav: About"
+  >
+    About
+  </a>
+</web-side-nav>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 ---
 
 {% set path = paths[pathName] %}

--- a/src/site/_includes/post.njk
+++ b/src/site/_includes/post.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
 tags:
   - post

--- a/src/site/_includes/text.njk
+++ b/src/site/_includes/text.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
 ---
 

--- a/src/site/content/en/404.md
+++ b/src/site/content/en/404.md
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: 404
 description: |
   Page Not Found

--- a/src/site/content/en/about/index.njk
+++ b/src/site/content/en/about/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: About
 description: |
   web.dev is the ultimate resource for developers of all backgrounds to learn,

--- a/src/site/content/en/authors/index.njk
+++ b/src/site/content/en/authors/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Authors
 permalink: /{{lang}}/{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 description: Our latest news, updates, and stories for developers

--- a/src/site/content/en/authors/individual.njk
+++ b/src/site/content/en/authors/individual.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Authors
 permalink: /{{lang}}/{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 description: Our latest news, updates, and stories for developers

--- a/src/site/content/en/blog/index.njk
+++ b/src/site/content/en/blog/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Blog
 permalink: /{{lang}}{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 override:tags: []

--- a/src/site/content/en/learn/css/index.md
+++ b/src/site/content/en/learn/css/index.md
@@ -1,0 +1,7 @@
+---
+permalink: false
+layout: course
+title: Overview
+---
+
+hey i'm a css course

--- a/src/site/content/en/learn/index.njk
+++ b/src/site/content/en/learn/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Learn
 description: |
   Learn best practices for the modern web and hone your skills with hands-on

--- a/src/site/content/en/live/index.njk
+++ b/src/site/content/en/live/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: web.dev LIVE
 description: |
   Bringing web developers together, from home

--- a/src/site/content/en/measure/index.njk
+++ b/src/site/content/en/measure/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Measure
 description: |
   See how well your website performs. Then, get tips to improve your user

--- a/src/site/content/en/newsletter/index.njk
+++ b/src/site/content/en/newsletter/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Newsletter
 permalink: /{{lang}}{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 description: Stay up to date with the latest about web platform.

--- a/src/site/content/en/offline.md
+++ b/src/site/content/en/offline.md
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Offline
 description: |
   Network Offline

--- a/src/site/content/en/podcasts/index.njk
+++ b/src/site/content/en/podcasts/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Podcasts
 description: |
   Level up your web development skills by listening to podcasts from Google

--- a/src/site/content/en/tags/index.njk
+++ b/src/site/content/en/tags/index.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Tags
 permalink: /{{lang}}/{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 description: Our latest news, updates, and stories for developers

--- a/src/site/content/en/tags/individual.njk
+++ b/src/site/content/en/tags/individual.njk
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Tags
 permalink: /{{lang}}/{{ paged.href }}{% if paged.index > 0 %}{{ paged.index + 1 }}/{% endif %}index.html
 description: Our latest news, updates, and stories for developers

--- a/src/site/content/pl/404.md
+++ b/src/site/content/pl/404.md
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: 404
 description: |
   Page Not Found

--- a/src/site/content/pl/offline.md
+++ b/src/site/content/pl/offline.md
@@ -1,5 +1,5 @@
 ---
-layout: layout
+layout: default
 title: Offline
 description: |
   Network Offline


### PR DESCRIPTION
This sets us up to have a completely separate layout for our Courses section, without duplicating anything.

**Changes in this pull request**
- Renames the `layout.njk` template to `base.njk` which matches the name we use on d.c.c.
- Creates a new layout called `default.njk` which inherits from `base.njk`. Every page on the site that is not a course will eventually inherit from `default`.
- Creates a new layout called `course.njk` which inherits from `base.njk`. Every page in a course will inherit from this layout.
- Moves elements like the header bar and side-nav into partials which are included in `default.njk`
- Creates a basic /learn/css page just to prove that all of the template inheritance is working as expected. Note this file is set to `permalink: false` so it won't generate any output. When we develop the course we could either do it entirely on a separate branch (which makes it hard to stay in sync with `main`) or use feature flags to set its published state to `false` using `eleventyComputed`.