### PR TITLE
Improve CLS on Authors page regression

### DIFF
--- a/src/site/content/en/authors/individual.njk
+++ b/src/site/content/en/authors/individual.njk
@@ -29,7 +29,8 @@ pagination:
         height="192",
         width="192",
         class="w-author-page__image",
-        sizes="(min-width: 481px) 192px, 128px"
+        sizes="(min-width: 481px) 192px, 128px",
+        options={minWidth: 128}
       %}
       <h1 class="w-page-header__headline w-author-page-header__headline">{{ renderData.title }}</h1>
       <p class="w-page-header__copy">{{ renderData.description | safe }}</p>

--- a/src/site/content/en/authors/individual.njk
+++ b/src/site/content/en/authors/individual.njk
@@ -23,32 +23,39 @@ pagination:
 
   <div class="w-layout-container w-pb--non">
     <header class="w-page-header w-author-page-header">
-      {% Img src=paged.data.hero, alt=paged.data.alt, height="192", width="192", class="w-author-page__image" %}
+      {% Img
+        src=paged.data.hero,
+        alt=paged.data.alt,
+        height="192",
+        width="192",
+        class="w-author-page__image",
+        sizes="(min-width: 481px) 192px, 128px"
+      %}
       <h1 class="w-page-header__headline w-author-page-header__headline">{{ renderData.title }}</h1>
       <p class="w-page-header__copy">{{ renderData.description | safe }}</p>
       <div class="w-author-page__links">
         {% if paged.homepage %}
           <a href="{{ paged.homepage }}" target="_blank" class="w-author-page__link">
-            <img src="/images/icons/language.svg" alt="Homepage" class="w-author-page__icon">
+            <img src="/images/icons/language.svg" alt="Homepage" class="w-author-page__icon" width="32" height="32">
           </a>
         {% endif %}
         {% if paged.twitter %}
           <a href="https://twitter.com/{{ paged.twitter }}" target="_blank" class="w-author-page__link">
-            <img src="/images/icons/twitter.svg" alt="Twitter" class="w-author-page__icon">
+            <img src="/images/icons/twitter.svg" alt="Twitter" class="w-author-page__icon" width="32" height="32">
           </a>
         {% endif %}
         {% if paged.github %}
           <a href="https://github.com/{{ paged.github }}" target="_blank" class="w-author-page__link">
-            <img src="/images/icons/github.svg" alt="GitHub" class="w-author-page__icon">
+            <img src="/images/icons/github.svg" alt="GitHub" class="w-author-page__icon" width="32" height="32">
           </a>
         {% endif %}
         {% if paged.glitch %}
           <a href="https://glitch.com/@{{ paged.glitch }}" target="_blank" class="w-author-page__link">
-            <img src="/images/icons/glitch.svg" alt="Glitch" class="w-author-page__icon">
+            <img src="/images/icons/glitch.svg" alt="Glitch" class="w-author-page__icon" width="32" height="32">
           </a>
         {% endif %}
         <a href="{{ renderData.rss }}" target="_blank" class="w-author-page__link">
-          <img src="/images/icons/rss.svg" alt="RSS Feed" class="w-author-page__icon">
+          <img src="/images/icons/rss.svg" alt="RSS Feed" class="w-author-page__icon" width="32" height="32">
         </a>
       </div>
     </header>

--- a/src/styles/pages/_author.scss
+++ b/src/styles/pages/_author.scss
@@ -26,7 +26,11 @@ $IMAGE_WIDTH: 192px;
 .w-author-page__image {
   border-radius: 100%;
   margin-bottom: 9px;
-  width: calc(#{$IMAGE_WIDTH} * calc(2/3));
+  width: calc(#{$IMAGE_WIDTH} * calc(2/3)); // 128px
+
+  @include bp(sm) {
+    width: $IMAGE_WIDTH;
+  }
 }
 
 .w-author-page__links {
@@ -42,12 +46,5 @@ $IMAGE_WIDTH: 192px;
   &:hover,
   &:focus {
     text-decoration: none;
-  }
-}
-
-
-@include bp(sm) {
-  .w-author-page__image {
-    width: $IMAGE_WIDTH;
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds dimensions to images
- Improves the `sizes` for the author image.

A note about the `Img` shortcode. In this example the image is 128px on small screens and then 192 px on large screens. The `Img` shortcode has this line `minWidth: Math.min(MIN_WIDTH, widthAsNumber),` where MIN_WIDTH is 200. This means that the minWidth would be 192px even though the true minimum size this image is displayed at is 128px. I passed in an explicit minWidth option to fix this, but I'm curious if that line of code in the shortcode is correct. I'm not sure what a better alternative would be off the top of my head.
