### PR TITLE
Mention and add reference to attribute selectors

### DIFF
--- a/src/site/content/en/learn/css/specificity/index.md
+++ b/src/site/content/en/learn/css/specificity/index.md
@@ -97,10 +97,11 @@ div {
 }
 ```
 
-### Class, attribute or pseudo-class selector
+### Class, pseudo-class, or attribute selector
 
-A [class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors) or
-[pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) selector gets **10 points of specificity**.
+A [class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors),
+[pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) or
+[attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) selector gets **10 points of specificity**.
 
 #### Class selector
 


### PR DESCRIPTION
- Adjust the heading so selector names order corresponds to the section content (keeping class and pseudo-class together seems helpful to the reader)
- Mention provide a reference to atttribute selectors in the discussion of specificity points
