### PR TITLE
Bug/scroll padding top header

### DIFF
--- a/src/lib/components/Header/index.js
+++ b/src/lib/components/Header/index.js
@@ -79,8 +79,7 @@ export class Header extends BaseStateElement {
    */
   manageFocus() {
     if (this.openDrawerBtn) {
-      // FIXME(robdodson): https://github.com/GoogleChrome/web.dev/pull/5335
-      // this.openDrawerBtn.focus();
+      this.openDrawerBtn.focus();
     }
   }
 }

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -67,6 +67,10 @@ html {
   scroll-padding-top: calc(#{$WEB_HEADER_HEIGHT} + 1.5rem);
 }
 
+web-header {
+  scroll-padding-top: unset !important;
+}
+
 // Fallback if scroll-padding-top is not supported
 *:not([href])[id]::before {
   content: ' ';

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -63,15 +63,11 @@ var {
   hyphens: none;
 }
 
-html {
-  scroll-padding-top: calc(#{$WEB_HEADER_HEIGHT} + 1.5rem);
-}
-
-web-header {
-  scroll-padding-top: unset !important;
-}
-
-// Fallback if scroll-padding-top is not supported
+// Give page headers some padding when they're scrolled into view.
+// Don't use scroll-padding-top until https://bugs.chromium.org/p/chromium/issues/detail?id=664246
+// is fixed. Otherwise we have weird issues with keyboard focus and sticky
+// positioned elements, demonstrated by this codepen: https://codepen.io/robdodson/pen/MWpKOOK
+// Use this workaround until we can use scroll-padding-top.
 *:not([href])[id]::before {
   content: ' ';
   display: block;


### PR DESCRIPTION
Fixes #5413

Changes proposed in this pull request:

- Add drawer focus management back for keyboard users
- Comment out scroll-padding-top for now and use funky pseudo element workaround. Note, this is what we used before scroll-padding-top was shipping in browsers so it's not that big of a change.
