### PR TITLE
fix linter and remove all smart quote styles

### DIFF
--- a/src/site/content/en/blog/codelab-address-form-best-practices/index.md
+++ b/src/site/content/en/blog/codelab-address-form-best-practices/index.md
@@ -291,7 +291,7 @@ accessible across a range of devices and platforms? (The `<select>` element does
   large number of items, but at least it's usable on virtually all browsers and assistive devices!)
   
   The blog post 
-  [&lt;input type=”country” /&gt;](https://shkspr.mobi/blog/2017/11/input-type-country/) discusses 
+  [&lt;input type="country" /&gt;](https://shkspr.mobi/blog/2017/11/input-type-country/) discusses 
   the complexity of standardizing a country selector. Localization of country names can also be 
   problematic. [Countries Lists](http://www.countries-list.info/Download-List) has a tool for 
   downloading country codes and names in multiple languages, in multiple formats. 

--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -204,7 +204,7 @@ arbitrary data using gzip.
 If you provide a body object that the browser doesn't specifically handle, it
 will call `toString()` on the object and use the result as the body. If the
 browser doesn't support request streams, that means the request body becomes
-`"[object ReadableStream]"` – probably not what you want to send to the server.
+`"[object ReadableStream]"`–probably not what you want to send to the server.
 To avoid this, use feature detection:
 
 ```js

--- a/src/site/content/en/blog/link-prefetch/index.md
+++ b/src/site/content/en/blog/link-prefetch/index.md
@@ -114,10 +114,10 @@ form.addEventListener("submit", e => {
 });
 ```
 
-This tells webpack to inject the `<link rel=”prefetch”>` tag into the HTML document:
+This tells webpack to inject the `<link rel="prefetch">` tag into the HTML document:
 
 ```html
-<link rel="prefetch" as=”script” href=”1.bundle.js”>
+<link rel="prefetch" as="script" href="1.bundle.js">
 ```
 
 ### Smart prefetching with quicklink and Guess.js

--- a/src/site/content/en/blog/min-max-clamp/index.md
+++ b/src/site/content/en/blog/min-max-clamp/index.md
@@ -1,4 +1,4 @@
-k---
+---
 title: 'min(), max(), and clamp(): three logical CSS functions to use today'
 subhead: Learn how to control element sizing, maintain proper spacing, and implement fluid typography using these well-supported CSS functions.
 authors:

--- a/src/site/content/en/blog/min-max-clamp/index.md
+++ b/src/site/content/en/blog/min-max-clamp/index.md
@@ -1,4 +1,4 @@
----
+k---
 title: 'min(), max(), and clamp(): three logical CSS functions to use today'
 subhead: Learn how to control element sizing, maintain proper spacing, and implement fluid typography using these well-supported CSS functions.
 authors:
@@ -141,7 +141,7 @@ card itself is getting clamped:
 
 You could break this up with just the `min()` or `max()` function. If you want
 the element to always be at `50%` width, and not exceed `75ch` in width (i.e. on
-larger screens), write: `width: min(75ch, 50%);`. This essentially sets a “max”
+larger screens), write: `width: min(75ch, 50%);`. This essentially sets a "max"
 size by using the `min()` function.
 
 <figure class="w-figure">
@@ -169,8 +169,8 @@ be at _least_ `45ch` or larger.
 
 ## Padding management
 
-Using the same concept as above, where the `min()` function can set a “max”
-value and `max()` sets a “min” value, you can use `max()` to set a minimum
+Using the same concept as above, where the `min()` function can set a "max"
+value and `max()` sets a "min" value, you can use `max()` to set a minimum
 padding size. This example comes from [CSS
 Tricks](https://css-tricks.com/using-max-for-an-inner-element-max-width/), where
 reader Caluã de Lacerda Pataca shared this idea: The idea is to enable an

--- a/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
+++ b/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
@@ -110,9 +110,9 @@ If you omit the `crossorigin` attribute, the browser only performs the DNS looku
 
 ## Resolve domain name early with `rel=dns-prefetch`
 
-You remember sites by their names, but servers remember them by IP addresses. This is why the domain name system (DNS) exists. The browser uses DNS to convert the site name to an IP address. This process — [domain name resolution](https://hacks.mozilla.org/2018/05/a-cartoon-intro-to-dns-over-https/)— is the first step in establishing a connection.
+You remember sites by their names, but servers remember them by IP addresses. This is why the domain name system (DNS) exists. The browser uses DNS to convert the site name to an IP address. This process—[domain name resolution](https://hacks.mozilla.org/2018/05/a-cartoon-intro-to-dns-over-https/)— is the first step in establishing a connection.
 
-If a page needs to make connections to many third-party domains, preconnecting all of them is counterproductive. The `preconnect` hint is best used for only the most critical connections. For all the rest, use  `<link rel=dns-prefetch>` to save time on the first step, the DNS lookup, which usually takes around [20–120 ms](https://www.keycdn.com/support/reduce-dns-lookups).
+If a page needs to make connections to many third-party domains, preconnecting all of them is counterproductive. The `preconnect` hint is best used for only the most critical connections. For all the rest, use `<link rel=dns-prefetch>` to save time on the first step, the DNS lookup, which usually takes around [20–120 ms](https://www.keycdn.com/support/reduce-dns-lookups).
 
 DNS resolution is initiated similarly to `preconnect`: by adding a `<link>` tag to the `<head>` of the document.
 

--- a/src/site/content/en/fast/prioritize-resources/index.md
+++ b/src/site/content/en/fast/prioritize-resources/index.md
@@ -15,8 +15,7 @@ feedback:
 
 Not every byte that is sent down the wire to the browser has the same degree of importance,
 and the browser knows this.
-Browsers have heuristics that attempt to make a best-guess at the most important resources to load first
-— such as CSS before scripts and images.
+Browsers have heuristics that attempt to make a best-guess at the most important resources to load first—such as CSS before scripts and images.
 
 That said, as with any heuristic, it doesn't always work out;
 the browser might make the wrong decision,

--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -151,7 +151,7 @@ Use straight quotation marks and apostrophes, not smart (curly).
 <div class="w-columns">
 <!-- lint disable no-smart-quotes -->
 {% Compare 'worse' %}
-The “Accessible to all” collection
+The "Accessible to all" collection
 {% endCompare %}
 <!-- lint enable no-smart-quotes -->
 

--- a/src/site/content/en/newsletter/archive/2020/03/index.njk
+++ b/src/site/content/en/newsletter/archive/2020/03/index.njk
@@ -604,7 +604,7 @@ a[x-apple-data-detectors] {
                                         <td class="padwhitebox" valign="top" bgcolor="#ffffff" style="padding: 27px 15px;"><table width="100%" border="0" cellspacing="0" cellpadding="0">
                                             <tbody>
                                               <tr>
-                                                <td align="center" valign="top" style="font-family:Google Sans, Roboto, Helvetica, Arial, sans-serif; font-size: 20px; color:#202124; line-height:28px; mso-line-height-rule: exactly;">New “Web on Android” guidance</td>
+                                                <td align="center" valign="top" style="font-family:Google Sans, Roboto, Helvetica, Arial, sans-serif; font-size: 20px; color:#202124; line-height:28px; mso-line-height-rule: exactly;">New "Web on Android" guidance</td>
                                               </tr>
                                               <tr>
                                                 <td class="padtop8" align="center"  valign="top" style="font-family:Roboto, Helvetica, Arial, sans-serif; font-size: 14px; color:#202124; line-height:20px; mso-line-height-rule: exactly; padding-top: 72px;">A new space for you to learn more about bringing more web content into Android apps.</td>

--- a/src/site/content/en/newsletter/archive/2020/06/index.njk
+++ b/src/site/content/en/newsletter/archive/2020/06/index.njk
@@ -359,7 +359,7 @@ text-align: center !important;
 </tbody></table></td>
 </tr>
 <tr>
-<td align="left" class="padR padtop20_t centertext" valign="top" style="font-family:Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color:#202124; line-height:22px; mso-line-height-rule: exactly; padding-top: 12px; padding-right: 10px;">Join our three-day digital event to celebrate our community's actions, learn modern web techniques, and connect with each other. Each day we’ll “travel” to different time zones to answer your questions real-time and bring unique content on topics such as <strong>Web Vitals, PWAs, and Google’s privacy updates.</strong></td>
+<td align="left" class="padR padtop20_t centertext" valign="top" style="font-family:Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color:#202124; line-height:22px; mso-line-height-rule: exactly; padding-top: 12px; padding-right: 10px;">Join our three-day digital event to celebrate our community's actions, learn modern web techniques, and connect with each other. Each day we’ll "travel" to different time zones to answer your questions real-time and bring unique content on topics such as <strong>Web Vitals, PWAs, and Google’s privacy updates.</strong></td>
 </tr>
 <tr>
 <td class="centertext" valign="top" align="left" style="padding-top: 12px;"><table role="presentation" border="0" cellspacing="0" cellpadding="0" class="mrg">

--- a/src/site/content/en/progressive-web-apps/define-install-strategy/index.md
+++ b/src/site/content/en/progressive-web-apps/define-install-strategy/index.md
@@ -158,9 +158,9 @@ Finally, create your own logic to map this information to device categories, and
 
 ```javascript
 if (isDeviceMidOrLowEnd()) {
-   // show “Lite app” install banner or PWA A2HS prompt
+   // show "Lite app" install banner or PWA A2HS prompt
 } else {
-  // show “Core app” install banner
+  // show "Core app" install banner
 }
 ```
 

--- a/src/site/content/en/reliable/broadcast-updates-guide/index.md
+++ b/src/site/content/en/reliable/broadcast-updates-guide/index.md
@@ -29,7 +29,7 @@ tabs it controls to inform of a certain event. Examples include:
 </figure>
 
 We'll call these types of use cases where the service worker doesn't need to receive a message from
-the page to start a communication **“broadcast updates”**. In this guide we'll review different
+the page to start a communication **"broadcast updates"**. In this guide we'll review different
 ways of implementing this type of communication between pages and service workers, by using standard
 browser APIs and the [Workbox library](https://developers.google.com/web/tools/workbox).
 
@@ -45,28 +45,28 @@ browser APIs and the [Workbox library](https://developers.google.com/web/tools/w
 ### Tinder {: #tinder }
 
 Tinder PWA uses [`workbox-window`](https://developers.google.com/web/tools/workbox/modules/workbox-window) to listen to
-important service worker lifecycle moments from the page (“installed”, “controlled” and
-“activated”). That way when a new service worker comes into play, it shows an **"Update Available"**
+important service worker lifecycle moments from the page ("installed", "controlled" and
+"activated"). That way when a new service worker comes into play, it shows an **"Update Available"**
 banner, so that they can refresh the PWA and access the latest features:
 
 <figure class="w-figure">
   <img src="tinder-screenshot.png"
        width="650"
        alt="A screenshot of Tinder's webapp 'Update Available' functionality.">
-  <figcaption class="w-figcaption">In the Tinder PWA, the service worker tells the page that a new version is ready, and the page shows users a “Update Available” banner.</figcaption>
+  <figcaption class="w-figcaption">In the Tinder PWA, the service worker tells the page that a new version is ready, and the page shows users a "Update Available" banner.</figcaption>
 </figure>
 
 ### Squoosh {: #squoosh }
 
 In the [Squoosh PWA](https://squoosh.app/), when the service worker has cached all of the necessary
-assets to make it work offline, it sends a message to the page to show a “Ready to work offline”
+assets to make it work offline, it sends a message to the page to show a "Ready to work offline"
 toast, letting the user know about the feature:
 
 <figure class="w-figure">
   <img src="squoosh-screenshot.png"
        width="550"
        alt="A screenshot of Squoosh webapp 'Ready to work offline' functionality.">
-  <figcaption class="w-figcaption">In the Squoosh PWA the service worker broadcasts an update to the page when cache is ready, and the page displays “Ready to work offline” toast.
+  <figcaption class="w-figcaption">In the Squoosh PWA the service worker broadcasts an update to the page when cache is ready, and the page displays "Ready to work offline" toast.
 </figcaption>
 </figure>
 
@@ -90,7 +90,7 @@ const wb = new Workbox('/sw.js');
 
 wb.addEventListener('installed', (event) => {
   if (event.isUpdate) {
-    // Show “Update App” banner
+    // Show "Update App" banner
   }
 });
 
@@ -144,7 +144,7 @@ navigator.serviceWorker.addEventListener('message', async (event) => {
 ## Using browser APIs {: #using-browser-apis }
 
 If the functionality that Workbox provides is not enough for your needs, use the following browser
-APIs to implement **“broadcast updates”**:
+APIs to implement **"broadcast updates"**:
 
 ### Broadcast Channel API {: #broadcast-channel-api }
 
@@ -173,7 +173,7 @@ const broadcast = new BroadcastChannel('sw-update-channel');
 
 broadcast.onmessage = (event) => {
   if (event.data && event.data.type === 'CRITICAL_SW_UPDATE') {
-    // Show “update to refresh” banner to the user.
+    // Show "update to refresh" banner to the user.
   }
 };
 ```
@@ -230,7 +230,7 @@ navigator.serviceWorker.controller.postMessage({type: 'PORT_INITIALIZATION'}, [
 ]);
 ```
 
-The page listens to messages by implementing an “onmessage” handler on that port:
+The page listens to messages by implementing an "onmessage" handler on that port:
 
 ```javascript
 // Listen to messages

--- a/src/site/content/en/reliable/imperative-caching-guide/index.md
+++ b/src/site/content/en/reliable/imperative-caching-guide/index.md
@@ -61,7 +61,7 @@ They use a mixed approach to decide which items to prefetch:
   add the resulting response objects to the cache.
 - For the remaining items, they listen to the [`mouseover`
   ](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseover_event) event, so that, when a
-  user moves the cursor on top of an item, they can trigger a fetch for the resource on “demand”.
+  user moves the cursor on top of an item, they can trigger a fetch for the resource on "demand".
 
 They use the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) to store JSON
 responses:

--- a/src/site/content/en/reliable/instant-navigation-experiences/index.md
+++ b/src/site/content/en/reliable/instant-navigation-experiences/index.md
@@ -30,7 +30,7 @@ In this guide we'll explore different ways in which [service workers](https://de
 
 ## Production cases
 
-[MercadoLibre](https://www.mercadolibre.com.ar/) is the biggest e-commerce site in Latin America. To speed up navigations, they dynamically inject `<link rel=”prefetch”>` tags in some parts of the flow. For example, in listing pages, they fetch the next result page as soon as the user scrolls to the bottom of the listing:
+[MercadoLibre](https://www.mercadolibre.com.ar/) is the biggest e-commerce site in Latin America. To speed up navigations, they dynamically inject `<link rel="prefetch">` tags in some parts of the flow. For example, in listing pages, they fetch the next result page as soon as the user scrolls to the bottom of the listing:
 
 <figure class="w-figure">
   <img src="mercadolibre-prefetch.png"

--- a/src/site/content/en/reliable/two-way-communication-guide/index.md
+++ b/src/site/content/en/reliable/two-way-communication-guide/index.md
@@ -85,7 +85,7 @@ support](https://caniuse.com/mdn-api_messagechannel_port1) this API has.
 ## Using Browser APIs {: #using-browser-apis }
 
 If the Workbox library is not enough for your needs, there are several lower-level APIs available to
-implement **“two-way”** communication between pages and service workers. They have some similarities
+implement **"two-way"** communication between pages and service workers. They have some similarities
 and differences:
 
 Similarities:

--- a/tools/linting/no-dash-spaces.js
+++ b/tools/linting/no-dash-spaces.js
@@ -32,14 +32,8 @@ function noDashSpaces(tree, file) {
 
   /* eslint-disable require-jsdoc */
   function visitor(node) {
-    const lines = node.value.split('\n');
-    let line;
-
-    for (let index = 0; index < lines.length; index++) {
-      line = lines[index].trim();
-      if (line.match(/\s—\s|\s–\s/g)) {
-        return file.message(reason, node);
-      }
+    if (node.value.match(/\s—\s|\s–\s/g)) {
+      return file.message(reason, node);
     }
   }
 }

--- a/tools/linting/no-smart-quotes.js
+++ b/tools/linting/no-smart-quotes.js
@@ -32,14 +32,8 @@ function noSmartQuotes(tree, file) {
 
   /* eslint-disable require-jsdoc */
   function visitor(node) {
-    const lines = node.value.split('\n');
-    let line;
-
-    for (let index = 0; index < lines.length; index++) {
-      line = lines[index].trim();
-      if (line.match(/[‘’]/g)) {
-        return file.message(reason, node);
-      }
+    if (node.value.match(/[‘’“”]/g)) {
+      return file.message(reason, node);
     }
   }
 }


### PR DESCRIPTION
We were matching single smart-quotes (‘’) but not doubles (“”).

This has actually fixed issues with inline samples already: e.g., the fix to "blog/link-prefetch/index.md".

This also fixes some issues with em/en dashes. We didn't hit these before as we considered all lines separately, but this would actually create space between content.