### PR TITLE
Make capitalization of 'web app manifest' match the handbook.

### DIFF
--- a/src/site/content/en/blog/deprecating-excalidraw-electron/index.md
+++ b/src/site/content/en/blog/deprecating-excalidraw-electron/index.md
@@ -12,7 +12,7 @@ description: |
 authors:
   - thomassteiner
 date: 2021-01-07
-updated: 2021-01-27
+updated: 2021-05-19
 canonical: https://blog.excalidraw.com/deprecating-excalidraw-electron/
 hero: image/admin/qfK9zbKBQalqq5zdr1P1.jpg
 alt: |
@@ -174,7 +174,7 @@ outline why we think we do not need Electron.
 
 Excalidraw today is an [installable](/installable/) Progressive Web App with a
 [service worker](https://excalidraw.com/service-worker.js) and a
-[Web App Manifest](https://excalidraw.com/manifest.json). It caches all its resources in two caches,
+[web app manifest](https://excalidraw.com/manifest.json). It caches all its resources in two caches,
 one for fonts and font-related CSS, and one for everything else.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/display-override/index.md
+++ b/src/site/content/en/blog/display-override/index.md
@@ -5,18 +5,19 @@ subhead: PWAs can use the "display_override" property to deal with special displ
 authors:
   - thomassteiner
 date: 2021-02-25
+updated: 2021-05-19
 description: |
   The display_override property allows developers to define a customized fallback chain of modes
   their PWAs should be displayed in.
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/woTD625c2X9tODE58koK.jpg
-alt: Web App Manifest source code excerpt.
+alt: Web app manifest source code excerpt.
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - progressive-web-apps
   - web-app-manifest
 ---
 
-A [Web App Manifest](/add-manifest/) is a JSON file that tells the browser about your Progressive
+A [web app manifest](/add-manifest/) is a JSON file that tells the browser about your Progressive
 Web App and how it should behave when installed on the user's desktop or mobile device.
 Via the [`display`](/add-manifest/#display) property, you can customize what browser UI is shown when your app is launched. For example, you can hide the
 address bar and browser chrome. Games can even be made to launch full screen.
@@ -111,7 +112,7 @@ In the example below, the display mode fallback chain would be as follows.
 To remain backward compatible, any future display mode will only be acceptable as a value of
 `display_override`, but not `display`.
 Browsers that do not support `display_override` fall back to the `display` property and ignore
-`display_override` as an unknown Web App Manifest property.
+`display_override` as an unknown web app manifest property.
 
 {% Aside %}
   The `display_override` property is defined independently from its potential values.

--- a/src/site/content/en/blog/excalidraw-and-fugu/index.md
+++ b/src/site/content/en/blog/excalidraw-and-fugu/index.md
@@ -10,6 +10,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-18
+updated: 2021-05-19
 scheduled: true
 description: |
   A write-up of Thomas Steiner's Google I/O 2021 talk titled Excalidraw and Fugu: Improving Core User Journeys
@@ -365,7 +366,7 @@ double-clicking would work, too, it's just less dramatic to demonstrate in a scr
 {% Video src="video/8WbTDNrhLsU0El80frMBGE4eMCD3/Gz1w0Gey1XerN86sIF01.mp4", autoplay=true, muted=true, playsinline=true, loop=true %}
 
 So how does this work? The first step is to make the file types my application can handle known to
-the operating system. I do this in a new field called `file_handlers` in the Web App Manifest. Its
+the operating system. I do this in a new field called `file_handlers` in the web app manifest. Its
 value is an array of objects with an action and an `accept` property. The action determines the URL
 path the operating system launches your app at and the accept object are key value pairs of MIME
 types and the associated file extensions.

--- a/src/site/content/en/blog/file-handling/index.md
+++ b/src/site/content/en/blog/file-handling/index.md
@@ -7,7 +7,7 @@ Description: |
   Register an app as a file handler with the operating system
   and open files with their proper app.
 date: 2020-10-22
-updated: 2020-11-02
+updated: 2021-05-19
 tags:
   - blog
   - file-handling
@@ -80,8 +80,8 @@ if ('launchQueue' in window) {
 
 ### The declarative part of the File Handling API
 
-As a first step, web apps need to declaratively describe in their [Web App Manifest](/add-manifest/)
-what kind of files they can handle. The File Handling API extends Web App Manifest with a new
+As a first step, web apps need to declaratively describe in their [web app manifest](/add-manifest/)
+what kind of files they can handle. The File Handling API extends web app manifest with a new
 property called `"file_handlers"` that accepts an array of, well, file handlers. A file handler is an
 object with two properties:
 
@@ -89,7 +89,7 @@ object with two properties:
 - An `"accept"` property with an object of MIME-types as keys and lists of file extensions as their
   values.
 
-The example below, showing only the relevant excerpt of the Web App Manifest, should make it clearer:
+The example below, showing only the relevant excerpt of the web app manifest, should make it clearer:
 
 ```json
 {

--- a/src/site/content/en/blog/load-faster-like-proxx/index.md
+++ b/src/site/content/en/blog/load-faster-like-proxx/index.md
@@ -4,6 +4,7 @@ subhead: How we used code splitting, code inlining, and server-side rendering in
 authors:
   - surma
 date: 2019-09-23
+updated: 2021-05-19
 hero: image/admin/14VzGmCgR470nlhPy3Fv.jpg
 # You can adjust the position of your hero image with this property.
 # Values: top | bottom | center (default)
@@ -107,7 +108,7 @@ Each thin line (`dns`, `connect`, `ssl`) stands for the creation of a new HTTP c
 - Request #5: The font styles from `fonts.googleapis.com`
 - Request #8: Google Analytics
 - Request #9: A font file from `fonts.gstatic.com`
-- Request #14: The Web App Manifest
+- Request #14: The web app manifest
 
 The new connection for `index.html` is unavoidable. The browser _has_ to create a connection to our server to get the contents. The new connection for Google Analytics could be avoided by inlining something like [Minimal Analytics], but Google Analytics is not blocking our app from rendering or becoming interactive, so we don't really care about how fast it loads. Ideally, Google Analytics should be loaded in idle time, when everything else has already loaded. That way it won't take up bandwidth or processing power during the initial load. The new connection for the web app manifest is [prescribed by the fetch spec][fetch connections], as the manifest has to be loaded over a non-credentialed connection. Again, the web app manifest doesn't block our app from rendering or becoming interactive, so we don't need to care that much.
 

--- a/src/site/content/en/blog/mainline-mensware/index.md
+++ b/src/site/content/en/blog/mainline-mensware/index.md
@@ -9,6 +9,7 @@ description: >
   Mainline Menswear implements a Progressive Web App (PWA) and sees a 55% conversion rate uplift for
   users that installed the app with caching and offline capabilities.
 date: 2021-04-20
+updated: 2021-05-19
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/Yz5G0leLpdHLidygym31.jpg
 tags:
   - blog
@@ -90,7 +91,7 @@ service worker file that they weren't able to or had issues with when using the 
 One such optimization was around the [offline functionality](#providing-offline-functionality) of
 the site like, for example, serving a default offline page and gathering analytics while offline.
 
-### Anatomy of the web application manifest
+### Anatomy of the web app manifest
 
 The team generated a manifest with icons for different mobile app icon sizes and other web app
 details like `name`, `description` and `theme_color`:
@@ -112,7 +113,7 @@ details like `name`, `description` and `theme_color`:
 ```
 
 The web app, once installed, can be launched from the home screen without the browser getting in the
-way. This is achieved by adding the `display` parameter in the web application manifest file:
+way. This is achieved by adding the `display` parameter in the web app manifest file:
 
 ```json
 {
@@ -131,7 +132,7 @@ the manifest:
 ```
 
 {% Aside %} See [Add a web app manifest](/add-manifest/) for a more in-depth explanation of all the
-web application manifest fields. {% endAside %}
+web app manifest fields. {% endAside %}
 
 ### Runtime caching for faster navigations
 

--- a/src/site/content/en/blog/maskable-icon/index.md
+++ b/src/site/content/en/blog/maskable-icon/index.md
@@ -9,7 +9,7 @@ authors:
   - tigeroakes
   - thomassteiner
 date: 2019-12-19
-updated: 2020-09-16
+updated: 2021-05-19
 hero: image/admin/lzLo9JCh6bcehH2nSH0n.png
 alt: Icons contained inside white circles compared to icons covering its entire circle
 tags:
@@ -95,12 +95,12 @@ then export the image.
 </figure>
 
 Once you've created a maskable icon image and tested it out in DevTools, you'll need to update your
-[Web App Manifest](https://developers.google.com/web/fundamentals/web-app-manifest) to point to the
-new assets. The Web App Manifest provides information about your web app in a JSON file, and
+[web app manifest](https://developers.google.com/web/fundamentals/web-app-manifest) to point to the
+new assets. The web app manifest provides information about your web app in a JSON file, and
 includes an [`icons` array](https://developers.google.com/web/fundamentals/web-app-manifest#icons).
 
 With the inclusion of maskable icons, a new property value has been added for image resources listed
-in a Web App Manifest. The `purpose` field tells the browser how your icon should be used. By
+in a web app manifest. The `purpose` field tells the browser how your icon should be used. By
 default, icons will have a purpose of `"any"`. These icons will be resized on top of a white
 background on Android.
 

--- a/src/site/content/en/blog/tabbed-application-mode/index.md
+++ b/src/site/content/en/blog/tabbed-application-mode/index.md
@@ -5,7 +5,7 @@ subhead: Work on more than one document at a time with tabs in your Progressive 
 authors:
   - thomassteiner
 date: 2021-02-25
-updated: 2021-04-07
+updated: 2021-05-19
 description: |
   Tabbed application mode allows Progressive Web App developers to add a tabbed document interface
   to their standalone PWAs.
@@ -33,7 +33,7 @@ panels to be contained within a single window, using tabs as a navigational widg
 between sets of documents.
 
 Progressive Web Apps can run in [various display modes](/add-manifest/#display) determined by the
-`display` property in the Web App Manifest. Examples are `fullscreen`, `standalone`, `minimal-ui`,
+`display` property in the web app manifest. Examples are `fullscreen`, `standalone`, `minimal-ui`,
 and `browser`. These display modes follow a
 [well-defined fallback chain](https://w3c.github.io/manifest/#dfn-fallback-display-mode)
 (`"fullscreen"` → `"standalone"` → `"minimal-ui"` → `"browser"`). If a browser does not support a
@@ -104,7 +104,7 @@ window.
 ## Using tabbed application mode
 
 To use tabbed application mode, developers need to opt their apps in by setting a specific
-[`"display_override"`](/display-override/) mode value in the Web App Manifest.
+[`"display_override"`](/display-override/) mode value in the web app manifest.
 
 ```json
 {
@@ -134,7 +134,7 @@ You can try tabbed application mode on Chrome&nbsp;OS devices running Chrome&nbs
 1. Open the app and interact with the tab strip.
 
 The video below shows the current iteration of the feature in action. There is no need to make any
-changes to the Web App Manifest for this to work.
+changes to the web app manifest for this to work.
 
 {% Video src="video/8WbTDNrhLsU0El80frMBGE4eMCD3/JwN0btyXFGiT9oPFh2qJ.webm", autoplay="true", loop="true", muted="true" %}
 
@@ -145,7 +145,7 @@ The Chrome team wants to hear about your experiences with tabbed application mod
 ### Tell us about the API design
 
 Is there something about tabbed application mode that does not work like you expected? Comment on
-the [Web App Manifest Issue][issue] that we have created.
+the [web app manifest Issue][issue] that we have created.
 
 ### Report a problem with the implementation
 
@@ -166,7 +166,7 @@ know where and how you are using it.
 
 ## Useful links
 
-- [Web App Manifest spec issue][issue]
+- [Web app manifest spec issue][issue]
 - [Chromium bug](https://crbug.com/897314)
 - Blink Component: [`UI>Browser>WebAppInstalls`][blink-component]
 

--- a/src/site/content/en/blog/url-protocol-handler/index.md
+++ b/src/site/content/en/blog/url-protocol-handler/index.md
@@ -6,7 +6,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-11
-updated: 2021-05-11
+updated: 2021-05-19
 description: |
   After registering a PWA as a protocol handler, when a user clicks on a hyperlink with a specific
   scheme such as mailto, bitcoin, or web+music from a browser or a platform-specific app,
@@ -118,9 +118,9 @@ token, enable the `#enable-desktop-pwas-protocol-handling` flag in `chrome://fla
 
 ## How to use URL protocol handler registration for PWAs
 
-The API for URL protocol handler registration is modeled closely on  
+The API for URL protocol handler registration is modeled closely on
 `navigator.registerProtocolHandler()`. Just this time the information is passed declaratively via
-the Web Application Manifest in a new property called `"protocol_handlers"` that takes an array of
+the web app manifest in a new property called `"protocol_handlers"` that takes an array of
 objects with the two required keys `"protocol"` and `"url"`. The code snippet below shows how to
 register `web+tea` and `web+coffee`. The values are strings containing the URL of the handler with
 the required `%s` placeholder for the escaped URL.

--- a/src/site/content/en/blog/window-controls-overlay/index.md
+++ b/src/site/content/en/blog/window-controls-overlay/index.md
@@ -7,7 +7,7 @@ authors:
   - thomassteiner
   - amandabaker
 date: 2021-04-22
-updated: 2021-05-07
+updated: 2021-05-19
 description: |
   With the Window Controls Overlay feature, developers can customize the title bar of installed PWAs
   so that their PWAs feel more like apps.
@@ -84,7 +84,7 @@ The origin trial is expected to end in Chrome&nbsp;94 (expected in July 2021).
 
 ## How to use Window Controls Overlay
 
-### Adding `window-controls-overlay` to the Web App Manifest
+### Adding `window-controls-overlay` to the web app manifest
 
 A progressive web app can opt-in to the window controls overlay by adding
 `"window-controls-overlay"` as the primary `"display_override"` member in the web app manifest:

--- a/src/site/content/en/progressive-web-apps/customize-install/index.md
+++ b/src/site/content/en/progressive-web-apps/customize-install/index.md
@@ -4,7 +4,7 @@ title: How to provide your own in-app install experience
 authors:
   - petelepage
 date: 2020-02-14
-updated: 2021-02-09
+updated: 2021-05-19
 description: |
   Use the beforeinstallprompt event to provide a custom, seamless, in-app
   install experience for your users.
@@ -53,7 +53,7 @@ in-app install flow:
 
 {% Aside %}
   The `beforeinstallprompt` event, and the `appinstalled` event have been moved
-  from the Web App Manifest spec to their own
+  from the web app manifest spec to their own
   [incubator](https://github.com/WICG/beforeinstallprompt). The Chrome team
   remains committed to supporting them, and has no plans to remove or deprecate
   support. Google's Web DevRel team continues to recommend using them to provide a customized

--- a/src/site/content/en/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/en/progressive-web-apps/install-criteria/index.md
@@ -4,7 +4,7 @@ title: What does it take to be installable?
 authors:
   - petelepage
 date: 2020-02-14
-updated: 2021-04-14
+updated: 2021-05-19
 description: |
   Progressive Web App installability criteria.
 tags:
@@ -56,7 +56,7 @@ promotion:
 * The web app is not already installed
 * Meets a user engagement heuristic
 * Be served over HTTPS
-* Includes a [Web App Manifest][add-manifest] that includes:
+* Includes a [web app manifest][add-manifest] that includes:
   * `short_name` or `name`
   * `icons` - must include a 192px and a 512px icon
   * `start_url`

--- a/src/site/content/en/progressive-web-apps/offline-fallback-page/index.md
+++ b/src/site/content/en/progressive-web-apps/offline-fallback-page/index.md
@@ -5,7 +5,7 @@ authors:
   - thomassteiner
   - petelepage
 date: 2020-09-24
-updated: 2021-03-24
+updated: 2021-05-19
 description: Learn how to create a simple offline experience for your app.
 tags:
   - progressive-web-apps
@@ -256,7 +256,7 @@ do in the example below. {% endAside %}
       document.querySelector("button").addEventListener("click", () => {
         window.location.reload();
       });
-      
+
       // Listen to changes in the network state, reload when online.
       // This handles the case when the device is completely offline.
       window.addEventListener('online', () => {
@@ -305,7 +305,7 @@ Glitch.
 ### Side note on making your app installable
 
 Now that your site has an offline fallback page, you might wonder about next steps. To make
-your app installable, you need to add a [Web App Manifest](/add-manifest/) and optionally come up
+your app installable, you need to add a [web app manifest](/add-manifest/) and optionally come up
 with an [install strategy](/define-install-strategy/).
 
 ### Side note on serving an offline fallback page with Workbox.js

--- a/src/site/content/en/react/add-manifest-react/index.md
+++ b/src/site/content/en/react/add-manifest-react/index.md
@@ -5,7 +5,7 @@ subhead: |
   A web app manifest is included into Create React App by default and allows anyone to install your React application on their device.
 hero: image/admin/pOjpReVK54kUJP6nZMwn.jpg
 date: 2019-04-29
-updated: 2021-02-18
+updated: 2021-05-19
 description: |
   Create React App includes a web app manifest by default. Modifying this file
   will allow you to change how your application is displayed when installed on
@@ -16,7 +16,7 @@ authors:
 
 {% Aside %}
   If you don't know how web app manifest files work, refer to the
-  [Add a Web App Manifest](/add-manifest) guide first.
+  [Add a web app manifest](/add-manifest) guide first.
 {% endAside %}
 
 Create React App (CRA) includes a web app manifest by default. Modifying this


### PR DESCRIPTION
This is per the [word list](https://web.dev/handbook/word-list/).