### PR TITLE
[Browser Flags article] Add `about:blank` exception

### DIFF
--- a/src/site/content/en/blog/browser-flags/index.md
+++ b/src/site/content/en/blog/browser-flags/index.md
@@ -79,7 +79,7 @@ web thing together, and this is `about://` all of us! Whenever you see instructi
 `about://` scheme, your Chromium browser of choice will do the right thing.
 
 {% Aside %}
-A notable exception from the rewriting mechanism is [`about:blank`](about:blank) (without the `//`), which
+A notable exception to the rewriting mechanism is [`about:blank`](about:blank) (without the `//`), which
 displays a blank, empty document.
 {% endAside %}
 

--- a/src/site/content/en/blog/browser-flags/index.md
+++ b/src/site/content/en/blog/browser-flags/index.md
@@ -7,7 +7,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-18
-# updated: 2021-05-19
+updated: 2021-05-25
 description: |
   For some of the new APIs we introduce in Chromium, you need to set a browser flag for experimentation.
   This article explains how to do this in the various Chromium derivatives like Google Chrome, Microsoft Edge, and others.
@@ -77,6 +77,11 @@ Luckily there is a hidden champion scheme that fits all our needs: `about://`. I
 URLs get rewritten to `chrome://`, in Edge to `edge://`, and so on for all vendors. We are in this
 web thing together, and this is `about://` all of us! Whenever you see instructions that include the
 `about://` scheme, your Chromium browser of choice will do the right thing.
+
+{% Aside %}
+A notable exception from the rewriting mechanism is `about:blank` (without the `//`), which
+displays a blank, empty window.
+{% endAside %}
 
 ## Acknowledgements
 

--- a/src/site/content/en/blog/browser-flags/index.md
+++ b/src/site/content/en/blog/browser-flags/index.md
@@ -79,7 +79,7 @@ web thing together, and this is `about://` all of us! Whenever you see instructi
 `about://` scheme, your Chromium browser of choice will do the right thing.
 
 {% Aside %}
-A notable exception from the rewriting mechanism is `about:blank` (without the `//`), which
+A notable exception from the rewriting mechanism is [`about:blank`](about:blank) (without the `//`), which
 displays a blank, empty window.
 {% endAside %}
 

--- a/src/site/content/en/blog/browser-flags/index.md
+++ b/src/site/content/en/blog/browser-flags/index.md
@@ -80,7 +80,7 @@ web thing together, and this is `about://` all of us! Whenever you see instructi
 
 {% Aside %}
 A notable exception from the rewriting mechanism is [`about:blank`](about:blank) (without the `//`), which
-displays a blank, empty window.
+displays a blank, empty document.
 {% endAside %}
 
 ## Acknowledgements


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `about:blank` exception. Thanks, @naskooskov!