### PR TITLE
adding link to MDN.

### DIFF
--- a/src/site/content/en/secure/cross-origin-resource-sharing/index.md
+++ b/src/site/content/en/secure/cross-origin-resource-sharing/index.md
@@ -182,8 +182,8 @@ Access-Control-Allow-Credentials: true
 
 ## Preflight requests for complex HTTP calls
 
-If a web app needs a complex HTTP request, the browser adds a **preflight
-request** to the front of the request chain.
+If a web app needs a complex HTTP request, the browser adds a **[preflight
+request](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests)** to the front of the request chain.
 
 The CORS specification defines a **complex request** as
 


### PR DESCRIPTION
Adds a link to the MDN information on preflighted requests to https://web.dev/cross-origin-resource-sharing/#preflight-requests-for-complex-http-calls

cc: @mihajlija @agektmr 