### PR TITLE
Fix \n appearing in path overview.

### DIFF
--- a/src/site/_data/i18n/paths/discoverable.yml
+++ b/src/site/_data/i18n/paths/discoverable.yml
@@ -5,7 +5,10 @@ description:
   en: Ensure users can find your site easily through search.
 
 overview:
-  en: Making your content discoverable matters because it's how you get more relevant users viewing your content. If a search engine has trouble seeing your page, you're possibly missing out on a source of traffic.\n\nBy making sure search engines can find and automatically understand your content, you are improving the visibility of your site for relevant searches. This is called SEO, or search engine optimization, which can result in more interested users coming to your site. Audit your site and check the SEO results to see how well search engines can surface your content.
+  en: |
+    Making your content discoverable matters because it's how you get more relevant users viewing your content. If a search engine has trouble seeing your page, you're possibly missing out on a source of traffic.
+
+    By making sure search engines can find and automatically understand your content, you are improving the visibility of your site for relevant searches. This is called SEO, or search engine optimization, which can result in more interested users coming to your site. Audit your site and check the SEO results to see how well search engines can surface your content.
 
 topics:
   how_search_works_and_how_to_measure_discoverability:

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -41,7 +41,7 @@ renderData:
   <section class="w-layout-container w-path-intro">
     <div class="w-path-intro__overview">
       <h2 class="w-headline--three no-link">Overview</h2>
-      <div>{{path.overview | i18n(locale)}}</div>
+      <div class="w-path-intro__overview-text">{{path.overview | i18n(locale)}}</div>
       {% if path.youtubeId %}
         <figure class="w-figure">
           {% YouTube path.youtubeId %}

--- a/src/styles/pages/_path.scss
+++ b/src/styles/pages/_path.scss
@@ -18,6 +18,13 @@
   }
 }
 
+.w-path-intro__overview-text {
+  // This text will come in as one big string from YAML.
+  // If the author has inserted multiple newlines we need to preserve those
+  // by making this pre-wrap.
+  white-space: pre-wrap;
+}
+
 .w-path-heading {
   // Pad the heading a bit so it lines up with the card padding for the
   // learning paths.


### PR DESCRIPTION
Fixes #5486

Changes proposed in this pull request:

- Change existing yaml to remove literal `\n` characters and instead use a yaml pipe to allow for newlines.
- Add a (somewhat gross) BEM class to the path overview. I think we're going to clean these pages up as part of Andy's work hopefully.
