### PR TITLE
Fix progress bar cls

### DIFF
--- a/src/lib/components/ProgressBar/_styles.scss
+++ b/src/lib/components/ProgressBar/_styles.scss
@@ -2,9 +2,15 @@
 
 // animate transforms instead of left/right
 @keyframes indeterminate {
-  0% { left: -35%; right: 100%; }
-  60% { left: 100%; right: -90%; }
-  100% { left: 100%; right: -90%; }
+  0% {
+    transform:  translateX(0) scaleX(0);
+  }
+  40% {
+    transform:  translateX(0) scaleX(0.4);
+  }
+  100% {
+    transform:  translateX(100%) scaleX(0.5);
+  }
 }
 
 web-progress-bar {
@@ -24,27 +30,8 @@ web-progress-bar {
 
 .web-progress-bar-indeterminate {
   background-color: $WEB_EXTENDED_TERTIARY_COLOR;
-}
-
-.web-progress-bar-indeterminate::before {
-  content: '';
-  position: absolute;
-  background-color: inherit;
-  top: 0;
-  left: 3px;
-  bottom: 0;
-  will-change: left, right;
-  animation: indeterminate 2.1s cubic-bezier(.65, .815, .735, .395) infinite;
-}
-
-.web-progress-bar-indeterminate::after {
-  content: '';
-  position: absolute;
-  background-color: inherit;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  will-change: left, right;
-  animation: indeterminate-short 2.1s cubic-bezier(.165, .84, .44, 1) infinite;
-  animation-delay: 1.15s;
+  width: 100%;
+  height: 100%;
+  animation: indeterminate 1s infinite linear;
+  transform-origin: 0% 50%;
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes the /measure progress bar to use transform instead of animating left, right which could be causing layout shift.