### PR TITLE
Fix drawer overscroll and add link states.

### DIFF
--- a/src/lib/components/CourseLinks/index.js
+++ b/src/lib/components/CourseLinks/index.js
@@ -21,7 +21,7 @@ import {trackEvent} from '../../analytics';
  * @fileoverview A drawer displaying the course ToC.
  */
 
-class DrawerCourse extends BaseElement {
+class CourseLinks extends BaseElement {
   static get properties() {
     return {
       current: {type: String},
@@ -69,4 +69,4 @@ class DrawerCourse extends BaseElement {
   }
 }
 
-customElements.define('web-drawer-course', DrawerCourse);
+customElements.define('course-links', CourseLinks);

--- a/src/lib/pages/course.js
+++ b/src/lib/pages/course.js
@@ -1,3 +1,3 @@
 import './content';
 import '../components/AudioFab';
-import '../components/DrawerCourse';
+import '../components/CourseLinks';

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -19,15 +19,15 @@
         <div class="input"></div>
       </div>
 
-      <web-drawer-course current="{{ page.url }}">
+      <course-links class="drawer-course__links scrollbar" current="{{ page.url }}">
         {% for item in pageNavigation %}
-        <a class="drawer-course__link" href="{{ item.url }}">
-          <span class="drawer-course__link-counter font-mono">{{ loop.index0 | padStart(3, '0') }}</span>
-          <span class="drawer-course__link-title gap-left-400">{{ item.page.data.title }}</span>
-          {{ icon('done', 'drawer-course__link-check gap-left-auto') }}
-        </a>
+          <a class="drawer-course__link" href="{{ item.url }}" {% if item.url == page.url %}data-active{% endif %}>
+            <span class="drawer-course__link-counter font-mono">{{ loop.index0 | padStart(3, '0') }}</span>
+            <span class="drawer-course__link-title gap-left-400">{{ item.page.data.title }}</span>
+            {{ icon('done', 'drawer-course__link-check gap-left-auto') }}
+          </a>
         {% endfor %}
-      </web-drawer-course>
+      </course-links>
     </div>
 
   </nav>

--- a/src/styles/components/_drawer-course.scss
+++ b/src/styles/components/_drawer-course.scss
@@ -41,6 +41,7 @@
   }
 
   &__links {
+    display: block; // this is a custom element so it needs display: block;
     flex: 1;
     overflow-y: auto;
     overscroll-behavior: contain; // sass-lint:disable-line no-misspelled-properties
@@ -56,18 +57,20 @@
     min-height: 48px;
     padding: 16px 24px;
 
+    &:hover {
+      background-color: rgba($GREY_800, .03);
+      text-decoration: none;
+    }
+
     &[data-complete] {
       --check-display: block;
       color: $GREY_700;
-      background-color: rgba($GREY_800, .03);
     }
 
-    &:hover,
     &[data-active] {
       --counter-color: #{$WEB_PRIMARY_COLOR};
       background: $BLUE_50;
       color: $WEB_PRIMARY_COLOR;
-      text-decoration: none;
     }
   }
 

--- a/src/styles/components/_web-navigation-drawer.scss
+++ b/src/styles/components/_web-navigation-drawer.scss
@@ -19,18 +19,18 @@
 
 // The navigation drawer has two types: standard and modal.
 //
+// modal (default)
+// -----
+// Modal navigation drawers block interaction with the rest of an app’s content
+// with a scrim. They are elevated above most of the app’s UI and don’t affect
+// the screen’s layout grid.
+//
 // standard
 // --------
 // Standard navigation drawers allow users to simultaneously access drawer
 // destinations and app content. They are often co-planar with app content and
 // affect the screen’s layout grid. They can be used on tablet and desktop only.
 // On mobile, they switch to a modal behavior.
-//
-// modal (default)
-// -----
-// Modal navigation drawers block interaction with the rest of an app’s content
-// with a scrim. They are elevated above most of the app’s UI and don’t affect
-// the screen’s layout grid.
 
 web-navigation-drawer {
   display: block;


### PR DESCRIPTION
Fixes #5210

Changes proposed in this pull request:

- Fixes an issue where the course links weren't scrolling if the viewport was shorter. I think this is a slight bug we accidentally introduced when we switched to the custom element as there was a `drawer-course__links` class which handled this previously (and does again now).
- Renames `DrawerCourse` -> `CourseLinks`. I did this because we have a `<web-navigation-drawer>` custom element as the parent and it was a bit confusing also seeing a `<web-drawer-course>` inside of it. This element only deals with tracking the visited state of the links so I think the naming may be ok.
- Fixes the visual states for active and completed links.

