### PR TITLE
Update 'uses-http2' article to be more accurate

### DIFF
--- a/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
+++ b/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
@@ -21,12 +21,11 @@ and with less data moving over the wire.
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/Gs0J63479ELUkMeI8MRS.png", alt="Lighthouse audit shows resources not served over HTTP/2 ", width="800", height="191", class="w-screenshot" %}
 </figure>
 
-Lighthouse gathers all resources from the same host as the page
-and checks the HTTP protocol version of each resource.
-
-Lighthouse doesn't check resources from other hosts
-because it assumes that you have no control
-over how third-party resources are served.
+Lighthouse gathers all resources requested by the page
+and checks the HTTP protocol version of each. There are some
+cases where non-HTTP/2 requests will be ignored in the audit
+results. [See the implementation](https://github.com/GoogleChrome/lighthouse/blob/9fad007174f240982546887a7e97f452e0eeb1d1/lighthouse-core/audits/dobetterweb/uses-http2.js#L138)
+for more.
 
 {% include 'content/lighthouse-best-practices/scoring.njk' %}
 

--- a/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
+++ b/src/site/content/en/lighthouse-best-practices/uses-http2/index.md
@@ -25,7 +25,7 @@ Lighthouse gathers all resources requested by the page
 and checks the HTTP protocol version of each. There are some
 cases where non-HTTP/2 requests will be ignored in the audit
 results. [See the implementation](https://github.com/GoogleChrome/lighthouse/blob/9fad007174f240982546887a7e97f452e0eeb1d1/lighthouse-core/audits/dobetterweb/uses-http2.js#L138)
-for more.
+for more details.
 
 {% include 'content/lighthouse-best-practices/scoring.njk' %}
 


### PR DESCRIPTION
> Lighthouse gathers all resources from the same host as the page
and checks the HTTP protocol version of each resource.

me and @paulirish don't think that's right... after inspecting our we know we don't do this.