### PR TITLE
Gravity sensor: Adding release estimation date

### DIFF
--- a/src/site/content/en/blog/generic-sensor/index.md
+++ b/src/site/content/en/blog/generic-sensor/index.md
@@ -206,7 +206,7 @@ terms of API ergonomics. The
 of acceleration along the device's X, Y, and Z axis due to gravity.
 
 {% Aside %}
-  `GravitySensor` is expected to start shipping in Chrome&nbsp;91.
+  `GravitySensor` is expected to ship in Chrome&nbsp;91.
 {% endAside %}
 
 ### Gyroscope {: #gyroscope-sensor }

--- a/src/site/content/en/blog/generic-sensor/index.md
+++ b/src/site/content/en/blog/generic-sensor/index.md
@@ -205,9 +205,7 @@ terms of API ergonomics. The
 [`GravitySensor`](https://w3c.github.io/accelerometer/#gravitysensor-interface) returns the effect
 of acceleration along the device's X, Y, and Z axis due to gravity.
 
-{% Aside %} As of February 2021, GravitySensor is still
-[under development](https://bugs.chromium.org/p/chromium/issues/detail?id=1163993) with no estimated
-release date. {% endAside %}
+{% Aside %} GravitySensor is expected to start shipping in Chrome 91. {% endAside %}
 
 ### Gyroscope {: #gyroscope-sensor }
 

--- a/src/site/content/en/blog/generic-sensor/index.md
+++ b/src/site/content/en/blog/generic-sensor/index.md
@@ -205,7 +205,9 @@ terms of API ergonomics. The
 [`GravitySensor`](https://w3c.github.io/accelerometer/#gravitysensor-interface) returns the effect
 of acceleration along the device's X, Y, and Z axis due to gravity.
 
-{% Aside %} GravitySensor is expected to start shipping in Chrome 91. {% endAside %}
+{% Aside %}
+  `GravitySensor` is expected to start shipping in Chrome&nbsp;91.
+{% endAside %}
 
 ### Gyroscope {: #gyroscope-sensor }
 


### PR DESCRIPTION
Fixes #4966

Release estimation for Gravity Sensor API is
chrome 91. [1]

[1] https://chromestatus.com/features/5384099747332096