### PR TITLE
Add pointer to Private Network Access update.

### DIFF
--- a/src/site/content/en/blog/cors-rfc1918-feedback/index.md
+++ b/src/site/content/en/blog/cors-rfc1918-feedback/index.md
@@ -19,9 +19,9 @@ tags:
 ---
 
 {% Aside %}
-  An update to this post was published to the [developer.chrome.com
+  CORS-RFC1918 has been renamed to Private Network Access for clarity.
+  An update to this post is published at [developer.chrome.com
   blog](https://developer.chrome.com/blog/private-network-access-update).
-  CORS-RFC1918 has also been renamed to Private Network Access for clarity.
 {% endAside %}
 
 Malicious websites making requests to devices and servers hosted on a private

--- a/src/site/content/en/blog/cors-rfc1918-feedback/index.md
+++ b/src/site/content/en/blog/cors-rfc1918-feedback/index.md
@@ -18,6 +18,12 @@ tags:
   - cors
 ---
 
+{% Aside %}
+  An update to this post was published to the [developer.chrome.com
+  blog](https://developer.chrome.com/blog/private-network-access-update).
+  CORS-RFC1918 has also been renamed to Private Network Access for clarity.
+{% endAside %}
+
 Malicious websites making requests to devices and servers hosted on a private
 network have long been a threat. Attackers may, for example, change a wireless
 router's configuration to enable


### PR DESCRIPTION
Updates the CORS-RFC1918 feedback article to point to updated news over on the developer.chrome.com blog. Also notifies readers that the specification's name has changed since the post was published.