### PR TITLE
Attempt to fix broken rendering of coop-coep article

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -216,6 +216,8 @@ applying `allow="cross-origin-isolated"` feature policy to the `<iframe>` tag
 and meeting the same conditions described in this document.
 {% endAside %}
 
+<br>
+
 {% Aside 'key-term' %}
 It's important that you understand the difference between "same-site" and
 "same-origin". Learn about the difference at [Understanding same-site and


### PR DESCRIPTION
The there's an extra end tag that causes the page's markup to be rendered outside of the center column:
https://web.dev/coop-coep/#:~:text=Understanding%20same-site%20and%20same-origin

> **Update:** this did not fix the issue. 