### PR TITLE
Rename Web OTP to WebOTP

### DIFF
--- a/src/site/content/en/blog/fugu-status/index.md
+++ b/src/site/content/en/blog/fugu-status/index.md
@@ -289,11 +289,11 @@ latest version of Chrome, and in many cases other Chromium based browsers.
       </tr>
       <tr>
         <td>
-          <a href="/sms-receiver-api-announcement/">Web OTP API</a>
+          <a href="/sms-receiver-api-announcement/">WebOTP API</a>
         </td>
         <td>
           Finding, memorizing, and typing OTPs sent via SMS is cumbersome.
-          The Web OTP API (formerly the SMS Receiver API) simplifies the OTP
+          The WebOTP API (formerly the SMS Receiver API) simplifies the OTP
           workflow for users.<br>
           <em>Updated March 26, 2020</em>
         </td>

--- a/src/site/content/en/blog/goibibo/index.md
+++ b/src/site/content/en/blog/goibibo/index.md
@@ -67,12 +67,12 @@ In their journey to improve user experience, Goibibo noticed a few trends:
   </figure>
 </div>
 
-### Web OTP {: #web-otp }
+### WebOTP {: #web-otp }
 
 <div class="w-columns">
   <p>
     Because secure authentication is a big challenge in India, Goibibo
-    used the <a href="/web-otp/">Web OTP (One-Time Password) API</a>
+    used the <a href="/web-otp/">WebOTP (One-Time Password) API</a>
     to reduce sign-in friction on their PWA.
   </p>
   <figure class="w-figure">
@@ -117,7 +117,7 @@ In their journey to improve user experience, Goibibo noticed a few trends:
 </style>
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rsENPcTITCviudxIhPU1.png", alt="1. Web Share improved returning user percentage 2. Contact Picker enhanced user experience, making it easier for guests to book 3. Web OTP reduced friction during transactions, resulting in less time spent on OTP screen and less retry API calls 4. Push notifications improved conversions of retargeted users", width="711", height="627", class="w-screenshot" %}
+  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rsENPcTITCviudxIhPU1.png", alt="1. Web Share improved returning user percentage 2. Contact Picker enhanced user experience, making it easier for guests to book 3. WebOTP reduced friction during transactions, resulting in less time spent on OTP screen and less retry API calls 4. Push notifications improved conversions of retargeted users", width="711", height="627", class="w-screenshot" %}
 </figure>
 
 ## Overall business results {: #results }

--- a/src/site/content/en/blog/payment-and-address-form-best-practices/index.md
+++ b/src/site/content/en/blog/payment-and-address-form-best-practices/index.md
@@ -760,7 +760,7 @@ That, in turn, gives you a solid basis for prioritizing effort, making changes, 
 
 * [Sign-in form best practices](/sign-in-form-best-practices)
 * [Sign-up form best practices](/sign-up-form-best-practices)
