### PR TITLE
Enforce CSP

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -22,7 +22,7 @@ if (process.env.ELEVENTY_ENV === 'prod') {
   const hashListJson = fs.readFileSync('dist/script-hash-list.json', 'utf-8');
   const hashList = JSON.parse(hashListJson);
   firebaseJson.hosting.headers[0].headers.push({
-    key: 'Content-Security-Policy-Report-Only',
+    key: 'Content-Security-Policy',
     value:
       `script-src 'strict-dynamic' ${hashList.join(' ')} ` +
       `'unsafe-inline' http: https:; object-src 'none'; base-uri 'self'; ` +


### PR DESCRIPTION
We have been experiencing minimal violations on [CSP frontend](https://csp.googleplex.com/#!/?query_mintimestamp=1619150400000&query_maxtimestamp=1620657600000&query_product=webdev&query_collectortable=EXTERNAL&query_deduplication=ACTIONABLE&f_domain=web.dev&f_version=&f_effectivedirective=script-src-elem,base-uri,script-src&f_policytype=STRICT_DYNAMIC&f_policywithunsafeeval=false).  I also did a site crawl using puppeteer looking for any CSP violations on chrome and found none. With these results, I think it is safe to enforce the CSP.

Follow up to https://github.com/GoogleChrome/web.dev/pull/5008