### PR TITLE
Don't apply 'new' badge to course launch content.

### DIFF
--- a/src/site/_data/courses/css/meta.yml
+++ b/src/site/_data/courses/css/meta.yml
@@ -1,5 +1,10 @@
-# Used to organize the courses on the /learn page
-date: 2021-05-01
+# The date is used to organize the courses on the /learn page.
+# This should be the initial publish date of the course. When new pages are
+# added to the course the site will check if they are <30 days old, and if they
+# are, it will give them a "New" badge. However, when you first launch a course
+# you don't want every entry to have a "New" badge, so anything that existed
+# on or before this date will not receive the "New" badge.
+date: 2021-05-10
 url: /learn/css/
 draft: false
 title: i18n.courses.learn_css.title

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -19,7 +19,15 @@
 
       <course-links class="drawer-course__links scrollbar" data-current="{{ page.url }}" data-course-key="{{ projectKey }}">
         {% for item in pageNavigation %}
-        {% set isNew = item.page.data.date | isNewContent %}
+          {# The isNew flag is used to display a 'NEW' badge next to content. #}
+          {% set isNew = false %}
+          {# Check to make sure the content was published after the course's #}
+          {# initial launch date (so everything doesn't say 'NEW' when we #}
+          {# first launch a course). #}
+          {% if item.page.data.date > courseData.meta.date %}
+            {# Only show the 'NEW' badge if content is less than thirty days old. #}
+            {% set isNew = item.page.data.date | isNewContent %}
+          {% endif %}
         <a class="drawer-course__link" href="{{ item.url }}" {% if item.url == page.url %} data-active {% endif %}>
           <span class="drawer-course__link-counter font-mono">{{ loop.index0 | padStart(3, '0') }}</span>
           <span class="drawer-course__link-title gap-left-400"


### PR DESCRIPTION
Fixes #5306

Only show the 'NEW' badge if content was launched after the course's initial publish date.