### PR TITLE
Update documentation on render-blocking stylesheet

### DIFF
--- a/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
+++ b/src/site/content/en/lighthouse-performance/render-blocking-resources/index.md
@@ -35,7 +35,7 @@ A `<link rel="stylesheet">` tag that:
 
 * Does not have a `disabled` attribute. When this attribute is present,
   the browser does not download the stylesheet.
-* Does not have a `media` attribute that matches the user's device.
+* Does not have a `media` attribute that matches the user's device specifically. `media="all"` is considered render-blocking.
 
 ## How to identify critical resources
 


### PR DESCRIPTION
This PR clarifies that `media=all` in a stylesheet link tag does _not_ constitute "matching the user's device" and thus is still considered render-blocking. I believe this could be potentially confusing if not clarified.

I realize the wording might not be very smooth / matches the overall writing style. Feel free to edit with better wording.