### PR TITLE
refactor(collections): clean up logic for authors and tags

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -16,54 +16,11 @@
 /** @type AuthorsData */
 const authorsData = require('../_data/authorsData.json');
 const {livePosts} = require('../_filters/live-posts');
-const setdefault = require('../_utils/setdefault');
 const {sortByUpdated} = require('../_utils/sort-by-updated');
 
 /** @type Authors */
 let processedCollection;
 const PLACEHOLDER_IMG = 'image/admin/1v5F1SOBl46ZghbHQMle.svg';
-
-/**
- * Generate map the posts by author's username/key
- *
- * @param {Array<{ data: { authors: any[] }}>} posts
- * @return {Map<string, Array<Object>>} Map of posts by author's username/key
- */
-const findAuthorsPosts = (posts) => {
-  const authorsMap = new Map();
-  posts.forEach((post) => {
-    const authors = post.data.authors || [];
-    authors.forEach((author) => {
-      const postsByAuthor = setdefault(authorsMap, author, []);
-      postsByAuthor.push(post);
-      authorsMap.set(author, postsByAuthor);
-    });
-  });
-  return authorsMap;
-};
-
-/**
- * @param {AuthorsItem} author to update
- * @param {any[]} allAuthorPosts posts including drafts
- * @return {boolean} whether this author is allowed here
- */
-const maybeUpdateAuthorHref = (author, allAuthorPosts) => {
-  if (author.elements.length !== 0) {
-    return true;
-  }
-
-  if (author.twitter) {
-    author.href = `https://twitter.com/${author.twitter}`;
-    return true;
-  }
-
-  // If the author has scheduled or draft posts, don't complain.
-  if (allAuthorPosts.length !== 0) {
-    return true;
-  }
-
-  return false;
-};
 
 /**
  * Returns all authors with their posts.
@@ -76,31 +33,11 @@ module.exports = (collections) => {
     return processedCollection;
   }
 
-  let allPosts = [];
-
-  if (collections) {
-    // Find all posts, sort and key by author. Don't yet filter to live posts.
-    allPosts = collections
-      .getFilteredByGlob('**/*.md')
-      .filter((item) => !item.data.excludeFromAuthors)
-      .sort(sortByUpdated);
-  }
-
-  const authorsPosts = findAuthorsPosts(allPosts);
-
   /** @type Authors */
   const authors = {};
 
