### PR TITLE
Fix SyntaxError in example of steams

### DIFF
--- a/src/site/content/en/blog/streams/index.md
+++ b/src/site/content/en/blog/streams/index.md
@@ -756,7 +756,7 @@ const writableStream = new WritableStream({
     // Called by constructor
     console.log('[start writable]');
   },
-  write(chunk, controller) {
+  async write(chunk, controller) {
     // Called upon writer.write()
     console.log('[write]', chunk);
     // Wait for next write.


### PR DESCRIPTION
Fix SyntaxError in example of "Piping a readable stream to a writable stream"

Fixes #4915