### PR TITLE
Potential savings are 4KiB or less

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-optimized-images/index.md
@@ -23,7 +23,7 @@ Optimize these images so that the page loads faster and consumes less data:
 Lighthouse collects all the JPEG or BMP images on the page,
 sets each image's compression level to 85,
 and then compares the original version with the compressed version.
-If the potential savings are 4KiB or greater, Lighthouse flags the image as optimizable.
+If the potential savings are 4KiB or less, Lighthouse flags the image as optimizable.
 
 ## How to optimize images
 


### PR DESCRIPTION
"If the potential savings are 4KiB or **greater**, Lighthouse flags the image as optimizable."

So if the potential savings are 100MiB then my images are optimized? :)