### PR TITLE
[Async Clipboard article] Document Safari's special way

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -113,7 +113,7 @@ try {
 
 {% Aside 'warning' %}
   Safari (WebKit) treats user activation differently than Chromium (Blink)
-  (see [WebKit bug #222262](https://bugs.webkit.org/show_bug.cgi?id=222262).
+  (see [WebKit bug #222262](https://bugs.webkit.org/show_bug.cgi?id=222262)).
   For Safari, run all asynchronous operations in a promise
   whose result you assign to the `ClipboardItem`:
   

--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -6,7 +6,7 @@ authors:
   - thomassteiner
 description: Async Clipboard API simplifies permissions-friendly copy and paste.
 date: 2020-07-31
-updated: 2021-04-27
+updated: 2021-05-10
 tags:
   - blog
   - capabilities
@@ -110,6 +110,22 @@ try {
   console.error(err.name, err.message);
 }
 ```
+
+{% Aside 'warning' %}
+  Safari (WebKit) treats user activation differently than Chromium (Blink)
+  (see [WebKit bug #222262](https://bugs.webkit.org/show_bug.cgi?id=222262).
+  For Safari, run all asynchronous operations in a promise
+  whose result you assign to the `ClipboardItem`:
+  
+  ```js
+  new ClipboardItem({
+    'foo/bar': new Promise(async (resolve) => {
+        // Prepare `blobValue` of type `foo/bar`
+        resolve(new Blob([blobValue], { type: 'foo/bar' }));
+      }),
+    }),  
+  ```
+{% endAside %}
 
 ### The copy event
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Safari requires async work to be done differently.