### PR TITLE
Match link href with anchor name on "Optimize First Input Delay" page

### DIFF
--- a/src/site/content/en/blog/optimize-fid/index.md
+++ b/src/site/content/en/blog/optimize-fid/index.md
@@ -58,7 +58,7 @@ browser can't respond to user interactions while the main thread is busy. To imp
 
 - [Break up Long Tasks](#long-tasks)
 - [Optimize your page for interaction readiness](#optimize-interaction-readiness)
-- [Use a web worker](#web-worker)
+- [Use a web worker](#use-a-web-worker)
 - [Reduce JavaScript execution time](#reduce-javascript-execution)
 
 ## Break up Long Tasks {: #long-tasks }


### PR DESCRIPTION
Fixes #4930 

Changes proposed in this pull request:
- Update "Use a web worker" link href to `#use-a-web-worker` to match anchor tag name.
