### PR TITLE
Move DevSat post

### DIFF
--- a/src/site/content/en/developer-satisfaction/index.md
+++ b/src/site/content/en/developer-satisfaction/index.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 title: Web Developer Satisfaction
 description: 
   Web Developer Satisfaction is a Google project to gather information about 
@@ -7,9 +8,6 @@ description:
   and adopt and use new features to grow the platform and their business.
 date: 2021-03-22
 updated: 2021-03-23
-tags:
-  - blog
-draft: true
 ---
 
 Web Developer Satisfaction, shortened DevSAT, is a Google project to gather


### PR DESCRIPTION
This PR moves the DevSat Dashboard to top-level content folder and removes the `draft` tag. The post will still not be anywhere in site's navigation, only accessible directly via the link.
