### PR TITLE
Incorporate timer story to why-coop-coep

### DIFF
--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -88,7 +88,10 @@ This all changed with
 makes any data that is loaded to the same browsing context group as your code
 potentially readable. By measuring the time certain operations take, attackers
 can guess the contents of the CPU caches, and through that, the contents of the
-process' memory. If `evil.com` embeds a cross-origin image, they can use a
+process' memory. Such timing attacks are possible with low-granularity timers
+that exist in the platform, but can be sped up with high-granularity timers,
+both explicit (like `performance.now()`) and implicit (like
+`SharedArrayBuffer`s). If `evil.com` embeds a cross-origin image, they can use a
 Spectre attack to read its pixel data, which makes protections relying on
 "opaqueness" ineffective.
 

--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -2,20 +2,20 @@
 title: Why you need "cross-origin isolated" for powerful features
 subhead: >
   Learn why cross-origin isolation is needed to use powerful features such as
-  `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`, and the JS Self-Profiling
-  API.
+  `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`, high
+  resolution timer with a better precision and the JS Self-Profiling API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Learn why cross-origin isolation is needed to use
   powerful features such as `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`,
-  and the JS Self-Profiling API.
+  high resolution timer with a better precision and the JS Self-Profiling API.
 authors:
   - agektmr
   - domenic
 hero: image/admin/h8g1TQjkfkJSpWJrPakB.jpg
 date: 2020-05-04
-updated: 2020-10-19
+updated: 2021-04-12
 tags:
   - blog
   - security
@@ -86,7 +86,9 @@ successful.
 This all changed with
 [Spectre](https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)), which
 makes any data that is loaded to the same browsing context group as your code
-potentially readable. If `evil.com` embeds a cross-origin image, they can use a
+potentially readable. By measuring the time certain operations take, attackers
+can guess the contents of the CPU caches, and through that, the contents of the
+process' memory. If `evil.com` embeds a cross-origin image, they can use a
 Spectre attack to read its pixel data, which makes protections relying on
 "opaqueness" ineffective.
 
@@ -101,8 +103,10 @@ This is exactly what COOP+COEP is about.
 
 Under a cross-origin isolated state, the requesting site is considered less
 dangerous and this unlocks powerful features such as `SharedArrayBuffer`,
-`performance.measureUserAgentSpecificMemory()` and the JS Self-Profiling API which could otherwise be
-used for Spectre-like attacks. It also prevents modifying `document.domain`.
+`performance.measureUserAgentSpecificMemory()`, [high resolution
+timers](https://www.w3.org/TR/hr-time/) with a better precision and the JS
+Self-Profiling API which could otherwise be used for Spectre-like attacks. It
+also prevents modifying `document.domain`.
 
 ### Cross Origin Embedder Policy {: #coep }
 [Cross Origin Embedder
@@ -239,11 +243,13 @@ protect your website in browsers that don't support COOP.
 ## Summary {: #summary }
 
 If you want guaranteed access to powerful features like `SharedArrayBuffer`,
-`performance.measureUserAgentSpecificMemory()` or JS Self-Profiling API, just remember that your
-document needs to use both COEP with the value of `require-corp` and COOP with
-the value of `same-origin`. In the absence of either, the browser will not
-guarantee sufficient isolation to safely enable those powerful features. You can
-determine your page's situation by checking if
+`performance.measureUserAgentSpecificMemory()`, [high resolution
+timers](https://www.w3.org/TR/hr-time/) with a better precision or JS
+Self-Profiling API, just remember that your document needs to use both COEP with
+the value of `require-corp` and COOP with the value of `same-origin`. In the
+absence of either, the browser will not guarantee sufficient isolation to safely
+enable those powerful features. You can determine your page's situation by
+checking if
 [`self.crossOriginIsolated`](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/crossOriginIsolated)
 returns `true`.
 

--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -3,13 +3,13 @@ title: Why you need "cross-origin isolated" for powerful features
 subhead: >
   Learn why cross-origin isolation is needed to use powerful features such as
   `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`, high
-  resolution timer with a better precision and the JS Self-Profiling API.
+  resolution timer with better precision and the JS Self-Profiling API.
 description: >
   Some web APIs increase the risk of side-channel attacks like Spectre. To
   mitigate that risk, browsers offer an opt-in-based isolated environment called
   cross-origin isolated. Learn why cross-origin isolation is needed to use
   powerful features such as `SharedArrayBuffer`, `performance.measureUserAgentSpecificMemory()`,
-  high resolution timer with a better precision and the JS Self-Profiling API.
+  high resolution timer with better precision and the JS Self-Profiling API.
 authors:
   - agektmr
   - domenic
@@ -104,7 +104,7 @@ This is exactly what COOP+COEP is about.
 Under a cross-origin isolated state, the requesting site is considered less
 dangerous and this unlocks powerful features such as `SharedArrayBuffer`,
 `performance.measureUserAgentSpecificMemory()`, [high resolution
-timers](https://www.w3.org/TR/hr-time/) with a better precision and the JS
+timers](https://www.w3.org/TR/hr-time/) with better precision and the JS
 Self-Profiling API which could otherwise be used for Spectre-like attacks. It
 also prevents modifying `document.domain`.
 
@@ -244,7 +244,7 @@ protect your website in browsers that don't support COOP.
 
 If you want guaranteed access to powerful features like `SharedArrayBuffer`,
 `performance.measureUserAgentSpecificMemory()`, [high resolution
-timers](https://www.w3.org/TR/hr-time/) with a better precision or JS
+timers](https://www.w3.org/TR/hr-time/) with better precision or JS
 Self-Profiling API, just remember that your document needs to use both COEP with
 the value of `require-corp` and COOP with the value of `same-origin`. In the
 absence of either, the browser will not guarantee sufficient isolation to safely


### PR DESCRIPTION
Updates "Why you need "cross-origin isolated" for powerful features" to incorporate the story about timer resolution.