### PR TITLE
Fix course description

### DIFF
--- a/src/styles/pages/_course.scss
+++ b/src/styles/pages/_course.scss
@@ -36,6 +36,9 @@
   @include apply-utility('font', 'google-sans');
   @include apply-utility('weight', 'regular');
   @include flex-font((16px 28px), (18px 28px), (18px 28px));
+  color: $GREY_800;
+  font-style: italic;
+  max-width: 60ch;
 }
 
 .course-copy {


### PR DESCRIPTION
Fixes #5253 

@una @argyleink @andy-piccalilli can I get y'alls thoughts on these changes? I didn't bump the text down to 0.9rem because then it would be smaller than the body copy below it (which is 18px). But I can bump it down if you think it would look better.