### PR TITLE
Change relative path to assets path for actions CTAs

### DIFF
--- a/src/styles/components/_actions.scss
+++ b/src/styles/components/_actions.scss
@@ -119,7 +119,7 @@ $W_FAB_LARGE_RADIUS: 28px;
 //------------------------------------------------------------------------------
 
 .w-actions__fab--share::before {
-  background-image: url('../images/icons/share_white.svg');
+  background-image: url('/images/icons/share_white.svg');
 }
 
 //------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ $W_FAB_LARGE_RADIUS: 28px;
 }
 
 .w-actions__fab--subscribe::before {
-  background-image: url('../images/icons/subscribe.svg');
+  background-image: url('/images/icons/subscribe.svg');
 }
 
 .w-actions__fab--subscribe:hover::after {


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #4807

- Share and Subscribe action CTAs used in https://web.dev/handbook/web-dev-components/ seemed to be using assets from the images subfolder in `src`.
- Changed the relative path to image cdn assets path.
