### PR TITLE
Adds podcasts, descriptions, and tidies things up

### DIFF
--- a/src/site/content/en/learn/css/box-model/index.md
+++ b/src/site/content/en/learn/css/box-model/index.md
@@ -1,12 +1,16 @@
 ---
 title: Box Model
-description:
+description: >
+  Everything displayed by CSS is a box.
+  Understanding how the CSS Box Model works is therefore a core foundation of CSS.
+audio:
+  title: 'The CSS Podcast - 001: The Box Model'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_001_v2.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-03-29
 ---
-
-# The box model
 
 Say you have this bit of HTML:
 

--- a/src/site/content/en/learn/css/color/index.md
+++ b/src/site/content/en/learn/css/color/index.md
@@ -1,12 +1,16 @@
 ---
 title: Color
-description:
+description: >
+  There are several different ways to specify color in CSS.
+  In this module we take a look at the most commonly used color values.
+audio:
+  title: 'The CSS Podcast - 006: Color Part One'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_006_v3.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-01
 ---
-
-# Color
 
 Color is an important part of any website and in CSS there are many options for color types,
 functions and treatments.

--- a/src/site/content/en/learn/css/flexbox/index.md
+++ b/src/site/content/en/learn/css/flexbox/index.md
@@ -1,13 +1,17 @@
 ---
 title: Flexbox
-description:
+description: >
+  Flexbox is a layout mechanism designed for laying out groups of items in one dimension.
+  Learn how to use it in this module.
+audio:
+  title: 'The CSS Podcast - 010: Flexbox'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_010_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - rachelandrew
   - andybell
 date: 2021-04-21
 ---
-
-# Flexbox
 
 A design pattern that can be tricky in responsive design is a sidebar that sits inline with some
 content. Where there is viewport space,

--- a/src/site/content/en/learn/css/gradients/index.md
+++ b/src/site/content/en/learn/css/gradients/index.md
@@ -4,6 +4,10 @@ description: >
   In this module you will find out how to use the various types of gradients available in CSS.
   Gradients can be used to create a whole host of useful effects,
   without needing to create an image using a graphics application.
+audio:
+  title: 'The CSS Podcast - 021: Gradients'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP021_TCP_CSS_Podcast_Episode_021_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-05-03

--- a/src/site/content/en/learn/css/grid/index.md
+++ b/src/site/content/en/learn/css/grid/index.md
@@ -1,6 +1,13 @@
 ---
 title: Grid
-description:
+description: >
+  CSS Grid Layout provides a two dimensional layout system,
+  controlling layout in rows and columns.
+  In this module discover everything grd has to offer.
+audio:
+  title: 'The CSS Podcast - 011: Grid'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_011_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - rachelandrew
   - andybell

--- a/src/site/content/en/learn/css/inheritance/index.md
+++ b/src/site/content/en/learn/css/inheritance/index.md
@@ -1,12 +1,16 @@
 ---
 title: Inheritance
-description:
+description: >
+  Some CSS properties inherit if you don't specify a value for them.
+  Find out how this works, and how to use it to your advantage in this module.
+audio:
+  title: 'The CSS Podcast - 005: Inheritance'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_005_v1.2.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-02
 ---
-
-# Inheritance
 
 Say you just wrote some CSS to make elements look like a button.
 

--- a/src/site/content/en/learn/css/layout/index.md
+++ b/src/site/content/en/learn/css/layout/index.md
@@ -1,6 +1,11 @@
 ---
 title: Layout
-description:
+description: >
+  An overview of the various layout methods you have to choose from when building a component or page layout.
+audio:
+  title: 'The CSS Podcast - 009: Layout'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_009_v1.1.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-20

--- a/src/site/content/en/learn/css/logical-properties/index.md
+++ b/src/site/content/en/learn/css/logical-properties/index.md
@@ -1,12 +1,17 @@
 ---
 title: Logical Properties
-description:
+description: >
+  Logical, flow relative properties and values are linked to the flow of text,
+  rather than the physical shape of the screen.
+  Learn how to take advantage of this newer approach to CSS.
+audio:
+  title: 'The CSS Podcast - 012: Logical Properties'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_012_v3.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-21
 ---
-
-# Logical Properties
 
 A really common user interface pattern is a text label with a supporting inline icon.
 

--- a/src/site/content/en/learn/css/pseudo-classes/index.md
+++ b/src/site/content/en/learn/css/pseudo-classes/index.md
@@ -1,6 +1,12 @@
 ---
 title: Pseudo-classes
-description: Pseudo-classes let you apply CSS based on state changes. This means that your design can react to user input such as an invalid email address.
+description: >
+  Pseudo-classes let you apply CSS based on state changes.
+  This means that your design can react to user input such as an invalid email address.
+audio:
+  title: 'The CSS Podcast - 015: Pseudo-classes'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_015_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-28

