### PR TITLE
Fix incorrect pagination value for next page

### DIFF
--- a/src/site/_includes/partials/course-pagination.njk
+++ b/src/site/_includes/partials/course-pagination.njk
@@ -20,7 +20,7 @@
         <a href="{{ next.url }}" class="course-pagination-control" data-next>
           <div class="course-pagination-control__top display-flex align-center">
             <span class="font-mono case-upper">{{ 'i18n.common.next' | i18n(locale) }}</span>
-            <span class="font-mono">{{ loop.index0 | padStart(3, '0') }}</span>
+            <span class="font-mono">{{ (loop.index0 + 1) | padStart(3, '0') }}</span>
             {{ icon('arrow-forward', {label: 'next'}) }}
           </div>
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #5395

Changes proposed in this pull request:

- Fixes incorrect increment value for next page in course pagination


Before (on page 1):

https://web.dev/learn/css/box-model/

<img width="1024" alt="Screenshot 2021-05-19 at 10 06 36" src="https://user-images.githubusercontent.com/11479290/118777930-e790f800-b889-11eb-8e4f-9a968fe55742.png">

After (on page 1):

https://deploy-preview-5398--web-dev-staging.netlify.app/learn/css/box-model/

<img width="1025" alt="Screenshot 2021-05-19 at 10 07 21" src="https://user-images.githubusercontent.com/11479290/118778048-01cad600-b88a-11eb-9c3c-5692032ede84.png">

