### PR TITLE
fix error

### DIFF
--- a/src/site/content/en/progressive-web-apps/customize-install/index.md
+++ b/src/site/content/en/progressive-web-apps/customize-install/index.md
@@ -177,7 +177,7 @@ To track if the user changes between `standalone`, and `browser tab`, listen for
 changes to the `display-mode` media query.
 
 ```js
-window.matchMedia('(display-mode: standalone)').addEventListener((evt) => {
+window.matchMedia('(display-mode: standalone)').addEventListener('change', (evt) => {
   let displayMode = 'browser';
   if (evt.matches) {
     displayMode = 'standalone';


### PR DESCRIPTION
I believe the correct signature should be:

`MediaQueryList.addEventListener('change', callback)`. See [doc](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList).

The old version does work, but VSCode complains about it.