--- a/src/site/content/en/learn/css/pseudo-elements/index.md
+++ b/src/site/content/en/learn/css/pseudo-elements/index.md
@@ -1,6 +1,12 @@
 ---
 title: Pseudo-elements
-description:
+description: >
+  A pseudo-element is like adding or targeting an extra element without having to add more HTML.
+  They have a variety of roles and you can learn about them in this module.
+audio:
+  title: 'The CSS Podcast - 014: Pseudo-elements'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_014_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-27
@@ -17,7 +23,7 @@ width="800",
 height="318" %}
 
 In CSS,
-you can use the `::first-letter` pseudo element to achieve this sort of design detail.
+you can use the `::first-letter` pseudo-element to achieve this sort of design detail.
 
 ```css
 p::first-letter {

--- a/src/site/content/en/learn/css/selectors/index.md
+++ b/src/site/content/en/learn/css/selectors/index.md
@@ -1,12 +1,17 @@
 ---
 title: Selectors
-description:
+description: >
+  To apply CSS to an element you need to select it.
+  CSS provides you with a number of different ways to do this,
+  and you can explore them in this module.
+audio:
+  title: 'The CSS Podcast - 002: Selectors'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_002_v2.0_FINAL.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-03-29
 ---
-
-# Selectors
 
 If you've got some text that you only want to be larger and red if it's the first paragraph of an article,
 how do you do that?

--- a/src/site/content/en/learn/css/shadows/index.md
+++ b/src/site/content/en/learn/css/shadows/index.md
@@ -4,6 +4,10 @@ description: >
   There are a number of ways to add shadows to text and elements in CSS.
   In this module you'll learn how to use each option,
   and the tasks they were designed for.
+audio:
+  title: 'The CSS Podcast - 017: Shadows'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_017_v2.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-05-03

--- a/src/site/content/en/learn/css/sizing/index.md
+++ b/src/site/content/en/learn/css/sizing/index.md
@@ -1,14 +1,18 @@
 ---
 title: Sizing Units
-description:
+description: >
+  In this module find out how to size elements using CSS,
+  working with the flexible medium of the web.
+audio:
+  title: 'The CSS Podcast - 008: Sizing Units'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_008_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-13
 tags:
   - css
 ---
-
-# Sizing
 
 The web is a responsive medium,
 but sometimes you want to control its dimensions to improve the overall interface quality.

--- a/src/site/content/en/learn/css/spacing/index.md
+++ b/src/site/content/en/learn/css/spacing/index.md
@@ -1,6 +1,12 @@
 ---
 title: Spacing
-description:
+description: >
+  Find out how to select the best method of spacing elements,
+  taking into consideration the layout method you are using and component that you need to build.
+audio:
+  title: 'The CSS Podcast - 013: Spacing'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_013_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-27

--- a/src/site/content/en/learn/css/specificity/index.md
+++ b/src/site/content/en/learn/css/specificity/index.md
@@ -1,12 +1,15 @@
 ---
 title: Specificity
-description:
+description: >
+  This module takes a deeper look at specificity, a key part of the cascade.
+audio:
+  title: 'The CSS Podcast - 003: Specificity'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_003_v2.0_FINAL.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-04-02
 ---
-
-# Specificity
 
 Suppose that you're working with the following HTML and CSS:
 

--- a/src/site/content/en/learn/css/the-cascade/index.md
+++ b/src/site/content/en/learn/css/the-cascade/index.md
@@ -1,14 +1,18 @@
 ---
 title: The cascade
-description:
+description: >
+  Sometimes two or more competing CSS rules could apply to an element.
+  In this module find out how the browser chooses which to use, and how to control this selection.
+audio:
+  title: 'The CSS Podcast - 004: The Cascade'
+  src: 'ttps://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_004_v1.0_FINAL.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-03-29
 tags:
   - css
 ---
-
-# The cascade
 
 CSS stands for Cascading Stylesheets.
 The cascade is the algorithm for solving conflicts where multiple CSS rules apply to an HTML element.

--- a/src/site/content/en/learn/css/z-index/index.md
+++ b/src/site/content/en/learn/css/z-index/index.md
@@ -3,6 +3,10 @@ title: Z-index and stacking contexts
 description: >
   In this module find out how to control the order in which things layer on top of each other,
   by using z-index and the stacking context.
+audio:
+  title: 'The CSS Podcast - 019: z-index and stacking contexts'
+  src: 'https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast_Episode_019_v1.0.mp3?dest-id=1891556'
+  thumbnail: image/foR0vJZKULb5AGJExlazy1xYDgI2/ECDb0qa4TB7yUsHwBic8.png
 authors:
   - andybell
 date: 2021-05-03


### PR DESCRIPTION
Going over the already merged Learn CSS modules:

- adds missing descriptions
- removes duplicate headings
- adds the podcast episodes