### PR TITLE
Removes a broken audit link

### DIFF
--- a/src/site/content/en/lighthouse-pwa/offline-start-url/index.md
+++ b/src/site/content/en/lighthouse-pwa/offline-start-url/index.md
@@ -45,7 +45,6 @@ guide for more information.
 
 ## Resources
 
-- [Source code for **`start_url` does not respond with a 200 when offline** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/offline-start-url.js)
 - [What is network reliability and how do you measure it?](/network-connections-unreliable/)
 - [Add a web app manifest](/add-manifest/)
 - [Workbox: Your high-level service worker toolkit](/workbox/)

--- a/src/site/content/en/lighthouse-pwa/works-offline/index.md
+++ b/src/site/content/en/lighthouse-pwa/works-offline/index.md
@@ -50,6 +50,5 @@ with the [Working with service workers](/codelab-service-workers) codelab.
 
 ## Resources
 
-- [Source code for **Current page does not respond with a 200 when offline** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/works-offline.js)
 - [What is network reliability and how do you measure it?](/network-connections-unreliable/)
 - [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers)


### PR DESCRIPTION
Hello everyone, everything good?

According to this [Pull Request](https://github.com/GoogleChrome/lighthouse/pull/11806), in the lighthouse repository where @paulirish remove works-offline and offline-start-url audits, the current link is pointing to a broken page.

Therefore, I believe that it would be the best solution to remove the link, since the file no longer exists.

This fixes Issue #4873.