### PR TITLE
Sw codelab typo

### DIFF
--- a/src/site/content/en/reliable/codelab-service-workers/index.md
+++ b/src/site/content/en/reliable/codelab-service-workers/index.md
@@ -124,7 +124,7 @@ Now that you've got the code added to `register-sw.js` and `service-worker.js`
 files, it's time to visit the Live version of your sample project, and observe
 the service worker in action.
 
-{% Instruction 'preview' %}i
+{% Instruction 'preview' %}
 {% Instruction 'devtools-console', 'ul' %}
 
 You should see something like the following log messages,

--- a/src/site/content/en/reliable/codelab-service-workers/index.md
+++ b/src/site/content/en/reliable/codelab-service-workers/index.md
@@ -124,8 +124,7 @@ Now that you've got the code added to `register-sw.js` and `service-worker.js`
 files, it's time to visit the Live version of your sample project, and observe
 the service worker in action.
 
-{% Instruction 'preview' %}
-{% Instruction 'devtools' %}
+{% Instruction 'preview' %}i
 {% Instruction 'devtools-console', 'ul' %}
 
 You should see something like the following log messages,


### PR DESCRIPTION
Changes proposed in this pull request:

Removing one of the devtools instructions, because in this [codelab](https://web.dev/codelab-service-workers/) the instruction for devtools is duplicated and causes this text to be displayed twice: 

Press Control+Shift+J (or Command+Option+J on Mac) to open DevTools.
Press Control+Shift+J (or Command+Option+J on Mac) to open DevTools.

