### PR TITLE
Correct the performance gain explanation

### DIFF
--- a/src/site/content/en/blog/variable-fonts/index.md
+++ b/src/site/content/en/blog/variable-fonts/index.md
@@ -628,7 +628,7 @@ individual fonts in a single variable font file meant a _88% reduction in file
 size_.
 
 However, if you are using a single font such as Roboto Regular and nothing
-else, you might see a net gain in font size if you were to switch to a
+else, you might not see a net gain in font size if you were to switch to a
 variable font with many axes. As always, it depends on your use-case.
 
 On the flip side, animating the font between settings may cause performance


### PR DESCRIPTION
The author most probably accidentally missed the negation. If a website uses only a single font such as Roboto Regular, they would most likely not see any meaningful gain in font file size  if they switch to a variable font with many axes.

Changes proposed in this pull request:

- Correct the performance gain explanation when using variable font against only a single style font