### PR TITLE
Fix broken search.

### DIFF
--- a/src/lib/components/Search/_styles.scss
+++ b/src/lib/components/Search/_styles.scss
@@ -97,7 +97,7 @@ web-search {
     padding: 8px 8px 8px 40px;
     width: 100%;
     font: inherit;
-    font-size: 16px;
+    font-size: 1rem;
     line-height: 20px;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
@@ -117,7 +117,7 @@ web-search {
     position: absolute;
     top: 55px;
     width: calc(100% - #{$WEB_CLOSE_BUTTON_WIDTH});
-    
+
     @include bp(md) {
       left: calc(#{$WEB_SEARCH_MARGIN} * 2);
       width: calc(100% - #{$WEB_SEARCH_MARGIN} * 2);
@@ -133,7 +133,7 @@ web-search {
   .web-search-popout__list {
     list-style: none;
     max-height: 50vh;
-    overflow: scroll;
+    overflow: auto;
   }
 
   .web-search-popout__link {

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -465,16 +465,6 @@ class Search extends BaseStateElement {
     });
     this.expanded = true;
 
-    // Collapse the search box if the user scrolls while the seach box is
-    // focused.
-    window.addEventListener(
-      'scroll',
-      () => {
-        /** @type HTMLElement */ (document.activeElement).blur();
-      },
-      {passive: true, once: true},
-    );
-
     // Wait for the expanding animation to finish before hiding the header
     // links and allowing overflow content.
     // Keep a reference to the timeout in case the user tabs out quickly.

--- a/src/styles/components/_header-course.scss
+++ b/src/styles/components/_header-course.scss
@@ -3,6 +3,7 @@
   background-repeat: no-repeat;
   background-position: right;
   background-size: 136px;
+  position: sticky;
 
   &__title {
     @include apply-utility('font', 'google-sans');

--- a/src/styles/components/_header-default.scss
+++ b/src/styles/components/_header-default.scss
@@ -1,4 +1,7 @@
 .header-default {
+  position: fixed;
+  top: 0;
+
   [data-open-drawer-button] {
     margin: 0 8px 0 -8px;
 
@@ -110,4 +113,9 @@ web-header.web-header--has-expanded-search {
       display: flex;
     }
   }
+}
+
+// Move main down 64px to account for the fixed positioning of the header.
+.header-default ~ main {
+  margin-top: $WEB_HEADER_HEIGHT;
 }

--- a/src/styles/components/_web-header.scss
+++ b/src/styles/components/_web-header.scss
@@ -22,8 +22,6 @@ web-header {
   font-size: 14px;
   height: $WEB_HEADER_HEIGHT;
   padding: 0 24px;
-  position: sticky;
-  top: 0;
   width: 100%;
   z-index: 200;
 


### PR DESCRIPTION
Fixes #5043, fixes #5067, fixes #5071, fixes #4687 (maybe 😅)

In a previous PR I changed the header from being position: fixed to position: sticky. This caused the page to scroll because we call `scrollIntoView()` on search results. We do this because focus never leaves the search input, so when you use the arrow keys to go down it needs to scroll into view any results that have overflowed.

The fix is to make the header position: fixed only on the pages that actually use the search bar. For the courses header we can leave it position: sticky, which is nice because we don't need to ship a third style to add top margin to the courses app-bar.

I also set the text input to have a font-size of `1rem` to see if it fixes #4687. The font-size was already set to 16px so I don't know if this will actually work. If anyone with an iOS device can test I would appreciate it 😁
