### PR TITLE
Fix broken Assessment shortcode

### DIFF
--- a/src/lib/components/BaseResponseElement/index.js
+++ b/src/lib/components/BaseResponseElement/index.js
@@ -37,7 +37,7 @@ export class BaseResponseElement extends BaseElement {
     this.maxSelections = null;
     this.minSelections = null;
 
-    this.deselectOption = /** @type {function(Node)} */ null;
+    this.deselectOption = this.deselectOption.bind(this);
     this.enforceCardinality = this.enforceCardinality.bind(this);
     this.submitResponse = this.submitResponse.bind(this);
     this.reset = this.reset.bind(this);
@@ -226,6 +226,10 @@ export class BaseResponseElement extends BaseElement {
       this.enableOption(option);
     }
   }
+
+  // @ts-ignore-start
+  deselectOption(option) {} // eslint-disable-line no-unused-vars
+  // @ts-ignore-end
 
   disableOption(option) {
     const inputs = option.querySelectorAll('input, button');

--- a/src/site/_drafts/_template-self-assessment/index.md
+++ b/src/site/_drafts/_template-self-assessment/index.md
@@ -11,7 +11,7 @@ tags:
 
 Include a self-assessment in your post using this short code:
 
-{% Assessment page, 'my-first-self-assessment' %}
+{% Assessment 'my-first-self-assessment' %}
 
 Rename the file and the shortcode argument
 so it conveys the topic of your assessment.

--- a/src/site/_includes/components/Assessment.js
+++ b/src/site/_includes/components/Assessment.js
@@ -207,7 +207,7 @@ function rationaleTemplate(option) {
  * Gets the assessment object from the YAML file passed in the shortcode
  * and passes it to the template functions above.
  * @this {EleventyPage}
- * @param {*} targetAssessment
+ * @param {TargetAssessment} targetAssessment
  * @returns
  */
 module.exports = function (targetAssessment) {

--- a/src/site/_includes/components/Assessment.js
+++ b/src/site/_includes/components/Assessment.js
@@ -203,22 +203,22 @@ function rationaleTemplate(option) {
   `;
 }
 
-// Gets the assessment object from the YAML file passed in the shortcode
-// and passes it to the template functions above.
-module.exports = (page, targetAssessment) => {
-  if (!page) {
-    throw new Error(
-      `Can't create Assessment component without the page argument.`,
-    );
-  }
-
+/**
+ * Gets the assessment object from the YAML file passed in the shortcode
+ * and passes it to the template functions above.
+ * @this {EleventyPage}
+ * @param {*} targetAssessment
+ * @returns
+ */
+module.exports = function (targetAssessment) {
   if (!targetAssessment) {
     throw new Error(`
       Can't create Assessment component without a target assessment.
       Pass the file name, without ".assess.yml", of the desired assessment as a string.
     `);
   }
-  const filePath = page.filePathStem.replace(/index$/, '');
+
+  const filePath = this.page.filePathStem.replace(/index$/, '');
   const source = path.join(
     site.contentDir,
     filePath,

--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -1,5 +1,7 @@
 ---
 layout: base
+pageScripts:
+  - '/js/content.js'
 ---
 
 {#

--- a/src/site/content/en/accessible/control-focus-with-tabindex/index.md
+++ b/src/site/content/en/accessible/control-focus-with-tabindex/index.md
@@ -148,7 +148,7 @@ You can learn more about them in our guide on
 [screen reader basics](/semantics-and-screen-readers).
 {% endAside %}
 
-{% Assessment page, 'self-assessment' %}
+{% Assessment 'self-assessment' %}
 
 ## Keyboard access recipes
 

--- a/src/site/content/en/accessible/labels-and-text-alternatives/index.md
+++ b/src/site/content/en/accessible/labels-and-text-alternatives/index.md
@@ -334,4 +334,4 @@ promotional offers?" like in the VoiceOver example below:
   {% Img src="image/admin/WklT2ymrCmceyrGUNizF.png", alt="VoiceOver text output showing 'Receive promotional offers?'", width="640", height="174", class="w-screenshot" %}
 </figure>
 
-{% Assessment page, 'self-assessment' %}
+{% Assessment 'self-assessment' %}

--- a/src/site/content/en/accessible/use-semantic-html/index.md
+++ b/src/site/content/en/accessible/use-semantic-html/index.md
@@ -105,7 +105,7 @@ The reason for this is that buttons and links are announced differently by
 screen readers. Using the correct element helps screen reader users know which
 outcome to expect.
 
-{% Assessment page, 'self-assessment' %}
+{% Assessment 'self-assessment' %}
 
 ## Styling
 

--- a/src/site/content/en/handbook/self-assessment-components/index.md
+++ b/src/site/content/en/handbook/self-assessment-components/index.md
@@ -9,7 +9,7 @@ description: |
 Self-assessments provide opportunities for users
 to check their understanding of concepts covered in your post.
 
-{% Assessment page, 'self-assessment' %}
+{% Assessment 'self-assessment' %}
 
 1. [Start a self-assessment](#start-a-self-assessment)
 1. [Question set parameters](#question-set-parameters)
@@ -25,7 +25,7 @@ to check their understanding of concepts covered in your post.
 To include a self-assessment in your post:
 1. Add this short code to your post where you want the self-assessment to appear:
     ```html
-    {% raw %}{% Assessment page, 'my-first-self-assessment' %}{% endraw %}
+    {% raw %}{% Assessment 'my-first-self-assessment' %}{% endraw %}
     ```
 1. Copy `my-first-self-assessment.assess.yml` in `src/site/_drafts/_template-self-assessment`
    to your post's directory.
@@ -229,6 +229,6 @@ You can add as many assessments as you want as long as each has a unique name.
 For example:
 
 ```html
-{% raw %}{% Assessment page, 'first-assessment' %}
-{% Assessment page, 'second-assessment' %}{% endraw %}
+{% raw %}{% Assessment 'first-assessment' %}
+{% Assessment 'second-assessment' %}{% endraw %}
 ```

--- a/src/site/content/en/handbook/self-assessment-components/index.md
+++ b/src/site/content/en/handbook/self-assessment-components/index.md
@@ -19,11 +19,16 @@ to check their understanding of concepts covered in your post.
     - [Think-and-checks](#think-and-checks)
     - [Composite questions](#composite-questions)
 1. [Multiple sets in one post](#multiple-sets-in-one-post)
+1. [Example assessment](#example-assessment)
+1. [Types](#types)
+    - [TargetAssessment](#targetassessment)
+    - [TargetAssessmentQuestion](#targetassessmentquestion)
+    - [TargetAssessmentOption](#targetassessmentoption)
 
 ## Start a self-assessment
 
 To include a self-assessment in your post:
-1. Add this short code to your post where you want the self-assessment to appear:
+1. Add this shortcode to your post where you want the self-assessment to appear:
     ```html
     {% raw %}{% Assessment 'my-first-self-assessment' %}{% endraw %}
     ```
@@ -231,4 +236,29 @@ For example:
 ```html
 {% raw %}{% Assessment 'first-assessment' %}
 {% Assessment 'second-assessment' %}{% endraw %}
+```
+
+## Example assessment
+
+```yml
+{% include '../../../../_drafts/_template-self-assessment/my-first-self-assessment.assess.yml' %}
+```
+
+## Types
+
+The `*.assess.yml` file can be broken down into the following types:
+
+### TargetAssessment
+```typescript
+{% include '../../../../../../types/site/_includes/components/Assessment/TargetAssessment.d.ts' %}
+```
+
+### TargetAssessmentQuestion
+```typescript
+{% include '../../../../../../types/site/_includes/components/Assessment/TargetAssessmentQuestion.d.ts' %}
+```
+
+### TargetAssessmentOption
+```typescript
+{% include '../../../../../../types/site/_includes/components/Assessment/TargetAssessmentOption.d.ts' %}
 ```

--- a/src/site/content/en/secure/same-origin-policy/index.md
+++ b/src/site/content/en/secure/same-origin-policy/index.md
@@ -101,7 +101,7 @@ cross-origin resource is blocked.
 [See how the same-origin policy works when accessing data inside an iframe](/codelab-same-origin-iframe).
 {% endAside %}
 
-{% Assessment page, 'self-assessment' %}
+{% Assessment 'self-assessment' %}
 
 ### How to prevent Clickjacking
 

--- a/types/site/_includes/components/Assessment/TargetAssessment.d.ts
+++ b/types/site/_includes/components/Assessment/TargetAssessment.d.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  export interface TargetAssessment {
+    setLeader?: string,
+    height?: string,
+    tabLabel: "question" | "sample" | "bare",
+    questions: TargetAssessmentQuestion[],
+  }
+}
+
+// empty export to keep file a module
+export {};

--- a/types/site/_includes/components/Assessment/TargetAssessmentOption.d.ts
+++ b/types/site/_includes/components/Assessment/TargetAssessmentOption.d.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  export interface TargetAssessmentOption {
+    content?: string,
+    rationale: string,
+  }
+}
+
+// empty export to keep file a module
+export {};

--- a/types/site/_includes/components/Assessment/TargetAssessmentQuestion.d.ts
+++ b/types/site/_includes/components/Assessment/TargetAssessmentQuestion.d.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  export interface TargetAssessmentQuestion {
+    type: string,
+    stimulus?: string,
+    stem: string,
+    cardinality?: string,
+    correctAnswers?: string,
+    options: TargetAssessmentOption[],
+    columns?: boolean,
+    components?: TargetAssessmentQuestion[],
+  }
+}
+
+// empty export to keep file a module
+export {};


### PR DESCRIPTION
Fixes #4973

Changes proposed in this pull request:

- Changes `Assessment` widget so it no longer needs a `page` argument.
- Adds types for the `*.assess.yml` file
- Fixes a bug where multiple choice responses were attempting to bind to `null`.
- Adds the `content.js` entrypoint to `course.njk` so it can use our fancy self assessment web component