### PR TITLE
Add OT frontmatter

### DIFF
--- a/src/site/content/en/blog/mediastreamtrack-insertable-media-processing/index.md
+++ b/src/site/content/en/blog/mediastreamtrack-insertable-media-processing/index.md
@@ -12,6 +12,8 @@ description: |
   as a stream that can be manipulated or used to generate new content.
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/Qu2wfQ3pxR8AeEfty88S.jpg
 alt: Cup of coffee and a laptop with a video conference showing many participants.
+origin_trial:
+  url: https://developer.chrome.com/origintrials/#/view_trial/-7811493553674125311
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - media


### PR DESCRIPTION
R: @tomayac 

This adds some missing frontmatter used by https://github.com/GoogleChrome/web.dev/blob/36cfd75e305a614c7dee27c18eb8dc26549e1a51/src/site/_includes/content/origin-trial-register.njk#L1

Without it, the link at https://web.dev/webtransport/#register-for-ot is broken.