### PR TITLE
Add supports to WebLayer

### DIFF
--- a/src/site/content/en/payments/android-payment-apps-delegation/index.md
+++ b/src/site/content/en/payments/android-payment-apps-delegation/index.md
@@ -383,7 +383,7 @@ request.
       <tr>
         <td>Google Quick Search Box (a WebLayer embedder)</td>
         <td>
-          <code>“com.google.android.googlequicksearchbox”</code>
+          <code>"com.google.android.googlequicksearchbox"</code>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Chrome 92 introduced the support of Android payment apps to WebLayer and an intent action "org.chromium.intent.action.UPDATE_PAYMENT_DETAILS" to make it possible to invoke the payment-details-update service in Chrome and other browsers (WebLayer, so far)[1]. The old example code was only able to do it on Chrome because the intent was limited to "org.chromium.components.payments.PaymentDetailsUpdateService" class which other browsers don't share.

Since WebLayer is an embedded browser. When the Android payment apps verify the calling browsers, they have to allowlist the specific embedders. So far, the only WebLayer embedder is the Google Quick Search Box app.

The example code will be updated with these two changes accordingly.

[1] https://groups.google.com/u/1/a/chromium.org/g/paymentrequest/c/VYMIMH-LRjM

Changes proposed in this pull request:

-  Updates the code to start the payment details update service.
-  Adds a WebLayer embedder to the suggested allowlist browsers.
