### PR TITLE
Handle empty arrays in reduce calls in "Debug Web Vitals in the field" article

### DIFF
--- a/src/site/content/en/blog/debug-web-vitals-in-the-field/index.md
+++ b/src/site/content/en/blog/debug-web-vitals-in-the-field/index.md
@@ -133,12 +133,12 @@ to CLS and returns the largest source element from the largest shift:
 function getCLSDebugTarget(entries) {
   const largestShift = entries.reduce((a, b) => {
     return a && a.value > b.value ? a : b;
-  });
+  }, null);
   if (largestShift && largestShift.sources) {
     const largestSource = largestShift.sources.reduce((a, b) => {
       return a.node && a.previousRect.width * a.previousRect.height >
           b.previousRect.width * b.previousRect.height ? a : b;
-    });
+    }, null);
     if (largestSource) {
       return largestSource.node;
     }
@@ -347,14 +347,14 @@ function getSelector(node, maxLen = 100) {
 }
 
 function getLargestLayoutShiftEntry(entries) {
-  return entries.reduce((a, b) => a && a.value > b.value ? a : b);
+  return entries.reduce((a, b) => a && a.value > b.value ? a : b, null);
 }
 
 function getLargestLayoutShiftSource(sources) {
   return sources.reduce((a, b) => {
     return a.node && a.previousRect.width * a.previousRect.height >
         b.previousRect.width * b.previousRect.height ? a : b;
-  });
+  }, null);
 }
 
 function wasFIDBeforeDCL(fidEntry) {

--- a/src/site/content/en/blog/debug-web-vitals-in-the-field/index.md
+++ b/src/site/content/en/blog/debug-web-vitals-in-the-field/index.md
@@ -138,7 +138,7 @@ function getCLSDebugTarget(entries) {
     const largestSource = largestShift.sources.reduce((a, b) => {
       return a.node && a.previousRect.width * a.previousRect.height >
           b.previousRect.width * b.previousRect.height ? a : b;
-    }, null);
+    });
     if (largestSource) {
       return largestSource.node;
     }
@@ -354,7 +354,7 @@ function getLargestLayoutShiftSource(sources) {
   return sources.reduce((a, b) => {
     return a.node && a.previousRect.width * a.previousRect.height >
         b.previousRect.width * b.previousRect.height ? a : b;
-  }, null);
+  });
 }
 
 function wasFIDBeforeDCL(fidEntry) {


### PR DESCRIPTION
Page with proposed change: https://web.dev/debug-web-vitals-in-the-field/

Changes proposed in this pull request:

For very simple pages it is possible the `entires` array is empty. This prevents `reduce` working properly with the following error:

```
(index):51 Uncaught TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at getLargestLayoutShiftEntry ((index):51)
    at sendWebVitalsGAEvents ((index):80)
    at web-vitals.js?module:1
    at web-vitals.js?module:1
    at n (web-vitals.js?module:1)
```
This will prevent 0 CLS values being logged for very simple pages.

This pull request adds an [`initialValue`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#:~:text=Calling%20reduce()%20on%20an%20empty%20array%20without%20an%20initialValue%20will%20throw%20a%20TypeError) of `null` to prevent this error:

> Calling reduce() on an empty array without an initialValue will throw a TypeError.

Demo of original code with the fault: https://www.tunetheweb.com/experiments/core-web-vitals-debug/
Demo of updated code with no fault: https://www.tunetheweb.com/experiments/core-web-vitals-debug/index2.html
Demo of updated code with no fault for page with a CLS: https://www.tunetheweb.com/experiments/core-web-vitals-debug/index3.html

CC: @philipwalton