### PR TITLE
Make lighthouse guides open in a new window

### DIFF
--- a/src/lib/components/LighthouseScoresAudits/index.js
+++ b/src/lib/components/LighthouseScoresAudits/index.js
@@ -39,6 +39,7 @@ function createRowForAuditCategory(lhr, category) {
             data-category="web.dev"
             data-label="audit todos, internal link"
             data-action="click"
+            target="_blank"
             >${guide.title}</a
           >
         `;


### PR DESCRIPTION
... as otherwise the audit disappears and need to be run again if users hits back button.

Fixes #4946 