### PR TITLE
Add background color and fix toc without contents.

### DIFF
--- a/src/site/_data/i18n/toc.yml
+++ b/src/site/_data/i18n/toc.yml
@@ -1,2 +1,2 @@
-table_of_contents:
-  en: Table of contents
+on_this_page:
+  en: On this page

--- a/src/site/_includes/partials/toc-inner.njk
+++ b/src/site/_includes/partials/toc-inner.njk
@@ -2,10 +2,10 @@
 {% if tocContents %}
   {% from 'macros/icon.njk' import icon with context %}
 
-  <details class="course-toc toc flow display-block xl:display-none" data-type="inner" role="navigation" aria-label="Table of contents">
+  <details class="course-toc toc flow display-block xl:display-none" data-type="inner" role="navigation" aria-label="{{ 'i18n.toc.on_this_page' | i18n(locale) }}">
     <summary>
       <div class="display-inline-flex align-center user-select-none">
-        <div class="course-toc__heading font-google-sans weight-medium">{{ 'i18n.toc.table_of_contents' | i18n(locale) }}</div>
+        <div class="course-toc__heading font-google-sans weight-medium">{{ 'i18n.toc.on_this_page' | i18n(locale) }}</div>
         <span class="toc__icon height-400">{{ icon('arrow-right', {label: 'toggle'}) }}</span>
       </div>
     </summary>

--- a/src/site/_includes/partials/toc-side.njk
+++ b/src/site/_includes/partials/toc-side.njk
@@ -1,6 +1,9 @@
-<nav class="course-toc toc flow scrollbar display-none xl:display-block" data-type="side" aria-label="{{ 'i18n.toc.table_of_contents' | i18n(locale) }}">
-  <div class="course-toc__heading font-google-sans weight-medium">{{ 'i18n.toc.table_of_contents' | i18n(locale) }}</div>
-  <div class="toc__wrapper flow-recursive">
-    {{ tocContents | safe }}
-  </div>
-</nav>
+{# This is used on the right hand side of the page as the ToC for larger viewports #}
+{% if tocContents %}
+  <nav class="course-toc toc flow scrollbar display-none xl:display-block" data-type="side" aria-label="{{ 'i18n.toc.on_this_page' | i18n(locale) }}">
+    <div class="course-toc__heading font-google-sans weight-medium">{{ 'i18n.toc.on_this_page' | i18n(locale) }}</div>
+    <div class="toc__wrapper flow-recursive">
+      {{ tocContents | safe }}
+    </div>
+  </nav>
+{% endif %}

--- a/src/styles/components/_course-toc.scss
+++ b/src/styles/components/_course-toc.scss
@@ -36,6 +36,7 @@
     width: fit-content;
     border-radius: 3px;
     padding-left: 4px;
+    background-color: $GREY_200;
 
     &::marker,
     &::-webkit-details-marker {
@@ -44,7 +45,8 @@
   }
 
   > summary:hover {
-    background-color: $GREY_200;
+    background-color: $GREY_300;
+    cursor: pointer;
   }
 
   &__heading {
@@ -68,9 +70,6 @@
 
 .toc__list {
   list-style: none;
-  // Give a little bottom margin so when we scroll to the bottom the last link
-  // clearly scrolls into view.
-  padding-bottom: 16px;
 }
 
 .toc__list .toc__list {


### PR DESCRIPTION
Fixes #5268, Fixes 5214

Changes proposed in this pull request:

- Adds a grayish background to the inner toc button
- Rewords toc label to "On this page"
- Hides the side toc if there are no headings
