### PR TITLE
add stuck state to course-app-bar

### DIFF
--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -45,6 +45,8 @@ inlineScripts:
   <div class="flex-1 min-width-0">
     {% include 'partials/course-app-bar.njk' %}
 
+    <div class="sticky-observer"></div>
+
     <div class="course-content display-flex justify-content-center">
       {% include 'partials/toc-side.njk' %}
       <main id="main">
@@ -70,3 +72,23 @@ inlineScripts:
     {% include 'partials/footer.njk' %}
   </div>
 </div>
+
+{# This little script just watches a sentinel element using an
+IntersectionObserver so we can add a "stuck" state to our course-app-bar and
+have it display a bottom border. #}
+{% set stickyObserver %}
+const target = document.querySelector('.sticky-observer');
+const callback = (entries, observer) => {
+  entries.forEach(entry => {
+    const appBar = document.querySelector('.course-app-bar');
+    if (entry.isIntersecting) {
+      appBar.removeAttribute('data-stuck');
+    } else {
+      appBar.setAttribute('data-stuck', '');
+    }
+  });
+};
+const observer = new IntersectionObserver(callback);
+observer.observe(target);
+{% endset %}
+<script>{{ stickyObserver | minifyJs | cspHash | safe }}</script>

--- a/src/styles/components/_app-bar.scss
+++ b/src/styles/components/_app-bar.scss
@@ -72,6 +72,14 @@
 }
 
 // Courses app bar specific subclass
+.course-app-bar {
+  transition: box-shadow $TRANSITION_SPEED $TRANSITION_EASE;
+}
+
+.course-app-bar[data-stuck] {
+  box-shadow: 0 1px $GREY_300;
+}
+
 .course-app-bar__logo {
   width: 101px;
 }


### PR DESCRIPTION
Fixes #5213

Changes proposed in this pull request:

- Adds a little inline script to watch a sentinel element and apply a `[data-stuck]` state to our app-bar so we can style it when it's doing its position: sticky thing.
