### PR TITLE
feat(updated): sort posts by updated and show updated date, fixes #2283

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -17,7 +17,7 @@
 const authorsData = require('../_data/authorsData.json');
 const {livePosts} = require('../_filters/live-posts');
 const setdefault = require('../_utils/setdefault');
-const {sortByDate} = require('../_utils/sort-by-date');
+const {sortByUpdated} = require('../_utils/sort-by-updated');
 
 /** @type Authors */
 let processedCollection;
@@ -80,7 +80,7 @@ module.exports = (collections) => {
 
   if (collections) {
     // Find all posts, sort and key by author. Don't yet filter to live posts.
-    allPosts = collections.getFilteredByGlob('**/*.md').sort(sortByDate);
+    allPosts = collections.getFilteredByGlob('**/*.md').sort(sortByUpdated);
   }
 
   const authorsPosts = findAuthorsPosts(allPosts);

--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -17,6 +17,7 @@
 const authorsData = require('../_data/authorsData.json');
 const {livePosts} = require('../_filters/live-posts');
 const setdefault = require('../_utils/setdefault');
+const {sortByDate} = require('../_utils/sort-by-date');
 
 /** @type Authors */
 let processedCollection;
@@ -79,9 +80,7 @@ module.exports = (collections) => {
 
   if (collections) {
     // Find all posts, sort and key by author. Don't yet filter to live posts.
-    allPosts = collections
-      .getFilteredByGlob('**/*.md')
-      .sort((a, b) => b.date.getTime() - a.date.getTime());
+    allPosts = collections.getFilteredByGlob('**/*.md').sort(sortByDate);
   }
 
   const authorsPosts = findAuthorsPosts(allPosts);

--- a/src/site/_collections/blog-posts-descending.js
+++ b/src/site/_collections/blog-posts-descending.js
@@ -15,7 +15,6 @@
  */
 
 const {livePosts} = require('../_filters/live-posts');
-const {sortByDate} = require('../_utils/sort-by-date');
 
 /**
  * @param {EleventyCollectionObject} collection
@@ -23,5 +22,5 @@ const {sortByDate} = require('../_utils/sort-by-date');
  */
 module.exports = (collection) => {
   const tag = process.env.PERCY ? 'test-post' : 'blog';
-  return collection.getFilteredByTag(tag).filter(livePosts).sort(sortByDate);
+  return collection.getFilteredByTag(tag).filter(livePosts).reverse();
 };

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -16,7 +16,7 @@
 /** @type TagsData */
 const tagsData = require('../_data/tagsData.json');
 const {livePosts} = require('../_filters/live-posts');
-const {sortByDate} = require('../_utils/sort-by-date');
+const {sortByUpdated} = require('../_utils/sort-by-updated');
 
 /** @type Tags */
 let processedCollection;
@@ -63,7 +63,7 @@ module.exports = (collections) => {
       tag.elements = collections
         .getFilteredByTag(tag.key)
         .filter(livePosts)
-        .sort(sortByDate);
+        .sort(sortByUpdated);
     }
 
     if (tag.elements.length > 0 || !collections) {

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -16,6 +16,7 @@
 /** @type TagsData */
 const tagsData = require('../_data/tagsData.json');
 const {livePosts} = require('../_filters/live-posts');
+const {sortByDate} = require('../_utils/sort-by-date');
 
 /** @type Tags */
 let processedCollection;
@@ -62,7 +63,7 @@ module.exports = (collections) => {
       tag.elements = collections
         .getFilteredByTag(tag.key)
         .filter(livePosts)
-        .sort((a, b) => b.date.getTime() - a.date.getTime());
+        .sort(sortByDate);
     }
 
     if (tag.elements.length > 0 || !collections) {

--- a/src/site/_data/i18n/common.yml
+++ b/src/site/_data/i18n/common.yml
@@ -36,3 +36,6 @@ next:
 
 prev:
   en: Prev # Short for "previous"
+
+updated:
+  en: Updated # Short for "previous"

--- a/src/site/_includes/codelab.njk
+++ b/src/site/_includes/codelab.njk
@@ -18,7 +18,7 @@ pageScripts:
       {% if date %}
         <div class="w-author__published">
           <time>{{date | prettyDate}}</time>
-          {% if updated %} <span class="w-author__separator">•</span> Updated <time>{{ updated | prettyDate }}</time> {% endif %}
+          {% if updated %} <span class="w-author__separator">•</span> {{ 'i18n.common.updated' | i18n((locale)) }} <time>{{ updated | prettyDate }}</time> {% endif %}
         </div>
       {% endif %}
 

--- a/src/site/_includes/components/AuthorsDate.js
+++ b/src/site/_includes/components/AuthorsDate.js
@@ -24,18 +24,43 @@ const {html} = require('common-tags');
 const {Img} = require('./Img');
 const authorsCollectionFn = require('../../_collections/authors');
 const prettyDate = require('../../_filters/pretty-date');
+const {i18n} = require('../../_filters/i18n');
 
-const renderDate = (date) => {
+/**
+ *
+ * @param {string} locale
+ * @param {Date} date
+ * @param {Date} [updated]
+ * @returns {string}
+ */
+const renderDate = (locale, date, updated) => {
+  let result = '';
+
   // nb. +date checks for valid dates, not just non-null dates
-  return +date
-    ? html`
-        <div class="w-author__published">
-          <time>${prettyDate(date)}</time>
-        </div>
-      `
-    : '';
+  if (+updated) {
+    result += html`
+      <div class="w-author__updated">
+        <time
+          >${i18n('i18n.common.updated', locale)}: ${prettyDate(updated)}</time
+        >
+      </div>
+    `;
+  } else if (+date) {
+    result += html`
+      <div class="w-author__published">
+        <time>${prettyDate(date)}</time>
+      </div>
+    `;
+  }
+  return result;
 };
 
+/**
+ *
+ * @param {number} limit
+ * @param {Array<TODO>} pairs
+ * @returns {string}
+ */
 const renderAuthorImages = (limit, pairs) => {
   if (!pairs.length || pairs.length > limit) {
     return ''; // don't render images if we have none, or too many
@@ -90,12 +115,12 @@ const renderAuthorNames = (pairs) => {
 /**
  * Render an authors card, including any number of authors and an optional date.
  *
- * @param {{authors: Array<string>, date?: Date, images?: number}} arg
+ * @param {{authors: Array<string>, date?: Date, images?: number, updated?: Date, locale: string}} arg
  * @param {Authors} [authorsCollectionArg]
  * @return {string}
  */
 const renderAuthorsDate = (
-  {authors, date, images = 2},
+  {authors, date, images = 2, updated, locale},
   authorsCollectionArg,
 ) => {
   const authorsCollection = authorsCollectionArg
@@ -129,7 +154,7 @@ const renderAuthorsDate = (
     <div class="w-authors__card">
       ${renderAuthorImages(images, pairs)}
       <div class="w-authors__card--holder">
-        ${renderAuthorNames(pairs)} ${renderDate(date)}
+        ${renderAuthorNames(pairs)} ${renderDate(locale, date, updated)}
       </div>
     </div>
   `;

--- a/src/site/_includes/components/BaseCard.js
+++ b/src/site/_includes/components/BaseCard.js
@@ -26,15 +26,15 @@ const AuthorsDate = require('./AuthorsDate');
 
 /**
  * BaseCard used to preview collection items.
- * @param {Object} collectionItem An eleventy collection item with additional data.
+ * @param {EleventyCollectionItem} collectionItem An eleventy collection item with additional data.
  * @param {string} className CSS class to apply to `div.w-card`
  * @param {boolean} featured If card is a featured card.
  * @return {string}
  */
 class BaseCard {
   constructor(collectionItem, className = '', featured = false) {
+    /** @type {EleventyCollectionItem} */
     this.collectionItem = collectionItem;
-    this.collectionItem.data = this.collectionItem.data || {};
     this.featured = featured;
     this.className = className;
     this.url = this.collectionItem.url;
@@ -141,7 +141,7 @@ class BaseCard {
                 ${md(this.data.title)}
               </h2>
             </a>
-            ${AuthorsDate({authors, date: this.collectionItem.date})}
+            ${AuthorsDate({authors, date: this.collectionItem.date, updated: this.data.updated, locale: this.data.locale})}
             <div
               class="w-card-base__desc ${this.className &&
                 `${this.className}__desc`}"

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -61,7 +61,7 @@
       {% if date %}
         <div class="w-author__published">
           <time>{{date | prettyDate}}</time>
-          {% if updated %} <span class="w-author__separator">•</span> Updated <time>{{ updated | prettyDate }}</time> {% endif %}
+          {% if updated %} <span class="w-author__separator">•</span> {{ 'i18n.common.updated' | i18n((locale)) }} <time>{{ updated | prettyDate }}</time> {% endif %}
         </div>
       {% endif %}
       {% SignPosts page.fileSlug %}

--- a/src/site/_utils/sort-by-date.js
+++ b/src/site/_utils/sort-by-date.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-const {livePosts} = require('../_filters/live-posts');
-const {sortByDate} = require('../_utils/sort-by-date');
-
 /**
- * @param {EleventyCollectionObject} collection
- * @returns {EleventyCollectionItem[]}
+ * @param {EleventyCollectionItem} a An eleventy post object.
+ * @param {EleventyCollectionItem} b An eleventy post object.
+ * @return {number} The difference in their date's.
  */
-module.exports = (collection) => {
-  const tag = process.env.PERCY ? 'test-post' : 'blog';
-  return collection.getFilteredByTag(tag).filter(livePosts).sort(sortByDate);
-};
+function sortByDate(a, b) {
+  const aTime = a.data.updated ? a.data.updated.getTime() : a.date.getTime();
+  const bTime = b.data.updated ? b.data.updated.getTime() : b.date.getTime();
+
+  return bTime - aTime;
+}
+
+module.exports = {sortByDate};

--- a/src/site/_utils/sort-by-updated.js
+++ b/src/site/_utils/sort-by-updated.js
@@ -19,11 +19,11 @@
  * @param {EleventyCollectionItem} b An eleventy post object.
  * @return {number} The difference in their date's.
  */
-function sortByDate(a, b) {
+function sortByUpdated(a, b) {
   const aTime = a.data.updated ? a.data.updated.getTime() : a.date.getTime();
   const bTime = b.data.updated ? b.data.updated.getTime() : b.date.getTime();
 
   return bTime - aTime;
 }
 
-module.exports = {sortByDate};
+module.exports = {sortByUpdated};

--- a/src/styles/components/_author.scss
+++ b/src/styles/components/_author.scss
@@ -42,7 +42,8 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
 }
 
 .w-author__name,
-.w-author__published {
+.w-author__published,
+.w-author__updated {
   display: block;
   font-size: 14px;
   font-style: normal;
@@ -72,7 +73,8 @@ $AUTHOR_IMAGE_SIZE_SMALL: 40px;
   }
 }
 
-.w-author__published {
+.w-author__published,
+.w-author__updated {
   color: $GREY_700;
 }
 

--- a/types/eleventy/collection-item.d.ts
+++ b/types/eleventy/collection-item.d.ts
@@ -92,6 +92,14 @@ declare global {
        * Tells search engines not to index page (this includes algolia)
        */
       noindex?: boolean;
+      /**
+       * When the post was last updated.
+       */
+      updated?: Date;
+      /**
+       * If post is a draft.
+       */
+      draft?: boolean;
     };
     /**
      * The rendered content of this template. This does not include layout wrappers.


### PR DESCRIPTION
Fixes #2283

Changes proposed in this pull request:

- Prefer sorting of posts in author and tag collections by their `updated` date rather than their posted date.
- Display the updated date on cards.
- Add the term "Updated" to `i18n.common`.
