### PR TITLE
Replace `chrome://` with `about://`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you need to debug the site's build process:
 
 1. Add a `debugger` statement to `.eleventy.js`
 1. Run `npm run debug:eleventy`
-1. Go to `chrome://inspect` to attach to the running process.
+1. Go to `about://inspect` to attach to the running process.
 
 <img
   width="295"

--- a/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
+++ b/src/site/content/en/blog/a11y-tips-for-web-dev/index.md
@@ -480,7 +480,7 @@ debugging the accessibility of your visual components.
   or [Windows Automation API Testing Tools](http://msdn.microsoft.com/en-us/library/windows/desktop/dd373661(v=vs.85).aspx)
   and [AccProbe](http://accessibility.linuxfoundation.org/a11yweb/util/accprobe/) (Windows).
   You can also see the full accessibility tree that Chrome creates
-  by navigating to `chrome://accessibility`.
+  by navigating to `about://accessibility`.
 - The best way to test for screen reader support on a Mac is using the VoiceOver utility.
   Use `⌘F5` to enable or disable it, `Ctrl+Option ←→` to move through the page,
   and `Ctrl+Shift+Option + ↑↓` to move up and down the accessibility tree.

--- a/src/site/content/en/blog/app-shortcuts/index.md
+++ b/src/site/content/en/blog/app-shortcuts/index.md
@@ -189,7 +189,7 @@ You should annotate app shortcuts `url` entries like you would do with
 
 App shortcuts are available on Android (Chrome 84), Windows (Chrome 85 and
 Edge 85), and Chrome OS (Chrome 92 behind the experimental
-`chrome://flags/#enable-desktop-pwas-app-icon-shortcuts-menu-ui` flag).
+`about://flags/#enable-desktop-pwas-app-icon-shortcuts-menu-ui` flag).
 More desktop platform support will follow.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/appcache-removal/index.md
+++ b/src/site/content/en/blog/appcache-removal/index.md
@@ -150,15 +150,15 @@ Adding the origin trial token to your AppCache manifests indicates that each man
 
 While the "reverse" origin trial officially starts with Chrome 84, you can [sign up](https://developers.chrome.com/origintrials/#/register_trial/1776670052997660673) for the origin trial today and add the tokens to your HTML and AppCache manifests. As your web app's audience gradually upgrades to Chrome 84, any tokens that you've already added will go into effect.
 
-Once you've added a token to your AppCache manifest, visit `chrome://appcache-internals` to confirm that your local instance of Chrome (version 84 or later) has properly associated the origin trial token with your manifest's cached entries. If your origin trial is recognized, you should see a field with `Token Expires: Tue Apr 06 2021...` on that page, associated with your manifest:
+Once you've added a token to your AppCache manifest, visit `about://appcache-internals` to confirm that your local instance of Chrome (version 84 or later) has properly associated the origin trial token with your manifest's cached entries. If your origin trial is recognized, you should see a field with `Token Expires: Tue Apr 06 2021...` on that page, associated with your manifest:
 
 <figure class="w-figure">
-  {% Img src="image/admin/Xid94kdPT5yGbQzBL4at.jpg", alt="chrome://appcache-internals interface showing a recognized token.", width="550", height="203", class="w-screenshot" %}
+  {% Img src="image/admin/Xid94kdPT5yGbQzBL4at.jpg", alt="about://appcache-internals interface showing a recognized token.", width="550", height="203", class="w-screenshot" %}
 </figure>
 
 ## Testing prior to removal
 
-We strongly encourage you to migrate off of AppCache as soon as is feasible. If you want to test removal of AppCache on your web apps, use the `chrome://flags/#app-cache` [flag](https://www.chromium.org/developers/how-tos/run-chromium-with-flags) to simulate its removal. This flag is available starting with Chrome 84.
+We strongly encourage you to migrate off of AppCache as soon as is feasible. If you want to test removal of AppCache on your web apps, use the `about://flags/#app-cache` [flag](https://www.chromium.org/developers/how-tos/run-chromium-with-flags) to simulate its removal. This flag is available starting with Chrome 84.
 
 ## Migration strategies {: #migration-strategies }
 

--- a/src/site/content/en/blog/bluetooth/index.md
+++ b/src/site/content/en/blog/bluetooth/index.md
@@ -46,7 +46,7 @@ Bluetooth descriptors]. See MDN's [Browser compatibility] table for more
 information.
 
 For Linux and earlier versions of Windows, enable the
-`#experimental-web-platform-features` flag in `chrome://flags`.
+`#experimental-web-platform-features` flag in `about://flags`.
 
 ### Available for origin trials
 
@@ -484,7 +484,7 @@ Check out our [curated Web Bluetooth Demos] and [official Web Bluetooth Codelabs
 ## Tips
 
 A **Bluetooth Internals** page is available in Chrome at
-`chrome://bluetooth-internals` so that you can inspect everything about nearby
+`about://bluetooth-internals` so that you can inspect everything about nearby
 Bluetooth devices: status, services, characteristics, and descriptors.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/building-a-media-scroller-component/index.md
+++ b/src/site/content/en/blog/building-a-media-scroller-component/index.md
@@ -137,7 +137,7 @@ favorite data source.
 
 Now it's time for CSS to take this generic list of content and turn it into an
 experience. Netflix, App stores and many more sites and apps use horizontal
-scrolling areas to pack the viewport with categories and options. 
+scrolling areas to pack the viewport with categories and options.
 
 ### Creating the scroller layout
 
@@ -193,12 +193,12 @@ With only a few more minor styles, complete the barebones of the media scroller:
 
   display: grid;
   grid-auto-flow: column;
-  gap: calc(var(--gap) / 2); 
+  gap: calc(var(--gap) / 2);
   margin: 0;
 
   overflow-x: auto;
   overscroll-behavior-inline: contain;
-  
+
   & > li {
     display: inline-block; /* removes the list-item bullet */
   }
@@ -212,7 +212,7 @@ With only a few more minor styles, complete the barebones of the media scroller:
 
 Setting `overflow` sets the `<ul>` up to allow scrolling and keyboard navigation
 through its list, then each direct child `<li>` element has its `::marker` removed
-by getting a new display type of `inline-block`. 
+by getting a new display type of `inline-block`.
 
 The images aren't responsive yet though, and burst right out of the boxes
 they're inside. Tame them with some sizes, fit, and border styles, and
@@ -232,10 +232,10 @@ img {
   overflow: hidden;
 
   /* if empty, show a gradient placeholder */
-  background-image: 
+  background-image:
     linear-gradient(
-      to bottom, 
-      hsl(0 0% 40%), 
+      to bottom,
+      hsl(0 0% 40%),
       hsl(0 0% 20%)
     );
 }
@@ -244,7 +244,7 @@ img {
 ### Scroll padding
 
 Alignment to page content, plus an edge-to-edge scrolling surface area, are
-critical to a harmonious and minimal component. 
+critical to a harmonious and minimal component.
 
 {% Video
   src="video/vS06HQ1YTsbMKSFTIPl2iogUQP73/hClUoh402H88dexfTpqS.mp4",
@@ -276,18 +276,18 @@ and layout lines, use `padding` that matches the `scroll-padding`:
 ```
 
 {% Aside %}
-I've simplified the example CSS here to only the logical properties. 
-The hosted demo linked in this post has fallbacks for browsers 
+I've simplified the example CSS here to only the logical properties.
+The hosted demo linked in this post has fallbacks for browsers
 without support for these logical shorthands.
 {%endAside%}
 
-**Horizontal scroll padding bug fix** 
+**Horizontal scroll padding bug fix**
 The above shows how easy it should be to
 pad a scroll container, but there's outstanding compatibility issues with it
 (fixed in Chromium 91+ though!). See
 [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1069614) for a bit
 of the history, but the short version is that padding wasn't always accounted
-for in a scroll view. 
+for in a scroll view.
 
 {% Img src="image/vS06HQ1YTsbMKSFTIPl2iogUQP73/jpOZQeMvnHwqiH0jatl7.png", alt="A
 box is highlighted on the inline-end side of the last list item, showing the
@@ -296,7 +296,7 @@ width="800", height="272" %}
 
 To trick browsers into putting the padding at the end of the scroller I'll
 target the last figure in each list and append a pseudo element that's the
-amount of padding desired. 
+amount of padding desired.
 
 ```css
 .horizontal-media-scroller > li:last-of-type figure {
@@ -320,7 +320,7 @@ and document direction.
 
 ### Scroll snapping
 
-A scrolling container with overflow can become a snapping viewport with one line of CSS, then it's on children to specify how they'd like to align with that viewport. 
+A scrolling container with overflow can become a snapping viewport with one line of CSS, then it's on children to specify how they'd like to align with that viewport.
 
 {% Video
   src="video/vS06HQ1YTsbMKSFTIPl2iogUQP73/hClUoh402H88dexfTpqS.mp4",
@@ -344,7 +344,7 @@ A scrolling container with overflow can become a snapping viewport with one line
 
   padding-inline: var(--gap);
   scroll-padding-inline: var(--gap);
-  padding-block-end: calc(var(--gap) / 2); 
+  padding-block-end: calc(var(--gap) / 2);
 
   scroll-snap-type: inline mandatory;
 
@@ -392,7 +392,7 @@ space. If the user has no motion preferences around reducing motion, the offset
 is transitioned, giving subtle motion to the focus event.
 
 {% Aside %}
-This focus state is an opportunity for unique 
+This focus state is an opportunity for unique
 and brand defining micro-interaction UX
 {%endAside%}
 
@@ -404,7 +404,7 @@ scrolling content and options. The common pattern for solving this is called
 container of items is keyboard focused but only 1 child is allowed to hold focus
 at a time. This single focusable item at a time experience is designed to allow
 bypassing the potentially long list of items, as opposed to pressing tab 50+
-times to reach the end. 
+times to reach the end.
 
 There's 300 items in that first scroller of the demo. We can do better than make
 them traverse all of them to reach the next section.
@@ -429,7 +429,7 @@ focus targets aren't direct descendants.
 
 ```js/2-4
 document.querySelectorAll('.horizontal-media-scroller')
-  .forEach(scroller => 
+  .forEach(scroller =>
     rovingIndex({
       element: scroller,
       target: 'a',
@@ -478,20 +478,20 @@ and 4:3", width="800", height="324", class="w-screenshot" %}
 
 If the browser supports `aspect-ratio` syntax, the media scroller pictures are
 upgraded to `aspect-ratio` sizing. Using the draft nesting syntax, each picture
-changes its aspect ratio depending if it's the first, second, or third rows. The 
+changes its aspect ratio depending if it's the first, second, or third rows. The
 [nest syntax](https://drafts.csswg.org/css-nesting-1/) also allows setting some small
-viewport adjustments, right there with the other sizing logic. 
+viewport adjustments, right there with the other sizing logic.
 
 With that CSS, as the feature is available in more browser engines, an easy to
 manage but more visually appealing layout will render.
 
 ### Prefers reduced data
 
-While this next technique is only available 
-[behind a flag](chrome://flags/#enable-experimental-web-platform-features) in
-[Canary](https://www.google.com/chrome/canary/), 
-I wanted to share how I could save a considerable amount of page load time and 
-data use with a few lines of CSS. The `prefers-reduced-data` media query from 
+While this next technique is only available
+[behind a flag](about://flags/#enable-experimental-web-platform-features) in
+[Canary](https://www.google.com/chrome/canary/),
+I wanted to share how I could save a considerable amount of page load time and
+data use with a few lines of CSS. The `prefers-reduced-data` media query from
 [level 5](https://drafts.csswg.org/mediaqueries-5/) allows asking if the device is in
 any reduced data states, like a data saver mode. If it is, I can modify the
 document, and in this case, hide the images.

--- a/src/site/content/en/blog/change-password-url/index.md
+++ b/src/site/content/en/blog/change-password-url/index.md
@@ -150,7 +150,7 @@ but has not signalled that it plans to do so as of August 2020.
 Let's have a look at how Chrome's password manager treats vulnerable passwords.
 
 Chrome's password manager is able to check for leaked passwords. By navigating
-to `chrome://settings/passwords` users can run **Check passwords** against stored
+to `about://settings/passwords` users can run **Check passwords** against stored
 passwords, and see a list of passwords that are recommended for update.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/content-indexing-api/index.md
+++ b/src/site/content/en/blog/content-indexing-api/index.md
@@ -87,7 +87,7 @@ The best way to get a feel for the Content Indexing API is to try a sample
 application.
 
 1. Make sure that you're using a supported browser and platform. Currently,
-   that's limited to **Chrome 84 or later on Android**. Go to `chrome://version` to see
+   that's limited to **Chrome 84 or later on Android**. Go to `about://version` to see
    what version of Chrome you're running.
 1. Visit [https://contentindex.dev](https://contentindex.dev)
 1. Click the `+` button next to one or more of the items on the list.

--- a/src/site/content/en/blog/cors-rfc1918-feedback/index.md
+++ b/src/site/content/en/blog/cors-rfc1918-feedback/index.md
@@ -119,7 +119,7 @@ Chrome is bringing CORS-RFC1918 in two steps:
 
 Chrome 87 adds a flag that mandates public websites making requests to private
 network resources to be on HTTPS. You can go to
-`chrome://flags#block-insecure-private-network-requests` to enable it. With this
+`about://flags#block-insecure-private-network-requests` to enable it. With this
 flag turned on, any requests to a private network resource from an HTTP website
 will be blocked.
 
@@ -168,7 +168,7 @@ If you are hosting a website within a private network that expects requests from
 public networks, the Chrome team is interested in your feedback and use cases. There
 are two things you can do to help:
 
-* Go to `chrome://flags#block-insecure-private-network-requests`, turn on the
+* Go to `about://flags#block-insecure-private-network-requests`, turn on the
   flag and see if your website sends requests to the private network resource as
   expected.
 * If you encounter any issues or have feedback, file an issue at

--- a/src/site/content/en/blog/declarative-shadow-dom/index.md
+++ b/src/site/content/en/blog/declarative-shadow-dom/index.md
@@ -377,7 +377,7 @@ constructable stylesheets in HTML, and no way to refer to them when populating `
 
 Declarative Shadow DOM is available in Chrome&nbsp;90 and Edge&nbsp;91. It can also be enabled
 using the **Experimental Web Platform Features** flag in Chrome&nbsp;85. Navigate to
-`chrome://flags/#enable-experimental-web-platform-features` to find that setting.
+`about://flags/#enable-experimental-web-platform-features` to find that setting.
 
 As a new web platform API, Declarative Shadow DOM does not yet have widespread support across all
 browsers. Browser support can be detected by checking for the existence of a `shadowroot` property

--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -36,7 +36,7 @@ Maybe you can think of a much more exciting use-case for request streaming.
 
 ## Try out request streams
 
-### Enabling via chrome://flags {: #enable-flags }
+### Enabling via about://flags {: #enable-flags }
 
 Try out request streams in Chrome 85 by flipping an experimental flag:
 `enable-experimental-web-platform-features`.

--- a/src/site/content/en/blog/file-handling/index.md
+++ b/src/site/content/en/blog/file-handling/index.md
@@ -53,10 +53,10 @@ Examples of sites that may use this API include:
 
 ## How to use the File Handling API {: #use }
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with the File Handling API locally, without an origin trial token, enable the
-`#file-handling-api` flag in `chrome://flags`.
+`#file-handling-api` flag in `about://flags`.
 
 ### Progressive enhancement
 

--- a/src/site/content/en/blog/gamepad/index.md
+++ b/src/site/content/en/blog/gamepad/index.md
@@ -21,9 +21,9 @@ Chrome's offline page easter egg is one of the worst-kept secrets in history
 If you press the <kbd>space</kbd> key or, on mobile devices, tap the dinosaur,
 the offline page becomes a playable arcade game.
 You might be aware that you do not actually have to go offline
-when you feel like playing: in Chrome, you can just navigate to `chrome://dino`, or,
+when you feel like playing: in Chrome, you can just navigate to `about://dino`, or,
 for the geek in you, browse to
-`chrome://network-error/-106`.
+`about://network-error/-106`.
 But did you know that there are currently
 [270 million Chrome dino games played every month](https://www.blog.google/products/chrome/chrome-dino#jump-content:~:text=There%20are%20currently%20270%20million%20games%20played%20every%20month)?
 

--- a/src/site/content/en/blog/hands-on-portals/index.md
+++ b/src/site/content/en/blog/hands-on-portals/index.md
@@ -67,11 +67,11 @@ Before Portals, we could have rendered another page using an `<iframe>`. We coul
 
 ## Try out Portals
 
-### Enabling via chrome://flags {: #enable-flags }
+### Enabling via about://flags {: #enable-flags }
 
 Try out Portals in Chrome 85 and later versions by flipping an experimental flag:
-- Enable the `chrome://flags/#enable-portals` flag for same-origin navigations.
-- For testing out cross-origin navigations, enable the `chrome://flags/#enable-portals-cross-origin` flag in addition.
+- Enable the `about://flags/#enable-portals` flag for same-origin navigations.
+- For testing out cross-origin navigations, enable the `about://flags/#enable-portals-cross-origin` flag in addition.
 
 During this early phase of the Portals experiment,
 we also recommend using a completely separate user data directory for your tests

--- a/src/site/content/en/blog/hid/index.md
+++ b/src/site/content/en/blog/hid/index.md
@@ -345,7 +345,7 @@ navigator.hid.addEventListener("disconnect", event => {
 
 ## Dev Tips {: #dev-tips }
 
-Debugging HID in Chrome is easy with the internal page, `chrome://device-log`
+Debugging HID in Chrome is easy with the internal page, `about://device-log`
 where you can see all HID and USB device related events in one single place.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/how-to-distribute-signed-http-exchanges/index.md
+++ b/src/site/content/en/blog/how-to-distribute-signed-http-exchanges/index.md
@@ -84,7 +84,7 @@ If the distributor wants to serve `app.js.sxg` from their own service and tries 
 {% Img src="image/admin/IRRFoXyhnmwVXwiDgeny.png", alt="An attempt to link the reference to app.js in distributor.test/index.html.sxg to distributor.test/app.js causes a signature mismatch.", width="592", height="258" %}
 
 To solve this problem, there's an experimental SXG subresource prefetching feature in Chrome now.
-You can enable it at: `chrome://flags/#enable-sxg-subresource-prefetching`.
+You can enable it at: `about://flags/#enable-sxg-subresource-prefetching`.
 To use subresource prefetching the following conditions must be met:
 
 - The publisher must embed a response header entry in SXG, such as: `link: <https://website.test/app.js>;rel="preload";as="script",<https://website.test/app.js>;rel="allowed-alt-sxg";header-integrity="sha256-h6GuCtTXe2nITIHHpJM+xCxcKrYDpOFcIXjihE4asxk="`. This specifies the subresource that can be substituted with the SXG's specific integrity hash.

--- a/src/site/content/en/blog/idle-detection/index.md
+++ b/src/site/content/en/blog/idle-detection/index.md
@@ -59,10 +59,10 @@ can limit these calculations to moments when the user interacts with their devic
 
 ## How to use the Idle Detection API {: #use }
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with the Idle Detection API locally, without an origin trial token, enable the
-`#enable-experimental-web-platform-features` flag in `chrome://flags`.
+`#enable-experimental-web-platform-features` flag in `about://flags`.
 
 ### Enabling support during the origin trial phase
 

--- a/src/site/content/en/blog/local-fonts/index.md
+++ b/src/site/content/en/blog/local-fonts/index.md
@@ -170,10 +170,10 @@ The Local Font Access API is an attempt at solving these challenges. It consists
 
 ### How to use the Local Font Access API
 
-#### Enabling via chrome://flags
+#### Enabling via about://flags
 
 To experiment with the Local Font Access API locally, enable the `#font-access` flag in
-`chrome://flags`.
+`about://flags`.
 
 ### Enabling support during the origin trial phase
 

--- a/src/site/content/en/blog/mediastreamtrack-insertable-media-processing/index.md
+++ b/src/site/content/en/blog/mediastreamtrack-insertable-media-processing/index.md
@@ -85,10 +85,10 @@ If necessary, a separate origin trial will continue for insertable streams for `
 
 {% include 'content/origin-trial-register.njk' %}
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with insertable streams for `MediaStreamTrack` locally, without an origin trial token,
-enable the `#enable-experimental-web-platform-features` flag in `chrome://flags`.
+enable the `#enable-experimental-web-platform-features` flag in `about://flags`.
 
 ### Feature detection
 

--- a/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
+++ b/src/site/content/en/blog/monitor-total-page-memory-usage/index.md
@@ -142,10 +142,10 @@ results for the same browser.
 
 ## Using `performance.measureUserAgentSpecificMemory()` {: use }
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with `performance.measureUserAgentSpecificMemory()` without an origin trial
-token, enable the `#experimental-web-platform-features` flag in `chrome://flags`.
+token, enable the `#experimental-web-platform-features` flag in `about://flags`.
 
 ### Enabling support during the origin trial phase
 

--- a/src/site/content/en/blog/multi-screen-window-placement/index.md
+++ b/src/site/content/en/blog/multi-screen-window-placement/index.md
@@ -56,10 +56,10 @@ Examples of sites that may use this API include:
 
 ## How to use the Multi-Screen Window Placement API {: #use }
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with the Multi-Screen Window Placement API locally, without an origin trial token,
-enable the `#enable-experimental-web-platform-features` flag in `chrome://flags`.
+enable the `#enable-experimental-web-platform-features` flag in `about://flags`.
 
 ### Enabling support during the origin trial phase
 

--- a/src/site/content/en/blog/new-responsive/index.md
+++ b/src/site/content/en/blog/new-responsive/index.md
@@ -31,7 +31,7 @@ Viewport-based media queries give you some powerful tools, but lack a lot of
 finesse. They lack the ability to respond to user needs, and the ability to
 inject responsive styles into components themselves.
 
-{% Aside %} 
+{% Aside %}
 When referring to components for the sake of this article, this
 means elements, including elements that are made up of other elements, like a
 card or sidebar. Those components make up our web pages.
@@ -45,7 +45,7 @@ The good news is, the ecosystem is changing, and it's changing pretty rapidly.
 CSS is evolving, and a new era of responsive design is right on the horizon.
 
 We see this happen about every 10 years. 10 years ago, around 2010-2012, we saw
-a huge change with mobile and responsive design, and the emergence of CSS3. 
+a huge change with mobile and responsive design, and the emergence of CSS3.
 
 
 <figure>
@@ -102,7 +102,7 @@ loader, or other flashy animations while using the web.
 
 With `prefers-reduced-motion` you can design your pages with reduced-motion in
 mind, and create a motion-enhanced experience for those who don't have this
-preference set. 
+preference set.
 
 {% Video src="video/HodOHWjMnbNw56hvNASHWSgZyAf2/r4z52PPvElemSUJwUCZp.mp4",
 autoplay=true, muted=true, playsinline=true, loop=true, controls=true %}
@@ -223,7 +223,7 @@ information rather than the viewport and user agent.
   .links {
     display: none;
   }
-  
+
   .time {
     font-size: 1.25rem;
   }
@@ -242,7 +242,7 @@ as decreasing the time font size when the container is less than `850px` wide.
 
 In this demo plant website, each of the product cards, including the one in the
 hero, the sidebar of recently viewed items, and the product grid, are all the
-exact same component, with the same markup. 
+exact same component, with the same markup.
 
 <figure>
 {% Video src="video/HodOHWjMnbNw56hvNASHWSgZyAf2/D4hBchz6kaPjkgx8BCmU.mp4",
@@ -254,7 +254,7 @@ There are _no_ media queries used to create this entire layout, just container
 queries. This allows for each product card to shift to the proper layout to fill
 its space. The grid for example, uses a minmax column layout to let the elements
 flow into their space, and re-layout the grid when that space is too compressed
-(which means that it hit the minimum size). 
+(which means that it hit the minimum size).
 
 ```css
 .product {
@@ -266,7 +266,7 @@ flow into their space, and re-layout the grid when that space is too compressed
     padding: 0.5rem 0 0;
     display: flex;
   }
-  
+
   .card-container button {
     /* ... */
   }
@@ -276,9 +276,9 @@ flow into their space, and re-layout the grid when that space is too compressed
 
 When there is at least `350px` of space in the grid, the card layout goes
 horizontal by being set to `display: flex`, which has a default flex-direction
-of "row". 
+of "row".
 
-With less space, the product cards stack. Each product card styles itself, 
+With less space, the product cards stack. Each product card styles itself,
 something that would be impossible with global styles alone.
 
 ### Mixing Container Queries with Media Queries
@@ -308,7 +308,7 @@ allow for some really nice nuanced design decisions.
 ### Using container queries today
 
 These demos are now available to play with behind a flag in Chrome Canary. Go to
-`chrome://flags` in Canary and turn on the `#enable-container-queries` flag.
+`about://flags` in Canary and turn on the `#enable-container-queries` flag.
 This will enable support for `@container`, `inline-size` and `block-size` values
 for the `contain` property, and the LayoutNG Grid implementation.
 
@@ -389,7 +389,7 @@ main {
 
 This enables a layout where the sidebar, the navigation in this case, fills the
 space of one of the folds, where the app UI fills the other. This prevents a
-"crease" in the UI. 
+"crease" in the UI.
 
 {% Video src="video/HodOHWjMnbNw56hvNASHWSgZyAf2/Uf3RL7EhVZGK2ECiD0sT.mp4",
 autoplay=true, muted=true, playsinline=true, loop=true, controls=true %}
@@ -433,7 +433,7 @@ on web.dev. You can access it via [web.dev/learnCSS](/learn/css).
 
 I hope you enjoyed this overview on the next era of responsive design, and some
 of the primitives that will come along with it, and I also hope you're as
-excited as I am about what this means for the future of web design. 
+excited as I am about what this means for the future of web design.
 
 It opens up a huge opportunity to us as a UI community to embrace
 component-based styles, new form factors, and create user-responsive

--- a/src/site/content/en/blog/notification-triggers/index.md
+++ b/src/site/content/en/blog/notification-triggers/index.md
@@ -72,10 +72,10 @@ alarms for telephone conferences or video calls.
 
 ## How to use notification triggers {: #use }
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with the Notification Triggers API locally, without an origin trial token, enable the
-`#enable-experimental-web-platform-features` flag in `chrome://flags`.
+`#enable-experimental-web-platform-features` flag in `about://flags`.
 
 {% Aside %} Two earlier origin trials for the feature, which gave developers a chance to try out the
 proposed API, ran from Chrome&nbsp;80 to&nbsp;83 and from Chrome&nbsp;86 to&nbsp;88. You can read

--- a/src/site/content/en/blog/periodic-background-sync/index.md
+++ b/src/site/content/en/blog/periodic-background-sync/index.md
@@ -152,7 +152,7 @@ Furthermore, since Chrome doesn't want unused or seldom used web apps to gratuit
 consume battery or data, Chrome designed periodic background sync such that
 developers will have to earn it by providing value to their users. Concretely,
 Chrome is using a [site engagement score](https://www.chromium.org/developers/design-documents/site-engagement)
-(`chrome://site-engagement/`) to determine if and how often periodic background syncs can happen
+(`about://site-engagement/`) to determine if and how often periodic background syncs can happen
 for a given web app. In other words, a `periodicsync` event won't be fired at all unless the engagement
 score is greater than zero, and its value affects the frequency at which the
 `periodicsync` event fires. This ensures that the only apps syncing in the

--- a/src/site/content/en/blog/profiling-web-audio-apps-in-chrome/index.md
+++ b/src/site/content/en/blog/profiling-web-audio-apps-in-chrome/index.md
@@ -2,10 +2,10 @@
 title: Profiling Web Audio apps in Chrome
 subhead: >
   Learn how to profile the performance of Web Audio apps in Chrome using
-  `chrome://tracing` and the **WebAudio** tab in DevTools.
+  `about://tracing` and the **WebAudio** tab in DevTools.
 description: >
   Learn how to profile the performance of Web Audio apps in Chrome using
-  `chrome://tracing` and the **WebAudio** panel in DevTools.
+  `about://tracing` and the **WebAudio** panel in DevTools.
 date: 2020-05-04
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
@@ -29,9 +29,9 @@ eventually fix, the issue.
 ## Web Audio profiling tools
 
 There are two tools that will help you when profiling Web Audio,
-`chrome://tracing` and the **WebAudio** tab in Chrome DevTools.
+`about://tracing` and the **WebAudio** tab in Chrome DevTools.
 
-### When do you use `chrome://tracing`?
+### When do you use `about://tracing`?
 
 When mysterious "glitches" happen. Profiling the app with the tracing tools
 gives you insights on:
@@ -54,7 +54,7 @@ render budget (for example, approximately 2.67ms @ 48KHz). If the capacity
 goes near 100%, that means your app is likely to produce glitches because the
 renderer is failing to finish the work in the render budget.
 
-## Use `chrome://tracing`
+## Use `about://tracing`
 
 ### How to capture tracing data
 
@@ -66,7 +66,7 @@ or use other builds from [different release channels][diff-channel] (e.g.
 Beta or Canary). Once you have the browser ready, follow the steps below:
 
 1. Open your application (web page) on a tab.
-1. Open another tab and go to `chrome://tracing`.
+1. Open another tab and go to `about://tracing`.
 1. Press the **Record** button and select **Manually select settings**.
 1. Press the **None** buttons on both the **Record Categories** and
    **Disabled by Default Categories** sections.

--- a/src/site/content/en/blog/samesite-cookies-explained/index.md
+++ b/src/site/content/en/blog/samesite-cookies-explained/index.md
@@ -382,7 +382,7 @@ You must ensure that you pair `SameSite=None` with the `Secure` attribute.
 {% endCompare %}
 
 You can test this behavior as of Chrome 76 by enabling
-`chrome://flags/#cookies-without-same-site-must-be-secure` and from Firefox 69
+`about://flags/#cookies-without-same-site-must-be-secure` and from Firefox 69
 in [`about:config`](http://kb.mozillazine.org/About:config) by setting
 `network.cookie.sameSite.noneRequiresSecure`.
 

--- a/src/site/content/en/blog/schemeful-samesite/index.md
+++ b/src/site/content/en/blog/schemeful-samesite/index.md
@@ -62,7 +62,7 @@ considered a temporary solution in the migration towards full HTTPS.
 
 You can enable these changes for testing in both Chrome and Firefox.
 
-- From Chrome 86, enable `chrome://flags/#schemeful-same-site`. Track progress
+- From Chrome 86, enable `about://flags/#schemeful-same-site`. Track progress
   on the [Chrome Status
   page](https://chromestatus.com/feature/5096179480133632).
 - From Firefox 79, set `network.cookie.sameSite.schemeful` to `true` via

--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -508,7 +508,7 @@ const [appReadable, devReadable] = port.readable.tee();
 ## Dev Tips {: #dev-tips }
 
 Debugging the Web Serial API in Chrome is easy with the internal page,
-`chrome://device-log` where you can see all serial device related events in one
+`about://device-log` where you can see all serial device related events in one
 single place.
 
 <figure class="w-figure">

--- a/src/site/content/en/blog/shape-detection/index.md
+++ b/src/site/content/en/blog/shape-detection/index.md
@@ -133,7 +133,7 @@ of use cases for all three features.
 
 If you want to experiment with the Shape Detection API locally,
 enable the `#enable-experimental-web-platform-features`
-flag in `chrome://flags`.
+flag in `about://flags`.
 
 The interfaces of all three detectors, `FaceDetector`, `BarcodeDetector`, and
 `TextDetector`, are similar. They all provide a single asynchronous method

--- a/src/site/content/en/blog/speed-at-scale/index.md
+++ b/src/site/content/en/blog/speed-at-scale/index.md
@@ -77,8 +77,8 @@ images and iframe content a little before it comes into the viewport.
 
 The `loading` attribute is implemented behind flags in Chrome Canary. You can
 try out [this demo](https://mathiasbynens.be/demo/img-loading-lazy) in Chrome
-75+ with the `chrome://flags/#enable-lazy-image-loading` and
-`chrome://flags/#enable-lazy-frame-loading` flags turned on.
+75+ with the `about://flags/#enable-lazy-image-loading` and
+`about://flags/#enable-lazy-frame-loading` flags turned on.
 
 A [write-up](https://addyosmani.com/blog/lazy-loading/) on the
 lazy-loading feature is available with more details.

--- a/src/site/content/en/blog/url-protocol-handler/index.md
+++ b/src/site/content/en/blog/url-protocol-handler/index.md
@@ -111,10 +111,10 @@ allowing the possibility for complementary user-experiences:
 
 </div>
 
-### Enabling via chrome://flags or edge://flags
+### Enabling via about://flags or edge://flags
 
 To experiment with URL protocol handler registration for PWAs locally, without an origin trial
-token, enable the `#enable-desktop-pwas-protocol-handling` flag in `chrome://flags` or `edge://flags`.
+token, enable the `#enable-desktop-pwas-protocol-handling` flag in `about://flags` or `edge://flags`.
 
 ## How to use URL protocol handler registration for PWAs
 

--- a/src/site/content/en/blog/usb/index.md
+++ b/src/site/content/en/blog/usb/index.md
@@ -285,7 +285,7 @@ and firmware.
 
 ## Tips
 
-Debugging USB in Chrome is easier with the internal page `chrome://device-log`
+Debugging USB in Chrome is easier with the internal page `about://device-log`
 where you can see all USB device related events in one single place.
 
 <figure class="w-figure">
@@ -293,7 +293,7 @@ where you can see all USB device related events in one single place.
   <figcaption class="w-figcaption">Device log page in Chrome for debugging the WebUSB API.</figcaption>
 </figure>
 
-The internal page `chrome://usb-internals` also comes in handy and allows you
+The internal page `about://usb-internals` also comes in handy and allows you
 to simulate connection and disconnection of virtual WebUSB devices.
 This is be useful for doing UI testing without for real hardware.
 

--- a/src/site/content/en/blog/user-agent-client-hints/index.md
+++ b/src/site/content/en/blog/user-agent-client-hints/index.md
@@ -170,7 +170,7 @@ concerns](https://bugs.chromium.org/p/chromium/issues/detail?id=1091285) are
 resolved. To force the functionality on for testing:
 
 - Use Chrome 84 **beta** or equivalent.
-- Enable the `chrome://flags/#enable-experimental-web-platform-features` flag.
+- Enable the `about://flags/#enable-experimental-web-platform-features` flag.
 
 By default, the browser returns the browser brand, significant / major version,
 and an indicator if the client is a mobile device:
@@ -315,7 +315,7 @@ You can try out both the headers and the JavaScript API on your own device at
 
 {% Aside %}
 Ensure you're using Chrome 84 Beta or equivalent with
-`chrome://flags/#enable-experimental-web-platform-features` enabled.
+`about://flags/#enable-experimental-web-platform-features` enabled.
 {% endAside %}
 
 ### Hint life-time and resetting
@@ -442,7 +442,7 @@ deferred until at least 2021 to provide additional time for the ecosystem to
 evaluate the new User Agent Client Hints capabilities.
 
 You can test a version of this by enabling the
-`chrome://flags/#freeze-user-agent` flag from Chrome 84. This will return a
+`about://flags/#freeze-user-agent` flag from Chrome 84. This will return a
 string with the historical entries for compatibility reasons, but with sanitized
 specifics. For example, something like:
 

--- a/src/site/content/en/blog/using-conversion-measurement/index.md
+++ b/src/site/content/en/blog/using-conversion-measurement/index.md
@@ -150,9 +150,9 @@ A few tips when developing locally with the conversion measurement API.
 ### Set up your browser for local development
 
 - Use Chrome version 86 or later. You can check what version of Chrome you're using by typing
-  `chrome://version` in the URL bar.
+  `about://version` in the URL bar.
 - To activate the feature locally (for example if you're developing on `localhost`), enable
-  flags. Go to flags by typing `chrome://flags` in Chrome's URL bar. Turn on the **two** flags
+  flags. Go to flags by typing `about://flags` in Chrome's URL bar. Turn on the **two** flags
   `#enable-experimental-web-platform-features` and `#conversion-measurement-api`.
 - Disable third-party cookie blocking. In the long term, dedicated browser settings will be
   available to allow/block the API. Until then, third-party cookie blocking is used as the signal
@@ -166,13 +166,13 @@ A few tips when developing locally with the conversion measurement API.
 ### Debug
 
 You can see the conversion reports the browser has scheduled to send at
-`chrome://conversion-internals/` > **Pending Reports**. Reports are sent at scheduled times, but for
+`about://conversion-internals/` > **Pending Reports**. Reports are sent at scheduled times, but for
 debugging purposes you may want to get the reports immediately.
 
 - To receive all of the scheduled reports now, click **Send All Reports** in
-  `chrome://conversion-internals/` > **Pending Reports**.
+  `about://conversion-internals/` > **Pending Reports**.
 - To always receive reports **immediately** without having to click this button, enable the flag
-  `chrome://flags/#conversion-measurement-debug-mode`.
+  `about://flags/#conversion-measurement-debug-mode`.
 
 ### Test your origin trial token(s)
 

--- a/src/site/content/en/blog/web-bundles/index.md
+++ b/src/site/content/en/blog/web-bundles/index.md
@@ -151,17 +151,17 @@ development.
 
 To try out a Web Bundle:
 
-1. Go to `chrome://version` to see what version of Chrome you're running. If you're running version
+1. Go to `about://version` to see what version of Chrome you're running. If you're running version
    80 or later, skip the next step.
 1. Download [Chrome Canary](https://www.google.com/chrome/canary/) if you're not running Chrome 80
    or later.
-1. Open `chrome://flags/#web-bundles`.
+1. Open `about://flags/#web-bundles`.
 1. Set the **Web Bundles** flag to **Enabled**.
 
    <figure class="w-figure">
-     {% Img src="image/admin/tt32OXyh9PdrKK9KnMto.png", alt="A screenshot of chrome://flags", width="800", height="315" %}
+     {% Img src="image/admin/tt32OXyh9PdrKK9KnMto.png", alt="A screenshot of about://flags", width="800", height="315" %}
      <figcaption class="w-figcaption">
-       Enabling Web Bundles in <code>chrome://flags</code>
+       Enabling Web Bundles in <code>about://flags</code>
      </figcaption>
    </figure>
 

--- a/src/site/content/en/blog/window-controls-overlay/index.md
+++ b/src/site/content/en/blog/window-controls-overlay/index.md
@@ -66,10 +66,10 @@ developers to place custom content in what was previously the browser-controlled
 
 </div>
 
-### Enabling via chrome://flags
+### Enabling via about://flags
 
 To experiment with Window Controls Overlay locally, without an origin trial token, enable the
-`#enable-desktop-pwas-window-controls-overlay` flag in `chrome://flags`.
+`#enable-desktop-pwas-window-controls-overlay` flag in `about://flags`.
 
 ### Enabling support during the origin trial phase
 

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -114,7 +114,7 @@ begin loading.
 In Chrome 77+, you can experiment with these different thresholds by [throttling the
 network](https://developers.google.com/web/tools/chrome-devtools/network/#throttle) in DevTools. In
 the meantime, you will need to override the effective connection type of the browser using the
-`chrome://flags/#force-effective-connection-type` flag.
+`about://flags/#force-effective-connection-type` flag.
 {% endAside %}
 
 ## Improved data-savings and distance-from-viewport thresholds

--- a/src/site/content/en/mini-apps/mini-app-about/index.md
+++ b/src/site/content/en/mini-apps/mini-app-about/index.md
@@ -133,7 +133,7 @@ as it asks the user for permission to share their location. In some super apps, 
 imperative API that mini apps can leverage to request permissions without immediately using them, or
 to only check the status of a permission. This may even include an API to open the central super app
 permission settings, which corresponds to
-[Chrome's _Site Settings_](chrome://settings/content/siteDetails?site=https%3A%2F%2Fexample.com%2F).
+[Chrome's _Site Settings_](about://settings/content/siteDetails?site=https%3A%2F%2Fexample.com%2F).
 Mini apps also have to declare beforehand the origins of all servers that they potentially will
 request data from.
 

--- a/src/site/content/en/mini-apps/mini-app-devtools/index.md
+++ b/src/site/content/en/mini-apps/mini-app-devtools/index.md
@@ -188,7 +188,7 @@ these markup languages [later](/mini-app-markup-styling-and-scripting/#markup-la
 
 ### Custom elements under the hood
 
-Inspecting the WebView on a real device via [chrome://inspect/#devices](chrome://inspect/#devices)
+Inspecting the WebView on a real device via [about://inspect/#devices](about://inspect/#devices)
 reveals that WeChat DevTools was deliberately hiding the truth. Where WeChat DevTools showed an
 `<image>`, the actual thing I am looking at is a custom element called `<wx-image>` with a `<div>`
 as its only child. It is interesting to note that this custom element does not use

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -281,7 +281,7 @@ In Chrome, the image must respond to certain criteria:
 {% Aside 'gotchas' %}
 The `description` and `screenshots` properties are currently used only in Chrome
 for Android when a user wants to install your app. The experimental flag
-`chrome://flags/#mobile-pwa-install-use-bottom-sheet` flag must be enabled in
+`about://flags/#mobile-pwa-install-use-bottom-sheet` flag must be enabled in
 Chrome 90.
 {% endAside %}
 

--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -70,13 +70,13 @@ preference is always respected.
 
 ### Testing manifest updates {: #cr-desktop-test }
 
-The `chrome://internals/web-app` page (available in Chrome 85 or later),
+The `about://internals/web-app` page (available in Chrome 85 or later),
 includes detailed information about all of the PWAs installed on the device,
 and can help you understand when the manifest was last updated, how often
 it's updated, and more.
 
 To manually force Chrome to check for an updated manifest, restart Chrome
-(use `chrome://restart`), this resets the timer so that Chrome will check for
+(use `about://restart`), this resets the timer so that Chrome will check for
 an updated manifest when the PWA is next launched. Then launch the PWA.
 After closing the PWA, it should be updated with the new manifest properties.
 
@@ -118,7 +118,7 @@ on Android Chrome, though work is underway to support them.
 
 ### Testing manifest updates {: #cr-android-test }
 
-The `chrome://webapks` page includes detailed information about all of the
+The `about://webapks` page includes detailed information about all of the
 PWAs installed on the device, and can tell you when the manifest was last
 updated, how often it's updated, and more.
 
@@ -128,7 +128,7 @@ local manifest do the following:
 1. Plug in the device and ensure it's connected to WiFi.
 2. Use the Android task manager to shut down the PWA, then use the App panel
    in Android settings to force stop the PWA.
-3. In Chrome, open `chrome://webapks` and click the "Update" button for the
+3. In Chrome, open `about://webapks` and click the "Update" button for the
    PWA. "Update Status" should change to "Pending".
 4. Launch the PWA, and verify it's loaded properly.
 5. Use the Android task manager to shut down the PWA, then use the App panel


### PR DESCRIPTION
Fixes #5372

Changes proposed in this pull request:

- Replace `chrome://` with `about://`.