### PR TITLE
Fix app bar squish and pagination colors.

### DIFF
--- a/src/styles/components/_app-bar.scss
+++ b/src/styles/components/_app-bar.scss
@@ -7,6 +7,7 @@
   background-color: rgba($WHITE, .96);
   color: $GREY_700;
   display: flex;
+  font-size: 0.875rem;
   height: var(--app-bar-height);
   padding: 0 24px;
 
@@ -24,7 +25,15 @@
 }
 
 .app-bar__item + .app-bar__item {
-  margin-left: 16px;
+  margin-left: 14px;
+}
+
+.app-bar__item:nth-of-type(2) {
+  display: none;
+
+  @include bp(sm) {
+    display: flex;
+  }
 }
 
 .app-bar__item:not(:last-of-type)::after {
@@ -34,7 +43,7 @@
   height: 10px;
   // sass-lint:disable quotes
   background-image: url("data:image/svg+xml,%3Csvg width='6' height='10' viewBox='0 0 6 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.47334 9.47333L0.526672 8.52667L4.06001 5L0.526672 1.47333L1.47334 0.526667L5.94001 5L1.47334 9.47333Z' fill='%235F6368'/%3E%3C/svg%3E");
-  margin-left: 16px;
+  margin-left: 14px;
 }
 
 .app-bar__item > a {
@@ -45,7 +54,6 @@
 .app-bar__share {
   align-items: center;
   display: flex;
-  font-size: 14px;
   margin-left: auto;
   text-transform: uppercase;
   cursor: pointer;

--- a/src/styles/components/_course-pagination.scss
+++ b/src/styles/components/_course-pagination.scss
@@ -9,6 +9,7 @@
 
 .course-pagination-control {
   border-top: 1px solid $GREY_300;
+  color: $GREY_700;
   display: block;
   padding: 24px;
   text-decoration: none;
@@ -38,8 +39,8 @@
 }
 
 .course-pagination-control__top {
-  color: $WEB_PRIMARY_COLOR;
   font-size: px-to-rem(11px);
+  font-weight: 600;
 
   > * + * {
     margin-left: 20px;
@@ -47,12 +48,15 @@
 
   svg {
     color: $GREY_800;
-    width: 20px;
     height: 20px;
+    margin-top: -2px;
+    width: 20px;
   }
 }
 
 .course-pagination-control[data-next] > .course-pagination-control__top {
+  color: $WEB_PRIMARY_COLOR;
+
   > svg {
     @include bp(md) {
       margin-left: 0;
@@ -64,7 +68,7 @@
 
 .course-pagination-control__title {
   @include apply-utility('font', 'google-sans');
-  color: $PRIMARY_TEXT_COLOR;
+  color: $GREY_800;
   font-size: px-to-rem(20px);
   line-height: px-to-rem(40px);
   margin-top: px-to-rem(12px);
@@ -75,9 +79,9 @@
 }
 
 .course-pagination-control__desc {
-  color: $GREY_700;
   font-size: px-to-rem(14px);
-  line-height: px-to-rem(20px);
+  font-weight: 500;
+  line-height: px-to-rem(22px);
   margin-top: px-to-rem(8px);
 }
 

--- a/src/styles/pages/_course.scss
+++ b/src/styles/pages/_course.scss
@@ -9,7 +9,7 @@
 }
 
 .course-content > main {
-  margin: 0 36px;
+  margin: 0 24px;
   max-width: 80ch;
   min-width: 0;
   padding: 0;


### PR DESCRIPTION
Fixes #5295

Changes proposed in this pull request:

- Drops the middle breadcrumb on smaller screens and adjusts breadcrumb font-size down to match mocks.
- Fixes the colors in course pagination to match the mocks.