### PR TITLE
Fix and harmonize links to caniuse for browser-fs-access

### DIFF
--- a/src/site/content/en/blog/browser-fs-access/index.md
+++ b/src/site/content/en/blog/browser-fs-access/index.md
@@ -167,13 +167,13 @@ const saveFile = async (blob) => {
 ## Introducing browser-fs-access
 
 As perfectly fine as the File System Access API is,
-it's [not yet  widely available](https://caniuse.com/#feat=file-system-access-api).
+it's [not yet  widely available](https://caniuse.com/native-filesystem-api).
 
 <figure class="w-figure">
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/G1jsSjCBR871W1uKQWeN.png", alt="Browser support table for the File System Access API. All browsers are marked as 'no support' or 'behind a flag'.", width="800", height="224", class="w-screenshot" %}
   <figcaption class="w-figcaption">
     Browser support table for the File System Access API.
-    (<a href="https://caniuse.com/?search=file%20system%20access%20api">Source</a>)
+    (<a href="https://caniuse.com/native-filesystem-api">Source</a>)
   </figcaption>
 </figure>
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

No issue created yet given the low complexity of the changes. But can create one if you want me to.

Changes proposed in this pull request:

- The first link, <https://caniuse.com/#feat=file-system-access-api>, was broken, linking to an empty page basically
- The second link, <https://caniuse.com/?search=file%20system%20access%20api>, was linking to a search rather than the single feature (which might lead to different results in the future)
- Therefore exchange both links with the correct one, <https://caniuse.com/native-filesystem-api>
- (The URL is still derived from the previous name of the File System Access API, because https://github.com/Fyrd/caniuse/pull/5622#issuecomment-701910863)