-  /** @type {!Array<string>} */
-  const invalidAuthors = [];
-
   Object.keys(authorsData).forEach((key) => {
     const authorData = authorsData[key];
-    // Get all authors but filter later.
-    const allAuthorPosts = authorsPosts.get(key) || [];
-    const href = `/authors/${key}/`;
-    // Generate the author's name out of valid given/family parts. This
-    // allows our authors to just have a single name.
     const title = [authorData.name.given, authorData.name.family]
       .filter((s) => s && s.length)
       .join(' ');
@@ -108,40 +45,62 @@ module.exports = (collections) => {
       authorData.descriptions && authorData.descriptions.en
         ? authorData.descriptions.en
         : `Our latest news, updates, and stories by ${title}.`;
+    const href = `/authors/${key}/`;
+    const image = authorData.image || PLACEHOLDER_IMG;
+
     /** @type AuthorsItem */
     const author = {
       ...authorData,
       data: {
+        alt: title,
+        hero: image,
         subhead: description,
         title,
       },
       description,
-      elements: allAuthorPosts.filter(livePosts),
+      elements: [],
       href,
+      image,
       key,
       title,
       url: href,
     };
 
-    // Update the author's href to be their Twitter profile, if they have no
-    // live posts on the site.
-    if (!maybeUpdateAuthorHref(author, allAuthorPosts)) {
-      // If they have no Twitter profile or posts (even draft ones), the
-      // author probably shouldn't be here.
-      invalidAuthors.push(key);
+    // Get posts
+    if (collections) {
+      author.elements = collections
+        .getFilteredByGlob('**/*.md')
+        .filter(
+          (item) =>
+            livePosts(item) &&
+            !item.data.excludeFromAuthors &&
+            (item.data.authors || []).includes(key),
+        )
+        .sort(sortByUpdated);
     }
 
-    if (!author.image) {
-      author.image = PLACEHOLDER_IMG;
-    }
-    author.data.hero = author.image;
-    author.data.alt = author.title;
-
+    // Limit posts for percy
     if (process.env.PERCY) {
       author.elements = author.elements.slice(-6);
     }
 
-    authors[key] = author;
+    // If author has no posts, point to their Twitter
+    if (author.elements.length === 0 && author.twitter) {
+      author.href = `https://twitter.com/${author.twitter}`;
+    }
+
+    // Set created on date and updated date
+    if (author.elements.length > 0) {
+      author.data.date = author.elements.slice(-1).pop().data.date;
+      const updated = author.elements.slice(0, 1).pop().data.updated;
+      if (author.data.date !== updated) {
+        author.data.updated = updated;
+      }
+    }
+
+    if (author.elements.length > 0 || !collections || author.twitter) {
+      authors[author.key] = author;
+    }
   });
 
   if (collections) {

--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -92,7 +92,7 @@ module.exports = (collections) => {
     // Set created on date and updated date
     if (author.elements.length > 0) {
       author.data.date = author.elements.slice(-1).pop().data.date;
-      const updated = author.elements.slice(0, 1).pop().data.updated;
+      const updated = author.elements.slice(0, 1).pop().data.date;
       if (author.data.date !== updated) {
         author.data.updated = updated;
       }

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -62,9 +62,13 @@ module.exports = (collections) => {
     // Get posts
     if (collections) {
       tag.elements = collections
-        .getFilteredByTag(tag.key)
-        .filter(livePosts)
-        .filter((item) => !item.data.excludeFromTags)
+        .getFilteredByGlob('**/*.md')
+        .filter(
+          (item) =>
+            livePosts(item) &&
+            !item.data.excludeFromTags &&
+            (item.data.tags || []).includes(key),
+        )
         .sort(sortByUpdated);
     }
 
@@ -76,7 +80,7 @@ module.exports = (collections) => {
     // Set created on date and updated date
     if (tag.elements.length > 0) {
       tag.data.date = tag.elements.slice(-1).pop().data.date;
-      const updated = tag.elements.slice(0, 1).pop().data.updated;
+      const updated = tag.elements.slice(0, 1).pop().data.date;
       if (tag.data.date !== updated) {
         tag.data.updated = updated;
       }

--- a/src/site/_collections/tags.js
+++ b/src/site/_collections/tags.js
@@ -37,15 +37,15 @@ module.exports = (collections) => {
 
   Object.keys(tagsData).forEach((key) => {
     const tagData = tagsData[key];
+    const title = tagData.title;
     const description =
       tagData.description ||
-      `Our latest news, updates, and stories about ${tagData.title.toLowerCase()}.`;
+      `Our latest news, updates, and stories about ${title.toLowerCase()}.`;
     const href = `/tags/${key}/`;
-    const title = tagData.title;
 
     /** @type TagsItem */
     const tag = {
-      ...tagsData[key],
+      ...tagData,
       data: {
         subhead: description,
         title,
@@ -59,12 +59,27 @@ module.exports = (collections) => {
       url: href,
     };
 
+    // Get posts
     if (collections) {
       tag.elements = collections
         .getFilteredByTag(tag.key)
         .filter(livePosts)
         .filter((item) => !item.data.excludeFromTags)
         .sort(sortByUpdated);
+    }
+
+    // Limit posts for percy
+    if (process.env.PERCY) {
+      tag.elements = tag.elements.slice(-6);
+    }
+
+    // Set created on date and updated date
+    if (tag.elements.length > 0) {
+      tag.data.date = tag.elements.slice(-1).pop().data.date;
+      const updated = tag.elements.slice(0, 1).pop().data.updated;
+      if (tag.data.date !== updated) {
+        tag.data.updated = updated;
+      }
     }
 
     if (tag.elements.length > 0 || !collections) {

--- a/types/site/_collections/authors.d.ts
+++ b/types/site/_collections/authors.d.ts
@@ -18,12 +18,20 @@ declare global {
   export interface AuthorsItem extends AuthorsDataItem {
     data: {
       alt?: string;
+      /**
+       * When the first post was created.
+       */
+      date?: Date;
       hero?: string;
       subhead: string;
       title: string;
+      /**
+       * When the last post was last created.
+       */
+      updated?: Date;
     };
     description: string;
-    elements: TODO[];
+    elements: EleventyCollectionItem[];
     href: string;
     key: string;
     title: string;

--- a/types/site/_collections/tags.d.ts
+++ b/types/site/_collections/tags.d.ts
@@ -17,12 +17,20 @@
 declare global {
   export interface TagsItem {
     data: {
+      /**
+       * When the first post was created.
+       */
+      date?: Date;
       subhead: string;
-      title: string;
       tags: string[];
+      title: string;
+      /**
+       * When the last post was last created.
+       */
+      updated?: Date;
     };
     description: string;
-    elements: TODO[];
+    elements: EleventyCollectionItem[];
     href: string;
     key: string;
     title: string;


### PR DESCRIPTION
In this PR I refactor the authors and the tags collections to be easier to read and to look more a like (considering they basically are the same sort of data, just organized by different ways).

But importantly both collections now support a `date` (created on) and an `updated` (updated on) field, which will be used in future indexing endeavors...