### PR TITLE
Fix flaky percy test

### DIFF
--- a/tools/percy/.percy.conf.yml
+++ b/tools/percy/.percy.conf.yml
@@ -5,6 +5,9 @@ snapshot:
     iframe {
       display: none !important;
     }
+    video {
+      visibility: hidden !important;
+    }
 agent:
   asset-discovery:
     network-idle-timeout: 250 # ms


### PR DESCRIPTION
Percy often flakes on this test of the /live page because it has an autoplaying video inline. So this just sets videos to be visibility: hidden;

![image](https://user-images.githubusercontent.com/1066253/117046666-cf37af80-acc5-11eb-94f2-606d20e38693.png)
