### PR TITLE
hide course tags and authors

### DIFF
--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -28,7 +28,7 @@ const i18nRegex = /i18n\/\w+\//;
 module.exports = (locale, page, collections, renderData = {}) => {
   const forbiddenCharacters = [{searchValue: /"/g, replaceValue: '&quot;'}];
   const pageData = {
-    ...collections.all.find((item) => item.fileSlug === page.fileSlug).data,
+    ...collections.all.find((item) => item.fileSlug === page.fileSlug)?.data,
     ...renderData,
     page,
   };

--- a/src/site/content/en/learn/css/css.11tydata.js
+++ b/src/site/content/en/learn/css/css.11tydata.js
@@ -5,6 +5,7 @@ module.exports = function () {
     // e.g. A course with a key of 'a11y' would have a corresponding
     // _data/courses/a11y directory.
     projectKey: 'css',
+    eleventyExcludeFromCollections: true,
     eleventyComputed: {
       thumbnail: (data) => {
         const {projectKey} = data;


### PR DESCRIPTION
Fixes #5260, fixes #5255

Changes proposed in this pull request:

- Exclude course content from collections. They'll no longer show up on authors or tags pages. If folks want they could remove the `eleventyExcludeFromCollections` property in their course to allow them to show up.
