### PR TITLE
replace "the the" with "the"

### DIFF
--- a/src/site/content/en/blog/keyboard-lock/index.md
+++ b/src/site/content/en/blog/keyboard-lock/index.md
@@ -29,7 +29,7 @@ By default, these keys are not available to the web application because they are
 
 ## Using the Keyboard Lock API
 
-The [`Keyboard` interface](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard) of the the Keyboard API provides functions that toggle capturing of key presses from the physical keyboard as well as getting information about the used [keyboard layout](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/getLayoutMap).
+The [`Keyboard` interface](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard) of the Keyboard API provides functions that toggle capturing of key presses from the physical keyboard as well as getting information about the used [keyboard layout](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/getLayoutMap).
 
 ### Prerequisite
 

--- a/src/site/content/en/blog/multi-screen-window-placement/index.md
+++ b/src/site/content/en/blog/multi-screen-window-placement/index.md
@@ -183,7 +183,7 @@ Read on to learn more.
 
 ### The `isMultiScreen()` method
 
-To use the the Multi-Screen Window Placement API, I will first call the
+To use the Multi-Screen Window Placement API, I will first call the
 `Window.isMultiScreen()` method. It returns a promise that resolves with either `true` or `false`,
 depending on whether one or multiple screens are currently connected to the machine. For my setup,
 it returns `true`.

--- a/src/site/content/en/blog/video-basics/index.md
+++ b/src/site/content/en/blog/video-basics/index.md
@@ -67,7 +67,7 @@ here](https://developers.google.com/web/fundamentals/media/manipulating/applicat
 In the example above, the first choice is the WebM format ([which can be encoded
 with VP8 or VP9 codecs](https://www.webmproject.org/about/)), and is supported
 (at the time of writing) by 78% of [global
-users](https://caniuse.com/#search=webm). The second choice is the the H.265
+users](https://caniuse.com/#search=webm). The second choice is the H.265
 codec of mp4, which is supported on [iOS and newer
 Macs](https://caniuse.com/#search=h265). These codecs are newer and have
 improved data compression, while delivering the same quality video as older

--- a/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
@@ -177,7 +177,7 @@ function onXRFrame(hrTime, xrFrame) {
 ```
 
 There's one viewer pose that represents the user's overall position, meaning
-either the viewer's head or the the phone camera in the case of a smartphone.
+either the viewer's head or the phone camera in the case of a smartphone.
 The pose tells your application where the viewer is. Actual image rendering uses
 `XRView` objects, which I'll get to in a bit.
 

--- a/src/site/content/en/handbook/audience/index.md
+++ b/src/site/content/en/handbook/audience/index.md
@@ -3,7 +3,7 @@ layout: handbook
 title: Audience
 date: 2019-06-26
 description: |
-  Definitions of the the key personas for web.dev and advice about how to write for them.
+  Definitions of the key personas for web.dev and advice about how to write for them.
 ---
 
 When you're writing for web.dev, it's important to consider the persona or personas you're writing for. Keeping your audience in mind helps you make good writing decisions, like how much background information to include or whether you need to define a key term. Those considerations help ensure that your readers can learn or accomplish something.

--- a/src/site/content/en/handbook/content-checklist/index.md
+++ b/src/site/content/en/handbook/content-checklist/index.md
@@ -446,7 +446,7 @@ isn't covered anywhere else in the content?
 
 ### All images use the Img shortcode and are sized correctly {: #images }
 
-Images must use the the [`{% raw %}{% Img %}{% endraw %}` shortcode](/handbook/markup-media/) and
+Images must use the [`{% raw %}{% Img %}{% endraw %}` shortcode](/handbook/markup-media/) and
 should contain `width` and `height` attributes.
 
 {% Compare 'worse' %}

--- a/src/site/content/en/learn/css/box-model/index.md
+++ b/src/site/content/en/learn/css/box-model/index.md
@@ -206,7 +206,7 @@ To break this analogy down:
 
 - The content box is the artwork.
 - The padding box is the white matte, between the frame and the artwork.
-- The border box is the the frame, providing a literal border for the artwork.
+- The border box is the frame, providing a literal border for the artwork.
 - The margin box is the space between each frame.
 - The shadow occupies the same space as the margin box.
 

--- a/src/site/content/en/lighthouse-pwa/themed-omnibox/index.md
+++ b/src/site/content/en/lighthouse-pwa/themed-omnibox/index.md
@@ -72,7 +72,7 @@ Set the property to any valid CSS color value:
 }
  ```
 
-The browser will set the the address bar color of every page of your app
+The browser will set the address bar color of every page of your app
 according to the manifest's `theme_color`.
 
 ## Resources


### PR DESCRIPTION
Fix typos by replacing `the the` with `the` (`s/\bthe the\b/the/g`).