### PR TITLE
updates to manifest updates

### DIFF
--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -20,7 +20,7 @@ comment in [issue #4038](https://github.com/GoogleChrome/web.dev/issues/4038).
 When a PWA is installed, the browser uses information from the web app
 manifest for the app name, the icons the app should use, and the URL that
 should be opened when the app is launched. But what if you need to update
-your app name, or provide new icons? When and how are those changes reflected
+information in your manifest file? When and how are those changes reflected
 in the browser?
 
 {% Aside 'caution' %}
@@ -41,19 +41,14 @@ compare it against the local copy.
 
 If select properties in the manifest have changed (see list below), Chrome
 queues the new manifest, and after all windows have been closed, installs it.
-Once installed, all fields from the new manifest (except `name`, `short_name`
-and `start_url`) are updated. If the PWA has been added to the dock on macOS,
-the icon will not update until the PWA is launched from the dock again.
+Once installed, all fields from the new manifest (except `name`, `short_name`,  `start_url` and `icons`) are updated. 
 
 ### Which properties will trigger an update? {: #cr-desktop-trigger }
 
 * `display` (see below)
-* `icons`
 * `scope`
 * `shortcuts`
 * `theme_color`
-* Pixel changes to primary icon file
-* Pixel changes to splash icon file
 
 {% Aside 'caution' %}
 Changes to `name`, `short_name`, and `start_url` are **not** currently
@@ -104,18 +99,13 @@ used.
 
 * `background_color`
 * `display`
-* `icons`
-* `name`
 * `orientation`
 * `scope`
 * `shortcuts`
-* `short_name`
 * `start_url`
 * `theme_color`
 * `web_share_target`
 * `maskable` value of primary icon has changed
-* File hash changes to the primary icon file
-* File hash changes to the splash icon file
 
 If Chrome is unable to get an updated manifest from the server, it may
 increase the time between checks to 30 days.

--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -4,6 +4,7 @@ title: How Chrome handles updates to the web app manifest
 subhead: What it takes to change icons, shortcuts, colors, and other metadata for your PWA
 authors:
   - petelepage
+  - ajara
 date: 2020-10-14
 updated: 2020-10-14
 description: What it takes to change icons, shortcuts, colors, and other metadata in your web app manifest for your PWA.
@@ -20,8 +21,8 @@ comment in [issue #4038](https://github.com/GoogleChrome/web.dev/issues/4038).
 When a PWA is installed, the browser uses information from the web app
 manifest for the app name, the icons the app should use, and the URL that
 should be opened when the app is launched. But what if you need to update
-information in your manifest file? When and how are those changes reflected
-in the browser?
+app shortcuts or try a new theme color? When and how are those changes
+reflected in the browser?
 
 {% Aside 'caution' %}
 Do not change the name or location of your web app manifest file, doing so
@@ -42,7 +43,7 @@ compare it against the local copy.
 If select properties in the manifest have changed (see list below), Chrome
 queues the new manifest, and after all windows have been closed, installs it.
 Once installed, all fields from the new manifest (except `name`, `short_name`,
-`start_url` and `icons`) are updated. 
+`start_url` and `icons`) are updated.
 
 ### Which properties will trigger an update? {: #cr-desktop-trigger }
 
@@ -52,8 +53,8 @@ Once installed, all fields from the new manifest (except `name`, `short_name`,
 * `theme_color`
 
 {% Aside 'caution' %}
-Changes to `name`, `short_name`, and `start_url` are **not** currently
-supported on desktop Chrome, though work is underway to support them.
+Changes to `name`, `short_name`, `icons` and `start_url` are **not**
+currently supported on desktop Chrome, though work is underway to support them.
 {% endAside %}
 
 <!-- CrBug for name/shortname https://crbug.com/1088338 -->
@@ -109,6 +110,11 @@ used.
 
 If Chrome is unable to get an updated manifest from the server, it may
 increase the time between checks to 30 days.
+
+{% Aside 'caution' %}
+Changes to `name`, `short_name` and `icons` are **not** currently supported
+on Android Chrome, though work is underway to support them.
+{% endAside %}
 
 ### Testing manifest updates {: #cr-android-test }
 

--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -6,7 +6,7 @@ authors:
   - petelepage
   - ajara
 date: 2020-10-14
-updated: 2020-10-14
+updated: 2021-04-05
 description: What it takes to change icons, shortcuts, colors, and other metadata in your web app manifest for your PWA.
 tags:
   - progressive-web-apps

--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -41,7 +41,8 @@ compare it against the local copy.
 
 If select properties in the manifest have changed (see list below), Chrome
 queues the new manifest, and after all windows have been closed, installs it.
-Once installed, all fields from the new manifest (except `name`, `short_name`,  `start_url` and `icons`) are updated. 
+Once installed, all fields from the new manifest (except `name`, `short_name`,
+`start_url` and `icons`) are updated. 
 
 ### Which properties will trigger an update? {: #cr-desktop-trigger }
 
@@ -105,7 +106,6 @@ used.
 * `start_url`
 * `theme_color`
 * `web_share_target`
-* `maskable` value of primary icon has changed
 
 If Chrome is unable to get an updated manifest from the server, it may
 increase the time between checks to 30 days.


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:
Icons and name can from the manifest can no longer be updated for PWAs, on mobile or desktop. 
This PR updates the corresponding article to reflect that.