### PR TITLE
Describe situation in which images without width/height are not lazy-loaded (#4273)

### DIFF
--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -163,9 +163,9 @@ Alternatively, specify their values directly in an inline style:
 
 The best practice of setting dimensions applies to `<img>` tags regardless of whether or not they are being loaded lazily. With lazy-loading, this can become more relevant. Setting `width` and `height` on images in modern browsers also allows browsers to infer their intrinsic size.
 
-In most scenarios images still lazy-load if dimensions are not included, but there are a few edge-cases you should be aware of. Without `width`/`height` specified, their dimensions are 0 × 0 pixels at first. If you have a gallery of such images, all of them may fit inside the viewport at start (as each takes up basically no space and no image is pushed offscreen). In this case the browser determines that all of them are visible to the user and decides to load everything.
+In most scenarios images still lazy-load if dimensions are not included, but there are a few edge cases you should be aware of. Without `width` and `height` specified, image dimensions are 0×0 pixels at first. If you have a gallery of such images, the browser may conclude that all of them fit inside the viewport at the start, as each takes up practically no space and no image is pushed offscreen. In this case the browser determines that all of them are visible to the user and decides to load everything.
 
-Also, [specifying them decreases the chance of layout shift](https://www.youtube.com/watch?v=4-d_SoCHeWE). If you are unable to include dimensions for your images, lazy-loading them can be a trade-off between saving network resources and potentially being more at risk of layout shift.
+Also, [specifying image dimensions decreases the chances of layout shifts happening](https://www.youtube.com/watch?v=4-d_SoCHeWE). If you are unable to include dimensions for your images, lazy-loading them can be a trade-off between saving network resources and potentially being more at risk of layout shift.
 
 While lazy-loading in Chromium is implemented in a way such that images are likely to be loaded once they are visible, there is still a small chance that they might not be loaded yet. In this case, missing `width` and `height` attributes on such images increase their impact on Cumulative Layout Shift.
 

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -163,7 +163,9 @@ Alternatively, specify their values directly in an inline style:
 
 The best practice of setting dimensions applies to `<img>` tags regardless of whether or not they are being loaded lazily. With lazy-loading, this can become more relevant. Setting `width` and `height` on images in modern browsers also allows browsers to infer their intrinsic size.
 
-Images will still lazy-load if dimensions are not included, but [specifying them decreases the chance of layout shift](https://www.youtube.com/watch?v=4-d_SoCHeWE). If you are unable to include dimensions for your images, lazy-loading them can be a trade-off between saving network resources and potentially being more at risk of layout shift.
+In most scenarios images still lazy-load if dimensions are not included, but there are a few edge-cases you should be aware of. Without `width`/`height` specified, their dimensions are 0 × 0 pixels at first. If you have a gallery of such images, all of them may fit inside the viewport at start (as each takes up basically no space and no image is pushed offscreen). In this case the browser determines that all of them are visible to the user and decides to load everything.
+
+Also, [specifying them decreases the chance of layout shift](https://www.youtube.com/watch?v=4-d_SoCHeWE). If you are unable to include dimensions for your images, lazy-loading them can be a trade-off between saving network resources and potentially being more at risk of layout shift.
 
 While lazy-loading in Chromium is implemented in a way such that images are likely to be loaded once they are visible, there is still a small chance that they might not be loaded yet. In this case, missing `width` and `height` attributes on such images increase their impact on Cumulative Layout Shift.
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #4273 

Changes proposed in this pull request:

- add into the article the situation described by https://github.com/GoogleChrome/web.dev/issues/4273#issuecomment-817172962 when images without width/height may not lazy-load
