### PR TITLE
Update the Evolving CLS post with tooling status

### DIFF
--- a/src/site/content/en/blog/evolving-cls/index.md
+++ b/src/site/content/en/blog/evolving-cls/index.md
@@ -13,6 +13,13 @@ tags:
   - performance
   - web-vitals
 ---
+
+{% Banner 'info', 'body' %}
+  **Jun 2, 2021:** The update to CLS described in this
+  post is now available across Chrome's web tooling surfaces. See [Evolving
+  Cumulative Layout Shift in web tooling](/cls-web-tooling/) for details.
+{% endBanner %}
+
 We (the Chrome Speed Metrics Team) recently outlined our initial research into
 [options for making the CLS metric more fair to pages that are open for a long
 time](/better-layout-shift-metric/). We've received a lot of very

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -16,10 +16,10 @@ tags:
 ---
 
 {% Banner 'caution', 'body' %}
-Jun 1, 2021: The implementation of CLS has changed.
-To learn more about the reasons behind the change, check out [Evolving the CLS metric](/evolving-cls).
+  **Jun 1, 2021:** The implementation of CLS has changed.
+  To learn more about the reasons behind the change, check out [Evolving the
+  CLS metric](/evolving-cls).
 {% endBanner %}
-
 
 {% Aside 'key-term' %}
   Cumulative Layout Shift (CLS) is an important, user-centric metric for


### PR DESCRIPTION
This PR adds an update to the Evolving CLS post indicating that the updates to CLS are now available across Chrome's web tooling surfaces.
