### PR TITLE
Redundancy-free internal links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 ## Authoring written content on the site
 
 If you plan to write a blog post or a guide for a collection take a moment to
-look over the [web.dev handbook](/handbook) and familiarize
+look over the [web.dev handbook](https://web.dev/handbook) and familiarize
 yourself with the process. When you're ready, follow the steps in the
-[Quickstart](/handbook/quick-start/) to create your content
+[Quickstart](https://web.dev/handbook/quick-start/) to create your content
 proposal.
 
 ## Submitting a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,27 +3,27 @@
 ## Authoring written content on the site
 
 If you plan to write a blog post or a guide for a collection take a moment to
-look over the [web.dev handbook](https://web.dev/handbook) and familiarize
+look over the [web.dev handbook](/handbook) and familiarize
 yourself with the process. When you're ready, follow the steps in the
-[Quickstart](https://web.dev/handbook/quick-start/) to create your content
+[Quickstart](/handbook/quick-start/) to create your content
 proposal.
 
 ## Submitting a pull request
 
 ### Contributor License Agreements
 
-We'd love to accept your code patches! However, before we can take them, we 
+We'd love to accept your code patches! However, before we can take them, we
 have to jump a couple of legal hurdles.
 
-Please fill out either the individual or corporate Contributor License 
+Please fill out either the individual or corporate Contributor License
 Agreement.
 
-* If you are an individual writing original source code and you're sure you 
+* If you are an individual writing original source code and you're sure you
 own the intellectual property, then sign an [individual CLA](https://developers.google.com/open-source/cla/individual).
-* If you work for a company that wants to allow you to contribute your work, 
+* If you work for a company that wants to allow you to contribute your work,
 then sign a [corporate CLA](https://developers.google.com/open-source/cla/corporate).
 
-Follow either of the two links above to access the appropriate CLA and 
+Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it.
 
 1. Sign the contributors license agreement above.
@@ -39,7 +39,7 @@ the CLA.
 
 ## Writing Code
 
-If your contribution contains code, please make sure that it follows 
+If your contribution contains code, please make sure that it follows
 [the style guide](https://google.github.io/styleguide/jsguide.html).
 Otherwise, we will have to ask you to make changes, and that's no fun for anyone.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Thanks for letting us know! Please [file an issue](https://github.com/GoogleChro
 ## Authoring content ✍️
 
 Before you start writing take a moment to look over the [web.dev
-handbook](https://web.dev/handbook) and familiarize yourself with the process.
+handbook](/handbook) and familiarize yourself with the process.
 When you're ready, follow the steps in the
-[Quickstart](https://web.dev/handbook/quick-start/) to create your content
+[Quickstart](/handbook/quick-start/) to create your content
 proposal.
 
 ## Building the site 🏗

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Thanks for letting us know! Please [file an issue](https://github.com/GoogleChro
 ## Authoring content ✍️
 
 Before you start writing take a moment to look over the [web.dev
-handbook](/handbook) and familiarize yourself with the process.
+handbook](https://web.dev/handbook) and familiarize yourself with the process.
 When you're ready, follow the steps in the
-[Quickstart](/handbook/quick-start/) to create your content
+[Quickstart](https://web.dev/handbook/quick-start/) to create your content
 proposal.
 
 ## Building the site 🏗

--- a/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
+++ b/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
@@ -464,7 +464,7 @@ debugging the accessibility of your visual components.
   Tenon has strong integration support across build tools, browsers (via extensions), and even text editors.
 - There are many library- and framework-specific tools
   for highlighting accessibility issues with components.
-  For example, [web.dev](https://web.dev/accessibility-auditing-react/)
+  For example, [web.dev](/accessibility-auditing-react/)
   explains how to use [eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y)
   to highlight accessibility issues for React components in your editor:
 

--- a/src/site/content/en/blog/agrofy/index.md
+++ b/src/site/content/en/blog/agrofy/index.md
@@ -20,10 +20,10 @@ America's agribusiness market. They match up buyers and sellers of farm
 machines, land, equipment, and financial services. In Q3 2020 a 4-person
 development team at Agrofy spent a month optimizing their website because they
 hypothesized that improved performance would lead to reduced bounce rates. They
-specifically focused on improving [LCP](https://web.dev/lcp/), which is one of
-the [Core Web Vitals](https://web.dev/vitals/#core-web-vitals). These
+specifically focused on improving [LCP](/lcp/), which is one of
+the [Core Web Vitals](/vitals/#core-web-vitals). These
 performance optimizations led to a 70% improvement in LCP, which correlated to a
-76% reduction in load abandonment (from 3.8% to 0.9%).  
+76% reduction in load abandonment (from 3.8% to 0.9%).
 
 <div class="w-stats">
   <div class="w-stat">
@@ -38,8 +38,8 @@ performance optimizations led to a 70% improvement in LCP, which correlated to a
 
 ## Problem
 
-While studying their business metrics, a development team at Agrofy noticed 
-that their bounce rates seemed higher than industry benchmarks. Technical 
+While studying their business metrics, a development team at Agrofy noticed
+that their bounce rates seemed higher than industry benchmarks. Technical
 debt was also increasing in the website codebase.
 
 ## Solution
@@ -52,22 +52,22 @@ The Agrofy team pitched their executives and got buy-in to:
 
 The migration took 2 months. Aside from the 4-person development team mentioned
 earlier, this migration also involved product and UX specialists and a software
-architect.  
+architect.
 The optimization project took the 4-person development team 1 month. They
-focused on LCP, [CLS](https://web.dev/cls/) (another Core Web Vitals metric),
-and [FCP](https://web.dev/fcp/). Specific optimizations included:
+focused on LCP, [CLS](/cls/) (another Core Web Vitals metric),
+and [FCP](/fcp/). Specific optimizations included:
 
 +   Lazy loading all non-visible elements with the
     [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 +   Delivering static resources faster with a [content delivery
-    network](https://web.dev/content-delivery-networks/).
-+   [Lazy loading images](https://web.dev/browser-level-image-lazy-loading/)
+    network](/content-delivery-networks/).
++   [Lazy loading images](/browser-level-image-lazy-loading/)
     with `loading="lazy"`.
 +   [Server-side rendering](https://developers.google.com/web/updates/2019/02/rendering-on-the-web)
     of
     [critical rendering path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path)
     content.
-+   [Preloading and preconnecting](https://web.dev/fast/#optimize-your-resource-delivery)
++   [Preloading and preconnecting](/fast/#optimize-your-resource-delivery)
     critical resources to minimize handshake times.
 +   Using real user monitoring (RUM) tools to identify which product detail
     pages were experiencing lots of layout shifts and then make adjustments to
@@ -75,7 +75,7 @@ and [FCP](https://web.dev/fcp/). Specific optimizations included:
 
 Check out the
 [Agrofy engineering blog post](https://mollar-luciano.medium.com/how-agrofy-optimised-core-web-vitals-and-improved-business-metrics-2f73311bca)
-for more technical details.  
+for more technical details.
 
 After enabling the new codebase on 20% of traffic, they launched the new site to
 all visitors in early September 2020.
@@ -88,11 +88,11 @@ different metrics:
 +   LCP improved 70%.
 +   CLS improved 72%.
 +   Blocking JS requests reduced 100% and blocking CSS requests 80%.
-+   [Long tasks](https://web.dev/long-tasks-devtools/) reduced 72%.
-+   [First CPU Idle](https://web.dev/first-cpu-idle/) improved 25%.
++   [Long tasks](/long-tasks-devtools/) reduced 72%.
++   [First CPU Idle](/first-cpu-idle/) improved 25%.
 
 Over the same time frame, real user monitoring data (also known as [field
-data](https://web.dev/how-to-measure-speed/#lab-data-vs-field-data)) showed that
+data](/how-to-measure-speed/#lab-data-vs-field-data)) showed that
 the load abandonment rate on product detail pages dropped 76%, from 3.8% to
 0.9%:
 

--- a/src/site/content/en/blog/app-shortcuts/index.md
+++ b/src/site/content/en/blog/app-shortcuts/index.md
@@ -238,7 +238,7 @@ Check out the [app shortcuts sample] and its [source].
 * Blink Component: [`UI>Browser>WebAppInstalls`]
 
 [Progressive Web Apps]: /progressive-web-apps/
-[What does it take to be installable?]: https://web.dev/install-criteria/
+[What does it take to be installable?]: /install-criteria/
 [scope]: /add-manifest/#scope
 [web app manifest]: /add-manifest
 [web app manifest icons]: /add-manifest/#icons

--- a/src/site/content/en/blog/ar-hit-test/index.md
+++ b/src/site/content/en/blog/ar-hit-test/index.md
@@ -33,9 +33,9 @@ In this article I assume you already know how to create an augmented reality
 session and that you know how to run a frame loop. If you're not familiar with
 these concepts, you should read the earlier articles in this series.
 
-* [Virtual reality comes to the web](https://web.dev/vr-comes-to-the-web/)
-* [Virtual reality comes to the web, part II](https://web.dev/vr-comes-to-the-web-pt-ii/)
-* [Web AR: you may already know how to use it](https://web.dev/web-ar)
+* [Virtual reality comes to the web](/vr-comes-to-the-web/)
+* [Virtual reality comes to the web, part II](/vr-comes-to-the-web-pt-ii/)
+* [Web AR: you may already know how to use it](/web-ar)
 
 ## The immersive AR session sample
 

--- a/src/site/content/en/blog/aspect-ratio/index.md
+++ b/src/site/content/en/blog/aspect-ratio/index.md
@@ -16,7 +16,7 @@ tags:
 {% Aside %}
 
 Summary: Maintaining a consistent width-to-height ratio, called an *aspect ratio*, is critical in
-responsive web design and for preventing [cumulative layout shift](https://web.dev/cls/). Now,
+responsive web design and for preventing [cumulative layout shift](/cls/). Now,
 there's a more straightforward way to do this with the new `aspect-ratio` property launching in
 [Chromium 88](https://www.chromestatus.com/feature/5738050678161408), [Firefox
 87](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features#property_aspect-ratio), and [Safari Technology Preview
@@ -241,7 +241,7 @@ img {
 
 ### Bonus tip: image attributes for aspect ratio
 
-Another way to set an image's aspect ratio is through [image attributes](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/). If you know the dimensions of the image ahead of time, it is a [best practice](https://web.dev/image-aspect-ratio/#check-the-image's-width-and-height-attributes-in-the-html) to
+Another way to set an image's aspect ratio is through [image attributes](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/). If you know the dimensions of the image ahead of time, it is a [best practice](/image-aspect-ratio/#check-the-image's-width-and-height-attributes-in-the-html) to
 set these dimensions as its `width` and `height`.
 
 For our example above, knowing the dimensions are 800px by 600px, the image markup would look like: `<img src="image.jpg"

--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -402,7 +402,7 @@ simplified events aligned with the
 [Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API).
 Because of potential risks Chrome is
 treading carefully. To stay up to date on Chrome's progress, watch this article
-and our [blog](https://web.dev/blog/) for updates.
+and our [blog](/blog/) for updates.
 
 For now, support for the Clipboard API is available in
 [a number of browsers](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#Browser_compatibility).

--- a/src/site/content/en/blog/at-property/index.md
+++ b/src/site/content/en/blog/at-property/index.md
@@ -129,8 +129,8 @@ each gradient declaration is parsed as a string.
 <figure class="w-figure">
   <img class="w-screenshot" src="https://storage.googleapis.com/web-dev-assets/at-property/support1.gif">
   <figcaption class="w-figcaption">
-    Using a custom property with a "number" syntax, the gradient on the left shows a smooth 
-    transition between stop values. The gradient on the right uses a default custom property 
+    Using a custom property with a "number" syntax, the gradient on the left shows a smooth
+    transition between stop values. The gradient on the right uses a default custom property
     (no syntax defined) and shows an abrupt transition.
   </figcaption>
 </figure>
@@ -140,8 +140,8 @@ each gradient declaration is parsed as a string.
     <source src="https://storage.googleapis.com/web-dev-assets/at-property/support1.mp4" type="video/mp4">
   </video>
   <figcaption class="w-figcaption">
-    Using a custom property with a "number" syntax, the gradient on the left shows a smooth 
-    transition between stop values. The gradient on the right uses a default custom property 
+    Using a custom property with a "number" syntax, the gradient on the left shows a smooth
+    transition between stop values. The gradient on the right uses a default custom property
     (no syntax defined) and shows an abrupt transition.
   </figcaption>
 </figure>
@@ -231,7 +231,7 @@ you could write something like:
 }
 ```
 
-## Conclusion 
+## Conclusion
 
 The `@property` rule makes an exciting technology even more accessible by
 allowing you to write semantically meaningful CSS within CSS itself. To learn
@@ -240,7 +240,7 @@ resources:
 
 - [Is Houdini Ready Yet?](http://ishoudinireadyyet.com/)
 - [MDN Houdini Reference](https://developer.mozilla.org/en-US/docs/Web/Houdini)
-- [Smarter custom properties with Houdini's new API](https://web.dev/css-props-and-vals/)
+- [Smarter custom properties with Houdini's new API](/css-props-and-vals/)
 - [Houdini CSSWG Issue Queue](https://github.com/w3c/css-houdini-drafts/issues)
 
 Photo by [Cristian Escobar](https://unsplash.com/@cristian1) on Unsplash.

--- a/src/site/content/en/blog/autowebperf/index.md
+++ b/src/site/content/en/blog/autowebperf/index.md
@@ -23,14 +23,14 @@ tags:
 [AutoWebPerf](https://github.com/GoogleChromeLabs/AutoWebPerf) (AWP) is a
 modular tool that enables automatic gathering of performance data from multiple
 sources. Currently there are [many tools
-available](https://web.dev/vitals-tools/) to measure website performance for
+available](/vitals-tools/) to measure website performance for
 different scopes ([lab and
-field](https://web.dev/how-to-measure-speed/#lab-data-vs-field-data)), such as
+field](/how-to-measure-speed/#lab-data-vs-field-data)), such as
 Chrome UX Report, PageSpeed Insights, or WebPageTest. AWP offers integration
 with various audit tools with a simple setup so you can continuously monitor the
 site performance in one place.
 
-The release of [Web Vitals](https://web.dev/vitals/) guidance means that close
+The release of [Web Vitals](/vitals/) guidance means that close
 and active monitoring of web pages is becoming increasingly important. The
 engineers behind this tool have been doing performance audits for years and they
 created AWP to automate a manual, recurring, and time consuming part of their
@@ -47,14 +47,14 @@ Although several tools and APIs are available to monitor the performance of web
 pages, most of them expose data measured at a specific time. To adequately
 monitor a website and maintain good performance of key pages, it's recommended
 to continuously take measurements of [Core Web
-Vitals](https://web.dev/vitals/#core-web-vitals) over time and observe trends.
+Vitals](/vitals/#core-web-vitals) over time and observe trends.
 
 AWP makes that easier by providing an engine and pre-built API integrations
 which can be programmatically configured to automate recurrent queries to
 various performance monitoring APIs.
 
 For example, with AWP, you can set a daily test on your home page to capture the
-field data from [CrUX API](https://web.dev/chrome-ux-report-api/) and lab data
+field data from [CrUX API](/chrome-ux-report-api/) and lab data
 from a
 [Lighthouse report from PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/).
 This data can be written and stored over time, for example, in [Google
@@ -82,8 +82,8 @@ Google Sheets).
 AWP comes with a number of pre-implemented gatherers and connectors:
 
 * Pre-implemented gatherers:
-  * [CrUX API](https://web.dev/chrome-ux-report-api/)
-  * [CrUX BigQuery](https://web.dev/chrome-ux-report-bigquery/)
+  * [CrUX API](/chrome-ux-report-api/)
+  * [CrUX BigQuery](/chrome-ux-report-bigquery/)
   * [PageSpeed Insights API](https://developers.google.com/speed/docs/insights/v5/get-started)
   * [WebPageTest API](https://www.webpagetest.org/getkey.php)
 * Pre-implemented connectors:

--- a/src/site/content/en/blog/betty-crocker/index.md
+++ b/src/site/content/en/blog/betty-crocker/index.md
@@ -61,7 +61,7 @@ Betty Crocker asked themselves how they could port the killer feature of their i
 over to the web app.
 This is when they learned about
 [Project Fugu](https://developers.google.com/web/updates/capabilities) and the
-[Wake Lock API](https://web.dev/wakelock/).
+[Wake Lock API](/wakelock/).
 
 {% Img src="image/admin/Yoj65m20XpoPdaL8ejAv.jpg", alt="A person kneading dough on a kitchen table covered in flour", width="800", height="533" %}
 
@@ -346,7 +346,7 @@ Other examples are boarding pass or ticket apps that need to keep the screen on
 until the barcode has been scanned, kiosk-style apps that keep the screen on continuously,
 or web-based presentation apps that prevent the screen from sleeping during a presentation.
 
-We have compiled [everything you need to know about the Wake Lock API](https://web.dev/wakelock/)
+We have compiled [everything you need to know about the Wake Lock API](/wakelock/)
 in a comprehensive article on this very site.
 Happy reading, and happy cooking!
 

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -55,7 +55,7 @@ loads:
       <td>
         A new request is initiated to load the previous page, and, depending
         on how well that page has been <a
-        href="https://web.dev/reliable/#the-options-in-your-caching-toolbox">
+        href="/reliable/#the-options-in-your-caching-toolbox">
         optimized</a> for repeat visits, the browser might have to re-download,
         re-parse, and re-execute some (or all) of resources it just downloaded.
       </td>

--- a/src/site/content/en/blog/browser-fs-access/index.md
+++ b/src/site/content/en/blog/browser-fs-access/index.md
@@ -251,7 +251,7 @@ the demo cannot be embedded in this article.
 ## The browser-fs-access library in the wild
 
 In my free time, I contribute a tiny bit to an
-[installable PWA](https://web.dev/progressive-web-apps/#installable)
+[installable PWA](/progressive-web-apps/#installable)
 called [Excalidraw](https://excalidraw.com/),
 a whiteboard tool that lets you easily sketch diagrams with a hand-drawn feel.
 It is fully responsive and works well on a range of devices from small mobile phones to computers with large screens.

--- a/src/site/content/en/blog/building-a-pwa-at-google-part-1/index.md
+++ b/src/site/content/en/blog/building-a-pwa-at-google-part-1/index.md
@@ -29,9 +29,9 @@ means a complete overview of PWAs. The aim is to share learnings from our team's
 For this first post we'll cover a little background information first and then dive into all the
 stuff we learned about service workers.
 
-{% Aside %}  
+{% Aside %}
 Bulletin was shut down in 2019 due to lack of product/market fit. We still learned a lot about PWAs
-along the way!  
+along the way!
 {% endAside %}
 
 ## Background {: #background }
@@ -44,7 +44,7 @@ Before we delve into the development process, let's examine why building a PWA w
 option for this project:
 
 * **Ability to iterate quickly**. Especially valuable since Bulletin would be piloted in
-  multiple markets. 
+  multiple markets.
 * **Single code base**. Our users were roughly evenly split between Android and iOS. A PWA meant
   we could build a single web app that would work on both platforms. This increased the velocity
   and impact of the team.
@@ -66,7 +66,7 @@ You can't have a PWA without a [service
 worker](https://developers.google.com/web/fundamentals/primers/service-workers/). Service workers
 give you a lot of power, such as advanced caching strategies, offline capabilities, background sync,
 etc. While service workers do add some complexity, we found that their benefits outweighed the added
-complexity. 
+complexity.
 
 ### Generate it if you can {: #generate }
 
@@ -142,13 +142,13 @@ disable the memory cache. In order to cover more browsers, we opted for a differ
 including a flag to disable caching in our service worker which is enabled by default on developer
 builds. This ensures that devs always get their most recent changes without any caching issues. It's
 important to include the `Cache-Control: no-cache` header as well to [prevent the browser from
-caching any assets](https://web.dev/http-cache/#unversioned-urls).
+caching any assets](/http-cache/#unversioned-urls).
 
 ### Lighthouse {: #lighthouse }
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) provides a number of debugging
 tools useful for PWAs. It scans a site and generates reports covering PWAs, performance,
-accessibility, SEO, and other best practices.  
+accessibility, SEO, and other best practices.
 We recommend [running Lighthouse on continuous
 integration](https://github.com/GoogleChrome/lighthouse-ci) to alert you if you break one of the
 criteria to be a PWA. This actually happened to us once, where the service worker wasn't installing

--- a/src/site/content/en/blog/building-a-settings-component/index.md
+++ b/src/site/content/en/blog/building-a-settings-component/index.md
@@ -194,8 +194,8 @@ want a large gap, but not as large as if we're on a wide screen.
 
 The `grid-template-columns` property uses 3 CSS functions: `repeat()`, `minmax()` and
 `min()`. [Una Kravets](#) has a [great layout blog
-post](https://web.dev/one-line-layouts/) about this, calling it
-[RAM](https://web.dev/one-line-layouts/#07.-ram-(repeat-auto-minmax):-grid-template-columns(auto-fit-minmax(lessbasegreater-1fr))).
+post](/one-line-layouts/) about this, calling it
+[RAM](/one-line-layouts/#07.-ram-(repeat-auto-minmax):-grid-template-columns(auto-fit-minmax(lessbasegreater-1fr))).
 
 There's 3 special additions in our layout, if you compare it to Una's:
 
@@ -433,8 +433,8 @@ a better location:
 ```
 
 Learn all about it in this [`color-scheme`
-article](https://web.dev/color-scheme/) by [Thomas
-Steiner](https://web.dev/authors/thomassteiner/). There's a lot more to gain
+article](/color-scheme/) by [Thomas
+Steiner](/authors/thomassteiner/). There's a lot more to gain
 than dark checkbox inputs!
 
 ### CSS `accent-color`
@@ -677,7 +677,7 @@ is a Level 5 spec addition that
 
 The goal was an easy to manage and animated visual highlight for user feedback.
 By using a box shadow I can avoid [triggering
-layout](https://web.dev/animations-guide/#triggers) with the effect. I do this
+layout](/animations-guide/#triggers) with the effect. I do this
 by creating a shadow that's not blurred and matches the circular shape of the
 thumb element. Then I change and transition it's spread size on hover.
 

--- a/src/site/content/en/blog/building-a-tabs-component/index.md
+++ b/src/site/content/en/blog/building-a-tabs-component/index.md
@@ -516,7 +516,7 @@ Mode](https://developers.google.com/web/tools/chrome-devtools/device-mode) by
 selecting any mode other than **Responsive**, and then resizing the device frame.
 Notice the element stays in view and locked with its content. This has been
 available since Chromium updated their implementation to match the spec. Here's
-a [blog post](https://web.dev/snap-after-layout/) about it.
+a [blog post](/snap-after-layout/) about it.
 
 ### Animation {: #animation }
 
@@ -524,7 +524,7 @@ The goal of the animation work here is to clearly link interactions with UI
 feedback. This helps guide or assist the user through to their (hopefully)
 seamless discovery of all the content. I'll be adding motion with purpose and
 conditionally. Users can now specify [their motion
-preferences](https://web.dev/prefers-reduced-motion/) in their operating system,
+preferences](/prefers-reduced-motion/) in their operating system,
 and I thoroughly enjoy responding to their preferences in my interfaces.
 
 I'll be linking a tab underline with the article scroll position. Snapping isn't

--- a/src/site/content/en/blog/carousel-best-practices/index.md
+++ b/src/site/content/en/blog/carousel-best-practices/index.md
@@ -136,7 +136,7 @@ carousels:
   carousel-related layout shifts. In a non-autoplay carousel these layout shifts
   typically occur within 500ms of a user interaction and [therefore do not count
   towards Cumulative Layout Shift
-  (CLS)](https://web.dev/cls/#expected-vs.-unexpected-layout-shifts). However,
+  (CLS)](/cls/#expected-vs.-unexpected-layout-shifts). However,
   for autoplay carousels, not only can these layout shifts potentially count
   towards CLS - but they can also repeat indefinitely. Thus, it is particularly
   important to verify that an autoplay carousel is not a source of layout
@@ -152,7 +152,7 @@ carousels:
   considered a layout shift provided that they occur in the same frame.
 
 For more information on layout shifts, see [Debug layout
-shifts](https://web.dev/debug-layout-shifts/#identifying-the-cause-of-a-layout-shift).
+shifts](/debug-layout-shifts/#identifying-the-cause-of-a-layout-shift).
 
 
 ### Use modern technology

--- a/src/site/content/en/blog/change-password-url/index.md
+++ b/src/site/content/en/blog/change-password-url/index.md
@@ -43,7 +43,7 @@ They can help users in various ways:
 **Autofill the password for the correct input field**: Some browsers can find
 the correct input heuristically even if the website is not optimized for this
 purpose. Web developers can help password managers by correctly [annotating HTML
-input tags](https://web.dev/sign-in-form-best-practices/#new-password).
+input tags](/sign-in-form-best-practices/#new-password).
 
 **Prevent phishing**: Because password managers remember where the password was
 recorded, the password can be autofilled only at appropriate URLs, and not at
@@ -116,7 +116,7 @@ friction:
   manager suggest a generated password.
 
 Learn more at [Sign-in form best
-practices](https://web.dev/sign-in-form-best-practices/#new-password).
+practices](/sign-in-form-best-practices/#new-password).
 
 ## How it is used in real world
 
@@ -217,6 +217,6 @@ repository](https://github.com/wicg/change-password-url/issues).
   Passwords](https://wicg.github.io/change-password-url/)
 * [Detecting the reliability of HTTP status
   codes](https://wicg.github.io/change-password-url/response-code-reliability.html)
-* [Sign-in form best practices](https://web.dev/sign-in-form-best-practices/)
+* [Sign-in form best practices](/sign-in-form-best-practices/)
 
 Photo by [Matthew Brodeur](https://unsplash.com/photos/zEFyM4sulJ8) on [Unsplash](https://unsplash.com)

--- a/src/site/content/en/blog/compat2021/index.md
+++ b/src/site/content/en/blog/compat2021/index.md
@@ -1,14 +1,14 @@
 ---
 title: "Compat2021: Eliminating five top compatibility pain points on the web"
-subhead: 
+subhead:
     "Google is working with other browser vendors and industry partners to fix the
-    top five browser compatibility pain points for web developers: CSS Flexbox, 
+    top five browser compatibility pain points for web developers: CSS Flexbox,
     CSS Grid, `position: sticky`, `aspect-ratio`, and CSS transforms."
 description:
-    "Learn more about how Google is working with other browser vendors and 
-    industry partners to fix the top five browser compatibility pain points for 
-    web developers: CSS Flexbox, CSS Grid, position: sticky, aspect-ratio, 
-    and CSS transforms."     
+    "Learn more about how Google is working with other browser vendors and
+    industry partners to fix the top five browser compatibility pain points for
+    web developers: CSS Flexbox, CSS Grid, position: sticky, aspect-ratio,
+    and CSS transforms."
 authors:
   - robertnyman
   - foolip
@@ -35,7 +35,7 @@ last couple of years, Google and other partners, including Mozilla and
 Microsoft, have set out to learn more about the top pain points for web
 developers, to drive our work and prioritization to make the situation better.
 This project is connected to [Google's Developer
-Satisfaction](https://web.dev/developer-satisfaction) (DevSAT) work, and it
+Satisfaction](/developer-satisfaction) (DevSAT) work, and it
 started on a larger scale with the creation of the
 [MDN DNA (Developer Needs Assessment) surveys](https://insights.developer.mozilla.org/)
 in 2019 and 2020, and a deep-dive research effort presented in the
@@ -67,7 +67,7 @@ prioritize, and some are:
     [Gecko](https://bugzilla.mozilla.org/describecomponents.cgi),
     [WebKit](https://bugs.webkit.org/)), and for Chromium, how many stars those
     bugs have.
-+   Survey results: 
++   Survey results:
 
     +   [MDN DNA surveys](https://insights.developer.mozilla.org/)
     +   [MDN Browser Compatibility Report](https://insights.developer.mozilla.org/reports/mdn-browser-compatibility-report-2020.html)
@@ -83,8 +83,8 @@ prioritize, and some are:
 In 2020, Chromium started work addressing the top areas outlined in
 [Improving Chromium's browser compatibility in 2020](https://blog.chromium.org/2020/06/improving-chromiums-browser.html).
 In 2021, we are beginning a dedicated effort to go even further. Google and
-[Microsoft are working together on addressing top issues in Chromium](https://blogs.windows.com/msedgedev/2021/03/22/better-compatibility-compat2021/), along with [Igalia](https://www.igalia.com/). Igalia, who are regular contributors 
-to Chromium and WebKit, and maintainers of the official WebKit port for embedded devices, 
+[Microsoft are working together on addressing top issues in Chromium](https://blogs.windows.com/msedgedev/2021/03/22/better-compatibility-compat2021/), along with [Igalia](https://www.igalia.com/). Igalia, who are regular contributors
+to Chromium and WebKit, and maintainers of the official WebKit port for embedded devices,
 have been very supportive and engaged in these compatibility efforts, and will be
 helping tackle and track the identified issues.
 
@@ -104,7 +104,7 @@ have had issues with `auto-height` flex containers leading to incorrectly sized 
     <figure class="w-figure" style="display: flex; flex-direction: column;">
     {% Img src="image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/qmKoKHkZga5hgBeiHuBz.png", alt="Stretched photo of a chessboard.", width="800", height="400" %}
         <figcaption class="w-figcaption" style="margin-top: auto">
-            Incorrectly sized image due to bugs. 
+            Incorrectly sized image due to bugs.
         </figcaption>
     </figure>
     <figure class="w-figure" style="display: flex; flex-direction: column;">
@@ -234,7 +234,7 @@ The new
 [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio)
 CSS property makes it easy to maintain a consistent width-to-height ratio for
 elements, removing the need for the well-known
-[`padding-top` hack](https://web.dev/aspect-ratio/#the-old-hack:-maintaining-aspect-ratio-with-padding-top):
+[`padding-top` hack](/aspect-ratio/#the-old-hack:-maintaining-aspect-ratio-with-padding-top):
 
 <div class="w-columns">
 {% Compare 'worse', 'Using padding-top' %}
@@ -308,7 +308,7 @@ flip effect can be very inconsistent across browsers:
 Follow and share any updates we post on
 [@ChromiumDev](https://twitter.com/ChromiumDev) or the [public mailing list,
 Compat 2021](https://groups.google.com/g/compat2021). Make sure bugs exist, or
-[file them](https://web.dev/how-to-file-a-good-bug/) for issues you have been
+[file them](/how-to-file-a-good-bug/) for issues you have been
 experiencing, and if there's anything missing, reach out through the above
 channels.
 

--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -416,7 +416,7 @@ This code specifies the following:
         </td>
       </tr>
       <tr>
-        <td><code>conversiondestination</code> (required): the <b><a href="https://web.dev/same-site-same-origin/#site" noopener>eTLD+1</a></b> where a conversion is expected for this ad.</td>
+        <td><code>conversiondestination</code> (required): the <b><a href="/same-site-same-origin/#site" noopener>eTLD+1</a></b> where a conversion is expected for this ad.</td>
         <td>(no default)</td>
         <td><code>https://advertiser.example</code>.<br/>If the <code>conversiondestination</code> is <code>https://advertiser.example</code>, conversions on both <code>https://advertiser.example</code> and <code>https://shop.advertiser.example</code> will be attributed.<br/>The same happens if the <code>conversiondestination</code> is <code>https://shop.advertiser.example</code>: conversions on both <code>https://advertiser.example</code> and <code>https://shop.advertiser.example</code> will be attributed.
         </td>

--- a/src/site/content/en/blog/cors-rfc1918-feedback/index.md
+++ b/src/site/content/en/blog/cors-rfc1918-feedback/index.md
@@ -62,7 +62,7 @@ Browsers that implement CORS check with target
 resources whether they are okay being loaded from a different origin. This is
 accomplished either with extra headers inline describing the access or by using
 a mechanism called preflight requests, depending on the complexity. Read [Cross
-Origin Resource Sharing](https://web.dev/cross-origin-resource-sharing/)
+Origin Resource Sharing](/cross-origin-resource-sharing/)
 to learn more.
 
 With [CORS-RFC1918](https://wicg.github.io/cors-rfc1918/) the browser will block

--- a/src/site/content/en/blog/detached-window-memory-leaks/index.md
+++ b/src/site/content/en/blog/detached-window-memory-leaks/index.md
@@ -533,9 +533,9 @@ have another technique for debugging detached windows or this article helped unc
 app, I'd love to know! You can find me on Twitter [@\_developit](https://twitter.com/_developit).
 
 [performance-memory-api]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory
-[performance-measurememory]: https://web.dev/monitor-total-page-memory-usage/
+[performance-measurememory]: /monitor-total-page-memory-usage/
 [postmessage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [finalizationregistry]: https://v8.dev/features/weak-references#:~:text=FinalizationRegistry
 [weakref]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
 [noopener]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open#noopener
-[rel-noopener]: https://web.dev/external-anchors-use-rel-noopener/
+[rel-noopener]: /external-anchors-use-rel-noopener/

--- a/src/site/content/en/blog/device-pixel-content-box/index.md
+++ b/src/site/content/en/blog/device-pixel-content-box/index.md
@@ -140,7 +140,7 @@ if (!(await hasDevicePixelContentBox())) {
 
 Pixels are a surprisingly complex topic on the web and up until now there was no way for you to know the exact number of physical pixels an element occupies on the user's screen. The new `devicePixelContentBox` property on a `ResizeObserverEntry` gives you that piece of information and allows you to do pixel-perfect renderings with `<canvas>`. `devicePixelContentBox` is supported in Chrome 84+.
 
-[resizeobserver]: https://web.dev/resize-observer/
+[resizeobserver]: /resize-observer/
 [subpixel rendering]: https://en.wikipedia.org/wiki/Subpixel_rendering
 [moiré effect]: https://en.wikipedia.org/wiki/Moir%C3%A9_pattern
 [ro support]: https://caniuse.com/#feat=resizeobserver

--- a/src/site/content/en/blog/drag-and-drop/index.md
+++ b/src/site/content/en/blog/drag-and-drop/index.md
@@ -313,7 +313,7 @@ function handleDrop(e) {
 }
 ```
 
-You can find more information about this in [Custom drag-and-drop](https://web.dev/read-files/#select-dnd).
+You can find more information about this in [Custom drag-and-drop](/read-files/#select-dnd).
 
 ## More resources
 

--- a/src/site/content/en/blog/fetch-metadata/index.md
+++ b/src/site/content/en/blog/fetch-metadata/index.md
@@ -72,7 +72,7 @@ Malicious cross-site requests can be rejected by the server because of the addit
 
 ### `Sec-Fetch-Site`
 
-`Sec-Fetch-Site` tells the server which [site](https://web.dev/same-site-same-origin) sent the request. The browser sets this value to one of the following:
+`Sec-Fetch-Site` tells the server which [site](/same-site-same-origin) sent the request. The browser sets this value to one of the following:
 
  - `same-origin`, if the request was made by your own application (e.g. `site.example`)
  - `same-site`, if the request was made by a subdomain of your site (e.g. `bar.site.example`)

--- a/src/site/content/en/blog/file-handling/index.md
+++ b/src/site/content/en/blog/file-handling/index.md
@@ -19,7 +19,7 @@ origin_trial:
 
 {% Aside %}
   The File Handling API is part of the
-  [capabilities project](https://web.dev/fugu-status/) and is currently in development. This post will
+  [capabilities project](/fugu-status/) and is currently in development. This post will
   be updated as the implementation progresses.
 {% endAside %}
 

--- a/src/site/content/en/blog/five-ways-airshift-improved-their-react-app/index.md
+++ b/src/site/content/en/blog/five-ways-airshift-improved-their-react-app/index.md
@@ -152,7 +152,7 @@ a 1 second total reduction in scripting time.
 
 AirSHIFT has a built-in chat application. Many store owners communicate with their staff members via the chat while looking at the shift table, which means that a user might be typing a message while the table is loading. If the main thread is occupied with scripts that are rendering the table, user input could be janky.
 
-To improve this experience, AirSHIFT now uses [React.lazy and Suspense](https://web.dev/code-splitting-suspense/) to show placeholders for table contents while lazily loading the actual components.
+To improve this experience, AirSHIFT now uses [React.lazy and Suspense](/code-splitting-suspense/) to show placeholders for table contents while lazily loading the actual components.
 
 The AirSHIFT team also migrated some of the expensive business logic
 within the lazily loaded components to
@@ -256,7 +256,7 @@ via Elasticsearch when they exceed their budget.
 </figure>
 
 {% Aside %}
-Related article: [Performance budgets 101](https://web.dev/performance-budgets-101)
+Related article: [Performance budgets 101](/performance-budgets-101)
 {% endAside %}
 
 ### Results

--- a/src/site/content/en/blog/floc/index.md
+++ b/src/site/content/en/blog/floc/index.md
@@ -19,56 +19,56 @@ feedback:
 
 ## Summary
 
-FLoC provides a privacy-preserving mechanism for interest-based ad selection. 
+FLoC provides a privacy-preserving mechanism for interest-based ad selection.
 
-As a user moves around the web, their browser uses the FLoC algorithm to work out its "interest 
-cohort", which will be the same for thousands of browsers with a similar recent browsing history. 
-The browser recalculates its cohort periodically, on the user's device, without sharing 
+As a user moves around the web, their browser uses the FLoC algorithm to work out its "interest
+cohort", which will be the same for thousands of browsers with a similar recent browsing history.
+The browser recalculates its cohort periodically, on the user's device, without sharing
 individual browsing data with the browser vendor or anyone else.
 
-Advertisers (sites that pay for advertisements) can include code on their own websites in order to 
-gather and provide cohort data to their adtech platforms (companies that provide software and tools 
-to deliver advertising). For example, an adtech platform might learn from an online shoe store that 
-browsers from cohorts 1101 and 1354 seem interested in the store's hiking gear. From other 
-advertisers, the adtech platform learns about other interests of those cohorts. 
+Advertisers (sites that pay for advertisements) can include code on their own websites in order to
+gather and provide cohort data to their adtech platforms (companies that provide software and tools
+to deliver advertising). For example, an adtech platform might learn from an online shoe store that
+browsers from cohorts 1101 and 1354 seem interested in the store's hiking gear. From other
+advertisers, the adtech platform learns about other interests of those cohorts.
 
-Subsequently, the ad platform can use this data to select relevant ads (such as an ad for hiking 
-boots from the shoe store) when a browser from one of those cohorts requests a page from a site that 
+Subsequently, the ad platform can use this data to select relevant ads (such as an ad for hiking
+boots from the shoe store) when a browser from one of those cohorts requests a page from a site that
 displays ads, such as a news website.
 
 {% Aside %}
-The Privacy Sandbox is a series of proposals to satisfy third-party use cases without third-party 
-cookies or other tracking mechanisms. See [Digging into the Privacy Sandbox](http://web.dev/digging-into-the-privacy-sandbox)
+The Privacy Sandbox is a series of proposals to satisfy third-party use cases without third-party
+cookies or other tracking mechanisms. See [Digging into the Privacy Sandbox](/digging-into-the-privacy-sandbox)
 for an overview of all the proposals.
 
 **This proposal needs your feedback!** If you have comments, please [create an
-issue](https://github.com/WICG/floc/issues/new) on the [FLoC Explainer](https://github.com/WICG/floc) 
-repository.  If you have feedback on Chrome's experiment with this proposal, please post a reply on 
+issue](https://github.com/WICG/floc/issues/new) on the [FLoC Explainer](https://github.com/WICG/floc)
+repository.  If you have feedback on Chrome's experiment with this proposal, please post a reply on
 the [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/MmijXrmwrJs).
 {% endAside %}
 
 ## Why do we need FLoC?
 
-Many businesses rely on advertising to drive traffic to their sites, and many publisher websites 
-fund content by selling advertising inventory. People generally prefer to see ads that are 
-relevant and useful to them, and relevant ads also bring more business to advertisers and 
-[more revenue to the websites that host them](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf). In other words, ad space is more valuable when 
-it displays relevant ads. Thus, selecting relevant ads increases revenue for ad-supported websites. 
+Many businesses rely on advertising to drive traffic to their sites, and many publisher websites
+fund content by selling advertising inventory. People generally prefer to see ads that are
+relevant and useful to them, and relevant ads also bring more business to advertisers and
+[more revenue to the websites that host them](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf). In other words, ad space is more valuable when
+it displays relevant ads. Thus, selecting relevant ads increases revenue for ad-supported websites.
 That, in turn, means that relevant ads help fund content creation that benefits users.
 
-However, many people are concerned about the privacy implications of tailored advertising, which 
-currently relies on techniques such as tracking cookies and device fingerprinting which are used to 
-track individual browsing behavior. The FLoC proposal aims to allow more effective ad selection 
+However, many people are concerned about the privacy implications of tailored advertising, which
+currently relies on techniques such as tracking cookies and device fingerprinting which are used to
+track individual browsing behavior. The FLoC proposal aims to allow more effective ad selection
 without compromising privacy.
 
 ## What can FLoC be used for?
 
-* Show ads to people whose browsers belong to a cohort that has been observed to frequently visit an 
+* Show ads to people whose browsers belong to a cohort that has been observed to frequently visit an
 advertiser's site or shows interest in relevant topics.
-* Use machine learning models to predict the probability a user will convert based on their cohort, 
+* Use machine learning models to predict the probability a user will convert based on their cohort,
 in order to inform ad auction bidding behavior.
-* Recommend content to users. For example, suppose a news site observes that their sports podcast 
-page has become especially popular with visitors from cohorts 1234 and 7. They can recommend that 
+* Recommend content to users. For example, suppose a news site observes that their sports podcast
+page has become especially popular with visitors from cohorts 1234 and 7. They can recommend that
 content to other visitors from those cohorts.
 
 ## How does FLoC work?
@@ -85,39 +85,39 @@ retailer: <br>
 * The **adtech platform** (which provides software and tools to deliver advertising) is: <br>
 **<u>adnetwork.example</u>**
 
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/wnJ1fSECf5STngywgE7V.png", 
-  alt="Diagram showing, step by step, the different roles in selecting and delivering an ad using 
-  FLoC: FLoC service, Browser, Advertisers, Publisher (to observe cohorts), Adtech, 
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/wnJ1fSECf5STngywgE7V.png",
+  alt="Diagram showing, step by step, the different roles in selecting and delivering an ad using
+  FLoC: FLoC service, Browser, Advertisers, Publisher (to observe cohorts), Adtech,
   Publisher (to display ads)", width="800", height="359" %}
 
 In this example we've called the users **Yoshi** and **Alex**. Initially their browsers both belong
 to the same cohort, 1354.
 
 {% Aside %}
-We've called the users here Yoshi and Alex, but this is only for the purpose of the example. Names 
-and individual identities are not revealed to the advertiser, publisher, or adtech platform with 
-FLoC.   
+We've called the users here Yoshi and Alex, but this is only for the purpose of the example. Names
+and individual identities are not revealed to the advertiser, publisher, or adtech platform with
+FLoC.
 
-Don't think of a cohort as a collection of people. Instead, think of a cohort as a grouping of 
+Don't think of a cohort as a collection of people. Instead, think of a cohort as a grouping of
 browsing activity.
 {% endAside %}
 
 ### 1. FLoC service
 1. The FLoC service used by the browser creates a mathematical model with thousands of "cohorts",
-each of which will correspond to thousands of web browsers with similar recent browsing histories. 
+each of which will correspond to thousands of web browsers with similar recent browsing histories.
 More about how this works [below](#floc-server).
 1. Each cohort is given a number.
 
 ### 2. Browser
-1. From the FLoC service, Yoshi's browser gets data describing the FLoC model. 
-1. Yoshi's browser works out its cohort [by using the FLoC model's algorithm](#floc-algorithm) 
-to calculate which cohort corresponds most closely to its own browsing history. In this example, 
-that will be the cohort 1354. Note that Yoshi's browser does not share any data with the FLoC 
+1. From the FLoC service, Yoshi's browser gets data describing the FLoC model.
+1. Yoshi's browser works out its cohort [by using the FLoC model's algorithm](#floc-algorithm)
+to calculate which cohort corresponds most closely to its own browsing history. In this example,
+that will be the cohort 1354. Note that Yoshi's browser does not share any data with the FLoC
 service.
-1. In the same way, Alex's browser calculates its cohort ID. Alex's browsing history is 
+1. In the same way, Alex's browser calculates its cohort ID. Alex's browsing history is
 different from Yoshi's, but similar enough that their browsers both belong to cohort 1354.
 
-### 3. Advertiser: <span style="font-weight:normal">shoestore.example</span> 
+### 3. Advertiser: <span style="font-weight:normal">shoestore.example</span>
 1. Yoshi visits <u>shoestore.example</u>.
 1. The site asks Yoshi's browser for its cohort: 1354.
 1. Yoshi looks at hiking boots.
@@ -125,45 +125,45 @@ different from Yoshi's, but similar enough that their browsers both belong to co
 1. The site later records additional interest in its products from cohort 1354, as well as from other
 cohorts.
 1. The site periodically aggregates and shares information about cohorts and product interests with
-its adtech platform <u>adnetwork.example</u>. 
+its adtech platform <u>adnetwork.example</u>.
 
 Now it's Alex's turn.
 
-### 4. Publisher: <span style="font-weight:normal">dailynews.example</span> 
+### 4. Publisher: <span style="font-weight:normal">dailynews.example</span>
 1. Alex visits <u>dailynews.example</u>.
 1. The site asks Alex's browser for its cohort.
-1. The site then makes a request for an ad to its adtech platform, <u>adnetwork.example</u>, including 
+1. The site then makes a request for an ad to its adtech platform, <u>adnetwork.example</u>, including
 Alex's browser's cohort: 1354.
 
 ### 5. Adtech platform: <span style="font-weight:normal">adnetwork.example</span>
-1. <u>adnetwork.example</u> can select an ad suitable for Alex by combining the data it has from 
-the publisher <u>dailynews.example</u> and the advertiser <u>shoestore.example</u>: 
+1. <u>adnetwork.example</u> can select an ad suitable for Alex by combining the data it has from
+the publisher <u>dailynews.example</u> and the advertiser <u>shoestore.example</u>:
 	- Alex's browser's cohort (1354) provided by <u>dailynews.example</u>.
-	- Data about cohorts and product interests from <u>shoestore.example</u>: "Browsers from cohort 1354 
+	- Data about cohorts and product interests from <u>shoestore.example</u>: "Browsers from cohort 1354
 	might be interested in hiking boots."
 1. <u>adnetwork.example</u> selects an ad appropriate to Alex: an ad for hiking boots on
 <u>shoestore.example</u>.
 1. <u>dailynews.example</u> displays the ad 🥾.
 
 {% Aside %}
-Current approaches for ad selection rely on techniques such as tracking cookies and device 
-fingerprinting, which are used by third parties such as advertisers to track individual browsing 
+Current approaches for ad selection rely on techniques such as tracking cookies and device
+fingerprinting, which are used by third parties such as advertisers to track individual browsing
 behavior.
 
-With FLoC, the browser **does not share** its browsing history with the FLoC service or anyone else. 
-The browser, on the user's device, works out which cohort it belongs to. The user's browsing history 
+With FLoC, the browser **does not share** its browsing history with the FLoC service or anyone else.
+The browser, on the user's device, works out which cohort it belongs to. The user's browsing history
 never leaves the device.
 {% endAside %}
 
 ## Who runs the back-end service that creates the FLoC model?
 
-Every browser vendor will need to make their own choice of how to group browsers into cohorts. 
-Chrome is running its own FLoC service; other browsers might choose to implement FLoC with a 
+Every browser vendor will need to make their own choice of how to group browsers into cohorts.
+Chrome is running its own FLoC service; other browsers might choose to implement FLoC with a
 different clustering approach, and would run their own service to do so.
 
 ## How does the FLoC service enable the browser to work out its cohort? {: #floc-server }
 
-1. The FLoC service used by the browser creates a multi-dimensional mathematical representation 
+1. The FLoC service used by the browser creates a multi-dimensional mathematical representation
 of all potential web browsing histories. We'll call this model "cohort space".
 1. The service divides up this space into thousands of segments. Each segment represents a
 cluster of thousands of similar browsing histories. These groupings aren't based on knowing
@@ -171,46 +171,46 @@ any actual browsing histories; they're simply based on picking random centers in
 cutting up the space with random lines.
 1. Each segment is given a cohort number.
 1. The web browser gets this data describing "cohort space" from its FLoC service.
-1. As a user moves around the web, their browser [uses an algorithm](#floc-algorithm) to 
-periodically calculate the region in "cohort space" that corresponds most closely to its own 
+1. As a user moves around the web, their browser [uses an algorithm](#floc-algorithm) to
+periodically calculate the region in "cohort space" that corresponds most closely to its own
 browsing history.
 
 <figure style="text-align: center">
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/32k5jByqLrgwSMwb9mqo.png", alt="Diagram of the 
-'browsing history space' created by a FLoC server, showing multiple segments, each with a cohort 
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/32k5jByqLrgwSMwb9mqo.png", alt="Diagram of the
+'browsing history space' created by a FLoC server, showing multiple segments, each with a cohort
 number.", width="400", height="359" %}
 <figcaption class="w-figcaption">The FLoC service divides up "cohort space" into
 thousands of segments (only a few are shown here).</figcaption>
 </figure>
 
 {% Aside %}
-At no point in this process is the user's browsing history shared with the FLoC service, or 
+At no point in this process is the user's browsing history shared with the FLoC service, or
 any third party. The browser's cohort is calculated by the browser, on the user's device. No
 user data is acquired or stored by the FLoC service.
 {% endAside %}
 
 ## Can a browser's cohort change?
 
-_Yes_! A browser's cohort definitely can change! You probably don't visit the same websites every 
+_Yes_! A browser's cohort definitely can change! You probably don't visit the same websites every
 week, and your browser's cohort will reflect that.
 
-A cohort represents a cluster of browsing activity, not a collection of people. The activity 
-characteristics of a cohort are generally consistent over time, and cohorts are useful for ad selection 
-because they group similar recent browsing behavior. Individual people's browsers will float in and 
-out of a cohort as their browsing behavior changes. Initially, we expect the browser to recalculate 
+A cohort represents a cluster of browsing activity, not a collection of people. The activity
+characteristics of a cohort are generally consistent over time, and cohorts are useful for ad selection
+because they group similar recent browsing behavior. Individual people's browsers will float in and
+out of a cohort as their browsing behavior changes. Initially, we expect the browser to recalculate
 its cohort every seven days.
 
-In the example above, both Yoshi and Alex's browser's cohort is 1354. In the future, Yoshi's 
+In the example above, both Yoshi and Alex's browser's cohort is 1354. In the future, Yoshi's
 browser and Alex's browser may move to a different cohort if their interests change. In the
 example below, Yoshi's browser moves to cohort 1101 and Alex's browser moves to cohort 1378. Other
 people's browsers will move into and out of cohorts as their browsing interests change.
 
 <figure style="text-align: center">
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/LMkb62V3iJTqkOrFACnM.png", alt="Diagram of the 
-'browsing history space' created by a FLoC server, showing multiple segments, each with a cohort 
-number. The diagram shows browsers belonging to users Yoshi and Alex moving from one cohort to 
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/LMkb62V3iJTqkOrFACnM.png", alt="Diagram of the
+'browsing history space' created by a FLoC server, showing multiple segments, each with a cohort
+number. The diagram shows browsers belonging to users Yoshi and Alex moving from one cohort to
 another as their browsing interests change over time.", width="800", height="533" %}
-<figcaption class="w-figcaption">Yoshi's and Alex's browser cohort may change if their interests 
+<figcaption class="w-figcaption">Yoshi's and Alex's browser cohort may change if their interests
 change.</figcaption>
 </figure>
 
@@ -220,65 +220,65 @@ A cohort defines a grouping of browsing activity, not a group of people. Browser
 
 ## How does the browser work out its cohort? {: #floc-algorithm }
 
-As described above, the user's browser gets data from its FLoC service that describes the 
+As described above, the user's browser gets data from its FLoC service that describes the
 mathematical model for cohorts: a multi-dimensional space that represents the browsing activity of
-all users. The browser then uses an algorithm to work out which region of this "cohort space" (that 
+all users. The browser then uses an algorithm to work out which region of this "cohort space" (that
 is, which cohort) most closely matches its own recent browsing behavior.
 
 ## How does FLoC work out the right size of cohort?
 
-There will be thousands of browsers in each cohort. 
+There will be thousands of browsers in each cohort.
 
-A smaller cohort size might be more useful for personalizing ads, but is less likely to stop user 
-tracking—and vice versa. A mechanism for assigning browsers to cohorts needs to make a trade off 
-between privacy and utility. The Privacy Sandbox uses [k-anonymity](https://en.wikipedia.org/wiki/K-anonymity) 
-to allow a user to "hide in a crowd". A cohort is k-anonymous if it is shared by at least k users. The higher the k 
-number, the more privacy-preserving the cohort. 
+A smaller cohort size might be more useful for personalizing ads, but is less likely to stop user
+tracking—and vice versa. A mechanism for assigning browsers to cohorts needs to make a trade off
+between privacy and utility. The Privacy Sandbox uses [k-anonymity](https://en.wikipedia.org/wiki/K-anonymity)
+to allow a user to "hide in a crowd". A cohort is k-anonymous if it is shared by at least k users. The higher the k
+number, the more privacy-preserving the cohort.
 
 ## Can FLoC be used to group people based on sensitive categories?
 
-The clustering algorithm used to construct the FLoC cohort model is designed to evaluate whether a 
-cohort may be correlated with sensitive categories, without learning why a category is sensitive. 
-Cohorts that might reveal sensitive categories such as race, sexuality, or medical history will be 
-blocked. In other words, when working out its cohort, a browser will only be choosing between 
-cohorts that won't reveal sensitive categories. 
+The clustering algorithm used to construct the FLoC cohort model is designed to evaluate whether a
+cohort may be correlated with sensitive categories, without learning why a category is sensitive.
+Cohorts that might reveal sensitive categories such as race, sexuality, or medical history will be
+blocked. In other words, when working out its cohort, a browser will only be choosing between
+cohorts that won't reveal sensitive categories.
 
 ## Is FLoC just another way of categorizing people online?
 
-With FLoC, a user's browser will belong to one of thousands of cohorts, along with thousands of 
-other users' browsers. Unlike with third-party cookies and other targeting mechanisms, FLoC only 
-reveals the cohort a user's browser is in, and not an individual user ID. It does not enable others 
-to distinguish an individual within a cohort. In addition, the information about browsing activity 
-that is used to work out a browser's cohort is kept local on the browser or device, and is not 
-uploaded elsewhere. The browser may further leverage other anonymization methods, such as 
-[differential privacy](https://en.wikipedia.org/wiki/Differential_privacy). 
+With FLoC, a user's browser will belong to one of thousands of cohorts, along with thousands of
+other users' browsers. Unlike with third-party cookies and other targeting mechanisms, FLoC only
+reveals the cohort a user's browser is in, and not an individual user ID. It does not enable others
+to distinguish an individual within a cohort. In addition, the information about browsing activity
+that is used to work out a browser's cohort is kept local on the browser or device, and is not
+uploaded elsewhere. The browser may further leverage other anonymization methods, such as
+[differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).
 
 ## Do websites have to participate and share information?
 
-Websites will have the ability to opt in or out of FLoC, so sites about sensitive topics will be 
-able to prevent visits to their site from being included in the FLoC calculation. As additional 
-protection, analysis by the FLoC service will evaluate whether a cohort may reveal sensitive 
-information about users without learning why that cohort is sensitive. If a cohort might represent a 
-greater-than-typical number of people who visit sites in a sensitive category, that entire cohort is 
-removed. Negative financial status and mental health are among the sensitive categories covered by 
-this analysis. 
+Websites will have the ability to opt in or out of FLoC, so sites about sensitive topics will be
+able to prevent visits to their site from being included in the FLoC calculation. As additional
+protection, analysis by the FLoC service will evaluate whether a cohort may reveal sensitive
+information about users without learning why that cohort is sensitive. If a cohort might represent a
+greater-than-typical number of people who visit sites in a sensitive category, that entire cohort is
+removed. Negative financial status and mental health are among the sensitive categories covered by
+this analysis.
 
-Websites [can exclude a page from the FLoC calculation](https://github.com/WICG/floc#opting-out-of-computation) 
-by setting a [Permissions-Policy](https://www.w3.org/TR/permissions-policy-1/#introduction) header 
-`interest-cohort=()` for that page. For pages that haven't been excluded, a page visit will be included 
-in the browser's FLoC calculation if `document.interestCohort()` is used on the page. During the current 
-[FLoC origin trial](https://developer.chrome.com/origintrials/#/view_trial/213920982300098561), a 
-page will also be included in the calculation if Chrome detects that the page 
-[load ads or ads-related resources](https://github.com/WICG/floc/issues/82). 
-([Ad Tagging in Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/ad_tagging.md) 
-explains how Chrome's ad detection mechanism works.) 
+Websites [can exclude a page from the FLoC calculation](https://github.com/WICG/floc#opting-out-of-computation)
+by setting a [Permissions-Policy](https://www.w3.org/TR/permissions-policy-1/#introduction) header
+`interest-cohort=()` for that page. For pages that haven't been excluded, a page visit will be included
+in the browser's FLoC calculation if `document.interestCohort()` is used on the page. During the current
+[FLoC origin trial](https://developer.chrome.com/origintrials/#/view_trial/213920982300098561), a
+page will also be included in the calculation if Chrome detects that the page
+[load ads or ads-related resources](https://github.com/WICG/floc/issues/82).
+([Ad Tagging in Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/ad_tagging.md)
+explains how Chrome's ad detection mechanism works.)
 
-Pages served from private IP addresses, such as intranet pages, won't be part of the FLoC 
+Pages served from private IP addresses, such as intranet pages, won't be part of the FLoC
 computation.
 
 ## As a web developer how can I try out FLoC?
 
-The FLoC API is very simple: just a single method that returns a promise that resolves to an object 
+The FLoC API is very simple: just a single method that returns a promise that resolves to an object
 providing the cohort `id` and `version`:
 
 ```javascript
@@ -296,35 +296,35 @@ The cohort data made available looks like this:
 }
 ```
 
-The `version` value enables sites using FLoC to know which browser and which FLoC model the cohort 
-ID refers to. As described below, the promise returned by `document.interestCohort()` will reject 
-for any frame that is not allowed the `interest-cohort` permission. 
+The `version` value enables sites using FLoC to know which browser and which FLoC model the cohort
+ID refers to. As described below, the promise returned by `document.interestCohort()` will reject
+for any frame that is not allowed the `interest-cohort` permission.
 
-The FLoC API is available in Chrome 89 and above, but if you are not taking part in the origin 
-trial, you will need to set flags and run Chrome from the command line. 
-[Run&nbsp;Chromium with flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags) 
+The FLoC API is available in Chrome 89 and above, but if you are not taking part in the origin
+trial, you will need to set flags and run Chrome from the command line.
+[Run&nbsp;Chromium with flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags)
 explains how to do this for different operating systems.
 
 1. Start Chrome with the following flags: <br>
 
     ```text
-    --enable-blink-features=InterestCohortAPI 
+    --enable-blink-features=InterestCohortAPI
     --enable-features="FederatedLearningOfCohorts:update_interval/10s/minimum_history_domain_size_required/1,FlocIdSortingLshBasedComputation,InterestCohortFeaturePolicy"
     ```
 2. Make sure third-party cookies are not blocked and that no ad blocker is running.
 3. View the demo at [floc.glitch.me](https://floc.glitch.me/).
 
 {% Aside %}
-[How to take part in the FLoC origin trial](https://developer.chrome.com/blog/floc) explains how 
+[How to take part in the FLoC origin trial](https://developer.chrome.com/blog/floc) explains how
 to try out FLoC in both first- and third-party contexts.
 {% endAside%}
 
 ## How can websites opt out of the FLoC computation?
 
-The `interest-cohort` permissions policy enables a site to declare that it does not want to be 
-included in the user's list of sites for cohort calculation. The policy will be `allow` by default. 
-The promise returned by `document.interestCohort()` will reject for any frame that is not allowed 
-`interest-cohort` permission. If the main frame does not have the `interest-cohort` permission, then the 
+The `interest-cohort` permissions policy enables a site to declare that it does not want to be
+included in the user's list of sites for cohort calculation. The policy will be `allow` by default.
+The promise returned by `document.interestCohort()` will reject for any frame that is not allowed
+`interest-cohort` permission. If the main frame does not have the `interest-cohort` permission, then the
 page visit will not be included in the interest cohort calculation.
 
 For example, a site can opt out of all FLoC cohort calculation by sending the following HTTP response header:
@@ -342,7 +342,7 @@ on the [FLoC Explainer](https://github.com/WICG/floc) repository.
 
 * [FLoC demo](https://floc.glitch.me)
 * [How to take part in the FLoC origin trial](https://developer.chrome.com/blog/floc)
-* [Digging in to the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox/)
+* [Digging in to the Privacy Sandbox](/digging-into-the-privacy-sandbox/)
 * [FLoC Explainer](https://github.com/WICG/floc)
 * [Evaluation of cohort Algorithms for the FLoC API](https://github.com/google/ads-privacy/blob/master/proposals/FLoC/README.md)
 

--- a/src/site/content/en/blog/goibibo/index.md
+++ b/src/site/content/en/blog/goibibo/index.md
@@ -124,7 +124,7 @@ In their journey to improve user experience, Goibibo noticed a few trends:
 
 +   Iterations to PWA interfaces resulted in a 60% jump in conversion rate (compared to the
     previous mobile web flow) and delighted users.
-+   [New web capabilities](https://web.dev/fugu-status/) improved UX and caused a 20% increase
++   [New web capabilities](/fugu-status/) improved UX and caused a 20% increase
     in logged-in users (who convert 6x more).
 
 <blockquote>

--- a/src/site/content/en/blog/hid-examples/index.md
+++ b/src/site/content/en/blog/hid-examples/index.md
@@ -115,7 +115,7 @@ getting started with HID.
 
 ## Acknowledgements {: #acknowledgements }
 
-Thank you to [Pete LePage](https://web.dev/authors/petelepage/) and [Kayce
+Thank you to [Pete LePage](/authors/petelepage/) and [Kayce
 Basques](https://github.com/kaycebasques) for reviews of this article.
 
 <span>Photo by <a

--- a/src/site/content/en/blog/houdini-how/index.md
+++ b/src/site/content/en/blog/houdini-how/index.md
@@ -26,7 +26,7 @@ the styles they write.
 Houdini enables more semantic CSS with the [Typed Object
 Model](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API/Guide). Developers can
 define advanced CSS custom properties with syntax, default values, and inheritance through the
-[Properties and Values API](https://web.dev/at-property/).
+[Properties and Values API](/at-property/).
 
 It also introduces paint, layout, and animation
 [worklets](https://developers.google.com/web/updates/2018/10/animation-worklet), which open up a

--- a/src/site/content/en/blog/how-mercadolibre-optimized-web-vitals/index.md
+++ b/src/site/content/en/blog/how-mercadolibre-optimized-web-vitals/index.md
@@ -30,8 +30,8 @@ monitor performance and apply optimizations across different parts of the site.
 This article summarizes the work done by [Guille Paz](https://twitter.com/pazguille), [Pablo
 Carminatti](https://www.linkedin.com/in/pcarminatti/), and [Oleh
 Burkhay](https://twitter.com/oburkhay) from Mercado Libre's frontend architecture team to optimize
-one of the Core Web Vitals: [First Input Delay (FID)](https://web.dev/fid/) and its lab proxy,
-[Total Blocking Time (TBT)](https://web.dev/tbt/).
+one of the Core Web Vitals: [First Input Delay (FID)](/fid/) and its lab proxy,
+[Total Blocking Time (TBT)](/tbt/).
 
 <div class="w-stats">
   <div class="w-stat">
@@ -46,7 +46,7 @@ one of the Core Web Vitals: [First Input Delay (FID)](https://web.dev/fid/) and 
 
 ## Long tasks, First Input Delay, and Total Blocking Time
 
-Running expensive Javascript code can lead to [long tasks](https://web.dev/long-tasks-devtools/),
+Running expensive Javascript code can lead to [long tasks](/long-tasks-devtools/),
 which are those that run for more than **50ms** in the browser's main thread.
 
 FID (First Input Delay) measures the time from when a user first interacts with a page (e.g. when
@@ -83,7 +83,7 @@ optimization, without interfering with valuable functionality.
 ## Measure interactivity of product detail pages
 
 FID requires a real user and thus cannot be measured in the lab. However, the [Total Blocking Time
-(TBT)](https://web.dev/tbt/) metric is lab-measurable, correlates well with FID in the field, and
+(TBT)](/tbt/) metric is lab-measurable, correlates well with FID in the field, and
 also captures issues that affect interactivity.
 
 In the following trace, for example, while the **total time** spent running tasks on the main thread
@@ -101,12 +101,12 @@ Here's the general approach they took:
   the main thread busy on a real device.
 - Use [Lighthouse](https://developers.google.com/web/tools/lighthouse) to determine the impact of
   the changes in [Max Potential First Input Delay (Max Potential
-  FID)](https://web.dev/lighthouse-max-potential-fid/).
+  FID)](/lighthouse-max-potential-fid/).
 
 {% Aside %} During this project Mercado Libre used [Max Potential
-FID](https://web.dev/lighthouse-max-potential-fid/) in Lighthouse because that was the tool's main
+FID](/lighthouse-max-potential-fid/) in Lighthouse because that was the tool's main
 metric for measuring interactivity at that time. Lighthouse now recommends using [Total Blocking
-Time](https://web.dev/tbt/) instead. {% endAside %}
+Time](/tbt/) instead. {% endAside %}
 
 ## Use WebPageTest to visualize long tasks
 
@@ -223,7 +223,7 @@ Based on that information they decided to implement the following changes:
 
 - Continue reducing the main bundle size to optimize compile and parse time (e.g. by removing
   duplicate dependencies throughout the different modules).
-- Apply [code splitting](https://web.dev/reduce-javascript-payloads-with-code-splitting/) at
+- Apply [code splitting](/reduce-javascript-payloads-with-code-splitting/) at
   component level, to divide JavaScript in smaller chunks and allow for smarter loading of the
   different components.
 - Defer [component
@@ -254,9 +254,9 @@ The [Chrome User Experience
 Report](https://developers.google.com/web/tools/chrome-user-experience-report) provides user
 experience metrics for how real-world Chrome users experience popular destinations on the web. The
 data from the report can be obtained by [running queries in
-BigQuery](https://web.dev/chrome-ux-report-bigquery/),
+BigQuery](/chrome-ux-report-bigquery/),
 [PageSpeedInsights](https://developers.google.com/speed/pagespeed/insights/), or the [CrUX
-API](https://web.dev/chrome-ux-report-api/).
+API](/chrome-ux-report-api/).
 
 The [CrUX
 dashboard](https://datastudio.google.com/c/datasources/create?connectorId=AKfycbxk7u2UtsqzgaA7I0bvkaJbBPannEx0_zmeCsGh9bBZy7wFMLrQ8x24WxpBzk_ln2i7)
@@ -273,7 +273,7 @@ is an easy way to visualize the progress of core metrics:
 
 Web performance is never a finished task, and Mercado Libre understands the value these
 optimizations bring to their users. While they continue applying several optimizations across the
-site, including [prefetching](https://web.dev/instant-navigation-experiences/#production-cases) in
+site, including [prefetching](/instant-navigation-experiences/#production-cases) in
 product listing pages, image optimizations, and others, they continue adding improvements to product
 listing pages to reduce Total Blocking Time (TBT), and by proxy FID, even more. These optimizations
 include:
@@ -285,5 +285,5 @@ include:
 
 Mercado Libre has a holistic view of performance, so while they continue optimizing interactivity in
 the site, they have also started assessing opportunities for improvement on the other two current
-[Core Web Vitals](https://web.dev/vitals/): [LCP (Largest Contentful Paint)](https://web.dev/lcp/)
-and [CLS (Cumulative Layout Shift)](https://web.dev/cls/) even more.
+[Core Web Vitals](/vitals/): [LCP (Largest Contentful Paint)](/lcp/)
+and [CLS (Cumulative Layout Shift)](/cls/) even more.

--- a/src/site/content/en/blog/how-we-build-webdev-and-use-web-components/index.md
+++ b/src/site/content/en/blog/how-we-build-webdev-and-use-web-components/index.md
@@ -80,7 +80,7 @@ Eleventy provides a programmatic way to build arbitrary collections of content.
 This has let us build pagination support and generate virtual pages (pages that don't have a matching Markdown file on disk) for post authors.
 For example, we construct our authors pages using a template containing [an expression for its permalink](https://github.com/GoogleChrome/web.dev/blob/2050fe6352e024943195a438841dc99217f34e63/src/site/content/en/authors/index.njk#L4) (so the template is re-rendered for every author) and a backing [collection](https://github.com/GoogleChrome/web.dev/blob/2050fe6352e024943195a438841dc99217f34e63/src/site/_collections/paginated-posts-by-author.js#L23).
 
-This results in, for example, a simple page containing [all of Addy's posts](https://web.dev/authors/addyosmani/)!
+This results in, for example, a simple page containing [all of Addy's posts](/authors/addyosmani/)!
 
 ### Limitations
 
@@ -146,7 +146,7 @@ And antiquated browsers just ignore Web Components altogether and render whateve
 Each Web Component is a class with methods including `connectedCallback()`, `disconnectedCallback()`, and `attributeChangedCallback()`.
 web.dev's custom elements mostly inherit from [LitElement](https://lit-element.polymer-project.org/), which provides a simple base for complex components.
 
-While web.dev uses Web Components on many pages, nowhere is it more necessary than on the [Measure](https://web.dev/measure) page.
+While web.dev uses Web Components on many pages, nowhere is it more necessary than on the [Measure](/measure) page.
 Two elements provide the bulk of the functionality you see on this page:
 
 ```html

--- a/src/site/content/en/blog/install-thumbor/index.md
+++ b/src/site/content/en/blog/install-thumbor/index.md
@@ -103,7 +103,7 @@ Note that this URL uses HTTP. Thumbor uses HTTP by default but can be [configure
 
 You should see an image that is 100 pixels wide by 100 pixels tall. Thumbor has taken the image `hero.jpg` and size specified in the URL string and served the result. You can replace the image in the URL string (i.e., `https://web.dev/install-thumbor/hero.jpg`) with any other image (e.g., `https://your-site.com/cat.jpg`) and Thumbor will resize that image too.
 
-The [Optimize images with Thumbor](https://web.dev/use-thumbor/#thumbor-url-format) article has more information on using the Thumbor API. In particular, you may be interested in [setting up a Thumbor configuration file](https://web.dev/use-thumbor/#appendix:-thumbor.conf).
+The [Optimize images with Thumbor](/use-thumbor/#thumbor-url-format) article has more information on using the Thumbor API. In particular, you may be interested in [setting up a Thumbor configuration file](/use-thumbor/#appendix:-thumbor.conf).
 
 ## Appendix: Configuring Systemd
 

--- a/src/site/content/en/blog/intersectionobserver-v2/index.md
+++ b/src/site/content/en/blog/intersectionobserver-v2/index.md
@@ -26,7 +26,7 @@ Observer&nbsp;v1 that is embedded below.
 You can also read Surma's in-depth
 [article](https://developers.google.com/web/updates/2016/04/intersectionobserver).
 People have used Intersection Observer&nbsp;v1 for a wide range of use cases like
-[lazy loading of images and videos](https://web.dev/fast/#lazy-load-images-and-video),
+[lazy loading of images and videos](/fast/#lazy-load-images-and-video),
 [being notified when elements reach `position: sticky`](https://developers.google.com/web/updates/2017/09/sticky-headers),
 [firing analytics events](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/visibility-manager.js),
 and many more.

--- a/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
+++ b/src/site/content/en/blog/lighthouse-evolution-cds-2019/index.md
@@ -57,7 +57,7 @@ Paint](/first-meaningful-paint/), [Time to Interactive](/interactive/), and
   {% Img src="image/admin/X0u1YQC63JaPfE0DWgz8.png", alt="Comparison of Lighthouse performance score formulas in versions 5 and 6.", width="800", height="211", class="w-screenshot" %}
 </figure>
 
-See [Lighthouse performance scoring](https://web.dev/performance-scoring/) for detailed
+See [Lighthouse performance scoring](/performance-scoring/) for detailed
 information.
 
 In Lighthouse version 6, new metrics, [Largest Contentful Paint (LCP)](/lcp/)

--- a/src/site/content/en/blog/lighthouse-whats-new-6.0/index.md
+++ b/src/site/content/en/blog/lighthouse-whats-new-6.0/index.md
@@ -19,7 +19,7 @@ helps developers with opportunities and diagnostics to improve the user experien
 It's available in Chrome DevTools, npm (as a Node module and a CLI), or as a browser extension (in
 [Chrome](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk) and
 [Firefox](https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/)). It powers many Google
-services, including [web.dev/measure](https://web.dev/measure/) and [PageSpeed
+services, including [web.dev/measure](/measure/) and [PageSpeed
 Insights](https://developers.google.com/speed/pagespeed/insights/).
 
 Lighthouse 6.0 is available immediately on npm and in [Chrome
@@ -56,7 +56,7 @@ the highlights in this article.
 
 Lighthouse 6.0 introduces three new metrics to the report. Two of these new metrics–Largest
 Contentful Paint (LCP) and Cumulative Layout Shift (CLS)–are lab implementations of [Core Web
-Vitals](https://web.dev/vitals/).
+Vitals](/vitals/).
 
 ### Largest Contentful Paint (LCP) {: #lcp }
 
@@ -89,12 +89,12 @@ TBT measures the total amount of time between First Contentful Paint (FCP) and T
 (TTI). It is a companion metric to TTI and it brings more nuance to quantifying main thread activity
 that blocks a user's ability to interact with your page.
 
-Additionally, TBT correlates well with the field metric [First Input Delay](https://web.dev/fid/)
+Additionally, TBT correlates well with the field metric [First Input Delay](/fid/)
 (FID), which is a Core Web Vital.
 
 ## Performance score update  {: #score }
 
-The [performance score in Lighthouse](https://web.dev/performance-scoring/) is calculated from a
+The [performance score in Lighthouse](/performance-scoring/) is calculated from a
 weighted blend of multiple metrics to summarize a page's speed. The 6.0 performance score formula
 follows.
 
@@ -271,7 +271,7 @@ with your results populated.
 
 We are leveraging [DevTools code
 coverage](https://developers.google.com/web/tools/chrome-devtools/coverage) in a new audit: [**Unused
-JavaScript**](https://web.dev/remove-unused-code/).
+JavaScript**](/remove-unused-code/).
 
 This audit isn't _entirely_ new: it was [added in
 mid-2017](https://github.com/GoogleChrome/lighthouse/issues/1852#issuecomment-306900595), but
@@ -284,24 +284,24 @@ it by default.
 Lighthouse uses the wonderful [axe-core](https://github.com/dequelabs/axe-core) library to power the
 accessibility category. In Lighthouse 6.0, we've added the following audits:
 
--  [aria-hidden-body](https://web.dev/aria-hidden-body/)
--  [aria-hidden-focus](https://web.dev/aria-hidden-focus/)
--  [aria-input-field-name](https://web.dev/aria-input-field-name/)
--  [aria-toggle-field-name](https://web.dev/aria-toggle-field-name/)
--  [form-field-multiple-labels](https://web.dev/form-field-multiple-labels/)
--  [heading-order](https://web.dev/heading-order/)
--  [duplicate-id-active](https://web.dev/duplicate-id-active/)
--  [duplicate-id-aria](https://web.dev/duplicate-id-aria/)
+-  [aria-hidden-body](/aria-hidden-body/)
+-  [aria-hidden-focus](/aria-hidden-focus/)
+-  [aria-input-field-name](/aria-input-field-name/)
+-  [aria-toggle-field-name](/aria-toggle-field-name/)
+-  [form-field-multiple-labels](/form-field-multiple-labels/)
+-  [heading-order](/heading-order/)
+-  [duplicate-id-active](/duplicate-id-active/)
+-  [duplicate-id-aria](/duplicate-id-aria/)
 
 ### Maskable icon {: #maskable-icon }
 
-[Maskable icons](https://web.dev/maskable-icon/) is a new icon format that makes icons for your PWA
+[Maskable icons](/maskable-icon/) is a new icon format that makes icons for your PWA
 look great across all types of devices. To help your PWA look as good as possible, we've introduced
 a new audit to check if your manifest.json supports this new format.
 
 ### Charset declaration {: #charset }
 
-The [meta charset element](https://web.dev/charset/) declares what character encoding should be used
+The [meta charset element](/charset/) declares what character encoding should be used
 to interpret an HTML document. If this element is missing, or if it is declared late in the
 document, browsers employ a number of heuristics to guess which encoding should be used. If a
 browser guesses incorrectly, and a late meta charset element is found, the parser generally throws
@@ -310,7 +310,7 @@ audit verifies the page has a valid character encoding and it's defined early an
 
 ## Lighthouse CI {: #ci }
 
-At [CDS last November](https://web.dev/lighthouse-evolution-cds-2019/#lighthouse-ci-alpha-release)
+At [CDS last November](/lighthouse-evolution-cds-2019/#lighthouse-ci-alpha-release)
 we announced [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci), the open source Node
 CLI and server that tracks Lighthouse results on every commit in your continuous integration
 pipeline, and we've come a long way since the alpha release. Lighthouse CI now has support
@@ -410,7 +410,7 @@ extension](https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/)!
 
 ## Budgets {: #budgets }
 
-Lighthouse 5.0 introduced [performance budgets](https://web.dev/performance-budgets-101/) which
+Lighthouse 5.0 introduced [performance budgets](/performance-budgets-101/) which
 supported adding thresholds for
 [how much of each resource type](https://github.com/GoogleChrome/lighthouse/blob/master/docs/performance-budgets.md#resource-budgets)
 (such as scripts, images, or css) a page can serve.
@@ -471,7 +471,7 @@ What can you do next?
 -  Use the Node CLI: `npm install -g lighthouse && lighthouse https://yoursite.com --view`.
 -  Get [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci#lighthouse-ci) running with
    your project.
--  Review the [Lighthouse audit documentation](https://web.dev/learn/#lighthouse).
+-  Review the [Lighthouse audit documentation](/learn/#lighthouse).
 -  Have fun making the web better!
 
 We're passionate about the web and we love working with the developer community to build tooling to

--- a/src/site/content/en/blog/live-wrap-up/index.md
+++ b/src/site/content/en/blog/live-wrap-up/index.md
@@ -74,7 +74,7 @@ of your web development project, taking on a key role in handling your developer
 lifecycle.
 
 We have all seen unwieldy build config files, so to help web developers _and_ tooling authors
-conquer the complexity of the web, we built [tooling.report](https://web.dev/introducing-tooling-report). It's a website
+conquer the complexity of the web, we built [tooling.report](/introducing-tooling-report). It's a website
 that helps you choose the right build tool for your next project, decide if migrating from one tool
 to another is worth it, or figure out how to incorporate best practices into your tooling
 configuration and code base.

--- a/src/site/content/en/blog/lowes/index.md
+++ b/src/site/content/en/blog/lowes/index.md
@@ -29,7 +29,7 @@ tags:
 This post was authored by [Ashish Choudhury](https://www.linkedin.com/in/choudhuryashish/),
 [Dinakar Chandolu](https://www.linkedin.com/in/dinakarchandolu/),
 [Abhimanyu Raibahadur](https://www.linkedin.com/in/abhimanyuraibahadur/), and
-[Dhilipvenkatesh Uvarajan](https://www.linkedin.com/in/dhilip-venkatesh-uvarajan-16914624/) 
+[Dhilipvenkatesh Uvarajan](https://www.linkedin.com/in/dhilip-venkatesh-uvarajan-16914624/)
 from Lowe's.
 {% endAside %}
 
@@ -74,7 +74,7 @@ the team can make proactive optimizations with ownership of problematic code bei
 
 ## Implementation
 
-The heart of the Site Speed Governance (SSG) app is [Lighthouse CI](https://web.dev/lighthouse-ci/).
+The heart of the Site Speed Governance (SSG) app is [Lighthouse CI](/lighthouse-ci/).
 The SSG app uses Lighthouse to validate and audit the page performance of every pull request.
 
 <figure class="w-figure">
@@ -82,7 +82,7 @@ The SSG app uses Lighthouse to validate and audit the page performance of every 
 </figure>
 
 The SSG app causes a build to fail if the Site Speed Team's defined
-[performance budget](https://web.dev/performance-budgets-101/) and metric targets are not reached.
+[performance budget](/performance-budgets-101/) and metric targets are not reached.
 It enforces not only load performance but also SEO, PWA, and accessibility.
 It can report status immediately to authors, reviewers, and SRE teams.
 It can also be configured to bypass the checks when exceptions are needed.

--- a/src/site/content/en/blog/multi-screen-window-placement/index.md
+++ b/src/site/content/en/blog/multi-screen-window-placement/index.md
@@ -21,7 +21,7 @@ feedback:
 
 {% Aside %}
   The Multi-Screen Window Placement API is part of the
-  [capabilities project](https://web.dev/fugu-status/) and is currently in
+  [capabilities project](/fugu-status/) and is currently in
   development. This post will be updated as the implementation progresses.
 {% endAside %}
 

--- a/src/site/content/en/blog/next-gen-css-2019/index.md
+++ b/src/site/content/en/blog/next-gen-css-2019/index.md
@@ -158,7 +158,7 @@ Try tabbing through the focusable elements in the demo below. You'll notice that
 Here are the new queries we think developers will be most excited about:
 
 *   [prefers-reduced-motion](https://developers.google.com/web/updates/2019/03/prefers-reduced-motion)
-*   [prefers-color-scheme](https://web.dev/prefers-color-scheme/)
+*   [prefers-color-scheme](/prefers-color-scheme/)
 *   [prefers-contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast)
 *   [prefers-reduced-transparency](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency)
 *   [forced-colors](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
@@ -261,7 +261,7 @@ For example, this demo uses `backdrop-filter` to achieve OS-style blurring:
   (<a href='https://codepen.io/una'>@una</a>) on <a href='https://codepen.io'>CodePen</a>.
 </iframe>
 
-We already have a [great post about `backdrop-filter`](https://web.dev/backdrop-filter/), so head there for more info.
+We already have a [great post about `backdrop-filter`](/backdrop-filter/), so head there for more info.
 
 ## `:is()`
 

--- a/src/site/content/en/blog/optimize-lcp/index.md
+++ b/src/site/content/en/blog/optimize-lcp/index.md
@@ -272,9 +272,9 @@ blocking JavaScript results in a faster render, and consequently a better LCP.
 
 This can be accomplished by optimizing your scripts in a few different ways:
 
-- [Minify and compress JavaScript files](https://web.dev/reduce-network-payloads-using-text-compression/)
-- [Defer unused JavaScript](https://web.dev/reduce-javascript-payloads-with-code-splitting/)
-- [Minimize unused polyfills](https://web.dev/serve-modern-code-to-modern-browsers/)
+- [Minify and compress JavaScript files](/reduce-network-payloads-using-text-compression/)
+- [Defer unused JavaScript](/reduce-javascript-payloads-with-code-splitting/)
+- [Minimize unused polyfills](/serve-modern-code-to-modern-browsers/)
 
 {% Aside %}
 The [Optimize First Input Delay](/optimize-fid/) guide covers all techniques needed to reduce

--- a/src/site/content/en/blog/origin-agent-cluster/index.md
+++ b/src/site/content/en/blog/origin-agent-cluster/index.md
@@ -217,7 +217,7 @@ clusters.
 ## Origin-keying is not a security feature
 
 While using an origin-keyed agent cluster does isolate your origin from synchronous access from
-same-site cross-origin pages, it does not give the [protection](https://web.dev/why-coop-coep/) of
+same-site cross-origin pages, it does not give the [protection](/why-coop-coep/) of
 security-related headers like
 [`Cross-Origin-Resource-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP))
 and

--- a/src/site/content/en/blog/origin-trials/index.md
+++ b/src/site/content/en/blog/origin-trials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting started with Chrome's origin trials
-subhead: Origin trials are a way to test a new or experimental web platform feature, and give feedback to the web standards community on the feature's usability, practicality, and effectiveness, before the feature is made available to all users. 
-authors: 
+subhead: Origin trials are a way to test a new or experimental web platform feature, and give feedback to the web standards community on the feature's usability, practicality, and effectiveness, before the feature is made available to all users.
+authors:
   - samdutton
 date: 2020-06-22
 updated: 2020-10-18
@@ -13,35 +13,35 @@ tags:
   - origin-trials
 ---
 
-Origin trials give you access to a new or experimental feature, to build 
-functionality your users can try out for a limited time before the feature 
-is made available to everyone. 
+Origin trials give you access to a new or experimental feature, to build
+functionality your users can try out for a limited time before the feature
+is made available to everyone.
 
-When Chrome offers an origin trial for a feature, you can register for the trial to enable 
-the feature for all users on your [origin](/same-site-same-origin/#origin), 
-without requiring them to toggle any flags or switch to an alternative build 
-of Chrome (though they may need to upgrade). Origin trials enable developers 
-to build demos and prototypes using new features. The trials also help Chrome engineers 
+When Chrome offers an origin trial for a feature, you can register for the trial to enable
+the feature for all users on your [origin](/same-site-same-origin/#origin),
+without requiring them to toggle any flags or switch to an alternative build
+of Chrome (though they may need to upgrade). Origin trials enable developers
+to build demos and prototypes using new features. The trials also help Chrome engineers
 understand how new features are used, and how they may interact with other web technologies.
 
 Origin trials are public and open to all developers. They are limited in duration and
-usage. Participation is a self-managed process with limited documentation and support. 
-Participants should be willing and able to work relatively independently using the 
-documentation available, which, at this stage, will likely be limited to API 
-specifications and explainers, though web.dev tries to provide guidance whenever 
+usage. Participation is a self-managed process with limited documentation and support.
+Participants should be willing and able to work relatively independently using the
+documentation available, which, at this stage, will likely be limited to API
+specifications and explainers, though web.dev tries to provide guidance whenever
 possible.
 
-If you register for a trial, the Chrome team will periodically ask you for specific 
-feedback on your use of the trial feature. Some features may undergo multiple origin 
-trials, as learnings are incorporated and adjustments are made.  
+If you register for a trial, the Chrome team will periodically ask you for specific
+feedback on your use of the trial feature. Some features may undergo multiple origin
+trials, as learnings are incorporated and adjustments are made.
 
 {% Aside %}
 **Third-party origin trials**
 
 Origin trials are usually only available on a first-party basis: they only work for a single
-registered [origin](https://web.dev/same-site-same-origin/#origin). Third-party origin trials make 
-it possible for providers of embedded content to try a new feature across multiple sites 
-without requiring a token for every origin.   
+registered [origin](/same-site-same-origin/#origin). Third-party origin trials make
+it possible for providers of embedded content to try a new feature across multiple sites
+without requiring a token for every origin.
 
 Find out more: [What are third-party origin trials?](/third-party-origin-trials).
 {% endAside %}
@@ -52,23 +52,23 @@ Find out more: [What are third-party origin trials?](/third-party-origin-trials)
 1. Request a token by clicking the **Register** button and filling out the form.
 1. Add the token to your web pages,
    using one of the following methods:
-   -  As a meta tag in the &lt;head&gt; of each page served:   
+   -  As a meta tag in the &lt;head&gt; of each page served:
       `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
-   -  As an HTTP header:  
+   -  As an HTTP header:
       `Origin-Trial: TOKEN_GOES_HERE`
 1. Try out the new feature.
-1. Submit feedback. Do this through the origin trial site. This feedback is 
+1. Submit feedback. Do this through the origin trial site. This feedback is
    not public and is available only to a limited group of people on the Chrome
    team. Each trial also provides a link for spontaneous community feedback.
    This typically points to the feature on GitHub or some other public
    channel.
 1. When your token expires, you will get an email with a renewal link.
    To do so, you are again asked to submit feedback.
-   
+
 {% Aside 'warning' %}
-Usually if an API lands unchanged after a successful origin trial, there is a short period between the 
-end of the origin trial and the date the implementation ships in the browser when the API will not 
-be available. This is by design. If Chrome were to avoid the mandatory total-breakage period, that would 
+Usually if an API lands unchanged after a successful origin trial, there is a short period between the
+end of the origin trial and the date the implementation ships in the browser when the API will not
+be available. This is by design. If Chrome were to avoid the mandatory total-breakage period, that would
 bias toward also avoiding breakages in the API surface, which are often needed to improve the API.
 The final shipping API might be worse for it.
 

--- a/src/site/content/en/blog/overloaded-server/index.md
+++ b/src/site/content/en/blog/overloaded-server/index.md
@@ -136,7 +136,7 @@ The decision to scale compute resources should be made carefully. Although it is
 
 #### Diagnose
 
-A high [Time To First Byte](https://web.dev/time-to-first-byte/) (TTFB) can be a sign that a server is nearing its capacity. You can find this information in the Lighthouse [Reduce server response times (TTFB)](https://developers.google.com/web/tools/lighthouse/audits/ttfb) audit.
+A high [Time To First Byte](/time-to-first-byte/) (TTFB) can be a sign that a server is nearing its capacity. You can find this information in the Lighthouse [Reduce server response times (TTFB)](https://developers.google.com/web/tools/lighthouse/audits/ttfb) audit.
 
 To investigate further, use a monitoring tool to assess CPU usage. If current or anticipated CPU usage exceeds 80% you should consider increasing your servers.
 
@@ -177,9 +177,9 @@ Lighthouse has a variety of audits that flag potential image optimizations. Alte
 Relevant Lighthouse audits:
 *   [Properly size images](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)
 *   [Defer offscreen images](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)
-*   [Efficiently encode images](https://web.dev/uses-optimized-images/)
+*   [Efficiently encode images](/uses-optimized-images/)
 *   [Serve images in next-gen formats](https://developers.google.com/web/tools/lighthouse/audits/webp)
-*   [Use video formats for animated content](https://web.dev/efficient-animated-content/)
+*   [Use video formats for animated content](/efficient-animated-content/)
 
 Chrome DevTools workflow:
 - [Log network activity](https://developers.google.com/web/tools/chrome-devtools/network#load)
@@ -195,14 +195,14 @@ Focus your time on Identifying large and frequently loaded images and manually o
 Things to keep in mind:
 *   Size: Images should be no larger than necessary.
 *   Compression: Generally speaking, a quality level of 80-85 will have a minimal effect on image quality while yielding a 30-40% reduction in file size.
-*   Format: Use JPEGs for photos rather than PNG; use MP4 for [animated content](https://web.dev/replace-gifs-with-videos/) rather than GIF.
+*   Format: Use JPEGs for photos rather than PNG; use MP4 for [animated content](/replace-gifs-with-videos/) rather than GIF.
 
 *If you have more time…*
 
 Consider setting up an image CDN if images make up a substantial portion of your site. Image CDNs are designed for serving and optimizing images and they will offload image serving from the origin server. Setting up an image CDN is straightforward but requires updating existing image URLs to point at the image CDN.
 
 Further reading:
-*   [Use image CDNs to optimize images](https://web.dev/image-cdns/#optimize-your-images)
+*   [Use image CDNs to optimize images](/image-cdns/#optimize-your-images)
 *   [images.guide](https://images.guide/)
 
 
@@ -212,13 +212,13 @@ Minification removes unnecessary characters from JavaScript and CSS.
 
 #### Diagnose
 
-Use the [Minify CSS](https://developers.google.com/web/tools/lighthouse/audits/minify-css) and [Minify JavaScript](https://web.dev/unminified-javascript/) Lighthouse audits to identify resources that are in need of minification.
+Use the [Minify CSS](https://developers.google.com/web/tools/lighthouse/audits/minify-css) and [Minify JavaScript](/unminified-javascript/) Lighthouse audits to identify resources that are in need of minification.
 
 #### Fix
 
 If you have limited time, focus on minifying your JavaScript. Most sites have more JavaScript than CSS, so this will be more impactful.
-*   [Minify JavaScript](https://web.dev/reduce-network-payloads-using-text-compression/)
-*   [Minify CSS](https://web.dev/minify-css/)
+*   [Minify JavaScript](/reduce-network-payloads-using-text-compression/)
+*   [Minify CSS](/minify-css/)
 
 
 ## Monitor

--- a/src/site/content/en/blog/preload-optional-fonts/index.md
+++ b/src/site/content/en/blog/preload-optional-fonts/index.md
@@ -49,7 +49,7 @@ for asynchronously loaded fonts. However, every one of these supported values ca
 in one of the two ways listed above, until now!
 
 {% Aside %}
-  The [Cumulative Layout Shift](https://web.dev/cls/) metric makes it possible to measure the layout
+  The [Cumulative Layout Shift](/cls/) metric makes it possible to measure the layout
   instability on a web page.
 {% endAside %}
 
@@ -88,7 +88,7 @@ This occurs even if the font is stored in the browser's disk cache and can load 
 block period is complete.
 
 [Optimizations](https://bugs.chromium.org/p/chromium/issues/detail?id=1040632) have landed in Chrome 83 to entirely remove the first render cycle for optional fonts
-that are preloaded with [`<link rel="preload'>`](https://web.dev/codelab-preload-web-fonts/).
+that are preloaded with [`<link rel="preload'>`](/codelab-preload-web-fonts/).
 Instead, rendering is blocked until the custom font has finished loading or a certain period of time
 has passed. This timeout period is currently set at 100ms, but may possibly change in the near
 future to optimize performance.

--- a/src/site/content/en/blog/progressively-enhance-your-pwa/index.md
+++ b/src/site/content/en/blog/progressively-enhance-your-pwa/index.md
@@ -35,7 +35,7 @@ and technically rigorous layers of presentation and features on top of the conte
 While in 2003, progressive enhancement was about using—at the time—modern
 CSS features, unobtrusive JavaScript, and even just Scalable Vector Graphics.
 Progressive enhancement in 2020 and beyond is about using
-[modern browser capabilities](https://web.dev/fugu-status/).
+[modern browser capabilities](/fugu-status/).
 
 <figure class="w-figure">
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/IEOd4MT9BqnbeXQ7z0vC.png", alt="Inclusive web design for the future with progressive enhancement. Title slide from Finck and Champeon's original presentation.", width="800", height="597", class="w-screenshot" %}
@@ -111,13 +111,13 @@ For this article, I work with a simple PWA, called
 The name of this app is a tip of the hat to Project Fugu 🐡, an effort to give the web all
 the powers of Android/iOS/desktop applications.
 You can read more about the project on its
-[landing page](https://web.dev/fugu-status).
+[landing page](/fugu-status).
 
 Fugu Greetings is a drawing app that lets you create virtual greeting cards, and send
 them to your loved ones. It exemplifies
-[PWA's core concepts](https://web.dev/progressive-web-apps/). It's
-[reliable](https://web.dev/reliable/) and fully offline enabled, so even if you don't
-have a network, you can still use it. It's also [Installable](https://web.dev/install-criteria/)
+[PWA's core concepts](/progressive-web-apps/). It's
+[reliable](/reliable/) and fully offline enabled, so even if you don't
+have a network, you can still use it. It's also [Installable](/install-criteria/)
 to a device's home screen and integrates seamlessly with the operating system
 as a stand-alone application.
 
@@ -215,7 +215,7 @@ and has put it straight into your Downloads folder. This isn't great.
 What if there were a better way?
 What if you could just open a local file, edit it, and then save the modifications,
 either to a new file, or back to the original file that you had initially opened?
-Turns out there is. The [File System Access API](https://web.dev/file-system-access/)
+Turns out there is. The [File System Access API](/file-system-access/)
 allows you to open and create files and
 directories, as well as modify and save them .
 
@@ -365,8 +365,8 @@ Now the file is ready to be preserved for eternity.
 ## The Web Share and Web Share Target APIs
 
 Apart from storing for eternity, maybe I actually want to share my greeting card.
-This is something that the [Web Share API](https://web.dev/web-share/) and
-[Web Share Target API](https://web.dev/web-share-target/) allow me to do.
+This is something that the [Web Share API](/web-share/) and
+[Web Share Target API](/web-share-target/) allow me to do.
 Mobile, and more recently desktop operating systems have gained built-in sharing
 mechanisms.
 For example, below is desktop Safari's share sheet on macOS triggered from an article on
@@ -472,7 +472,7 @@ When you write a greeting card, it may not always be easy to correctly write
 someone's name.
 For example, I have a friend Sergey who prefers his name to be spelled in Cyrillic letters. I'm
 using a German QWERTZ keyboard and have no idea how to type their name.
-This is a problem that the [Contact Picker API](https://web.dev/contact-picker/) can solve.
+This is a problem that the [Contact Picker API](/contact-picker/) can solve.
 Since I have my friend stored in my phone's contacts app,
 via the Contacts Picker API, I can tap into my contacts from the web.
 
@@ -537,7 +537,7 @@ As a greeting card author, at times, I may want to do the same.
 I may want to either paste an image into a greeting card I'm working on,
 or copy my greeting card so I can continue editing it from
 somewhere else.
-The [Async Clipboard API](https://web.dev/image-support-for-async-clipboard/),
+The [Async Clipboard API](/image-support-for-async-clipboard/),
 supports both text and images.
 Let me walk you through how I added copy and paste support to the Fugu
 Greetings app.
@@ -627,7 +627,7 @@ the greeting card gets pasted into a new untitled image.
 
 ## The Badging API
 
-Another useful API is the [Badging API](https://web.dev/badging-api/).
+Another useful API is the [Badging API](/badging-api/).
 As an installable PWA, Fugu Greetings of course does have an app icon
 that users can place on the app dock or the home screen.
 A fun and easy way to demonstrate the API is to (ab)use it in Fugu Greetings
@@ -680,7 +680,7 @@ The badge counter on the icon is now at seven.
 Want to start each day fresh with something new?
 A neat feature of the Fugu Greetings app is that it can inspire you each morning
 with a new background image to start your greeting card.
-The app uses the [Periodic Background Sync API](https://web.dev/periodic-background-sync/)
+The app uses the [Periodic Background Sync API](/periodic-background-sync/)
 to achieve this.
 
 The first step is to *register* a periodic sync event in the service worker registration.
@@ -765,7 +765,7 @@ that is updated every day via the Periodic Background Sync API.
 
 Sometimes even with a lot of inspiration, you need a nudge to finish a started greeting
 card.
-This is a feature that is enabled by the [Notification Triggers API](https://web.dev/notification-triggers/).
+This is a feature that is enabled by the [Notification Triggers API](/notification-triggers/).
 As a user, I can enter a time when I want to be nudged to finish my greeting card.
 When that time comes, I will get a notification that my greeting card is waiting.
 
@@ -818,7 +818,7 @@ it didn't require a network connection.
 
 ## The Wake Lock API
 
-I also want to include the [Wake Lock API](https://web.dev/wakelock/).
+I also want to include the [Wake Lock API](/wakelock/).
 Sometimes you just need to stare long enough at the screen until inspiration
 kisses you.
 The worst that can happen then is for the screen to turn off.
@@ -872,7 +872,7 @@ screen awake.
 
 At times, even if you stare at the screen for hours,
 it's just useless and you can't come up with the slightest idea what to do with your greeting card.
-The [Idle Detection API](https://web.dev/idle-detection/) allows the app to detect user idle time.
+The [Idle Detection API](/idle-detection/) allows the app to detect user idle time.
 If the user is idle for too long, the app resets to the initial state
 and clears the canvas.
 This API is currently gated behind the

--- a/src/site/content/en/blog/rakuten-24/index.md
+++ b/src/site/content/en/blog/rakuten-24/index.md
@@ -24,7 +24,7 @@ one of the largest e-commerce companies in Japan. It provides a wide selection
 of everyday items including grocery, medicine, healthcare, kitchen utensils, and
 more. The team's main goal over the last year was to improve mobile customer
 retention and re-engagement. By making their web app
-[installable](https://web.dev/define-install-strategy/), they saw a 450% jump in
+[installable](/define-install-strategy/), they saw a 450% jump in
 visitor retention rate as compared to the previous mobile web flow over a
 1-month timeframe.
 
@@ -46,8 +46,8 @@ identified the following areas of opportunities:
 ### Installability {: #installability }
 
 To capture the two opportunities identified above, Rakuten 24 decided to build
-[Progressive Web App](https://web.dev/pwa) (PWA) features on an incremental
-basis, starting with [installability](https://web.dev/define-install-strategy/).
+[Progressive Web App](/pwa) (PWA) features on an incremental
+basis, starting with [installability](/define-install-strategy/).
 Implementing installability resulted in increased traffic, visitor retention,
 sales per customer, and conversions.
 
@@ -78,14 +78,14 @@ The Rakuten 24 team used
 [workbox-webpack-plugin](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin)
 to be precise) to ensure their PWA worked well even when the user was offline or
 on a bad network.  Workbox's APIs for controlling
-[the cache](https://web.dev/service-workers-cache-storage/#the-cache-storage-api)
+[the cache](/service-workers-cache-storage/#the-cache-storage-api)
 worked significantly better than Rakuten 24's previous in-house script.
 Moreover, with workbox-webpack-plugin (and Babel), was able to automate the
 process of supporting a wider range of browsers. To further build network
 resilience, they implemented a
 [cache-first strategy](https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker)
 for their CSS and JS assets, and used
-[stale-while-revalidate](https://web.dev/stale-while-revalidate/) for their
+[stale-while-revalidate](/stale-while-revalidate/) for their
 images that don't change frequently.
 
 ## Overall business results {: #results }
@@ -134,5 +134,5 @@ images that don't change frequently.
   (A2HS).
 {% endAside %}
 
-Check out the [Scale on web case studies](https://web.dev/scale-on-web) page for
+Check out the [Scale on web case studies](/scale-on-web) page for
 more success stories from India and Asia.

--- a/src/site/content/en/blog/referrer-best-practices/index.md
+++ b/src/site/content/en/blog/referrer-best-practices/index.md
@@ -393,7 +393,7 @@ policy (and a malicious actor could even spoof the referrer).
 Use [CSRF
 tokens](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#token-based-mitigation)
 as your primary protection. For extra protection, use
-[SameSite](https://web.dev/samesite-cookie-recipes/#%22unsafe%22-requests-across-sites)—and instead
+[SameSite](/samesite-cookie-recipes/#%22unsafe%22-requests-across-sites)—and instead
 of `Referer`, use headers such as
 [`Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) (available on POST and
 CORS requests) and
@@ -480,7 +480,7 @@ David Van Cleve, Mike West, Sam Dutton, Rowan Merewood, Jxck and Kayce Basques._
 
 ## Resources
 
-- [Understanding "same-site" and "same-origin"](https://web.dev/same-site-same-origin/)
+- [Understanding "same-site" and "same-origin"](/same-site-same-origin/)
 - [A new security header: Referrer Policy
   (2017)](https://scotthelme.co.uk/a-new-security-header-referrer-policy/)
 - [Referrer-Policy on

--- a/src/site/content/en/blog/schemeful-samesite/index.md
+++ b/src/site/content/en/blog/schemeful-samesite/index.md
@@ -36,7 +36,7 @@ Same-Site](https://mikewest.github.io/cookie-incrementalism/draft-west-cookie-in
 modifies the definition of a (web)site from just the registrable domain to the
 scheme + registrable domain. You can find more details and examples in
 [Understanding "same-site" and
-"same-origin"](https://web.dev/same-site-same-origin/#%22schemeful-same-site%22).
+"same-origin"](/same-site-same-origin/#%22schemeful-same-site%22).
 
 {% Aside 'key-term' %}
 This means that the insecure HTTP version of a site, for example,

--- a/src/site/content/en/blog/shopping-for-speed-on-ebay/index.md
+++ b/src/site/content/en/blog/shopping-for-speed-on-ebay/index.md
@@ -37,7 +37,7 @@ search page loading time, eBay saw a 0.5% increase in "Add to Cart" count.**
   </div>
 </div>
 
-Through the adoption of [Performance Budgets](https://web.dev/performance-budgets-101/) (derived
+Through the adoption of [Performance Budgets](/performance-budgets-101/) (derived
 after doing a competitive study with the [Chrome User Experience
 Report](https://developers.google.com/web/tools/chrome-user-experience-report)) and a focus on key
 [user-centric performance metrics](/user-centric-performance-metrics/), eBay was able to make
@@ -55,7 +55,7 @@ significant improvements to site speed.
 <figure class="w-figure">
   {% Img src="image/admin/YeJPjxdDBrdbgLxcbl7E.png", alt="Screenshots of PageSpeed Insights view of Chrome User Experience Report data highlighting fast FCP of 70% and fast FID of 88% for eBay.com", width="800", height="237", class="w-screenshot" %}
   <figcaption class="w-figcaption">
-    Chrome User Experience Report data for <a href="https://web.dev/fcp/">First Contentful Paint</a> and <a href="https://web.dev/fid/">First Input Delay</a> for the eBay.com origin.
+    Chrome User Experience Report data for <a href="/fcp/">First Contentful Paint</a> and <a href="/fid/">First Input Delay</a> for the eBay.com origin.
   </figcaption>
 </figure>
 
@@ -70,7 +70,7 @@ the web developer community at large, rather than eBay-specific topics.
 ## Reduce payload across all text resources
 
 One way to make sites fast is to simply load less code. eBay reduced their text payloads by trimming
-all the [unused and unnecessary bytes](https://web.dev/remove-unused-code/) of JavaScript, CSS,
+all the [unused and unnecessary bytes](/remove-unused-code/) of JavaScript, CSS,
 HTML, and JSON responses served to users. Previously, with every new feature, eBay kept increasing
 the payload of their responses, without cleaning up what was unused. This added up over time and
 became a performance bottleneck. Teams usually procrastinated on this cleanup activity, but you'd
@@ -81,7 +81,7 @@ The "cut" here is the wasted bytes in the response payload.
 ## Critical path optimization for above-the-fold content
 
 Not every pixel on the screen is equally important. The content [above-the-fold][atf] is [more
-critical](https://web.dev/extract-critical-css/) than something below-the-fold. iOS/Android/desktop and web apps
+critical](/extract-critical-css/) than something below-the-fold. iOS/Android/desktop and web apps
 are aware of this, but what about services? eBay's service architecture has a layer called
 [Experience
 Services](https://tech.ebayinc.com/engineering/experience-services-ebays-solution-to-multi-screen-application-development/),
@@ -103,7 +103,7 @@ Images are [one of the largest contributors to page
 bloat](https://almanac.httparchive.org/en/2019/media). Even
 small optimizations go a long way. eBay did two optimizations for images.
 
-First, eBay standardized on the [WebP image format](https://web.dev/serve-images-webp/) for search
+First, eBay standardized on the [WebP image format](/serve-images-webp/) for search
 results across all platforms, including iOS, Android, and [supported browsers][webp]. The search
 results page is the most image-heavy page at eBay, and they were already using WebP, but not in a
 consistent pattern.
@@ -125,7 +125,7 @@ The "cut" here is the wasted image bytes sent to users.
 
 ## Predictive prefetch of static assets
 
-A user session on eBay is not just one page. It is a flow. For example, the flow can be a navigation from the homepage to a search page to an item page. So why don't pages in the flow help each other? That is the idea of [predictive prefetch](https://web.dev/predictive-prefetching/), where one page prefetches the static assets required for the next likely page.
+A user session on eBay is not just one page. It is a flow. For example, the flow can be a navigation from the homepage to a search page to an item page. So why don't pages in the flow help each other? That is the idea of [predictive prefetch](/predictive-prefetching/), where one page prefetches the static assets required for the next likely page.
 
 With predictive prefetch, when a user navigates to the predicted page, the assets are already in the browser cache. This is done for CSS and JavaScript assets, where the URLs can be retrieved ahead of time. One thing to note here is that it helps only on first-time navigations. On subsequent navigations, the static assets will already be in the cache.
 
@@ -217,7 +217,7 @@ All the performance "cuts" eBay made collectively contributed towards moving the
   </figcaption>
 </figure>
 
-Performance is a feature and a [competitive advantage](https://web.dev/value-of-speed/). Optimized experiences lead to higher user engagement, conversions, and ROI. In eBay's case, these optimizations varied from things that were low-effort to a few that were advanced.
+Performance is a feature and a [competitive advantage](/value-of-speed/). Optimized experiences lead to higher user engagement, conversions, and ROI. In eBay's case, these optimizations varied from things that were low-effort to a few that were advanced.
 
 Check out [Speed by a thousand cuts][cuts] to learn more and be on the lookout for more detailed articles by eBay engineers on their performance work in the near future.
 

--- a/src/site/content/en/blog/sign-in-form-best-practices/index.md
+++ b/src/site/content/en/blog/sign-in-form-best-practices/index.md
@@ -54,9 +54,9 @@ Here is an example of a simple sign-in form that demonstrates all of the best pr
 between page loads or website deployments.
 * Put sign-in [in its own &lt;form&gt; element](#single-form).
 * [Ensure successful form submission](#submission).
-* Use [`autocomplete="new-password"`](#new-password) and [`id="new-password"`](#new-password) for 
+* Use [`autocomplete="new-password"`](#new-password) and [`id="new-password"`](#new-password) for
 the password input in a sign-up form, and for the new password in a reset-password form.
-* Use [`autocomplete="current-password"`](#current-password) and [`id="current-password"`](#current-password) 
+* Use [`autocomplete="current-password"`](#current-password) and [`id="current-password"`](#current-password)
 for a sign-in password input.
 * Provide [Show password](#show-password) functionality.
 * [Use `aria-label` and `aria-describedby`](#accessible-password-inputs) for
@@ -84,7 +84,7 @@ third-party identity services as well as its content.
 
 There are also two relatively new APIs not covered in this article which can
 help you build a better sign-in experience:
-*  [**WebOTP**](https://web.dev/web-otp/): to deliver one-time passcodes or
+*  [**WebOTP**](/web-otp/): to deliver one-time passcodes or
 PIN numbers via SMS to mobile phones. This can allow users to select a phone
 number as an identifier (no need to enter an email address!) and also enables
 two-step verification for sign-in and one-time codes for payment confirmation.
@@ -333,12 +333,12 @@ differentiate between new and current passwords.
 
 ### Use `autocomplete="new-password"` and `id="new-password"` for a new password {: #new-password }
 
-* Use `autocomplete="new-password"` and `id="new-password"` for the password input in a sign-up 
+* Use `autocomplete="new-password"` and `id="new-password"` for the password input in a sign-up
 form, or the new password in a change-password form.
 
 ### Use `autocomplete="current-password"` and `id="current-password"` for an existing password {: #current-password }
 
-* Use `autocomplete="current-password"` and `id="current-password"` for the password input in a 
+* Use `autocomplete="current-password"` and `id="current-password"` for the password input in a
   sign-in form, or the input for the user's old password in a change-password form. This tells the
   browser that you want it to use the current password that it has stored for the site.
 
@@ -355,12 +355,12 @@ For sign-in:
 ```
 
 {% Aside %}
-Browsers such as Chrome can use the browser's password manager to autofill fields in the sign-in 
-process for returning users. For these features to work, the browser needs to be able to 
+Browsers such as Chrome can use the browser's password manager to autofill fields in the sign-in
+process for returning users. For these features to work, the browser needs to be able to
 distinguish when a user changes their password.
 
-Specifically the form for changing the user's password should be cleared or hidden from the page 
-after the new password is set up. If the form for changing the user's password stays filled out on 
+Specifically the form for changing the user's password should be cleared or hidden from the page
+after the new password is set up. If the form for changing the user's password stays filled out on
 the page after the password change has occurred, the browser may not be able to record the update.
 {% endAside %}
 
@@ -388,7 +388,7 @@ Browser password and autofill systems are not simple. The algorithms for
 guessing, storing and displaying values are not standardized, and vary from
 platform to platform. For example, as pointed out by [Hidde de
 Vries](https://hiddedevries.nl/en/blog/2018-01-13-making-password-managers-play-ball-with-your-login-form):
-"Firefox's password manager complements its heuristics with a 
+"Firefox's password manager complements its heuristics with a
 [recipe system](https://bugzilla.mozilla.org/show_bug.cgi?id=1119454)."
 
 [Autofill: What web devs should know, but
@@ -473,7 +473,7 @@ mobile, and around 10 px on desktop. Try this out with a real mobile device and
 a real finger or thumb. You should comfortably be able to tap each of your
 inputs and buttons.
 
-The [Tap targets are not sized appropriately](https://web.dev/tap-targets/)
+The [Tap targets are not sized appropriately](/tap-targets/)
 Lighthouse audit can help you automate the process of detecting input elements
 that are too small.
 
@@ -508,7 +508,7 @@ queries](https://developers.google.com/web/fundamentals/design-and-ux/responsive
 `20px` is about right on mobile—but you should test this out with friends or
 colleagues who have low vision.
 
-The [Document doesn't use legible font sizes](https://web.dev/font-size/)
+The [Document doesn't use legible font sizes](/font-size/)
 Lighthouse audit can help you automate the process of detecting text that's too
 small.
 
@@ -748,6 +748,6 @@ Well designed UI and UX can reduce sign-in form abandonment:
 * [More capable form controls](/more-capable-form-controls)
 * [Creating Accessible Forms](https://webaim.org/techniques/forms/)
 * [Streamlining the Sign-in Flow Using Credential Management API](https://developers.google.com/web/updates/2016/04/credential-management-api)
-* [Verify phone numbers on the web with the WebOTP API](https://web.dev/web-otp/)
+* [Verify phone numbers on the web with the WebOTP API](/web-otp/)
 
 Photo by [Meghan Schiereck](https://unsplash.com/photos/_XFObcM_7KU) on [Unsplash](https://unsplash.com).

--- a/src/site/content/en/blog/tabbed-application-mode/index.md
+++ b/src/site/content/en/blog/tabbed-application-mode/index.md
@@ -19,7 +19,7 @@ tags:
 
 {% Aside %}
   Tabbed application mode is part of the
-  [capabilities project](https://web.dev/fugu-status/) and is currently in development. This post
+  [capabilities project](/fugu-status/) and is currently in development. This post
   will be updated as the implementation progresses. Tabbed application mode is an early-stage
   exploration of the Chrome team. It is not ready for production yet.
 {% endAside %}

--- a/src/site/content/en/blog/text-fragments/index.md
+++ b/src/site/content/en/blog/text-fragments/index.md
@@ -26,7 +26,7 @@ feedback:
 ## Fragment Identifiers
 
 Chrome&nbsp;80 was a big release. It contained a number of highly anticipated features like
-[ECMAScript Modules in Web Workers](https://web.dev/module-workers/),
+[ECMAScript Modules in Web Workers](/module-workers/),
 [nullish coalescing](https://v8.dev/features/nullish-coalescing),
 [optional chaining](https://v8.dev/features/optional-chaining), and more. The release was, as usual,
 announced through a

--- a/src/site/content/en/blog/third-party-origin-trials/index.md
+++ b/src/site/content/en/blog/third-party-origin-trials/index.md
@@ -17,7 +17,7 @@ tags:
 feature.
 
 Origin trials are usually only available on a first-party basis: they only work for a single
-registered [origin](https://web.dev/same-site-same-origin/#origin). If a developer wants to test an
+registered [origin](/same-site-same-origin/#origin). If a developer wants to test an
 experimental feature on other origins where their content is embedded, those origins all need to be
 registered for the origin trial, each with a unique trial token. This is not a scalable approach for
 testing scripts that are embedded across a number of sites.

--- a/src/site/content/en/blog/tokopedia/index.md
+++ b/src/site/content/en/blog/tokopedia/index.md
@@ -45,7 +45,7 @@ improve user experience and engagement, and also showed the impact of performanc
 patterns and APIs.
 
 {% Aside %}
-Check out web.dev's [Build a performance culture](https://web.dev/fast/#build-a-performance-culture)
+Check out web.dev's [Build a performance culture](/fast/#build-a-performance-culture)
 collection for tips on how to persuade your cross-functional stakeholders to focus on website
 performance.
 {% endAside %}

--- a/src/site/content/en/blog/trust-tokens/index.md
+++ b/src/site/content/en/blog/trust-tokens/index.md
@@ -44,7 +44,7 @@ in the Chrome DevTools **Network** and **Application** tabs.
 {% Aside %}
 The Privacy Sandbox is a series of proposals to satisfy third-party use cases
 without third-party cookies or other tracking mechanisms. See
-[Digging into the Privacy Sandbox](http://web.dev/digging-into-the-privacy-sandbox)
+[Digging into the Privacy Sandbox](/digging-into-the-privacy-sandbox)
 for an overview of all the proposals.
 
 **This proposal needs your feedback!** If you have comments, please [create an
@@ -299,7 +299,7 @@ Trust Token [explainer repository](https://github.com/WICG/trust-token-api).
 ## Find out more
 
 -  [Trust Tokens demo](https://trust-token-demo.glitch.me)
--  [Digging in to the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox/)
+-  [Digging in to the Privacy Sandbox](/digging-into-the-privacy-sandbox/)
 -  [Trust Token API Explainer](https://github.com/WICG/trust-token-api)
 -  [Chromium Projects: Trust Token API](https://sites.google.com/a/chromium.org/dev/updates/trust-token)
 -  [Intent to Implement: Trust Token API](https://groups.google.com/a/chromium.org/g/blink-dev/c/X9sF2uLe9rA/m/1xV5KEn2DgAJ)

--- a/src/site/content/en/blog/use-thumbor/index.md
+++ b/src/site/content/en/blog/use-thumbor/index.md
@@ -19,18 +19,18 @@ tags:
 
 ## Prequisites
 
-This post assumes that you understand how image CDNs can improve your load performance. If not, check out [Use image CDNs to optimize images](https://web.dev/image-cdns). It also assumes that you've built basic websites before.
+This post assumes that you understand how image CDNs can improve your load performance. If not, check out [Use image CDNs to optimize images](/image-cdns). It also assumes that you've built basic websites before.
 
 {% Aside %}
 
-If you would like to install Thumbor on your own server and then follow along with this post, check out [How to install the Thumbor image CDN](https://web.dev/install-thumbor). Whenever you see `http://34.67.235.246:8888` in this post you'll need to replace that origin with your Thumbor instance's origin.
+If you would like to install Thumbor on your own server and then follow along with this post, check out [How to install the Thumbor image CDN](/install-thumbor). Whenever you see `http://34.67.235.246:8888` in this post you'll need to replace that origin with your Thumbor instance's origin.
 
 {% endAside %}
 
 
 ## Thumbor URL Format
 
-As mentioned in [Use Image CDNs to Optimize Images](https://web.dev/image-cdns), each image CDN uses a slightly different URL format for images. Figure 1 represents Thumbor's format.
+As mentioned in [Use Image CDNs to Optimize Images](/image-cdns), each image CDN uses a slightly different URL format for images. Figure 1 represents Thumbor's format.
 
 <figure class="w-figure">
   {% Img src="image/admin/lo1hS8qn53XCztrlgvl7.jpg", alt="A Thumbor URL has the following components: origin, security key, size, filters and image.", width="800", height="89", class="w-screenshot" %}

--- a/src/site/content/en/blog/user-agent-client-hints/index.md
+++ b/src/site/content/en/blog/user-agent-client-hints/index.md
@@ -417,7 +417,7 @@ or `navigator.platform`) to make use of User-Agent Client Hints instead.
 Taking this a step further, you should re-examine your use of User-Agent
 information, and replace it with other methods whenever possible. Often, you can
 accomplish the same goal by making use of progressive enhancement, feature
-detection, or [responsive design](https://web.dev/responsive-web-design-basics).
+detection, or [responsive design](/responsive-web-design-basics).
 The base problem with relying on the User-Agent data is that you are always
 maintaining a mapping between the property you're inspecting and the behavior it
 enables. It's a maintenance overhead to ensure that your detection is

--- a/src/site/content/en/blog/using-conversion-measurement/index.md
+++ b/src/site/content/en/blog/using-conversion-measurement/index.md
@@ -174,8 +174,8 @@ more use cases—please [share it](/conversion-measurement/#share-your-feedback)
 
 ## Further reading
 
-- [Origin trials developer guide](https://web.dev/third-party-origin-trials/)
-- [Getting started with Chrome's origin trials](https://web.dev/origin-trials/)
+- [Origin trials developer guide](/third-party-origin-trials/)
+- [Getting started with Chrome's origin trials](/origin-trials/)
 - [What are third-party origin
   trials?](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
 

--- a/src/site/content/en/blog/vitals-measurement-getting-started/index.md
+++ b/src/site/content/en/blog/vitals-measurement-getting-started/index.md
@@ -20,7 +20,7 @@ Collecting data on your site's Web Vitals is the first step towards improving th
 
 ## Measuring Web Vitals using RUM data
 
-[Real User Monitoring](https://en.wikipedia.org/wiki/Real_user_monitoring) (RUM) data, also known as field data, captures the performance experienced by a site's actual users. RUM data is what Google uses to determine whether a site meets the [recommended Core Web Vitals thresholds.](https://web.dev/vitals/)
+[Real User Monitoring](https://en.wikipedia.org/wiki/Real_user_monitoring) (RUM) data, also known as field data, captures the performance experienced by a site's actual users. RUM data is what Google uses to determine whether a site meets the [recommended Core Web Vitals thresholds.](/vitals/)
 
 ### Getting started
 
@@ -48,11 +48,11 @@ If you don't have a RUM provider, you may be able to augment your existing analy
 
 ### The web-vitals JavaScript library
 
-If you're implementing your own RUM setup for Web Vitals, the easiest way to collect Web Vitals measurements is to use the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) JavaScript library. `web-vitals` is a small, modular library (~1KB) that provides a convenient API for collecting and reporting each of the [field-measurable](https://web.dev/user-centric-performance-metrics/#in-the-field) Web Vitals metrics.
+If you're implementing your own RUM setup for Web Vitals, the easiest way to collect Web Vitals measurements is to use the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) JavaScript library. `web-vitals` is a small, modular library (~1KB) that provides a convenient API for collecting and reporting each of the [field-measurable](/user-centric-performance-metrics/#in-the-field) Web Vitals metrics.
 
-The metrics that make up Web Vitals are not all directly exposed by the browser's built-in performance APIs - but rather built on top of them. For example, [Cumulative Layout Shift (CLS)](https://web.dev/cls/) is implemented using the [Layout Instability API](https://wicg.github.io/layout-instability/). By using `web-vitals`, you don't need to worry about implementing these metrics yourself; it also ensures that the data you collect matches the methodology and best practices for each metric.
+The metrics that make up Web Vitals are not all directly exposed by the browser's built-in performance APIs - but rather built on top of them. For example, [Cumulative Layout Shift (CLS)](/cls/) is implemented using the [Layout Instability API](https://wicg.github.io/layout-instability/). By using `web-vitals`, you don't need to worry about implementing these metrics yourself; it also ensures that the data you collect matches the methodology and best practices for each metric.
 
-For more information on implementing `web-vitals`, refer to the [documentation](https://github.com/GoogleChrome/web-vitals) and the [Best practices for measuring Web Vitals in the field](https://web.dev/vitals-field-measurement-best-practices/) guide.
+For more information on implementing `web-vitals`, refer to the [documentation](https://github.com/GoogleChrome/web-vitals) and the [Best practices for measuring Web Vitals in the field](/vitals-field-measurement-best-practices/) guide.
 
 ### Data aggregation
 
@@ -60,24 +60,24 @@ It is essential that you report the measurements collected by `web-vitals`. If t
 
 If you already have a favorite reporting tool, consider using that. If not, Google Analytics is free and can be used for this purpose.
 
-When considering which tool to use, it is helpful to think about who will need to have access to the data. Businesses typically achieve the biggest performance wins when the whole company, rather than a single department, is interested in improving performance. See [Fixing website speed cross-functionally](https://web.dev/fixing-website-speed-cross-functionally/) to learn how to get buy-in from different departments.
+When considering which tool to use, it is helpful to think about who will need to have access to the data. Businesses typically achieve the biggest performance wins when the whole company, rather than a single department, is interested in improving performance. See [Fixing website speed cross-functionally](/fixing-website-speed-cross-functionally/) to learn how to get buy-in from different departments.
 
 ### Data interpretation
 
-When analyzing performance data, it's important to pay attention to the tails of the distribution. RUM data often reveals that performance varies widely - some users have fast experiences, others have slow experiences. However, using the median to summarize data can easily mask this behavior. 
+When analyzing performance data, it's important to pay attention to the tails of the distribution. RUM data often reveals that performance varies widely - some users have fast experiences, others have slow experiences. However, using the median to summarize data can easily mask this behavior.
 
 With regards to Web Vitals, Google uses the percentage of "good" experiences, rather than statistics like medians or averages, to determine whether a site or page meets the recommended thresholds. Specifically, for a site or page to be considered as meeting the Core Web Vitals thresholds, 75% of page visits should meet the "good" threshold for each metric.
 
 ## Measuring Web Vitals using lab data
 
-[Lab data](https://web.dev/user-centric-performance-metrics/#in-the-lab), also known as synthetic data, is collected from a controlled environment, rather than actual users. Unlike RUM data, lab data can be collected from pre-production environments and therefore incorporated into developer workflows and continuous integration processes. Examples of tools that collect synthetic data are Lighthouse and WebPageTest. 
+[Lab data](/user-centric-performance-metrics/#in-the-lab), also known as synthetic data, is collected from a controlled environment, rather than actual users. Unlike RUM data, lab data can be collected from pre-production environments and therefore incorporated into developer workflows and continuous integration processes. Examples of tools that collect synthetic data are Lighthouse and WebPageTest.
 
 ### Considerations
 
 There will always be discrepancies between RUM data and lab data - particularly if the network conditions, device type, or location of the lab environment differs significantly from that of users. However, when it comes to collecting lab data on Web Vitals metrics in particular, there are a couple specific considerations that are important to note:
 
-* **Cumulative Layout Shift (CLS):** The [Cumulative Layout Shift](https://web.dev/cls/) measured in lab environments can be artificially lower than the CLS observed in RUM data. CLS is defined as the "sum total of all individual layout shift scores for every unexpected layout shift that occurs _during the entire lifespan of the page_." However, the lifespan of a page is typically very different depending on whether it is being loaded by a real user or a synthetic performance measurement tool. Many lab tools only load the page - they don't interact with it. As a result, they only capture layout shifts that occur during initial page load. By contrast, the CLS measured by RUM tools captures [unexpected layout shifts](https://web.dev/cls/#expected-vs.-unexpected-layout-shifts) that occur throughout the entire lifespan of the page.
-*  **First Input Delay (FID):** [First Input Delay](https://web.dev/fid/) can't be measured in lab environments because it requires user interactions with the page. As a result, [Total Blocking Time](https://web.dev/tbt/) (TBT) is the recommended lab proxy for FID. TBT measures the "total amount of time between First Contentful Paint and Time to Interactive during which the page is blocked from responding to user input". Although FID and TBT are calculated differently, they are both reflections of a blocked main thread during the bootstrap process. When the main thread is blocked, the browser is delayed in responding to user interactions. FID measures the delay, if any, that occurs the first time a user tries to interact with a page.
+* **Cumulative Layout Shift (CLS):** The [Cumulative Layout Shift](/cls/) measured in lab environments can be artificially lower than the CLS observed in RUM data. CLS is defined as the "sum total of all individual layout shift scores for every unexpected layout shift that occurs _during the entire lifespan of the page_." However, the lifespan of a page is typically very different depending on whether it is being loaded by a real user or a synthetic performance measurement tool. Many lab tools only load the page - they don't interact with it. As a result, they only capture layout shifts that occur during initial page load. By contrast, the CLS measured by RUM tools captures [unexpected layout shifts](/cls/#expected-vs.-unexpected-layout-shifts) that occur throughout the entire lifespan of the page.
+*  **First Input Delay (FID):** [First Input Delay](/fid/) can't be measured in lab environments because it requires user interactions with the page. As a result, [Total Blocking Time](/tbt/) (TBT) is the recommended lab proxy for FID. TBT measures the "total amount of time between First Contentful Paint and Time to Interactive during which the page is blocked from responding to user input". Although FID and TBT are calculated differently, they are both reflections of a blocked main thread during the bootstrap process. When the main thread is blocked, the browser is delayed in responding to user interactions. FID measures the delay, if any, that occurs the first time a user tries to interact with a page.
 
 ### Tooling
 

--- a/src/site/content/en/blog/vodafone/index.md
+++ b/src/site/content/en/blog/vodafone/index.md
@@ -77,7 +77,7 @@ differences between the two versions other than that. Vodafone used the
 [`PerformanceObserver`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver) API to
 measure LCP on real user sessions and sent the
 [field data](https://www.searchenginejournal.com/google-explains-why-field-data-is-more-reliable-than-lab-data/372404/)
-to their analytics provider. 
+to their analytics provider.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/bDOhlrGwsiuknDTBjUJg.png", alt="A diagram of the A/B test setup.", width="800", height="398" %}
 
@@ -86,19 +86,19 @@ to their analytics provider.
 Vodafone made the following changes on the optimized page (version A):
 
 -  **Moved the rendering logic for a widget from client-side to server-side**, which resulted in
-   less [render-blocking JavaScript](https://web.dev/render-blocking-resources/)
+   less [render-blocking JavaScript](/render-blocking-resources/)
 -  **Server-side rendered** critical HTML
--  **Optimized images**, including [resizing](https://web.dev/uses-responsive-images/) the hero
+-  **Optimized images**, including [resizing](/uses-responsive-images/) the hero
    image, [optimizing SVG images](https://jakearchibald.github.io/svgomg/), using media queries to
-   [avoid loading images](https://web.dev/browser-level-image-lazy-loading/) that weren't yet
-   visible in the viewport, and [optimizing PNG images](https://web.dev/squoosh-v2/)
+   [avoid loading images](/browser-level-image-lazy-loading/) that weren't yet
+   visible in the viewport, and [optimizing PNG images](/squoosh-v2/)
 
 ## Overall business results {: #results }
 
 <div class="w-columns">
   <div>
     <p>
-      After optimizing version A for Web Vitals and comparing it to the 
+      After optimizing version A for Web Vitals and comparing it to the
       unoptimized version B, Vodafone found that version A led to:
     </p>
     <ul>

--- a/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
@@ -21,7 +21,7 @@ tags:
 ---
 
 Recently, I published [Virtual reality comes to the
-web](https://web.dev/vr-comes-to-the-web/), an article that introduced basic
+web](/vr-comes-to-the-web/), an article that introduced basic
 concepts behind the [WebXR Device
 API](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API). I
 also provided instructions for requesting, entering, and ending an XR session.
@@ -68,7 +68,7 @@ origin. The origin is specified based on the requested reference space type when
 calling `XRSession.requestReferenceSpace()`.
 
 Reference spaces take a bit to explain. I cover them in depth in [Augmented
-reality](https://web.dev/web-ar/). The sample I'm using as the basis for this
+reality](/web-ar/). The sample I'm using as the basis for this
 article uses a `'local'` reference space which means the origin is at the
 viewer's position at the time of session creation without a well-defined floor,
 and its precise position may vary by platform.
@@ -129,7 +129,7 @@ corresponds to the viewer's device and the other corresponds to the web page.
 
 Now that we know who the players are, let's look at the game they play. It's a
 game that starts over with every frame. Recall that frames are part of a [frame
-loop](https://web.dev/vr-comes-to-the-web/#running-a-frame-loop) that happens at
+loop](/vr-comes-to-the-web/#running-a-frame-loop) that happens at
 a rate that depends on the underlying hardware. For VR applications the frames
 per second can be anywhere from 60 to 144. AR for Android runs at 30 frames per
 second. Your code should not assume any particular frame rate.
@@ -162,7 +162,7 @@ get the viewer's pose by calling `XRFrame.getViewerPose()` on the current
 animation frame. I pass it the reference space I acquired when I set up the
 session. The values returned by this object are always relative to the reference
 space I requested when I [entered the current
-session](https://web.dev/vr-comes-to-the-web/#entering-a-session). As you may
+session](/vr-comes-to-the-web/#entering-a-session). As you may
 recall, I have to pass the current reference space when requesting the pose.
 
 ```js/3-4
@@ -199,7 +199,7 @@ loop will continue. If not, the user agent will end the session and call the
 ### A short detour
 
 The next step requires objects created during [session
-set-up](https://web.dev/vr-comes-to-the-web/#requesting-a-session). Recall that
+set-up](/vr-comes-to-the-web/#requesting-a-session). Recall that
 I created a canvas and instructed it to create an XR-compatible Web GL rendering
 context, which I got by calling `canvas.getContext()`. All drawing is done using
 the WebGL API, the WebGL2 API, or a WebGL-based framework such as Three.js. This

--- a/src/site/content/en/blog/web-ar/index.md
+++ b/src/site/content/en/blog/web-ar/index.md
@@ -35,11 +35,11 @@ differences lie in configurations that allow content to be shown appropriately
 for augmented reality. If you're not familiar with the basic concepts of WebXR,
 you should read my earlier posts on the WebXR Device API, or at least be
 familiar with the topics covered therein. You should know how to [request and
-enter a session](https://web.dev/vr-comes-to-the-web/) and you should know how
-to run [a frame loop](https://web.dev/vr-comes-to-the-web-pt-ii).
+enter a session](/vr-comes-to-the-web/) and you should know how
+to run [a frame loop](/vr-comes-to-the-web-pt-ii).
 
 For information on hit testing, see the companion article [Positioning virtual
-objects in real-world views](https://web.dev/ar-hit-test). The code in this
+objects in real-world views](/ar-hit-test). The code in this
 article is based on the Immersive AR Session sample
 ([demo](https://immersive-web.github.io/webxr-samples/immersive-ar-session.html)
 [source](https://github.com/immersive-web/webxr-samples/blob/master/immersive-vr-session.html)) from

--- a/src/site/content/en/blog/web-on-android/index.md
+++ b/src/site/content/en/blog/web-on-android/index.md
@@ -141,8 +141,8 @@ platform, also known as in-app browsers.
 [1]: https://research.google/pubs/pub46739/
 [2]: https://android-developers.googleblog.com/2015/09/chrome-custom-tabs-smooth-transition.html
 [3]: https://developer.android.com/reference/androidx/browser/customtabs/package-summary
-[4]: https://web.dev/progressive-web-apps/
+[4]: /progressive-web-apps/
 [5]: https://developers.google.com/web/android/trusted-web-activity/
-[6]: https://web.dev/using-a-pwa-in-your-android-app/
+[6]: /using-a-pwa-in-your-android-app/
 [7]: https://developers.google.com/digital-asset-links
-[8]: https://web.dev/using-a-pwa-in-your-android-app/#quality-criteria
+[8]: /using-a-pwa-in-your-android-app/#quality-criteria

--- a/src/site/content/en/blog/web-share-target/index.md
+++ b/src/site/content/en/blog/web-share-target/index.md
@@ -208,7 +208,7 @@ window.addEventListener('DOMContentLoaded', () => {
 Be sure to use a service worker to [precache](https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker) the `action`
 page so that it will load quickly and work reliably, even if the user is offline.
 [Workbox](https://developers.google.com/web/tools/workbox/) is a tool that can help you
-[implement precaching](https://web.dev/precache-with-workbox/) in your service worker.
+[implement precaching](/precache-with-workbox/) in your service worker.
 
 ### Processing POST shares
 

--- a/src/site/content/en/blog/why-coop-coep/index.md
+++ b/src/site/content/en/blog/why-coop-coep/index.md
@@ -24,7 +24,7 @@ feedback:
 ---
 ## Introduction
 In [Making your website "cross-origin isolated" using COOP and
-COEP](https://web.dev/coop-coep/) we explained how to adopt to "cross-origin
+COEP](/coop-coep/) we explained how to adopt to "cross-origin
 isolated" state using COOP and COEP. This is a companion article that explains
 why cross-origin isolation is required to enable powerful features on the browser.
 
@@ -47,7 +47,7 @@ clearer, let's define them:
 ## Background
 
 The web is built on the [same-origin
-policy](https://web.dev/same-origin-policy/): a security feature that restricts
+policy](/same-origin-policy/): a security feature that restricts
 how documents and scripts can interact with resources from another origin. This
 principle restricts the ways websites can access cross-origin resources. For
 example, a document from `https://a.example` is prevented from accessing data
@@ -257,7 +257,7 @@ checking if
 returns `true`.
 
 Learn the steps to implement this at [Making your website "cross-origin
-isolated" using COOP and COEP](https://web.dev/coop-coep/).
+isolated" using COOP and COEP](/coop-coep/).
 
 ## Resources
 * [COOP and COEP

--- a/src/site/content/en/blog/workbox-share-targets/index.md
+++ b/src/site/content/en/blog/workbox-share-targets/index.md
@@ -20,7 +20,7 @@ feedback:
   - api
 ---
 
-The [Web Share Target API](https://web.dev/web-share-target/) lets you display
+The [Web Share Target API](/web-share-target/) lets you display
 your [Progressive Web App](https://developers.google.com/web/progressive-web-apps/checklist) in a
 user's system-level share [sheet] after it's been installed. While it works great if you have a server
 available to receive the request, it's much harder to get working if you don't.
@@ -42,7 +42,7 @@ single-page apps serve as share targets without a dedicated server endpoint.
 ## On the same page
 
 If you're unfamiliar with how Web Share Target Works, [Receiving shared data with the Web Share
-Target API](https://web.dev/web-share-target/) gives you an in-depth introduction.
+Target API](/web-share-target/) gives you an in-depth introduction.
 Here's a quick review.
 
 There are two parts to implementing web share target functionality. First,
@@ -125,7 +125,7 @@ code](https://github.com/chromeos/bridging-the-native-app-gap/blob/master/fugu-j
 
 One common thing you might do is hold shared resources until better network
 connections are available. Workbox also supports [periodic background
-sync](https://web.dev/periodic-background-sync/).
+sync](/periodic-background-sync/).
 
 ## Conclusion
 

--- a/src/site/content/en/blog/zdf/index.md
+++ b/src/site/content/en/blog/zdf/index.md
@@ -49,7 +49,7 @@ offline support. The player takes a content ID as input, talks to the ZDF API,
 and plays back the associated video.
 
 This is where one of the web's most powerful features comes to the rescue:
-[service workers](https://web.dev/service-worker-mindset/).
+[service workers](/service-worker-mindset/).
 
 The service worker can intercept the various requests done by the player and
 respond with the data from IndexedDB. This transparently adds offline

--- a/src/site/content/en/developer-satisfaction/index.md
+++ b/src/site/content/en/developer-satisfaction/index.md
@@ -1,10 +1,10 @@
 ---
 layout: post
 title: Web Developer Satisfaction
-description: 
-  Web Developer Satisfaction is a Google project to gather information about 
-  the needs of web developers. The goal is a more reliable, predictable and 
-  interoperable web platform, enabling developers to invest in and trust it, 
+description:
+  Web Developer Satisfaction is a Google project to gather information about
+  the needs of web developers. The goal is a more reliable, predictable and
+  interoperable web platform, enabling developers to invest in and trust it,
   and adopt and use new features to grow the platform and their business.
 date: 2021-03-22
 updated: 2021-03-23
@@ -35,7 +35,7 @@ is called [#Compat2021](https://twitter.com/search?q=%23compat2021&src=typed_que
 You can follow along with the process in the Compat 2021 dashboard to see how
 each major browser engine is doing in the five areas:
 
-<iframe src="https://wpt.fyi/compat2021?embedded" 
+<iframe src="https://wpt.fyi/compat2021?embedded"
 frameborder="0" style="height: 1000px; width: 100%;"></iframe>
 
 The dashboard and all related bugs are listed at
@@ -57,7 +57,7 @@ compatibility pain points on the web](/compat2021).
 
 Follow any updates on [@ChromiumDev](https://twitter.com/ChromiumDev) or through
 the [Compat 2021 public mailing list](https://groups.google.com/g/compat2021).
-Make sure bugs exist, or [file them](https://web.dev/how-to-file-a-good-bug/)
+Make sure bugs exist, or [file them](/how-to-file-a-good-bug/)
 for issues you have been experiencing, and if there's anything missing, reach
 out through the above channels.
 

--- a/src/site/content/en/fast/content-delivery-networks/index.md
+++ b/src/site/content/en/fast/content-delivery-networks/index.md
@@ -139,7 +139,7 @@ The next level of CHR optimization, broadly speaking, is to fine tune your CDN s
 
 ### Initial audit
 
-Most CDNs will provide cache analytics. In addition, tools like [WebPageTest](https://webpagetest.org/) and [Lighthouse](https://web.dev/uses-long-cache-ttl/) can also be used to quickly verify that all of a page's static resources are being cached for the correct length of time. This is accomplished by checking the HTTP Cache headers of each resource. Caching a resource using the maximum appropriate Time To Live (TTL) will avoid unnecessary origin fetches in the future and therefore increase CHR.
+Most CDNs will provide cache analytics. In addition, tools like [WebPageTest](https://webpagetest.org/) and [Lighthouse](/uses-long-cache-ttl/) can also be used to quickly verify that all of a page's static resources are being cached for the correct length of time. This is accomplished by checking the HTTP Cache headers of each resource. Caching a resource using the maximum appropriate Time To Live (TTL) will avoid unnecessary origin fetches in the future and therefore increase CHR.
 
 At a minimum, one of these headers typically needs to be set in order for a resource to be cached by a CDN:
 
@@ -149,7 +149,7 @@ At a minimum, one of these headers typically needs to be set in order for a reso
 
 In addition, although it does not impact if or how a resource is cached by a CDN, it is good practice to also set the [`Cache-Control: immutable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading) directive.`Cache-Control: immutable` indicates that a resource "will not be updated during its freshness lifetime". As a result, the browser will not revalidate the resource when serving it from the browser cache, thereby eliminating an unnecessary server request. Unfortunately, this directive is only [supported](https://caniuse.com/#feat=mdn-http_headers_cache-control_immutable) by Firefox and Safari - it is not supported by Chromium-based browsers. This [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=611416) tracks Chromium support for `Cache-Control: immutable`. Starring this issue can help encourage support for this feature.
 
-For a more detailed explanation of HTTP caching, refer to [Prevent unnecessary network requests with the HTTP Cache](https://web.dev/http-cache/).
+For a more detailed explanation of HTTP caching, refer to [Prevent unnecessary network requests with the HTTP Cache](/http-cache/).
 
 
 ### Fine tuning

--- a/src/site/content/en/fast/cookie-notice-best-practices/index.md
+++ b/src/site/content/en/fast/cookie-notice-best-practices/index.md
@@ -74,13 +74,13 @@ attribute to the script tag.
 
 Scripts that are not asynchronous block the browser parser. This delays page
 load and LCP. For more information, see [Efficiently load third-party
-JavaScript](https://web.dev/efficiently-load-third-party-javascript/).
+JavaScript](/efficiently-load-third-party-javascript/).
 
 {% Aside %}
 If you must use synchronous scripts (for example, some cookie notices rely on
 synchronous scripts to implement cookie blocking) you should make sure that this
 request loads as quickly as possible. One way to do this is to [use resource
-hints](https://web.dev/preconnect-and-dns-prefetch/).
+hints](/preconnect-and-dns-prefetch/).
 {% endAside %}
 
 
@@ -100,7 +100,7 @@ All sites that load their cookie notice scripts from a third-party location
 should use either the `dns-prefetch` or `preconnect` resource hints to help
 establish an early connection with the origin that hosts cookie notice
 resources. For more information, see [Establish network connections early to
-improve perceived page speed](https://web.dev/preconnect-and-dns-prefetch/).
+improve perceived page speed](/preconnect-and-dns-prefetch/).
 
 ```html
 <link rel="preconnect" href="https://cdn.cookie-notice.com/">
@@ -160,7 +160,7 @@ notices:
 *   **Animations**: Many cookie notices use animations—for example, "sliding in"
     a cookie notice is a common design pattern. Depending on how these effects
     are implemented, they can cause layout shifts. For more information, see
-    [Debugging layout shifts](https://web.dev/debugging-layout-shifts/).
+    [Debugging layout shifts](/debugging-layout-shifts/).
 *   **Fonts**: Late-loading fonts can block render and or cause layout shifts.
     This phenomena is more apparent on slow connections.
 
@@ -224,7 +224,7 @@ helpful for incorporating cookie notices into performance measurement workflows.
 However, cookies and cookie notices are just one of many factors that can be
 difficult to perfectly simulate in lab environments. For this reason, it is
 important to make [RUM
-data](https://web.dev/user-centric-performance-metrics/#how-metrics-are-measured)
+data](/user-centric-performance-metrics/#how-metrics-are-measured)
 the cornerstone of your performance benchmarking, rather than synthetic tooling.
 
 
@@ -236,7 +236,7 @@ You can use scripting to have a [WebPageTest](https://webpagetest.org/) "click"
 the cookie consent banner while collecting a trace.
 
 Add a script by going to the **Script** tab. The script below navigates to the URL
-to be tested and then clicks the DOM element with the id `cookieButton`. 
+to be tested and then clicks the DOM element with the id `cookieButton`.
 
 {% Aside 'caution' %}
 WebPageTest scripts are
@@ -265,7 +265,7 @@ When using this script be aware that:
 If you've configured this script correctly, the screenshot taken by WebPageTest
 should not show a cookie notice (the cookie notice has been accepted).
 
-For more information on WebPageTest scripting, check out [WebPageTest 
+For more information on WebPageTest scripting, check out [WebPageTest
 documentation](https://docs.webpagetest.org/scripting/).
 
 #### Set cookies
@@ -316,7 +316,7 @@ use the following
 [command](https://github.com/GoogleChrome/lighthouse#cli-options):
 
 ```shell
-lighthouse <url> --extra-headers "{\"Cookie\":\"cookie1=abc; cookie2=def; \_id=foo\"}" 
+lighthouse <url> --extra-headers "{\"Cookie\":\"cookie1=abc; cookie2=def; \_id=foo\"}"
 ```
 
 For more information on setting custom request headers in Lighthouse CLI, see
@@ -386,7 +386,7 @@ Modals can look and perform quite differently depending on their size.
 
 Smaller, partial-screen modals can be a good alternative for sites that are
 struggling to implement cookie notices in a way that doesn't cause [layout
-shifts](https://web.dev/cls/).
+shifts](/cls/).
 
 On the other hand, large modals that obscure the majority of page content should
 be used carefully. In particular, smaller sites may find that users bounce
@@ -441,7 +441,7 @@ configuring the cookie usage that they accept.
     Controls for configuring cookie usage are most commonly displayed using a
     separate modal that is launched when the user responds to the initial cookie
     consent notice. However, if space permits, some sites will display these
-    controls inline within the initial cookie consent notice. 
+    controls inline within the initial cookie consent notice.
 
 *  **Granularity:**
     The most common approach to cookie configurability is to allow users to

--- a/src/site/content/en/fast/debug-layout-shifts/index.md
+++ b/src/site/content/en/fast/debug-layout-shifts/index.md
@@ -43,8 +43,8 @@ non-Chromium browsers.
 
 #### Usage
 
-The same code [snippet](https://web.dev/cls/#measure-cls-in-javascript) that
-measures [Cumulative Layout Shift (CLS)](https://web.dev/cls/) can also
+The same code [snippet](/cls/#measure-cls-in-javascript) that
+measures [Cumulative Layout Shift (CLS)](/cls/) can also
 serve to debug layout shifts. The snippet below logs information about layout
 shifts to the console. Inspecting this log will provide you information
 about when, where, and how a layout shift occurred.
@@ -118,7 +118,7 @@ debugging layout shifts:
 | Property | Description |
 |----------|-------------|
 |`sources`| The `sources` property lists the DOM elements that moved during the layout shift. This array can contain up to five sources. In the event that there are more than five elements impacted by the layout shift, the five largest (as measured by impact on layout stability) sources of layout shift are reported. This information is reported using the LayoutShiftAttribution interface (explained in more detail below).|
-|`value`| The `value` property reports the [layout shift score](https://web.dev/cls/#layout-shift-score) for a particular layout shift.|
+|`value`| The `value` property reports the [layout shift score](/cls/#layout-shift-score) for a particular layout shift.|
 |`hadRecentInput`| The `hadRecentInput` property indicates whether a layout shift occurred within 500 milliseconds of user input.|
 |`startTime`| The `startTime` property indicates when a layout shift occurred. `startTime` is indicated in milliseconds and is measured relative to the [time that the page load was initiated](https://www.w3.org/TR/hr-time-2/#sec-time-origin).|
 |`duration`| The `duration` property will always be set to `0`. This property is inherited from the [`PerformanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) interface (the `LayoutShift` interface extends the `PerformanceEntry` interface). However, the concept of duration does not apply to layout shift events, so it is set to `0`. For information on the `PerformanceEntry` interface, refer to the [spec](https://w3c.github.io/performance-timeline/#the-performanceentry-interface).|
@@ -409,7 +409,7 @@ layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a). A common
 example of this is when DOM elements are 'animated' by incrementing properties
 like `top` or `left` rather than using CSS's
 [`transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
-property. Read [How to create high-performance CSS animations](https://web.dev/animations-guide/)
+property. Read [How to create high-performance CSS animations](/animations-guide/)
 for more information.
 
 

--- a/src/site/content/en/fast/optimize-css-background-images-with-media-queries/index.md
+++ b/src/site/content/en/fast/optimize-css-background-images-with-media-queries/index.md
@@ -119,7 +119,7 @@ For desktop devices:
 Open the optimized version of [style.css](https://use-media-queries-optimized.glitch.me/style.css) in your browser to see the changes made.
 
 {% Aside %}
-The images used in the optimized demo are already resized to fit into different screen sizes. Showing how to resize images is out of the scope of this guide, but if you want to know more about this, the [Serve responsive images guide](https://web.dev/serve-responsive-images/) covers some useful tools, like the [sharp npm package](https://www.npmjs.com/package/sharp) and the [ImageMagick CLI](https://www.imagemagick.org/script/index.php).
+The images used in the optimized demo are already resized to fit into different screen sizes. Showing how to resize images is out of the scope of this guide, but if you want to know more about this, the [Serve responsive images guide](/serve-responsive-images/) covers some useful tools, like the [sharp npm package](https://www.npmjs.com/package/sharp) and the [ImageMagick CLI](https://www.imagemagick.org/script/index.php).
 {% endAside %}
 
 ## Measure for different devices

--- a/src/site/content/en/fast/optimize-webfont-loading/index.md
+++ b/src/site/content/en/fast/optimize-webfont-loading/index.md
@@ -123,9 +123,9 @@ To work with the `font-display` property, add it to your `@font-face` rules:
 
 For more information on preloading fonts, and the `font-display` property, see the following posts:
 
-- [Avoid invisible text during font loading](https://web.dev/avoid-invisible-text/)
+- [Avoid invisible text during font loading](/avoid-invisible-text/)
 - [Controlling font performance using font-display](https://developers.google.com/web/updates/2016/02/font-display)
-- [Prevent layout shifting and flashes of invisibile text (FOIT) by preloading optional fonts](https://web.dev/preload-optional-fonts/)
+- [Prevent layout shifting and flashes of invisibile text (FOIT) by preloading optional fonts](/preload-optional-fonts/)
 
 ### The Font Loading API
 
@@ -214,6 +214,6 @@ can help automate the process of making sure that you're following web font opti
 
 The following audits can help you make sure that your pages are continuing to follow web font optimization best practices over time:
 
-* [Preload key requests](https://web.dev/uses-rel-preload/)
-* [Uses inefficient cache policy on static assets](https://web.dev/uses-long-cache-ttl/)
-* [All text remains visible during WebFont loads](https://web.dev/font-display/)
+* [Preload key requests](/uses-rel-preload/)
+* [Uses inefficient cache policy on static assets](/uses-long-cache-ttl/)
+* [All text remains visible during WebFont loads](/font-display/)

--- a/src/site/content/en/fast/rail/index.md
+++ b/src/site/content/en/fast/rail/index.md
@@ -185,9 +185,9 @@ viewability](https://www.thinkwithgoogle.com/intl/en-154/insights-inspiration/re
 
 * Optimize for fast loading performance relative to the device and network
   capabilities of your users. Currently, a good target for first loads is to
-  load the page and be [interactive](https://web.dev/interactive/) in [5 seconds
+  load the page and be [interactive](/interactive/) in [5 seconds
   or less on mid-range mobile devices with slow 3G
-  connections](https://web.dev/performance-budgets-101/#establish-a-baseline).
+  connections](/performance-budgets-101/#establish-a-baseline).
 
 * For subsequent loads, a good target is to load the page in under 2 seconds.
 
@@ -201,8 +201,8 @@ Be aware that these targets may change over time.
 
 * Test your load performance on the mobile devices and network connections that
   are common among your users. You can use [Chrome User Experience
-  Report](https://web.dev/chrome-ux-report/) to find out the [connection
-  distribution](https://web.dev/chrome-ux-report-data-studio-dashboard/#using-the-dashboard)
+  Report](/chrome-ux-report/) to find out the [connection
+  distribution](/chrome-ux-report-data-studio-dashboard/#using-the-dashboard)
   of your users. If the data is not available for your site, [The Mobile Economy
   2019](https://www.gsma.com/mobileeconomy/) suggests that a good global
   baseline is a mid-range Android phone, such as a Moto G4, and a slow 3G
@@ -211,17 +211,17 @@ Be aware that these targets may change over time.
 
 * Keep in mind that although your typical mobile user's device might claim that
   it's on a 2G, 3G, or 4G connection, in reality the [effective connection
-  speed](https://web.dev/adaptive-serving-based-on-network-quality/#how-it-works)
+  speed](/adaptive-serving-based-on-network-quality/#how-it-works)
   is often significantly slower, due to packet loss and network variance.
 
 * [Eliminate render blocking
-  resources](https://web.dev/render-blocking-resources/).
+  resources](/render-blocking-resources/).
 
 * You don't have to load everything in under 5 seconds to produce the perception
   of a complete load. Consider [lazy-loading
-  images](https://web.dev/native-lazy-loading/), [code-splitting JavaScript
-  bundles](https://web.dev/reduce-javascript-payloads-with-code-splitting/), and
-  other [optimizations suggested on web.dev](https://web.dev/fast/).
+  images](/native-lazy-loading/), [code-splitting JavaScript
+  bundles](/reduce-javascript-payloads-with-code-splitting/), and
+  other [optimizations suggested on web.dev](/fast/).
 
 {% Aside %} Recognize the factors that affect page load performance:
 
@@ -296,7 +296,7 @@ The following DevTools features are especially relevant:
 ### Lighthouse
 
 [Lighthouse](https://developers.google.com/web/tools/lighthouse) is available in
-Chrome DevTools,  at [web.dev/measure](https://web.dev/measure/), as a
+Chrome DevTools,  at [web.dev/measure](/measure/), as a
 Chrome Extension, as a Node.js module, and within WebPageTest. You give it a
 URL, it simulates a mid-range device with a slow 3G connection, runs a series of
 audits on the page, and then gives you a report on load performance, as well as
@@ -307,13 +307,13 @@ The following audits are especially relevant:
 **Response**
 
 * [Max Potential First Input
-  Delay](https://web.dev/lighthouse-max-potential-fid/). Estimates how long your
+  Delay](/lighthouse-max-potential-fid/). Estimates how long your
   app will take to respond to user input, based on main thread idle time.
 
 * [Does not use passive listeners to improve scrolling
-  performance](https://web.dev/uses-passive-event-listeners/).
+  performance](/uses-passive-event-listeners/).
 
-* [Total Blocking Time](https://web.dev/lighthouse-total-blocking-time/).
+* [Total Blocking Time](/lighthouse-total-blocking-time/).
   Measures the total amount of time that a page is blocked from responding to
   user input, such as mouse clicks, screen taps, or keyboard presses.
 
@@ -324,34 +324,34 @@ The following audits are especially relevant:
 **Load**
 
 * [Does not register a service worker that controls page and
-  start_url](https://web.dev/service-worker/). A service worker can cache common
+  start_url](/service-worker/). A service worker can cache common
   resources on a user's device, reducing time spent fetching resources over the
   network.
 
 * [Page load is not fast enough on mobile
-  networks](https://web.dev/load-fast-enough-for-pwa/).
+  networks](/load-fast-enough-for-pwa/).
 
 * [Eliminate render-blocking
   resources](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).
 
-* [Defer offscreen images](https://web.dev/offscreen-images/). Defer the loading
+* [Defer offscreen images](/offscreen-images/). Defer the loading
   of offscreen images until they're needed.
 
-* [Properly size images](https://web.dev/uses-responsive-images/). Don't serve
+* [Properly size images](/uses-responsive-images/). Don't serve
   images that are significantly larger than the size that's rendered in the
   mobile viewport.
 
-* [Avoid chaining critical requests](https://web.dev/critical-request-chains/).
+* [Avoid chaining critical requests](/critical-request-chains/).
 
-* [Does not use HTTP/2 for all of its resources](https://web.dev/uses-http2/).
+* [Does not use HTTP/2 for all of its resources](/uses-http2/).
 
-* [Efficiently encode images](https://web.dev/uses-optimized-images/).
+* [Efficiently encode images](/uses-optimized-images/).
 
-* [Enable text compression](https://web.dev/uses-text-compression/).
+* [Enable text compression](/uses-text-compression/).
 
-* [Avoid enormous network payloads](https://web.dev/total-byte-weight/).
+* [Avoid enormous network payloads](/total-byte-weight/).
 
-* [Avoid an excessive DOM size](https://web.dev/dom-size/). Reduce network bytes
+* [Avoid an excessive DOM size](/dom-size/). Reduce network bytes
   by only shipping DOM nodes that are needed for rendering the page.
 
 ### WebPageTest

--- a/src/site/content/en/fast/reduce-webfont-size/index.md
+++ b/src/site/content/en/fast/reduce-webfont-size/index.md
@@ -109,7 +109,7 @@ Instead of needing to load the regular and bold styles plus their italic version
 you can load a single file that contains all of the information.
 
 Variable fonts are now supported by all modern browsers,
-find out more in the [Introduction to variable fonts on the web](https://web.dev/variable-fonts/).
+find out more in the [Introduction to variable fonts on the web](/variable-fonts/).
 
 ### Select the right format
 
@@ -357,4 +357,4 @@ formats. Make sure to apply GZIP compression to the EOT and TTF formats, because
 compressed by default.
 - **Give precedence to `local()` in your `src` list:** listing `local('Font Name')` first in your
 `src` list ensures that HTTP requests aren't made for fonts that are already installed.
-- **Use [Lighthouse](https://developers.google.com/web/tools/lighthouse)** to test for [text compression](https://web.dev/uses-text-compression/).
+- **Use [Lighthouse](https://developers.google.com/web/tools/lighthouse)** to test for [text compression](/uses-text-compression/).

--- a/src/site/content/en/fast/signed-exchanges/index.md
+++ b/src/site/content/en/fast/signed-exchanges/index.md
@@ -282,7 +282,7 @@ proxy](https://en.wikipedia.org/wiki/Reverse_proxy) for serving SXGs. Given a
 URL, `webpkgserver` will fetch the URL's contents, package them as an SXG, and
 serve the SXG in response. For instructions on setting up the Web Packager
 server, see [How to set up signed exchanges using Web
-Packager](http://web.dev/signed-exchanges-webpackager).
+Packager](/signed-exchanges-webpackager).
 
 In production, `webpkgserver` should not use a public endpoint. Instead, the
 frontend web server should forward SXG requests to `webpkgserver`. These
@@ -304,7 +304,7 @@ options, you can also choose to build your own SXG generator.
 
   The NGINX SXG module only works with `CanSignHttpExchanges` certificates.
   Setup instructions can be found
-  [here](https://web.dev/how-to-set-up-signed-http-exchanges/).
+  [here](/how-to-set-up-signed-http-exchanges/).
 
 
 - `libsxg`
@@ -328,5 +328,5 @@ options, you can also choose to build your own SXG generator.
 
 *   [Spec draft](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html)
 *   [Explainer](https://github.com/WICG/webpackage/blob/master/explainer.md)
-*   [How to set up Signed Exchanges using Web Packager](https://web.dev/signed-exchanges-webpackager)
+*   [How to set up Signed Exchanges using Web Packager](/signed-exchanges-webpackager)
 *   [Demo of Signed Exchanges](https://signed-exchange-testing.dev/)

--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -403,7 +403,7 @@ to avoid confusion.
 
 The URL of a page should not be overly general, unless that page is our
 authoritative content on that topic. For example, the URL of
-[Introducing `<model-viewer>` 1.1](https://web.dev/introducing-model-viewer/)
+[Introducing `<model-viewer>` 1.1](/introducing-model-viewer/)
 is `https://web.dev/introducing-model-viewer/` because we wanted to reserve
 `https://web.dev/model-viewer/` for our authoritative guide on that topic.
 

--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -43,7 +43,7 @@ Paste the copied code from the previous step into your article.
 
 Be sure to replace the text that says "ALT_TEXT_HERE" with your own description
 of the image. You can read more about writing effective alt text over on [the
-web.dev handbook](https://web.dev/handbook/inclusion-and-accessibility/#use-inclusive-images).
+web.dev handbook](/handbook/inclusion-and-accessibility/#use-inclusive-images).
 
 {% Aside %}
 You may notice that the generated code is using either the
@@ -99,7 +99,7 @@ directly.
 ```
 ## Captions
 
-To include a caption along with an image, use `<figure>` with `<figcaption>` and 
+To include a caption along with an image, use `<figure>` with `<figcaption>` and
 place the shortcode snippet inside:
 
 ```md
@@ -117,7 +117,7 @@ place the shortcode snippet inside:
 ```
 
 <figure class="w-figure">
-{% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/QlgeHQrzaD9IOKBXB68I.jpg", 
+{% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/QlgeHQrzaD9IOKBXB68I.jpg",
 alt="ALT_TEXT_HERE", width="380", height="240" %}
   <figcaption class="w-figcaption">
     A good boy.

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -35,7 +35,7 @@ If the piece you'd like to publish is time sensitive, make sure to submit the is
 1. After you get approval from a web.dev team member that your content can be published on the site,
    submit a GitHub pull request.
 1. Check out the [web.dev markup section](/handbook/#web.dev-markup) to learn how to make your markdown squeaky clean.
-   In particular, check out the [web.dev components](https://web.dev/handbook/web-dev-components/) guide
+   In particular, check out the [web.dev components](/handbook/web-dev-components/) guide
    to discover UI elements that can make your content more engaging or aesthetically pleasing.
 1. Once your PR is merged, the content will be deployed to the site immediately.
 
@@ -55,7 +55,7 @@ If applicable, launch translation process for this content by emailing web.dev@.
 
 ### Tags
 
-Tags are used to categorize articles and also to generate [web.dev/tags](https://web.dev/tags/) pages.
+Tags are used to categorize articles and also to generate [web.dev/tags](/tags/) pages.
 The canonical list of tags is published in [tagsData.json](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_data/tagsData.json) on Github.
 
 - to add a new tag, add it first to `tagsData.json`

--- a/src/site/content/en/handbook/yaml-front-matter/index.md
+++ b/src/site/content/en/handbook/yaml-front-matter/index.md
@@ -33,7 +33,7 @@ authors:
 
 Author avatars appear underneath the page title.
 Clicking an author's avatar takes you to a page where you can see all of that author's
-content. See [Pete LePage](https://web.dev/authors/petelepage/) for an example.
+content. See [Pete LePage](/authors/petelepage/) for an example.
 
 See [Author profile](/handbook/author-profile/) to learn how to add a new author.
 
@@ -155,7 +155,7 @@ hero: image/admin/tyBs8QP5pbMVpY3yp1dM.jpg
 See [Hero images](/handbook/markup-media/#hero).
 
 <figure class="w-figure">
-  <img class="w-screenshot w-screenshot--filled" 
+  <img class="w-screenshot w-screenshot--filled"
        src="hero.jpg"
        alt="A page with a hero image.">
 </figure>
@@ -284,7 +284,7 @@ A page's full list of tags is shown at the bottom of its main content:
 
 ### Supported keywords {: #supported-keywords }
 
-Make sure tags added to the page are listed in 
+Make sure tags added to the page are listed in
 [`tagsData.json`](https://github.com/GoogleChrome/web.dev/blob/master/src/site/_data/tagsData.json).
 
 ## `thumbnail`: present a slightly different version of the hero on the homepages {: #thumbnail }
@@ -304,7 +304,7 @@ cropping, or rearranging the hero image's content is OK. Using a completely
 different image is not OK.
 
 <figure class="w-figure">
-  <img class="w-screenshot w-screenshot--filled" 
+  <img class="w-screenshot w-screenshot--filled"
        src="thumbnail.jpg"
        alt="A page with a thumbnail that's different from its hero.">
   <figcaption>
@@ -313,7 +313,7 @@ different image is not OK.
 </figure>
 
 <figure class="w-figure">
-  <img class="w-screenshot w-screenshot--filled" 
+  <img class="w-screenshot w-screenshot--filled"
        src="hero.jpg"
        alt="The page's hero image.">
 </figure>
@@ -329,7 +329,7 @@ title: Web developer tools for debugging JavaScript issues in Google Search
 ```
 
 <figure class="w-figure">
-  <img class="w-screenshot w-screenshot--filled" 
+  <img class="w-screenshot w-screenshot--filled"
        src="hero.jpg"
        alt="A screenshot of a page's title.">
 </figure>

--- a/src/site/content/en/lighthouse-accessibility/accessibility-scoring/index.md
+++ b/src/site/content/en/lighthouse-accessibility/accessibility-scoring/index.md
@@ -20,7 +20,7 @@ but others don't, the page gets a 0 for the
 
 The following table shows the weighting for each accessibility audit.
 More heavily weighted audits have a bigger effect on your score.
-[Manual audits](https://web.dev/lighthouse-accessibility/#additional-items-to-manually-check)
+[Manual audits](/lighthouse-accessibility/#additional-items-to-manually-check)
 aren't included in the table because they don't affect your score.
 
 <div class="w-table-wrapper">

--- a/src/site/content/en/lighthouse-accessibility/aria-name/index.md
+++ b/src/site/content/en/lighthouse-accessibility/aria-name/index.md
@@ -66,7 +66,7 @@ to assistive technology users:
 Using the [clip pattern](https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/) you can hide the inner text on screen, but still have it announced by assistive technology. This can be especially handy if you translate your pages for localization.
 
 ```html
-<a href="https://web.dev/accessible">Learn more <span class="visually-hidden">about accessibility on web.dev</span></a>
+<a href="/accessible">Learn more <span class="visually-hidden">about accessibility on web.dev</span></a>
 ```
 
 ### Option 2: Add an `aria-label` attribute to the element

--- a/src/site/content/en/lighthouse-performance/unused-javascript/index.md
+++ b/src/site/content/en/lighthouse-performance/unused-javascript/index.md
@@ -83,7 +83,7 @@ bundling](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/js-b
 ### React
 
 If you are not server-side rendering, [split your JavaScript
-bundles](https://web.dev/code-splitting-suspense/) with `React.lazy()`.
+bundles](/code-splitting-suspense/) with `React.lazy()`.
 Otherwise, code-split using a third-party library such as
 [loadable-components](https://www.smooth-code.com/open-source/loadable-components/docs/getting-started/).
 

--- a/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-responsive-images/index.md
@@ -59,7 +59,7 @@ either when you upload an image, or request it from your page.
 Use the
 [`amp-img`](https://amp.dev/documentation/components/amp-img/?format=websites)
 component's support for
-[`srcset`](https://web.dev/use-srcset-to-automatically-choose-the-right-image/)
+[`srcset`](/use-srcset-to-automatically-choose-the-right-image/)
 to specify which image assets to use based on the screen size. See
 also [Responsive images with srcset, sizes &
 heights](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction/).

--- a/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
+++ b/src/site/content/en/lighthouse-pwa/installable-manifest/index.md
@@ -83,4 +83,4 @@ Check their respective sites for full details:
 - [Add a web app manifest](/add-manifest/)
 - [Discover what it takes to be installable](/discover-installable)
 - [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)
-- [Does not use HTTPS](https://web.dev/is-on-https/)
+- [Does not use HTTPS](/is-on-https/)

--- a/src/site/content/en/media/video-and-source-tags/index.md
+++ b/src/site/content/en/media/video-and-source-tags/index.md
@@ -211,7 +211,7 @@ You can control video dimensions using CSS. If CSS does not meat all of your
 needs, JavaScript libraries and plugins such as [FitVids](http://fitvidsjs.com/)
 (outside the scope of this article) can help, even for videos from YouTube and
 other sources. Unfortunately, these resources can increase your [network payload
-sizes](https://web.dev/total-byte-weight/) with negative consequences for your
+sizes](/total-byte-weight/) with negative consequences for your
 revenues and your users' wallets.
 
 For simple uses like the ones I'm describing here, use [CSS media

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -403,7 +403,7 @@ few guiding principles:
   from state to state.
 
 For a deep dive on how to improve CLS, see [Optimize
-CLS](https://web.dev/optimize-cls/).
+CLS](/optimize-cls/).
 
 ## Additional resources
 

--- a/src/site/content/en/payments/android-payment-apps-delegation/index.md
+++ b/src/site/content/en/payments/android-payment-apps-delegation/index.md
@@ -21,9 +21,9 @@ rate.
 That's why the Payment Request API supports a feature to request shipping
 address and contact information. This provides multiple benefits:
 
-* Users can pick the right address with just a few taps.    
+* Users can pick the right address with just a few taps.
 * The address is always returned in [the standardized
-  format](https://w3c.github.io/payment-request/#paymentaddress-interface).    
+  format](https://w3c.github.io/payment-request/#paymentaddress-interface).
 * Submitting an incorrect address is less likely.
 
 This functionality can be deferred to a payment app to offer a unified payment
@@ -51,7 +51,7 @@ option.
 
 {% Aside %}
 Learn how to implement an [Android payment
-app](https://web.dev/android-payment-apps-developers-guide/) in advance.
+app](/android-payment-apps-developers-guide/) in advance.
 {% endAside %}
 
 To add delegation support to an already existing Android payment app,
@@ -83,7 +83,7 @@ app. Declare the supported delegations as a `<meta-data>` in your app's
 </activity>
 ```
 
-`<resource>` must be a list of strings chosen from the following valid values: 
+`<resource>` must be a list of strings chosen from the following valid values:
 
 ```json
 [ "payerName", "payerEmail", "payerPhone", "shippingAddress" ]
@@ -201,7 +201,7 @@ To do so the following parameters must be specified as Intent extras:
     * `recipient`
     * `region`
     * `sortingCode`
-    * `addressLine`  
+    * `addressLine`
   All keys other than the `addressLine` have string values. The `addressLine`
   is an array of strings.
 * `shippingOptionId` - The identifier of the user-selected shipping option. This

--- a/src/site/content/en/payments/setting-up-a-payment-method/index.md
+++ b/src/site/content/en/payments/setting-up-a-payment-method/index.md
@@ -205,7 +205,7 @@ documentation](https://github.com/w3c/payment-request-info/wiki/PaymentMethodPra
 
 A [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) is
 used to define a web app as the name suggests. It's a widely used manifest file
-to [define a Progressive Web App (PWA)](https://web.dev/add-manifest/).
+to [define a Progressive Web App (PWA)](/add-manifest/).
 
 Typical web app manifest would look like this:
 

--- a/src/site/content/en/progressive-web-apps/app-like-pwas/index.md
+++ b/src/site/content/en/progressive-web-apps/app-like-pwas/index.md
@@ -13,7 +13,7 @@ tags:
   - capabilities
 ---
 
-When you play Progressive Web App buzzword bingo, it is a safe bet to set on "PWAs are just websites". Microsoft's PWA documentation [agrees](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/#progressive-web-apps-on-windows:~:text=PWAs%20are%20just%20websites), we [say it](https://web.dev/progressive-web-apps/#content:~:text=Progressive%20Web%20Apps,Websites) on this very site, and even PWA nominators Frances Berriman and Alex Russell [write so](https://infrequently.org/2015/06/progressive-apps-escaping-tabs-without-losing-our-soul/#post-2263:~:text=they%E2%80%99re%20just%20websites), too. Yes, PWAs are just websites, but they are also way more than that. If done right, a PWA will not feel like a website, but like a "real" app. Now what does it mean to feel like a real app?
+When you play Progressive Web App buzzword bingo, it is a safe bet to set on "PWAs are just websites". Microsoft's PWA documentation [agrees](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/#progressive-web-apps-on-windows:~:text=PWAs%20are%20just%20websites), we [say it](/progressive-web-apps/#content:~:text=Progressive%20Web%20Apps,Websites) on this very site, and even PWA nominators Frances Berriman and Alex Russell [write so](https://infrequently.org/2015/06/progressive-apps-escaping-tabs-without-losing-our-soul/#post-2263:~:text=they%E2%80%99re%20just%20websites), too. Yes, PWAs are just websites, but they are also way more than that. If done right, a PWA will not feel like a website, but like a "real" app. Now what does it mean to feel like a real app?
 
 In order to answer this question, let me use the Apple [Podcasts](https://support.apple.com/en-us/HT201859) app as an example.
 It is available on macOS on desktop and on iOS (and iPadOS respectively) on mobile.
@@ -68,16 +68,16 @@ and are displayed with all metadata like artwork and descriptions.
   Previously downloaded media content can be served from the cache, for example using the
   <a href="https://developers.google.com/web/tools/workbox/guides/advanced-recipes#cached-av">Serve cached audio and video</a>
   recipe from the <a href="https://developers.google.com/web/tools/workbox">Workbox</a> library.
-  Other content can always be stored in the cache, or in IndexedDB. Read the article <a href="https://web.dev/storage-for-the-web/">Storage for the web</a>
+  Other content can always be stored in the cache, or in IndexedDB. Read the article <a href="/storage-for-the-web/">Storage for the web</a>
   for all details and to know when to use what storage technology.
   If you have data that should be persistently stored without the risk of being purged when the
   available amount of memory gets low, you can use the
-  <a href="https://web.dev/persistent-storage/">Persistent Storage API</a>.
+  <a href="/persistent-storage/">Persistent Storage API</a>.
 {% endDetails %}
 
 ## Proactive background downloading
 
-When I am back online, I can of course search for content with a query like `http 203`, and when I decide to subscribe to the search result, the [HTTP 203 podcast](https://web.dev/podcasts/), the latest episode of the series is immediately downloaded, no questions asked.
+When I am back online, I can of course search for content with a query like `http 203`, and when I decide to subscribe to the search result, the [HTTP 203 podcast](/podcasts/), the latest episode of the series is immediately downloaded, no questions asked.
 
 <figure class="w-figure">
   <img src="./image10.png" alt="The Podcasts app downloading the latest episode of a podcast immediately after subscribing." width="600">
@@ -106,13 +106,13 @@ The Podcasts app integrates naturally with other applications. For example, when
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/web-share/">Web Share API</a> and the <a href="https://web.dev/web-share-target/">Web Share Target API</a>
+  The <a href="/web-share/">Web Share API</a> and the <a href="/web-share-target/">Web Share Target API</a>
   allow your app to share and receive texts, files, and links to and from other applications on the device.
   Although it is not yet possible for a web app to add menu items to the operating system's built-in right-click menu, there are lots of other ways to link to and from other apps on the device.
-  With the <a href="https://web.dev/image-support-for-async-clipboard/">Async Clipboard API</a>, you can programmatically read and write
+  With the <a href="/image-support-for-async-clipboard/">Async Clipboard API</a>, you can programmatically read and write
   text and image data (PNG images) to the system clipboard.
-  On Android, you can use the <a href="https://web.dev/contact-picker/">Contact Picker API</a> to select entries from the device's contacts manager.
-  If you offer both a platform-specific app and a PWA, you can use the <a href="https://web.dev/get-installed-related-apps/">Get Installed Related Apps API</a>
+  On Android, you can use the <a href="/contact-picker/">Contact Picker API</a> to select entries from the device's contacts manager.
+  If you offer both a platform-specific app and a PWA, you can use the <a href="/get-installed-related-apps/">Get Installed Related Apps API</a>
   to check if the platform-specific app is installed, in which case you do not need to encourage the user to install the PWA or accept web push notifications.
 {% endDetails %}
 
@@ -129,7 +129,7 @@ In the Podcasts app's settings, I can configure the app to download new episodes
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/periodic-background-sync/">Periodic Background Sync API</a>
+  The <a href="/periodic-background-sync/">Periodic Background Sync API</a>
   allows your app to refresh its content regularly in the background without the need for it to be running.
   This means new content is proactively available, so your users can start delving into it right away whenever they decide.
 {% endDetails %}
@@ -164,7 +164,7 @@ There is no need to switch to the app just to skip forward or backward.
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  Media keys are supported by the <a href="https://web.dev/media-session/">Media Session API</a>.
+  Media keys are supported by the <a href="/media-session/">Media Session API</a>.
   Like that, users can make use of the hardware media keys on their physical keyboards, headphones, or even control the web app
   from the software media keys on their smartwatches.
   An additional idea to smooth seeking operations is to send a
@@ -187,7 +187,7 @@ Of course I can always multitask back to the Podcasts app from anywhere. The app
 {% endDetailsSummary %}
   Progressive Web Apps on both desktop and mobile can be installed to the home screen, start menu, or application dock.
   Installation can happen based on a proactive prompt, or fully controlled by the app developer.
-  The article <a href="https://web.dev/install-criteria/">What does it take to be installable?</a> covers everything you need to know.
+  The article <a href="/install-criteria/">What does it take to be installable?</a> covers everything you need to know.
   When multitasking, PWAs appear independent from the browser.
 {% endDetails %}
 
@@ -204,7 +204,7 @@ The most common app actions, **Search** for new content and **Check for New Epis
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  By specifying <a href="https://web.dev/app-shortcuts/">app icon shortcuts</a>
+  By specifying <a href="/app-shortcuts/">app icon shortcuts</a>
   in the PWA's web app manifest, you can register quick routes to common tasks that users can reach directly from the app icon.
   On operating systems like macOS, users can also right-click the app icon and set the app to launch at login time.
   There is ongoing work on a proposal for <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/RunOnLogin/Explainer.md">run on login</a>.
@@ -242,7 +242,7 @@ Other storage mechanisms than files are referenced in the [offline content](#off
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/file-system-access/">File System Access API</a> enables developers to get access to the local file system
+  The <a href="/file-system-access/">File System Access API</a> enables developers to get access to the local file system
   of the device. You can use it directly or via the <a href="https://github.com/GoogleChromeLabs/browser-fs-access">browser-fs-access</a>
   support library that transparently provides a fallback for browsers that do not support the API.
   For security reasons, system directories are not web-accessible.
@@ -275,7 +275,7 @@ There is a more subtle thing that is self-evident for an iOS application like Po
   The <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#<generic-name>:~:text=system%2Dui,-Glyphs"><code>system-ui</code></a>
   value for the <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/font-family"><code>font-family</code></a> CSS property allows you to
   specify the default UI font of the system to be used for your app.
-  Finally, your app can obey to the user's color scheme preference by respecting their <a href="https://web.dev/prefers-color-scheme/"><code>prefers-color-scheme</code></a> choice, with an optional <a href="https://github.com/GoogleChromeLabs/dark-mode-toggle">dark mode toggle</a>
+  Finally, your app can obey to the user's color scheme preference by respecting their <a href="/prefers-color-scheme/"><code>prefers-color-scheme</code></a> choice, with an optional <a href="https://github.com/GoogleChromeLabs/dark-mode-toggle">dark mode toggle</a>
   to override it.
   Another thing to decide on might be what the browser should do when reaching
   the boundary of a scrolling area, for example, to implement custom <em>pull to refresh</em>.
@@ -301,8 +301,8 @@ When you look at the Podcasts app window, you notice that it does not have a cla
   How to do this on the web
 {% endDetailsSummary %}
   While not currently possible, <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/TitleBarCustomization/explainer.md">title bar customization</a> is being worked on at the moment.
-  You can (and should), however, specify the <a href="https://web.dev/add-manifest/#display"><code>display</code></a> and the
-  <a href="https://web.dev/add-manifest/#theme-color"><code>theme-color</code></a> properties of the web app manifest to
+  You can (and should), however, specify the <a href="/add-manifest/#display"><code>display</code></a> and the
+  <a href="/add-manifest/#theme-color"><code>theme-color</code></a> properties of the web app manifest to
   determine the look and feel of your application window and to decide which default browser controls—potentially none of them—should be shown.
 {% endDetails %}
 
@@ -338,7 +338,7 @@ The Podcasts app on iOS can surface content in other locations than the actual a
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/content-indexing-api/">Content Index API</a> allows your application
+  The <a href="/content-indexing-api/">Content Index API</a> allows your application
   to tell the browser which content of the PWA is available offline.
   This allows the browser to surface this content outside of the main app.
   By marking up interesting content in your app as suitable for <a href="https://developers.google.com/search/docs/data-types/speakable">speakable</a>
@@ -359,7 +359,7 @@ When a podcast episode is playing, the Podcasts app shows a beautiful control wi
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/media-session/">Media Session API</a> lets you specify metadata like artwork, track titles, etc.
+  The <a href="/media-session/">Media Session API</a> lets you specify metadata like artwork, track titles, etc.
   that then gets displayed on the lock screen, smartwatches, or other media widgets in the browser.
 {% endDetails %}
 
@@ -382,7 +382,7 @@ For example, the iOS Podcasts app can optionally notify me of new episodes of po
   The <a href="https://developers.google.com/web/fundamentals/push-notifications">Push API</a>
   allows your app to receive push notifications so you can notify your users about noteworthy events around your PWA.
   For notifications that should fire at a known time in the future and that do not require a network connection,
-  you can use the <a href="https://web.dev/notification-triggers/">Notification Triggers API</a>.
+  you can use the <a href="/notification-triggers/">Notification Triggers API</a>.
 {% endDetails %}
 
 ## App icon badging
@@ -398,7 +398,7 @@ Whenever there are new episodes available for one of the podcasts I am subscribe
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  You can set app icon badges with the <a href="https://web.dev/badging-api/">Badging API</a>.
+  You can set app icon badges with the <a href="/badging-api/">Badging API</a>.
   This is especially useful when your PWA has some notion of "unread" items or when you need a means
   to unobtrusively draw the user's attention back to the app.
 {% endDetails %}
@@ -417,7 +417,7 @@ Apps can optionally keep the screen awake, too, for example to display lyrics or
 {% DetailsSummary %}
   How to do this on the web
 {% endDetailsSummary %}
-  The <a href="https://web.dev/wakelock/">Screen Wake Lock API</a> allows you to prevent the screen from turning off.
+  The <a href="/wakelock/">Screen Wake Lock API</a> allows you to prevent the screen from turning off.
   Media playback on the web automatically prevents the system from entering standby mode.
 {% endDetails %}
 
@@ -436,7 +436,7 @@ A quick search for `podcast`, `podcasts`, or `apple podcasts` immediately turns 
   How to do this on the web
 {% endDetailsSummary %}
   While Apple does not allow PWAs on the App Store, on Android, you can submit your PWA
-  <a href="https://web.dev/using-a-pwa-in-your-android-app/">wrapped in a Trusted Web Activity</a>.
+  <a href="/using-a-pwa-in-your-android-app/">wrapped in a Trusted Web Activity</a>.
   The <a href="https://github.com/GoogleChromeLabs/bubblewrap"><code>bubblewrap</code></a> script makes this a painless operation.
   This script is also what internally powers <a href="https://www.pwabuilder.com/">PWABuilder</a>'s Android app export feature,
   which you can use without touching the command line.
@@ -478,8 +478,8 @@ The table below shows a compact overview of all features and provides a list of 
               >
             </li>
             <li><a href="https://developers.google.com/web/tools/workbox">Workbox library</a></li>
-            <li><a href="https://web.dev/storage-for-the-web/">Storage API</a></li>
-            <li><a href="https://web.dev/persistent-storage/">Persistent Storage API</a></li>
+            <li><a href="/storage-for-the-web/">Storage API</a></li>
+            <li><a href="/persistent-storage/">Persistent Storage API</a></li>
           </ul>
         </td>
       </tr>
@@ -499,14 +499,14 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#sharing-to-and-interacting-with-other-applications">Sharing to and interacting with other applications</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/web-share/">Web Share API</a></li>
-            <li><a href="https://web.dev/web-share-target/">Web Share Target API</a></li>
+            <li><a href="/web-share/">Web Share API</a></li>
+            <li><a href="/web-share-target/">Web Share Target API</a></li>
             <li>
-              <a href="https://web.dev/image-support-for-async-clipboard/">Async Clipboard API</a>
+              <a href="/image-support-for-async-clipboard/">Async Clipboard API</a>
             </li>
-            <li><a href="https://web.dev/contact-picker/">Contact Picker API</a></li>
+            <li><a href="/contact-picker/">Contact Picker API</a></li>
             <li>
-              <a href="https://web.dev/get-installed-related-apps/"
+              <a href="/get-installed-related-apps/"
                 >Get Installed Related Apps API</a
               >
             </li>
@@ -518,7 +518,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td>
           <ul>
             <li>
-              <a href="https://web.dev/periodic-background-sync/">Periodic Background Sync API</a>
+              <a href="/periodic-background-sync/">Periodic Background Sync API</a>
             </li>
           </ul>
         </td>
@@ -539,7 +539,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#hardware-media-key-controls">Hardware media key controls</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/media-session/">Media Session API</a></li>
+            <li><a href="/media-session/">Media Session API</a></li>
           </ul>
         </td>
       </tr>
@@ -547,7 +547,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#multitasking-and-app-shortcut">Multitasking and app shortcut</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/install-criteria/">Installability criteria</a></li>
+            <li><a href="/install-criteria/">Installability criteria</a></li>
           </ul>
         </td>
       </tr>
@@ -555,7 +555,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#quick-actions-in-context-menu">Quick actions in context menu</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/app-shortcuts/">App icon shortcuts</a></li>
+            <li><a href="/app-shortcuts/">App icon shortcuts</a></li>
             <li>
               <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/tree/master/RunOnLogin"
                 >Run on login</a
@@ -587,7 +587,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#local-file-system-integration">Local file system integration</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/file-system-access/">File System Access API</a></li>
+            <li><a href="/file-system-access/">File System Access API</a></li>
             <li>
               <a href="https://github.com/GoogleChromeLabs/browser-fs-access"
                 >browser-fs-access library</a
@@ -612,7 +612,7 @@ The table below shows a compact overview of all features and provides a list of 
               >
             </li>
             <li>
-              <a href="https://web.dev/prefers-color-scheme/"><code>prefers-color-scheme</code></a>
+              <a href="/prefers-color-scheme/"><code>prefers-color-scheme</code></a>
             </li>
             <li>
               <a href="https://github.com/GoogleChromeLabs/dark-mode-toggle">Dark mode toggle</a>
@@ -630,8 +630,8 @@ The table below shows a compact overview of all features and provides a list of 
                 >Title bar customization</a
               > (early stage)
             </li>
-            <li><a href="https://web.dev/add-manifest/#display">Display mode</a></li>
-            <li><a href="https://web.dev/add-manifest/#theme-color">Theme color</a></li>
+            <li><a href="/add-manifest/#display">Display mode</a></li>
+            <li><a href="/add-manifest/#theme-color">Theme color</a></li>
           </ul>
         </td>
       </tr>
@@ -662,7 +662,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#content-surfaced-outside-of-app">Content surfaced outside of app</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/content-indexing-api/">Content Index API</a></li>
+            <li><a href="/content-indexing-api/">Content Index API</a></li>
             <li>
               <a href="https://developers.google.com/search/docs/data-types/speakable"
                 >Speakable content</a
@@ -680,7 +680,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#lock-screen-media-control-widget">Lock screen media control widget</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/media-session/">Media Session API</a></li>
+            <li><a href="/media-session/">Media Session API</a></li>
           </ul>
         </td>
       </tr>
@@ -693,7 +693,7 @@ The table below shows a compact overview of all features and provides a list of 
                 >Push API</a
               >
             </li>
-            <li><a href="https://web.dev/notification-triggers/">Notification Triggers API</a></li>
+            <li><a href="/notification-triggers/">Notification Triggers API</a></li>
           </ul>
         </td>
       </tr>
@@ -701,7 +701,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#app-icon-badging">App icon badging</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/badging-api/">Badging API</a></li>
+            <li><a href="/badging-api/">Badging API</a></li>
           </ul>
         </td>
       </tr>
@@ -709,7 +709,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td><a href="#media-playback-takes-precedence-over-energy-saver-settings">Media playback trumps energy saver settings</a></td>
         <td>
           <ul>
-            <li><a href="https://web.dev/wakelock/">Screen Wake Lock API</a></li>
+            <li><a href="/wakelock/">Screen Wake Lock API</a></li>
           </ul>
         </td>
       </tr>
@@ -718,7 +718,7 @@ The table below shows a compact overview of all features and provides a list of 
         <td>
           <ul>
             <li>
-              <a href="https://web.dev/using-a-pwa-in-your-android-app/">Trusted Web Activity</a>
+              <a href="/using-a-pwa-in-your-android-app/">Trusted Web Activity</a>
             </li>
             <li>
               <a href="https://github.com/GoogleChromeLabs/bubblewrap"
@@ -745,12 +745,12 @@ how your app is built (and why should they?), as long as it feels like a *real* 
 ## Acknowledgements
 
 This article was reviewed by
-[Kayce Basques](https://web.dev/authors/kaycebasques/),
-[Joe Medley](https://web.dev/authors/joemedley/),
+[Kayce Basques](/authors/kaycebasques/),
+[Joe Medley](/authors/joemedley/),
 [Joshua Bell](https://github.com/inexorabletash),
 [Dion Almaer](https://blog.almaer.com/),
 [Ade Oshineye](http://www.oshineye.com/),
-[Pete LePage](https://web.dev/authors/petelepage/),
-[Sam Thorogood](https://web.dev/authors/samthor/),
+[Pete LePage](/authors/petelepage/),
+[Sam Thorogood](/authors/samthor/),
 [Reilly Grant](https://github.com/reillyeon),
 and [Jeffrey Yasskin](https://github.com/jyasskin).

--- a/src/site/content/en/progressive-web-apps/define-install-strategy/index.md
+++ b/src/site/content/en/progressive-web-apps/define-install-strategy/index.md
@@ -18,7 +18,7 @@ In the past, app installs were only possible in the context of platform-specific
 
 You can achieve this in different ways:
 
-- Installing the PWA [from the browser](https://web.dev/customize-install/).
+- Installing the PWA [from the browser](/customize-install/).
 - Installing the PWA [from the app store](https://developers.google.com/web/android/trusted-web-activity).
 
 Having different distribution channels is a powerful way of reaching a broad number of users, but choosing the right strategy to promote them can be challenging.
@@ -50,7 +50,7 @@ In this section we'll explore different ways of maximizing the installation rate
 
 ### PWA as primary installable experience
 
-Once a PWA meets the [installability criteria](https://web.dev/install-criteria/), most browsers will show an indication that the PWA is installable. For example, Desktop Chrome will show an installable icon in the address bar, and on mobile, it will show a mini-infobar:
+Once a PWA meets the [installability criteria](/install-criteria/), most browsers will show an indication that the PWA is installable. For example, Desktop Chrome will show an installable icon in the address bar, and on mobile, it will show a mini-infobar:
 
 <figure class="w-figure w-figure--inline-right">
   <img src="a2hs-infobar.png" alt="Standard Chrome install prompt called mini-infobar">
@@ -59,7 +59,7 @@ Once a PWA meets the [installability criteria](https://web.dev/install-criteria/
   </figcaption>
 </figure>
 
-While that may be enough for some experiences, if your goal is to drive installations of your PWA, we highly recommend you listen for the [`BeforeInstallPromptEvent`](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent), and follow the [patterns for promoting the installation](https://web.dev/promote-install/) of your PWA.
+While that may be enough for some experiences, if your goal is to drive installations of your PWA, we highly recommend you listen for the [`BeforeInstallPromptEvent`](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent), and follow the [patterns for promoting the installation](/promote-install/) of your PWA.
 
 
 ## Prevent your PWA from cannibalizing your platform-specific app install rate
@@ -75,7 +75,7 @@ Then, the heuristic can be implemented in the following way:
 1. Show the platform-specific app install banner.
 1. If a user dismisses the banner, set a cookie with that information (e.g. `document.cookie = "app-install-banner=dismissed"`).
 1. Use another cookie to track the number of user visits to the site (e.g. `document.cookie = "user-visits=1"`).
-1. Write a function, such as `isPWAUser()`, that uses the information previously stored in the cookies along with the [`getInstalledRelatedApps()`](https://web.dev/get-installed-related-apps/) API to determine if a user is considered a "PWA user".
+1. Write a function, such as `isPWAUser()`, that uses the information previously stored in the cookies along with the [`getInstalledRelatedApps()`](/get-installed-related-apps/) API to determine if a user is considered a "PWA user".
 1. At the moment when the user performs a meaningful action, call `isPWAUser()`. If the function returns true and the PWA install prompt was saved previously, you can show the PWA install button.
 
 ## Promoting the installing of your PWA through an app store
@@ -93,7 +93,7 @@ According to a [Google Play study](https://medium.com/googleplaydev/shrinking-ap
 
 To address this, some companies are leveraging their PWA to provide a lightweight version of their app in the Play Store using Trusted Web Activities. [Trusted Web Activities](https://developers.google.com/web/android/trusted-web-activity) make it possible to deliver your PWA in the Play Store, and because it's built using the web, the app size is usually only a few megabytes.
 
-Oyo, one of India's largest hospitality companies, built a [Lite version of their app](https://web.dev/oyo-lite-twa/), and made it available in the Play Store using TWA.  It's only 850 KB, just 7% the size of their Android app. And once installed, it's indistinguishable from their Android app:
+Oyo, one of India's largest hospitality companies, built a [Lite version of their app](/oyo-lite-twa/), and made it available in the Play Store using TWA.  It's only 850 KB, just 7% the size of their Android app. And once installed, it's indistinguishable from their Android app:
 
 <figure class="w-figure">
   <video controls autoplay loop muted class="w-screenshot">

--- a/src/site/content/en/react/codelab-quicklink/index.md
+++ b/src/site/content/en/react/codelab-quicklink/index.md
@@ -37,7 +37,7 @@ Complete the following instructions in the new tab that just opened:
 
 <img class="w-screenshot" src="./cdt-home-unoptimized.png" alt="Network panel showing the home page chunks.">
 
-The site uses [route-based code splitting](https://web.dev/reduce-javascript-payloads-with-code-splitting/), thanks to which only the necessary code is requested at the beginning.
+The site uses [route-based code splitting](/reduce-javascript-payloads-with-code-splitting/), thanks to which only the necessary code is requested at the beginning.
 
 1. [Clear the network requests in DevTools](https://developers.google.com/web/tools/chrome-devtools/network/reference#clear).
 1. Within the app, click the **Blog** link to navigate to that page.
@@ -48,7 +48,7 @@ The JS and CSS chunks for the new route are loaded to render the page.
 
 Next, you'll implement Quicklink in this site, so that these chunks can be prefetched in the home page, making the navigation faster.
 
-This allows you to combine the best of both techniques: 
+This allows you to combine the best of both techniques:
 
 - Route-based code splitting tells the browser to only load the necessary chunks at a higher priority at page load time.
 - Prefetching tells the browser to load the chunks for in-viewport links at the lowest priority, during the browser's idle time.
@@ -184,7 +184,7 @@ When the home page loads the chunks for that route are loaded. After that, Quick
 
 These chunks are requested at the lowest priority and without blocking the page.
 
-Next: 
+Next:
 
 1. Clear the Network log again.
 1. Disable the **Disable cache** checkbox.

--- a/src/site/content/en/react/quicklink/index.md
+++ b/src/site/content/en/react/quicklink/index.md
@@ -17,11 +17,11 @@ feedback:
   - api
 ---
 
-[Prefetching](https://web.dev/link-prefetch/) is a technique to speed up navigations by downloading the resources for the next page, ahead of time. [Quicklink](https://github.com/GoogleChromeLabs/quicklink) is a library that allows you to implement this technique at scale, by automatically prefetching links as they come into the view.
+[Prefetching](/link-prefetch/) is a technique to speed up navigations by downloading the resources for the next page, ahead of time. [Quicklink](https://github.com/GoogleChromeLabs/quicklink) is a library that allows you to implement this technique at scale, by automatically prefetching links as they come into the view.
 
-In multi-page apps the library prefetches documents (e.g. `/article.html`), for in-viewport links, so that when the user clicks on these links they can be picked up from the [HTTP cache](https://web.dev/http-cache/).
+In multi-page apps the library prefetches documents (e.g. `/article.html`), for in-viewport links, so that when the user clicks on these links they can be picked up from the [HTTP cache](/http-cache/).
 
-[Single-page apps](https://en.wikipedia.org/wiki/Single-page_application) commonly use a technique called [route-based code splitting](https://web.dev/reduce-javascript-payloads-with-code-splitting/). This allows the site to load the code for a given route only when the user navigates to it. These files (JS, CSS) are commonly referred to as "chunks".
+[Single-page apps](https://en.wikipedia.org/wiki/Single-page_application) commonly use a technique called [route-based code splitting](/reduce-javascript-payloads-with-code-splitting/). This allows the site to load the code for a given route only when the user navigates to it. These files (JS, CSS) are commonly referred to as "chunks".
 
 With that said, in these sites, instead of prefetching documents the biggest performance gains come from prefetching these chunks before the page needs them.
 
@@ -133,7 +133,7 @@ const App = () => (
 
 The `withQuicklink()` HOC uses the path of the route as a key to obtain its associated chunks from `rmanifest.json`.
 Under the hood, as links come into the view, the library injects a `<link rel="prefetch">` tag in the page for each chunk so they can be prefetched.
-Prefetched resources will be requested at the lowest priority by the browser and kept in the [HTTP Cache](https://web.dev/http-cache/) for 5 minutes, after which point, the `cache-control` rules of the resource apply.
+Prefetched resources will be requested at the lowest priority by the browser and kept in the [HTTP Cache](/http-cache/) for 5 minutes, after which point, the `cache-control` rules of the resource apply.
 As a result of this, when a user clicks on a link and moves to a given route, the chunks will be retrieved from the cache, greatly improving the time it takes to render that route.
 
 ## Conclusion

--- a/src/site/content/en/reliable/adaptive-loading-with-service-workers/index.md
+++ b/src/site/content/en/reliable/adaptive-loading-with-service-workers/index.md
@@ -27,9 +27,9 @@ feedback:
 Users access websites through a wide variety of devices and network connections. Even in major cities, where mobile networks are fast and reliable, one can end up experiencing slower load times, for example, when commuting in the subway, in a car, or just when moving around.
 In regions like emerging markets, this phenomenon is even more common, not only due to unreliable networks, but also because devices tend to have less memory and CPU processing power.
 
-[Adaptive loading](https://web.dev/adaptive-loading-cds-2019/) is a web performance pattern that lets you adapt your site based on the user's network and device conditions.
+[Adaptive loading](/adaptive-loading-cds-2019/) is a web performance pattern that lets you adapt your site based on the user's network and device conditions.
 
-The adaptive loading pattern is made possible by [service workers](https://web.dev/service-workers-cache-storage/), the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API), the [Hardware Concurrency API](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency), and the [Device Memory API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory). In this guide we explore how you can use service workers and the Network Information API to achieve an adaptive loading strategy.
+The adaptive loading pattern is made possible by [service workers](/service-workers-cache-storage/), the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API), the [Hardware Concurrency API](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency), and the [Device Memory API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory). In this guide we explore how you can use service workers and the Network Information API to achieve an adaptive loading strategy.
 
 ## Production case
 
@@ -38,7 +38,7 @@ The adaptive loading pattern is made possible by [service workers](https://web.d
 To provide a more reliable experience to all their users, Terra combines service workers and the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) to deliver lower quality images to users on 2G or 3G connections.
 
 <figure class="w-figure">
-  <img src="terra-adaptive-images.png" 
+  <img src="terra-adaptive-images.png"
        alt="A screenshot of Terra's home page connected to different image qualities according to the connection type.">
 </figure>
 
@@ -51,7 +51,7 @@ Taking that into consideration, Terra decided to start serving AMP versions of t
 To achieve that, they use the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) in the service worker to detect if the request comes from 3G or slower. If that's the case, they change the URL of the page to request the AMP version of the page instead.
 
 <figure class="w-figure">
-  <img src="terra-adaptive-amp.png" 
+  <img src="terra-adaptive-amp.png"
        alt="A screenshot of Terra's article page connected to different image qualities according to the connection type.">
 </figure>
 
@@ -59,9 +59,9 @@ Thanks to this technique, they send **70% less bytes** to users on slower connec
 
 ## Implement adaptive loading with Workbox
 
-In this section we'll explore how [Workbox](https://web.dev/workbox/) can be used to implement adaptive loading strategies.
+In this section we'll explore how [Workbox](/workbox/) can be used to implement adaptive loading strategies.
 
-Workbox provides several [runtime caching strategies](https://web.dev/runtime-caching-with-workbox/) out of the box. They are used to indicate how the service worker generates a response after receiving a `fetch` event.
+Workbox provides several [runtime caching strategies](/runtime-caching-with-workbox/) out of the box. They are used to indicate how the service worker generates a response after receiving a `fetch` event.
 
 For example, in a [Cache First](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) strategy the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) will be fulfilled using the cached response (if available). If there isn't a cached response, the `Request` will be fulfilled by a network request and the response will be cached.
 
@@ -141,7 +141,7 @@ Finally the response will be persisted in the cache, and sent back to the page.
 Cloudinary, a video and image hosting service, has a [Workbox Plugin](https://www.npmjs.com/package/cloudinary-workbox-plugin) that encapsulates the functionality explained in the previous section, making it even easier to implement.
 
 <figure class="w-figure">
-  <img src="cloudinary-workbox.png" 
+  <img src="cloudinary-workbox.png"
        alt="Cloudinary and Workbox logos.">
 </figure>
 

--- a/src/site/content/en/reliable/app-shell-ux-with-service-workers/index.md
+++ b/src/site/content/en/reliable/app-shell-ux-with-service-workers/index.md
@@ -37,20 +37,20 @@ In this article we'll analyze how you can achieve an SPA-like architecture in mu
 [DEV](https://dev.to/) is a community where software developers write articles, take part in discussions, and build their professional profiles.
 
 <figure class="w-figure">
-  <img class="w-screenshot w-screenshot--filled" 
-       src="homepage.jpg" 
+  <img class="w-screenshot w-screenshot--filled"
+       src="homepage.jpg"
        alt="A screenshot of https://dev.to">
 </figure>
 
-Their architecture is a multi-page app based on traditional backend templating through Ruby on Rails. Their team was interested in some of the benefits of an app shell model, but didn't want to undertake a major architectural change or move away from their original tech stack. 
+Their architecture is a multi-page app based on traditional backend templating through Ruby on Rails. Their team was interested in some of the benefits of an app shell model, but didn't want to undertake a major architectural change or move away from their original tech stack.
 
 Here's how their solution works:
 
-1. First, they create partials of their home page for the header and the footer (`shell_top.html` and `shell_bottom.html`) and deliver them as standalone HTML snippets with an endpoint. These assets are added to the cache at the service worker `install` event (what's commonly referred to as [precaching](https://web.dev/precache-with-workbox/)).
+1. First, they create partials of their home page for the header and the footer (`shell_top.html` and `shell_bottom.html`) and deliver them as standalone HTML snippets with an endpoint. These assets are added to the cache at the service worker `install` event (what's commonly referred to as [precaching](/precache-with-workbox/)).
 1. When a navigation request is intercepted by the service worker, they create a [streamed response](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) by combining the cached header and footer with the main page content that just came from the server. The body is the only actual part of the page that requires fetching data from the network.
 
 <figure class="w-figure">
-  <img src="dev-architecture.png" 
+  <img src="dev-architecture.png"
        alt="Dev's architecture consisting on static headers and footers that are cached and a body requested from the network.">
 </figure>
 
@@ -59,13 +59,13 @@ This way, the header of the page can be rendered as soon as it's picked from the
 
 The resulting UX is similar to the app shell UX pattern of SPAs, implemented on a MPA site.
 
-{% Aside %} 
+{% Aside %}
 The previous section contains a quick summary of DEV's solution. For a more detailed explanation check out their [blog post](https://dev.to/devteam/instant-webpages-and-terabytes-of-data-savings-through-the-magic-of-service-workers-1mkc) on this topic.
 {% endAside %}
 
 ## Implement an app shell UX architecture in MPAs with Workbox
 
-In this section we'll cover a summary of the different parts involved in implementing an app shell UX architecture in MPAs. 
+In this section we'll cover a summary of the different parts involved in implementing an app shell UX architecture in MPAs.
 For a more detailed post on how to implement this on a real site, check out [Beyond SPAs: alternative architectures for your PWA](https://developers.google.com/web/updates/2018/05/beyond-spa).
 
 ### The server
@@ -101,7 +101,7 @@ After the first page load, the service worker is registered, allowing you to fet
 
 #### Precaching static assets
 
-The first step is to cache the partial HTML templates, so they are immediately available. 
+The first step is to cache the partial HTML templates, so they are immediately available.
 With [Workbox precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching) you can store these files at the `install` event of the service worker and keep them up to date when changes are deployed to the web app.
 
 Depending on the build process, Workbox has different solutions to generate a service worker and indicate the list of files to precache, including [webpack](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin) and [gulp](https://developers.google.com/web/tools/workbox/guides/codelabs/gulp) plugins, a [generic node module](https://developers.google.com/web/tools/workbox/modules/workbox-build) and a [command line interface](https://developers.google.com/web/tools/workbox/modules/workbox-cli).
@@ -125,7 +125,7 @@ workbox.precaching.precacheAndRoute([
 #### Streaming
 
 Next, add the service worker logic so that the precached partial HTML can be sent back to the web app immediately. This is a crucial part of being reliably fast. Using the [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) within our service worker makes that possible.
-[Workbox Streams](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-streams) abstracts the details of how streaming works. The package lets you pass to the library a mix of streaming sources, both from caches and runtime data that might come from the network. Workbox takes care of coordinating the individual sources and stitching them together into a single, streaming response. 
+[Workbox Streams](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-streams) abstracts the details of how streaming works. The package lets you pass to the library a mix of streaming sources, both from caches and runtime data that might come from the network. Workbox takes care of coordinating the individual sources and stitching them together into a single, streaming response.
 
 First, set up the strategies in Workbox to handle the different sources that will make up the streaming response.
 

--- a/src/site/content/en/reliable/imperative-caching-guide/index.md
+++ b/src/site/content/en/reliable/imperative-caching-guide/index.md
@@ -1,12 +1,12 @@
 ---
-layout: post 
-title: "Imperative caching guide" 
+layout: post
+title: "Imperative caching guide"
 authors:
   - demianrenzulli
-  - andrewguan 
+  - andrewguan
 date: 2020-12-08
-description: | 
-  How to communicate window and service worker to perform tasks related to performance, caching and offline. 
+description: |
+  How to communicate window and service worker to perform tasks related to performance, caching and offline.
 tags:
   - service-worker
   - performance
@@ -17,9 +17,9 @@ Some websites might need to communicate to the service worker without the need o
 informed about the result. Here are some examples:
 
 - A page sends the service worker a list of URLs [to
-  prefetch](https://web.dev/instant-navigation-experiences/), so that, when the user clicks on a
+  prefetch](/instant-navigation-experiences/), so that, when the user clicks on a
   link the document or page subresources are already available in the cache, making subsequent
-  navigation much faster. 
+  navigation much faster.
 - The page asks the service worker to retrieve and cache a set of top articles, to have them
   available for offline purposes.
 
@@ -150,13 +150,13 @@ If the operation was successful, the user will be able to get the benefits from 
 One of the most common applications of **imperative caching** is **prefetching**, meaning fetching
 resources for a given URL, before the user moves to it, in order to speed up navigation.
 
-There are different ways of implementing prefetching in sites: 
+There are different ways of implementing prefetching in sites:
 
-- Using [Link prefetch tags](https://web.dev/link-prefetch/) in pages: resources are kept in the
+- Using [Link prefetch tags](/link-prefetch/) in pages: resources are kept in the
   browser cache for five minutes, after which the normal `Cache-Control` rules for the resource
-  apply. 
+  apply.
 - Complementing the previous technique with [a runtime caching strategy in the service
-  worker](https://web.dev/instant-navigation-experiences/) to extend the lifetime of the prefetch
+  worker](/instant-navigation-experiences/) to extend the lifetime of the prefetch
   resource beyond this limit.
 
 For relatively simple prefetching scenarios, like prefetching documents, or specific assets (JS,

--- a/src/site/content/en/reliable/instant-navigation-experiences/index.md
+++ b/src/site/content/en/reliable/instant-navigation-experiences/index.md
@@ -24,7 +24,7 @@ Performing a task on a site commonly involves several steps. For example, purcha
 In technical terms, moving through different pages means making a **navigation request**. As a general rule, you **don't** want to use long-lived `Cache-Control` headers to cache the HTML response for a navigation request. They should normally be satisfied via the network, with `Cache-Control: no-cache`, to ensure that the HTML, along with the chain of subsequent network requests, is (reasonably) fresh.
 Having to go against the network each time the user navigates to a new page unfortunately means that each navigation might be slow—at the very least, it means that it won't be *reliably* fast.
 
-To speed up these requests, if you can anticipate the user's action, you can request these pages and assets beforehand and keep them in the cache for a short period of time until the user clicks on these links. This technique is called [prefetching](https://web.dev/link-prefetch/) and it's commonly implemented by adding `<link rel="prefetch">` tags to pages, indicating the resource to prefetch.
+To speed up these requests, if you can anticipate the user's action, you can request these pages and assets beforehand and keep them in the cache for a short period of time until the user clicks on these links. This technique is called [prefetching](/link-prefetch/) and it's commonly implemented by adding `<link rel="prefetch">` tags to pages, indicating the resource to prefetch.
 
 In this guide we'll explore different ways in which [service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be used as a complement of traditional prefetching techniques.
 
@@ -37,7 +37,7 @@ In this guide we'll explore different ways in which [service workers](https://de
        alt="Screenshot of MercadoLibre's listing pages one and two and a Link Prefetch tag connecting both.">
 </figure>
 
-Prefetched files are requested at the "Lowest" priority and stored in the [HTTP cache](https://web.dev/http-cache/) or the [memory cache](https://calendar.perfplanet.com/2016/a-tale-of-four-caches/) (depending on whether the resource is cacheable or not), for an amount of time that varies by browsers. For example, as of Chrome 85, this value is 5 minutes. Resources are kept around for five minutes, after which the normal `Cache-Control` rules for the resource apply.
+Prefetched files are requested at the "Lowest" priority and stored in the [HTTP cache](/http-cache/) or the [memory cache](https://calendar.perfplanet.com/2016/a-tale-of-four-caches/) (depending on whether the resource is cacheable or not), for an amount of time that varies by browsers. For example, as of Chrome 85, this value is 5 minutes. Resources are kept around for five minutes, after which the normal `Cache-Control` rules for the resource apply.
 
 Using service worker caching can help you extend the lifetime of prefetch resources beyond the five-minute window.
 
@@ -57,14 +57,14 @@ As a result of this, over 3 weeks of observation Virgilio Sport witnessed load t
 
 ## Implement precaching with Workbox
 
-In the following section we'll use [Workbox](https://web.dev/workbox/) to show how to implement different caching techniques in the service worker that can be used as a complement to `<link rel="prefetch">`, or even a replacement for it, by delegating this task completely to the service worker.
+In the following section we'll use [Workbox](/workbox/) to show how to implement different caching techniques in the service worker that can be used as a complement to `<link rel="prefetch">`, or even a replacement for it, by delegating this task completely to the service worker.
 
 {% Aside 'caution' %} You must take steps to ensure that adding a service worker to your site doesn't end up actually slowing down your navigations. Starting up the service worker without using it to respond to a navigation request will introduce a small amount of latency (as explained in [Building Faster, More Resilient Apps with Service Workers](https://www.youtube.com/watch?v=25aCD5XL1Jk)). You can mitigate this overhead by enabling a feature called [navigation preload](https://developers.google.com/web/updates/2017/02/navigation-preload), and then using the [network response](https://developers.google.com/web/updates/2017/02/navigation-preload#using_the_preloaded_response) that's been preloaded inside of your fetch event handler.
 {% endAside %}
 
 ### 1. Precache static pages and page subresources
 
-[Precaching](https://web.dev/precache-with-workbox/) is the ability of the service worker to save files to the cache while it's installing.
+[Precaching](/precache-with-workbox/) is the ability of the service worker to save files to the cache while it's installing.
 
 {% Aside %}
 Precaching sounds similar to prefetching, but it's a different technique. In the first one, the service worker fetches and stores resources (typically static files) while it's installing and keeps them in the cache until a new version of the file is available. In the second, resources are requested ahead of time to have it in the cache for brief periods of time in order to speed up subsequent navigations.
@@ -112,7 +112,7 @@ As mentioned earlier, `<link rel="prefetch">` fetches and keeps resources in the
 
 Service workers allow you to extend the lifetime of the prefetch pages, while providing the added benefit of making those resources available for offline usage.
 
-In the previous example, one could complement the `<link rel="prefetch">` used to prefetch a product page with a [Workbox runtime caching strategy](https://web.dev/runtime-caching-with-workbox/).
+In the previous example, one could complement the `<link rel="prefetch">` used to prefetch a product page with a [Workbox runtime caching strategy](/runtime-caching-with-workbox/).
 
 To implement that:
 

--- a/src/site/content/en/reliable/offline-cookbook/index.md
+++ b/src/site/content/en/reliable/offline-cookbook/index.md
@@ -345,7 +345,7 @@ Your origin is given a certain amount of free space to do what it wants with. Th
 shared between all origin storage:
 [(local) Storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage),
 [IndexedDB](https://developer.mozilla.org/en-US/docs/Glossary/IndexedDB),
-[File System Access](https://web.dev/file-system-access/), and of course
+[File System Access](/file-system-access/), and of course
 [Caches](https://developer.mozilla.org/en-US/docs/Web/API/Cache).
 
 The amount you get isn't spec'd. It will differ depending on device and storage conditions. You can

--- a/src/site/content/en/reliable/resilient-search-experiences/index.md
+++ b/src/site/content/en/reliable/resilient-search-experiences/index.md
@@ -51,7 +51,7 @@ When the user performs a search, the service worker allows the query to be defer
 
 {% Img src="image/admin/ZZItVQMLUPmVbwJlfDck.png", alt="A screenshot of the offline flow in Google Search.", width="800", height="436" %}
 
-Service workers allow Google Search to provide a [meaningful offline experience](https://web.dev/google-search-sw/#meaningful-offline-experience) and keep the user engaged, letting them complete their task.
+Service workers allow Google Search to provide a [meaningful offline experience](/google-search-sw/#meaningful-offline-experience) and keep the user engaged, letting them complete their task.
 
 ## Implement resilient search experiences with Workbox
 

--- a/src/site/content/en/reliable/two-way-communication-guide/index.md
+++ b/src/site/content/en/reliable/two-way-communication-guide/index.md
@@ -1,12 +1,12 @@
 ---
-layout: post 
-title: "Two-way communication with service workers" 
+layout: post
+title: "Two-way communication with service workers"
 authors:
   - demianrenzulli
-  - andrewguan 
+  - andrewguan
 date: 2020-12-08
-description: | 
-    How establish a two-way communication channel between the page and the service worker. 
+description: |
+    How establish a two-way communication channel between the page and the service worker.
 tags:
   - service-worker
   - offline
@@ -16,7 +16,7 @@ In some cases, a web app might need to establish a **two-way** communication cha
 page and the service worker.
 
 For example: in a podcast PWA one could build a feature to let the user [download episodes for
-offline consumption](https://web.dev/app-like-pwas/#proactive-background-downloading) and allow the
+offline consumption](/app-like-pwas/#proactive-background-downloading) and allow the
 service worker to keep the page regularly informed about the progress, so the [main
 thread](https://developer.mozilla.org/en-US/docs/Glossary/Main_thread) can update the UI.
 
@@ -51,10 +51,10 @@ The following page code creates a new `Workbox` instance and sends a message to 
 to obtain its version:
 
 ```javascript
-const wb = new Workbox('/sw.js'); 
-wb.register(); 
+const wb = new Workbox('/sw.js');
+wb.register();
 
-const swVersion = await wb.messageSW({type: 'GET_VERSION'}); 
+const swVersion = await wb.messageSW({type: 'GET_VERSION'});
 console.log('Service Worker version:', swVersion);
 ```
 
@@ -112,13 +112,13 @@ Differences:
 
 The [Broadcast Channel API](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API)
 allows basic communication between browsing contexts via [BroadcastChannel
-objects](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel). 
+objects](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
 
 To implement it, first, each context has to instantiate a `BroadcastChannel` object with the same ID
 and send and receive messages from it:
 
 ```javascript
-const broadcast = new BroadcastChannel('channel-123'); 
+const broadcast = new BroadcastChannel('channel-123');
 ```
 
 The BroadcastChannel object exposes a `postMessage()` interface to send a message to any listening
@@ -283,7 +283,7 @@ scenarios: lack of connectivity and long downloads.
 A chat app might want to make sure that messages are never lost due to bad connectivity. The
 [Background Sync API](https://developers.google.com/web/updates/2015/12/background-sync) lets you
 defer actions to be retried when the user has stable connectivity. This is useful for ensuring that
-whatever the user wants to send, is actually sent. 
+whatever the user wants to send, is actually sent.
 
 Instead of the `postMessage()` interface, the page registers a `sync`:
 
@@ -305,7 +305,7 @@ self.addEventListener('sync', function (event) {
 
 The function `doSomeStuff()` should return a promise indicating the success/failure of whatever it's
 trying to do. If it fulfills, the sync is complete. If it fails, another sync will be scheduled to
-retry. Retry syncs also wait for connectivity, and employ an exponential back-off. 
+retry. Retry syncs also wait for connectivity, and employ an exponential back-off.
 
 Once the operation has been performed, the service worker can then communicate back with the page to
 update the UI, by using any of the communication APIs explored earlier.
@@ -321,7 +321,7 @@ the user via a web push notification:
 </figure>
 
 {% Aside %} Check out [Resilient search experiences
-](https://web.dev/resilient-search-experiences/) to learn how to implement this feature using [Workbox Background
+](/resilient-search-experiences/) to learn how to implement this feature using [Workbox Background
 Sync](https://developers.google.com/web/tools/workbox/modules/workbox-background-sync). {% endAside
 %}
 
@@ -329,11 +329,11 @@ Sync](https://developers.google.com/web/tools/workbox/modules/workbox-background
 
 For relatively short bits of work like sending a message, or a list of URLs to cache, the options
 explored so far are a good choice. If the task takes too long the browser will kill the service
-worker, otherwise it's a risk to the user's privacy and battery. 
+worker, otherwise it's a risk to the user's privacy and battery.
 
 The [Background Fetch API](https://developers.google.com/web/updates/2018/12/background-fetch)
 allows you to offload a long task to a service worker, like downloading movies, podcasts, or levels
-of a game. 
+of a game.
 
 To communicate to the service worker from the page, use `backgroundFetch.fetch`, instead of
 `postMessage()`:

--- a/src/site/content/en/reliable/workers-overview/index.md
+++ b/src/site/content/en/reliable/workers-overview/index.md
@@ -109,7 +109,7 @@ thread, to avoid blocking the UI.
 
 - **Example:** the team that built the videogame [PROXX](https://proxx.app/) wanted to leave the
   main thread as free as possible to take care of user input and animations. To achieve that, they
-  [used web workers](https://web.dev/proxx-announce/#web-workers) to run the game logic and state
+  [used web workers](/proxx-announce/#web-workers) to run the game logic and state
   maintenance on a separate thread.
 
 <figure class="w-figure">
@@ -181,4 +181,4 @@ The rest of this series focuses on patterns for window and service worker commun
   (e.g. a heavy download), and keeping the page informed on the progress.
 
 For patterns of window and web worker communication check out: [Use web workers to run JavaScript
-off the browser's main thread](https://web.dev/off-main-thread/).
+off the browser's main thread](/off-main-thread/).


### PR DESCRIPTION
Changes proposed in this pull request:

- Internal links don't need the `https://web.dev` prefix. This saves some bytes.