### PR TITLE
Remove course tags.

### DIFF
--- a/src/site/content/en/learn/css/box-model/index.md
+++ b/src/site/content/en/learn/css/box-model/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-03-29
-tags:
-  - css
 ---
 
 # The box model

--- a/src/site/content/en/learn/css/color/index.md
+++ b/src/site/content/en/learn/css/color/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-04-01
-tags:
-  - css
 ---
 
 # Color

--- a/src/site/content/en/learn/css/flexbox/index.md
+++ b/src/site/content/en/learn/css/flexbox/index.md
@@ -5,8 +5,6 @@ authors:
   - rachelandrew
   - andybell
 date: 2021-04-21
-tags:
-  - css
 ---
 
 # Flexbox

--- a/src/site/content/en/learn/css/inheritance/index.md
+++ b/src/site/content/en/learn/css/inheritance/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-04-02
-tags:
-  - css
 ---
 
 # Inheritance

--- a/src/site/content/en/learn/css/logical-properties/index.md
+++ b/src/site/content/en/learn/css/logical-properties/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-04-21
-tags:
-  - css
 ---
 
 

--- a/src/site/content/en/learn/css/selectors/index.md
+++ b/src/site/content/en/learn/css/selectors/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-03-29
-tags:
-  - css
 ---
 
 # Selectors

--- a/src/site/content/en/learn/css/specificity/index.md
+++ b/src/site/content/en/learn/css/specificity/index.md
@@ -4,8 +4,6 @@ description:
 authors:
   - andybell
 date: 2021-04-02
-tags:
-  - css
 ---
 
 # Specificity


### PR DESCRIPTION
Changes proposed in this pull request:

- Untag course pages. These were appearing in the /tags/ section of the site but we don't want that. Instead we might add a banner to /tags/css promoting the course, but that'd be a separate PR.