### PR TITLE
allow strikethrough

### DIFF
--- a/tools/linting/no-repeat-punctuation.js
+++ b/tools/linting/no-repeat-punctuation.js
@@ -43,7 +43,8 @@ const rule = require('unified-lint-rule');
 const map = require('unist-util-map');
 const toList = require('unist-util-to-list-of-char');
 
-const punctuations = '！!~～.。,，·?？';
+// nb. We removed "~" here because it flagged strikethrough content.
+const punctuations = '！!～.。,，·?？';
 
 /* eslint-disable require-jsdoc */
 class Traveler {


### PR DESCRIPTION
This allows strikethrough (denoted by "~~").

We still trigger on "no-duplicate-headings-in-section", but a number of blog posts repeat headings. Can we turn this one off—or perhaps limit it to only top-level headings? @robdodson

"fixes" part of #4820.