### PR TITLE
Show live links in course and fix overscroll

### DIFF
--- a/src/site/_filters/navigation.js
+++ b/src/site/_filters/navigation.js
@@ -46,7 +46,7 @@ function buildTree(toc, map) {
     }
   }
 
-  list.forEach((item, idx) => {
+  list.forEach((/** @type {NavigationItem} */ item, idx) => {
     item.prev = list[idx - 1] || null;
     item.next = list[idx + 1] || null;
   });

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -20,14 +20,10 @@
       </div>
 
       <div class="drawer-course__links scrollbar">
-        {% for i in range(0, 40) %}
-        <a class="drawer-course__link" {% if i == 2 %} data-active {% endif %} {% if i == 4 %} data-complete {% endif %} href="/learn/">
-          <span class="drawer-course__link-counter font-mono">{{ i | padStart(3, '0') }}</span>
-          {% if i % 2 == 0 %}
-          <span class="drawer-course__link-title gap-left-400">Flexbox</span>
-          {% else %}
-          <span class="drawer-course__link-title gap-left-400">Learn borders and shadows and this is pretty long</span>
-          {% endif %}
+        {% for item in pageNavigation %}
+        <a class="drawer-course__link" href="{{ item.url }}">
+          <span class="drawer-course__link-counter font-mono">{{ loop.index0 | padStart(3, '0') }}</span>
+          <span class="drawer-course__link-title gap-left-400">{{ item.page.data.title }}</span>
           {{ icon('done', 'drawer-course__link-check gap-left-auto') }}
         </a>
         {% endfor %}

--- a/src/styles/components/_course-toc.scss
+++ b/src/styles/components/_course-toc.scss
@@ -16,6 +16,7 @@
     flex-shrink: 0;
     order: 1;
     overflow-y: auto;
+    overscroll-behavior: contain; // sass-lint:disable-line no-misspelled-properties
     padding: 0 get-size(300);
     position: sticky;
     // TODO: Move these into variables

--- a/src/styles/components/_drawer-course.scss
+++ b/src/styles/components/_drawer-course.scss
@@ -41,6 +41,7 @@
   &__links {
     flex: 1;
     overflow-y: auto;
+    overscroll-behavior: contain; // sass-lint:disable-line no-misspelled-properties
   }
 
   &__link {


### PR DESCRIPTION
Changes proposed in this pull request:

- Makes the courses show correct titles for pages in the navigation drawer
- Sets `overscroll-behavior: contain` on the drawer and toc so they don't accidentally scroll the page
