### PR TITLE
[Handbook update] Add instructions for inlcuding image captions

### DIFF
--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -91,3 +91,29 @@ directly.
 ```typescript
 {% include '../../../../../../types/site/_includes/components/Video.d.ts' %}
 ```
+## Captions
+
+To include a caption along with an image, use `<figure>` with `<figcaption>` and 
+place the shortcode snippet inside:
+
+```md
+<figure class="w-figure">
+{% raw %}{% Img
+  src="image/foR0vJZKULb5AGJExlazy1xYDgI2/iuwBXAyKJMz4b7oRyIdI.jpg",
+  alt="ALT_TEXT_HERE",
+  width="380",
+  height="240",
+%}{% endraw%}
+  <figcaption class="w-figcaption">
+    A good boy.
+  </figcaption>
+</figure>
+```
+
+<figure class="w-figure">
+{% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/QlgeHQrzaD9IOKBXB68I.jpg", 
+alt="ALT_TEXT_HERE", width="380", height="240" %}
+  <figcaption class="w-figcaption">
+    A good boy.
+  </figcaption>
+</figure>


### PR DESCRIPTION
I was working on a PR where I wanted to include captions with an image and had to do a little deducing to figure out how it works with the new image shortcodes. This should save our contributors some time.

Also, instructions with CSS classes for images (w-screenshot etc.) are gone from the handbook and I think we should bring them back. They still work and I find them very useful.

cc @kaycebasques 