### PR TITLE
Update link in content review checklists page

### DIFF
--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -378,7 +378,7 @@ to this rule, which will be done on a case-by-case basis.
 
 ### Avoid insensitive words {: #insensitive-words }
 
-Refer to the [GDDSG word list][gddsg] and make sure that you're not using
+Refer to the [GDDSG word list][wordlist] and make sure that you're not using
 any insensitive words, such as:
 
 * [blacklist](https://developers.google.com/style/word-list#blacklist)


### PR DESCRIPTION
Changes proposed in this pull request:

- Update link to [GDDSG word list](https://developers.google.com/style/word-list)

Screenshot from https://web.dev/handbook/content-checklist/#insensitive-words:
![Screenshot 2021-03-23 at 15 29 20](https://user-images.githubusercontent.com/9759549/112172553-b7600c80-8bec-11eb-80b1-efd2a78d189c.png)
