### PR TITLE
Disable translation banner

### DIFF
--- a/src/site/content/es/es.11tydata.js
+++ b/src/site/content/es/es.11tydata.js
@@ -26,6 +26,5 @@ module.exports = function () {
     home: {
       paths,
     },
-    translated: 'none',
   };
 };


### PR DESCRIPTION
The translation banner uses outdated canonicalUrl property. Let's disable it until we find a good replacement for it.