### PR TITLE
Fix article title typo

### DIFF
--- a/src/site/content/en/blog/preload-optional-fonts/index.md
+++ b/src/site/content/en/blog/preload-optional-fonts/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Prevent layout shifting and flashes of invisibile text (FOIT) by preloading optional fonts'
+title: 'Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts'
 subhead: 'Starting in Chrome 83, link rel="preload" and font-display: optional can be combined to remove layout jank completely'
 authors:
   - houssein


### PR DESCRIPTION
The article title on https://web.dev/preload-optional-fonts/ had a typo, quick fix to address ☺️