### PR TITLE
Warn developers about absolute/relative UVC controls

### DIFF
--- a/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
+++ b/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
@@ -106,7 +106,7 @@ try {
 
 To know whether a Chromium-based browser supports PTZ for a camera, go to the
 internal `about://media-internals` page and check out the "Pan-Tilt-Zoom" column
-in the "Video Capture" tab: "pan tilt" and "zoom" respectively mean the camera supports
+in the "Video Capture" tab; "pan tilt" and "zoom" respectively mean the camera supports
 the "PanTilt (Absolute)" and "Zoom (Absolute)" [UVC controls]. The "PanTilt (Relative)"
 and "Zoom (Relative)" UVC controls are not supported in Chromium-based browsers.
 

--- a/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
+++ b/src/site/content/en/blog/camera-pan-tilt-zoom/index.md
@@ -5,7 +5,7 @@ subhead:
 authors:
   - beaufortfrancois
 date: 2020-10-05
-updated: 2020-11-18
+updated: 2021-03-22
 hero: image/admin/wbcUb7ooaR1nCeYnSiCV.jpg
 thumbnail: image/admin/eBugU3Spjq9df1qb5l0b.jpg
 alt: Five persons in a conference room photo.
@@ -106,10 +106,18 @@ try {
 
 To know whether a Chromium-based browser supports PTZ for a camera, go to the
 internal `about://media-internals` page and check out the "Pan-Tilt-Zoom" column
-in the "Video Capture" tab.
+in the "Video Capture" tab: "pan tilt" and "zoom" respectively mean the camera supports
+the "PanTilt (Absolute)" and "Zoom (Absolute)" [UVC controls]. The "PanTilt (Relative)"
+and "Zoom (Relative)" UVC controls are not supported in Chromium-based browsers.
 
 <figure class="w-figure">
-  {% Img src="image/admin/TbU7mM3pfq0bNTkgiOnZ.jpg", alt="Screenshot of the internal page in Chrome OS to debug PTZ camera support.", width="800", height="500", class="w-screenshot" %}
+  {% Img
+    src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/4EDS8fYYifXAUY6SBaiV.png",
+    alt="Screenshot of the internal page in Chrome OS to debug PTZ camera support.",
+    width="800",
+    height="481",
+    class="w-screenshot"
+  %}
   <figcaption class="w-figcaption">Internal page to debug PTZ camera support.</figcaption>
 </figure>
 
@@ -220,8 +228,9 @@ Hero image by [Christina @ wocintechchat.com] on [Unsplash].
 [mandatory constraints]: https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#Specifying_a_range_of_values:~:text=mandatory
 [`MediaStream`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaStream
 [Permissions API]: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API
+[UVC controls]: https://www.usb.org/document-library/video-class-v15-document-set
 [PTZ advanced constraints]: https://bugs.chromium.org/p/chromium/issues/detail?id=1126045
-[Page Visibilty API]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+[Page Visibility API]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [demo]: https://ptz.glitch.me/
 [check out the source code]: https://glitch.com/edit/#!/ptz?path=public%2Fscript.js
 [run Chrome with the switch]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags


### PR DESCRIPTION
This PR is about updating the "Control camera pan, tilt, and zoom" blog post with a note on Chromium using the absolute UVC controls, not the relative ones. This will hopefully reduce developer confusion as seen in https://github.com/w3c/mediacapture-image/issues/263#issuecomment-804053608.