### PR TITLE
Make course header sticky. Partial fix for focus bug.

### DIFF
--- a/src/lib/components/Header/index.js
+++ b/src/lib/components/Header/index.js
@@ -79,7 +79,8 @@ export class Header extends BaseStateElement {
    */
   manageFocus() {
     if (this.openDrawerBtn) {
-      this.openDrawerBtn.focus();
+      // FIXME(robdodson): https://github.com/GoogleChrome/web.dev/pull/5335
+      // this.openDrawerBtn.focus();
     }
   }
 }

--- a/src/styles/components/_app-bar.scss
+++ b/src/styles/components/_app-bar.scss
@@ -85,7 +85,9 @@
 }
 
 .course-app-bar[data-stuck] {
-  box-shadow: 0 1px $GREY_300;
+  @include bp(lg) {
+    box-shadow: 0 1px $GREY_300;
+  }
 }
 
 .course-app-bar__logo {

--- a/src/styles/components/_header-course.scss
+++ b/src/styles/components/_header-course.scss
@@ -4,6 +4,7 @@
   background-position: right;
   background-size: 136px;
   position: sticky;
+  top: 0;
 
   &__title {
     height: 30px;


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #5320 

Changes proposed in this pull request:

- Makes the course header sticky on mobile.
- Temporarily disables moving focus to the header when the drawer closes.