-* [Verify phone numbers on the web with the Web OTP API](/web-otp)
+* [Verify phone numbers on the web with the WebOTP API](/web-otp)
 * [Create Amazing Forms](https://developers.google.com/web/fundamentals/design-and-ux/input/forms)
 * [Best Practices For Mobile Form Design](https://www.smashingmagazine.com/2018/08/best-practices-for-mobile-form-design/)
 * [More capable form controls](/more-capable-form-controls)

--- a/src/site/content/en/blog/sign-in-form-best-practices/index.md
+++ b/src/site/content/en/blog/sign-in-form-best-practices/index.md
@@ -84,7 +84,7 @@ third-party identity services as well as its content.
 
 There are also two relatively new APIs not covered in this article which can
 help you build a better sign-in experience:
-*  [**Web OTP**](https://web.dev/web-otp/): to deliver one-time passcodes or
+*  [**WebOTP**](https://web.dev/web-otp/): to deliver one-time passcodes or
 PIN numbers via SMS to mobile phones. This can allow users to select a phone
 number as an identifier (no need to enter an email address!) and also enables
 two-step verification for sign-in and one-time codes for payment confirmation.
@@ -748,6 +748,6 @@ Well designed UI and UX can reduce sign-in form abandonment:
 * [More capable form controls](/more-capable-form-controls)
 * [Creating Accessible Forms](https://webaim.org/techniques/forms/)
 * [Streamlining the Sign-in Flow Using Credential Management API](https://developers.google.com/web/updates/2016/04/credential-management-api)
-* [Verify phone numbers on the web with the Web OTP API](https://web.dev/web-otp/)
+* [Verify phone numbers on the web with the WebOTP API](https://web.dev/web-otp/)
 
 Photo by [Meghan Schiereck](https://unsplash.com/photos/_XFObcM_7KU) on [Unsplash](https://unsplash.com).

--- a/src/site/content/en/blog/sign-up-form-best-practices/index.md
+++ b/src/site/content/en/blog/sign-up-form-best-practices/index.md
@@ -412,6 +412,6 @@ exposed by local testing.
 - [More capable form controls](/more-capable-form-controls)
 - [Creating Accessible Forms](https://webaim.org/techniques/forms/)
 - [Streamlining the Sign-up Flow Using Credential Management API](https://developers.google.com/web/updates/2016/04/credential-management-api)
-- [Verify phone numbers on the web with the Web OTP API](/web-otp)
+- [Verify phone numbers on the web with the WebOTP API](/web-otp)
 
 Photo by [@ecowarriorprincess](https://unsplash.com/@ecowarriorprincess) on [Unsplash](https://unsplash.com/photos/lUShu7PHIGA).

--- a/src/site/content/en/blog/sms-otp-form/index.md
+++ b/src/site/content/en/blog/sms-otp-form/index.md
@@ -66,7 +66,7 @@ To provide the best user experience with the SMS OTP, follow these steps:
     * `inputmode="numeric"`
     * `autocomplete="one-time-code"`
 * Use `@BOUND_DOMAIN #OTP_CODE` as the last line of the OTP SMS message.
-* Use the [Web OTP API](/web-otp/).
+* Use the [WebOTP API](/web-otp/).
 
 ## Use the `<input>` element
 
@@ -190,7 +190,7 @@ The precise rules are:
 Make sure the number of characters doesn't exceed 140 in total.
 
 To learn more about Chrome specific rules, read [Format the SMS message section
-of Web OTP API post](/web-otp/#format).
+of WebOTP API post](/web-otp/#format).
 {% endAside %}
 
 Using this format provides a couple of benefits:
@@ -216,11 +216,11 @@ codes](https://developer.apple.com/news/?id=z0i801mg).
 
 This SMS message format also benefits browsers other than Safari. Chrome, Opera,
 and Vivaldi on Android also support the origin-bound one-time codes rule with
-the Web OTP API, though not through `autocomplete="one-time-code"`.
+the WebOTP API, though not through `autocomplete="one-time-code"`.
 
-## Use the Web OTP API
+## Use the WebOTP API
 
-[The Web OTP API](https://wicg.github.io/web-otp/) provides access to the OTP
+[The WebOTP API](https://wicg.github.io/web-otp/) provides access to the OTP
 received in an SMS message. By calling
 [`navigator.credentials.get()`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/get)
 with `otp` type (`OTPCredential`) where `transport` includes `sms`, the website
@@ -229,7 +229,7 @@ delivered and granted access by the user. Once the OTP is passed to JavaScript,
 the website can use it in a form or POST it directly to the server.
 
 {% Aside 'caution' %}
-The Web OTP API requires a secure origin (HTTPS).
+The WebOTP API requires a secure origin (HTTPS).
 {% endAside %}
 
 ```js
@@ -245,12 +245,12 @@ navigator.credentials.get({
     <source src="https://storage.googleapis.com/web-dev-assets/sms-otp-form/android-chrome.mp4" type="video/mp4">
   </video>
   <figcaption class="w-figcaption">
-    Web OTP API in action.
+    WebOTP API in action.
   </figcaption>
 </figure>
 
-Learn how to use the Web OTP API in detail in [Verify phone numbers on the web
-with the Web OTP API](/web-otp/) or copy and paste the following snippet. (Make
+Learn how to use the WebOTP API in detail in [Verify phone numbers on the web
+with the WebOTP API](/web-otp/) or copy and paste the following snippet. (Make
 sure the `<form>` element has an `action` and `method` attribute properly set.)
 
 ```js
@@ -259,16 +259,16 @@ if ('OTPCredential' in window) {
   window.addEventListener('DOMContentLoaded', e => {
     const input = document.querySelector('input[autocomplete="one-time-code"]');
     if (!input) return;
-    // Cancel the Web OTP API if the form is submitted manually.
+    // Cancel the WebOTP API if the form is submitted manually.
     const ac = new AbortController();
     const form = input.closest('form');
     if (form) {
       form.addEventListener('submit', e => {
-        // Cancel the Web OTP API.
+        // Cancel the WebOTP API.
         ac.abort();
       });
     }
-    // Invoke the Web OTP API
+    // Invoke the WebOTP API
     navigator.credentials.get({
       otp: { transport:['sms'] },
       signal: ac.signal

--- a/src/site/content/en/blog/web-otp/index.md
+++ b/src/site/content/en/blog/web-otp/index.md
@@ -1,5 +1,5 @@
 ---
-title: Verify phone numbers on the web with the Web OTP API
+title: Verify phone numbers on the web with the WebOTP API
 subhead: Help users with OTPs received through SMS
 authors:
   - agektmr
@@ -10,7 +10,7 @@ alt: A drawing of a woman using OTP to log in to a web app.
 
 description: |
   Finding, memorizing, and typing OTPs sent via SMS is cumbersome. The
-  Web OTP API simplifies the OTP workflow for users.
+  WebOTP API simplifies the OTP workflow for users.
 
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
@@ -22,11 +22,11 @@ feedback:
 ---
 
 {% Aside 'gotchas' %}
-If you want to learn more general SMS OTP form best practices including Web OTP
+If you want to learn more general SMS OTP form best practices including WebOTP
 API, checkout [SMS OTP form best practices](/sms-otp-form).
 {% endAside %}
 
-## What is the Web OTP API?
+## What is the WebOTP API?
 
 These days, most people in the world own a mobile device and developers are
 commonly using phone numbers as an identifier for users of their services.
@@ -36,7 +36,7 @@ one-time password (OTP) sent by SMS is one of the most common. Sending this code
 back to the developer's server demonstrates control of the phone number.
 
 {% Aside %}
-The Web OTP API was originally called the SMS Receiver API. You may still see it
+The WebOTP API was originally called the SMS Receiver API. You may still see it
 named that way in some places. If you used that API, you should still read this
 article. [There are significant differences](#differences) between the current
 and earlier versions of the API.
@@ -63,7 +63,7 @@ this](https://developers.google.com/identity/sms-retriever/). So does
 and
 [Safari](https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element).
 
-The Web OTP API lets your app receive specially-formatted messages bound to
+The WebOTP API lets your app receive specially-formatted messages bound to
 your app's domain. From this, you can programmatically obtain an OTP from an SMS
 message and verify a phone number for the user more easily.
 
@@ -79,7 +79,7 @@ establish new sessions for these users.
 
 ## Current status
 
-The table below explains the current status of the Web OTP API.
+The table below explains the current status of the WebOTP API.
 
 <table>
 <tr>
@@ -149,7 +149,7 @@ Let's say a user wants to verify their phone number with a website. The website
 sends a text message to the user over SMS and the user enters the OTP from the
 message to verify the ownership of the phone number.
 
-With the Web OTP API, these steps are as easy as one tap for the user, as
+With the WebOTP API, these steps are as easy as one tap for the user, as
 demonstrated in the video. When the text message arrives, a bottom sheet pops up
 and prompts the user to verify their phone number. After clicking the **Verify**
 button on the bottom sheet, the browser pastes the OTP into the form and the
@@ -165,14 +165,14 @@ The whole process is diagrammed in the image below.
 <figure class="w-figure">
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/GrFHzEg98jxCOguAQwHe.png", alt="", width="494", height="391" %}
   <figcaption class="w-figcaption w-figcaption--fullbleed">
-    Web OTP API diagram
+    WebOTP API diagram
   </figcaption>
 </figure>
 
 Try [the demo](https://web-otp.glitch.me) yourself. It doesn't ask for
 your phone number or send an SMS to your device, but you can send one from
 another device by copying the text displayed in the demo. This works because it
-doesn't matter who the sender is when using the Web OTP API.
+doesn't matter who the sender is when using the WebOTP API.
 
 1. Go to [https://web-otp.glitch.me](https://web-otp.glitch.me) in Chrome 84 or
    later on an Android device.
@@ -185,13 +185,13 @@ Your OTP is: 123456.
 ```
 
 Did you receive the SMS and see the prompt to enter the code to the input area?
-That is how the Web OTP API works for users.
+That is how the WebOTP API works for users.
 
 {% Aside 'gotcha' %}
 If the dialog doesn't appear for you, check out [the FAQ](#no-dialog).
 {% endAside %}
 
-Using the Web OTP API consists of three parts:
+Using the WebOTP API consists of three parts:
 
 * A properly annotated `<input>` tag
 * JavaScript in your web app
@@ -201,13 +201,13 @@ I'll cover the `<input>` tag first.
 
 ## Annotate an `<input>` tag
 
-Web OTP itself works without any HTML annotation, but for cross-browser
+WebOTP itself works without any HTML annotation, but for cross-browser
 compatibility, I highly recommend that you add `autocomplete="one-time-code"` to
 the `<input>` tag where you expect the user entering an OTP.
 
 This allows Safari 14 or later to suggest that the user to autofill the `<input>`
 field with an OTP when they receive an SMS with the format described in [Format
-the SMS message](#format) even though it doesn't support Web OTP.
+the SMS message](#format) even though it doesn't support WebOTP.
 
 {% Label %}
 HTML
@@ -220,9 +220,9 @@ HTML
 </form>
 ```
 
-## Use the Web OTP API
+## Use the WebOTP API
 
-Because Web OTP is simple, just copying and pasting the following code will do the
+Because WebOTP is simple, just copying and pasting the following code will do the
 job. I'll walk you through what's happening anyway.
 
 {% Label %}
@@ -276,15 +276,15 @@ if ('OTPCredential' in window) {
 ```
 
 {% Aside 'caution' %}
-The Web OTP API requires a secure origin (HTTPS). The feature detection on an
+The WebOTP API requires a secure origin (HTTPS). The feature detection on an
 HTTP website will fail.
 {% endAside %}
 
 ### Process the OTP
 
-The Web OTP API itself is simple enough. Use
+The WebOTP API itself is simple enough. Use
 [`navigator.credentials.get()`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/get)
-to obtain the OTP. Web OTP adds a new `otp` option to that method. It only has
+to obtain the OTP. WebOTP adds a new `otp` option to that method. It only has
 one property: `transport`, whose value must be an array with the string `'sms'`.
 
 {% Label %}
@@ -409,7 +409,7 @@ There are a couple of caveats when testing the API:
   API will not be triggered due to the design of the underlying [SMS User
   Consent
   API](https://developers.google.com/identity/sms-retriever/user-consent/request#2_start_listening_for_incoming_messages).
-* If you are using a work profile on your Android device and the Web OTP does
+* If you are using a work profile on your Android device and the WebOTP does
   not work, try installing and using Chrome on your personal profile instead
   (i.e. the same profile in which you receive SMS messages).
 
@@ -424,7 +424,7 @@ Did you find a bug with Chrome's implementation?
 
 ### How can I help this feature?
 
-Are you planning to use the Web OTP API? Your public support helps us prioritize
+Are you planning to use the WebOTP API? Your public support helps us prioritize
 features, and shows other browser vendors how critical it is to support them.
 Send a tweet to [@ChromiumDev](https://twitter.com/chromiumdev) using the hashtag
 [`#WebOTP`](https://twitter.com/search?q=%23WebOTP&src=typed_query&f=live)
@@ -432,7 +432,7 @@ and let us know where and how you're using it.
 
 ### What are the differences with the SMS Receiver API? {: #differences }
 
-Consider Web OTP API an evolved version of the SMS Receiver API. Web OTP API has
+Consider WebOTP API an evolved version of the SMS Receiver API. WebOTP API has
 a few significant differences compared to the SMS Receiver API.
 
 * The [expected text format](#format) for the SMS message has changed.
@@ -448,7 +448,7 @@ a few significant differences compared to the SMS Receiver API.
 Chromium and WebKit agreed on [the SMS text message
 format](https://wicg.github.io/sms-one-time-codes) and [Apple announced Safari's
 support for it](https://developer.apple.com/news/?id=z0i801mg) starting in iOS 14
-and macOS Big Sur. Though Safari doesn't support the Web OTP JavaScript API, by
+and macOS Big Sur. Though Safari doesn't support the WebOTP JavaScript API, by
 annotating `input` element with `autocomplete=["one-time-code"]`, the default
 keyboard automatically suggests that you enter the OTP if the SMS message complies
 with the format.
@@ -458,7 +458,7 @@ with the format.
 While SMS OTP is useful to verify a phone number when the number is first
 provided, phone number verification via SMS must be used carefully for
 re-authentication since phone numbers can be hijacked and recycled by carriers.
-Web OTP is a convenient re-auth and recovery mechanism, but services should
+WebOTP is a convenient re-auth and recovery mechanism, but services should
 combine it with additional factors, such as a knowledge challenge, or use the
 [Web Authentication
 API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API)


### PR DESCRIPTION
Changes proposed in this pull request:

This PR updates the API name from "Web OTP" to "WebOTP" to be consistent with other APIs such as WebRTC, WebID and WebAuthn.