### PR TITLE
Only exclude course content from authors and tags pages.

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -80,7 +80,10 @@ module.exports = (collections) => {
 
   if (collections) {
     // Find all posts, sort and key by author. Don't yet filter to live posts.
-    allPosts = collections.getFilteredByGlob('**/*.md').sort(sortByUpdated);
+    allPosts = collections
+      .getFilteredByGlob('**/*.md')
+      .filter((item) => !item.data.excludeFromAuthors)
+      .sort(sortByUpdated);
   }
 
   const authorsPosts = findAuthorsPosts(allPosts);

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -63,6 +63,7 @@ module.exports = (collections) => {
       tag.elements = collections
         .getFilteredByTag(tag.key)
         .filter(livePosts)
+        .filter((item) => !item.data.excludeFromTags)
         .sort(sortByUpdated);
     }
 

--- a/src/site/content/en/learn/css/css.11tydata.js
+++ b/src/site/content/en/learn/css/css.11tydata.js
@@ -5,7 +5,10 @@ module.exports = function () {
     // e.g. A course with a key of 'a11y' would have a corresponding
     // _data/courses/a11y directory.
     projectKey: 'css',
-    eleventyExcludeFromCollections: true,
+    // Exclude course content from the /tags/ pages.
+    excludeFromTags: true,
+    // Exclude course content from the /authors/ pages.
+    excludeFromAuthors: true,
     eleventyComputed: {
       thumbnail: (data) => {
         const {projectKey} = data;

--- a/types/eleventy/collection-item.d.ts
+++ b/types/eleventy/collection-item.d.ts
@@ -41,8 +41,6 @@ declare global {
      */
     data: {
       authorsData: AuthorsData;
-      resourceCSS: TODO;
-      resourceJS: TODO;
       tagsData: TagsData;
       paths: TODO;
       countries: TODO;
@@ -100,6 +98,14 @@ declare global {
        * If post is a draft.
        */
       draft?: boolean;
+      /**
+       * If the post should be excluded from /authors/ pages.
+       */
+      excludeFromAuthors?: boolean;
+      /**
+       * If the post should be excluded from /tags/ pages.
+       */
+      excludeFromTags?: boolean;
     };
     /**
      * The rendered content of this template. This does not include layout wrappers.


### PR DESCRIPTION
It looks like https://github.com/GoogleChrome/web.dev/commit/1f026fe0fe257883756a1cf31752b7972b0cbcde was a little too aggressive and was causing course titles to not appear in the course sidebar. It also means they would have probably been hard to add to our algolia index. So instead of excluding them from all collections I've added flags to specifically exclude content from the tags and authors collections.