### PR TITLE
Update the close port example in the serial article

### DIFF
--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -4,7 +4,7 @@ subhead: The Web Serial API allows websites to communicate with serial devices.
 authors:
   - beaufortfrancois
 date: 2020-08-12
-updated: 2021-03-02
+updated: 2021-03-03
 hero: image/admin/PMOws2Au6GPLq9sXSSqw.jpg
 thumbnail: image/admin/8diipQ5aHdP03xNuFNp7.jpg
 alt: |
@@ -323,7 +323,7 @@ async function readUntilClosed() {
     }
   }
 
-  return port.close();
+  await port.close();
 }
 
 const closedPromise = readUntilClosed();

--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -4,7 +4,7 @@ subhead: The Web Serial API allows websites to communicate with serial devices.
 authors:
   - beaufortfrancois
 date: 2020-08-12
-updated: 2021-03-01
+updated: 2021-03-02
 hero: image/admin/PMOws2Au6GPLq9sXSSqw.jpg
 thumbnail: image/admin/8diipQ5aHdP03xNuFNp7.jpg
 alt: |
@@ -323,18 +323,19 @@ async function readUntilClosed() {
     }
   }
 
-  await port.close();
+  return port.close();
 }
 
-const closed = readUntilClosed();
+const closedPromise = readUntilClosed();
 
-
-// Sometimes later...
-keepReading = false;
-// Force reader.read() to resolve immediately and subsequently
-// call reader.releaseLock() in the loop example above.
-reader.cancel();
-await closed;
+document.querySelector('button').addEventListener('click', async () => {
+  // User clicked a button to close the serial port.
+  keepReading = false;
+  // Force reader.read() to resolve immediately and subsequently
+  // call reader.releaseLock() in the loop example above.
+  reader.cancel();
+  await closedPromise;
+});
 ```
 
 Closing a serial port is more complicated when using [transform streams] (like


### PR DESCRIPTION
This PR updates an example in the serial article to make the design pattern for closing a serial port clearer as raised in https://github.com/WICG/serial/issues/126.