### PR TITLE
Added font preload content type

### DIFF
--- a/src/site/content/en/lighthouse-performance/font-display/index.md
+++ b/src/site/content/en/lighthouse-performance/font-display/index.md
@@ -51,7 +51,7 @@ for more information.)
 
 ### Preload web fonts
 
-Use `<link rel="preload">` to fetch your font files earlier. Learn more:
+Use `<link rel="preload" as="font">` to fetch your font files earlier. Learn more:
 
 * [Preload web fonts to improve loading speed (codelab)](/codelab-preload-web-fonts/)
 * [Prevent layout shifting and flashes of invisibile text (FOIT) by preloading optional fonts](/preload-optional-fonts/)


### PR DESCRIPTION
Add as="font" to avoid Chrome warning "<link rel=preload> must have a valid `as` value"

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
