### PR TITLE
Fix analysis anchor in cross origin isolation guide

### DIFF
--- a/src/site/content/en/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/en/secure/cross-origin-isolation-guide/index.md
@@ -47,7 +47,7 @@ two ways find out:
 * (Advanced) Using Deprecation Reporting
 
 If you already know where you are using `SharedArrayBuffer`, skip to 
-[Analyze the impact of cross-origin isolation](:analysis).
+[Analyze the impact of cross-origin isolation](#analysis).
 
 ### Using Chrome DevTools
 


### PR DESCRIPTION
Changes proposed in this pull request:

- The link of `Analyze the impact of cross-origin isolation` in https://web.dev/cross-origin-isolation-guide/ is 404 now because it's a typo with leading colon. Instead, it should use `#` to be an anchor. 
