### PR TITLE
Improve learn css course tracking.

### DIFF
--- a/src/lib/components/CourseLinks/index.js
+++ b/src/lib/components/CourseLinks/index.js
@@ -113,9 +113,8 @@ class CourseLinks extends HTMLElement {
     if (ga && newPercent - oldPercent >= 10) {
       ga('send', 'event', {
         eventCategory: 'Course Events',
-        eventAction: 'progress',
-        eventLabel: courseKey,
-        eventValue: newPercent.toString(),
+        eventAction: `course: ${courseKey} progress`,
+        eventLabel: newPercent.toString(),
       });
     }
 

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -51,7 +51,7 @@ module.exports = {
       SIGNED_IN: 'dimension1',
       TRACKING_VERSION: 'dimension5',
     },
-    version: 3,
+    version: 4,
   },
   firebase: {
     prod: {


### PR DESCRIPTION
Analytics are hard :P

I think this should make reading the course progress easier. I don't think we're supposed to use the `value` field. Otherwise it tries to average all of the values together and we don't get useful data.