### PR TITLE
Add markdown definition list support.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,9 +20,7 @@ const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const yaml = require('js-yaml');
 
 const toc = require('eleventy-plugin-toc');
-const markdownIt = require('markdown-it');
-const markdownItAnchor = require('markdown-it-anchor');
-const markdownItAttrs = require('markdown-it-attrs');
+const markdown = require('./src/site/_plugins/markdown');
 
 const componentsDir = 'src/site/_includes/components';
 const ArticleNavigation = require(`./${componentsDir}/ArticleNavigation`);
@@ -126,42 +124,7 @@ module.exports = function (config) {
   // ----------------------------------------------------------------------------
   // MARKDOWN
   // ----------------------------------------------------------------------------
-  const markdownItOptions = {
-    html: true,
-  };
-  const markdownItAnchorOptions = {
-    level: 2,
-    permalink: true,
-    permalinkClass: 'w-headline-link',
-    permalinkSymbol: '#',
-    slugify,
-  };
-  const markdownItAttrsOpts = {
-    leftDelimiter: '{:',
-    rightDelimiter: '}',
-    allowedAttributes: ['id', 'class', /^data-.*$/],
-  };
-
-  const mdLib = markdownIt(markdownItOptions)
-    .use(markdownItAnchor, markdownItAnchorOptions)
-    .use(markdownItAttrs, markdownItAttrsOpts)
-    .disable('code');
-
-  // custom renderer rules
-  const fence = mdLib.renderer.rules.fence;
-
-  const rules = {
-    fence: (tokens, idx, options, env, slf) => {
-      const fenced = fence(tokens, idx, options, env, slf);
-      return `<web-copy-code>${fenced}</web-copy-code>`;
-    },
-    table_close: () => '</table>\n</div>',
-    table_open: () => '<div class="w-table-wrapper">\n<table>\n',
-  };
-
-  mdLib.renderer.rules = {...mdLib.renderer.rules, ...rules};
-
-  config.setLibrary('md', mdLib);
+  config.setLibrary('md', markdown);
 
   // ----------------------------------------------------------------------------
   // NON-11TY FILES TO WATCH

--- a/package-lock.json
+++ b/package-lock.json
@@ -18873,6 +18873,12 @@
       "integrity": "sha512-fcpdmxdEsctDVJEunPyrirVtU/6zcTMxPxAu4Ofz51PKAa8vRMpmGQXsmXx1HTdIdUPoDonm/RhS/+jTNywj/Q==",
       "dev": true
     },
+    "markdown-it-deflist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg==",
+      "dev": true
+    },
     "markdown-table": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "markdown-it": "^8.4.2",
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-attrs": "^3.0.0",
+    "markdown-it-deflist": "^2.1.0",
     "mocha": "^6.2.0",
     "moment": "^2.24.0",
     "move-file": "^2.0.0",

--- a/src/site/_plugins/markdown.js
+++ b/src/site/_plugins/markdown.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is di_plstributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const md = require('markdown-it');
+const slugify = require('slugify');
+
+const markdown = md({
+  html: true,
+})
+  // Let folks author definition lists using markdown syntax.
+  .use(require('markdown-it-deflist'))
+  // Let folks customize markdown output with attributes (id, class, data-*)
+  .use(require('markdown-it-attrs'), {
+    leftDelimiter: '{:',
+    rightDelimiter: '}',
+    allowedAttributes: ['id', 'class', /^data-.*$/],
+  })
+  // Automatically add anchors to headings
+  .use(require('markdown-it-anchor'), {
+    level: 2,
+    permalink: true,
+    permalinkClass: 'w-headline-link',
+    permalinkSymbol: '#',
+    // @ts-ignore
+    slugify: (s) => slugify(s, {lower: true}),
+  })
+  // Disable indented code blocks.
+  // We only support fenced code blocks.
+  .disable('code');
+
+// Custom renderer rules
+const fence = markdown.renderer.rules.fence;
+const rules = {
+  // Wrap code blocks in a web-copy-code element so folks can copy the
+  // snippet.
+  fence: (tokens, idx, options, env, slf) => {
+    const fenced = fence(tokens, idx, options, env, slf);
+    return `<web-copy-code>${fenced}</web-copy-code>`;
+  },
+  // Wrap tables in a <div class="w-table-wrapper"> element to make them
+  // responsive.
+  table_close: () => '</table>\n</div>',
+  table_open: () => '<div class="w-table-wrapper">\n<table>\n',
+};
+
+markdown.renderer.rules = {...markdown.renderer.rules, ...rules};
+
+module.exports = markdown;

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -26,6 +26,7 @@ guidance about how to use them effectively.
 1. [Columns](#columns)
 1. [Code](#code)
 1. [Compare](#compare)
+1. [Definition lists](#definition-lists)
 1. [Details](#details)
 1. [Glitches](#glitches)
 1. [Images](#images)
@@ -553,6 +554,24 @@ Lorem ipsum dolor sit amet consectetur, adipisicing elit. Enim necessitatibus
 incidunt harum reprehenderit laboriosam labore consequuntur quod. Doloribus,
 deleniti! Atque aliquam facilis labore odio similique provident illo culpa
 assumenda perspiciatis.
+
+## Definition lists
+
+```md
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+```
+
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
 
 ## Details
 

--- a/src/styles/generic/_lists.scss
+++ b/src/styles/generic/_lists.scss
@@ -98,6 +98,15 @@ li > ol:not([class]) {
 }
 
 // Definition lists
+dt {
+  font-weight: $FONT_WEIGHT_BOLD;
+  margin-left: 1em;
+}
+
 dd {
-  margin-bottom: 16px;
+  margin-left: 2em;
+}
+
+dd + dt {
+  margin-top: .5em;
 }


### PR DESCRIPTION
Fixes #4929, fixes #1535

Changes proposed in this pull request:

- Adds markdown-it-deflist 
- Tidies up markdown config and puts it into its own file, similar to what we do for d.c.c. I'm not sure why but once I did this I noticed it started uppercasing all of the w-heading-link slugs. That's actually the default behavior for `slugify` but on the live site they're always lowercased. So I passed an explicit argument for it to lowercase them 🤷‍♂️
- Adds styles for dt and dd that match d.c.c.