### PR TITLE
A proposal to fix language confusion with LanguageSelect

### DIFF
--- a/src/lib/components/LanguageSelect/index.js
+++ b/src/lib/components/LanguageSelect/index.js
@@ -56,7 +56,15 @@ class LanguageSelect extends BaseStateElement {
   }
 
   render() {
-    const langList = lang.supportedLanguages;
+    const languageVersions = Array.from(document
+      .querySelectorAll('link[rel="alternate"]'))
+      .filter(link => link['hreflang'])
+      .map(link => link['hreflang']);
+    const langList = lang.supportedLanguages.filter(
+      lang => languageVersions.includes(lang));
+    if (!langList.length) {
+      return '';
+    }
     return html`
       <div class="w-display-flex">
         <label class="w-visually-hidden" for="preferred-language">

--- a/src/lib/components/LanguageSelect/index.js
+++ b/src/lib/components/LanguageSelect/index.js
@@ -56,12 +56,14 @@ class LanguageSelect extends BaseStateElement {
   }
 
   render() {
-    const languageVersions = Array.from(document
-      .querySelectorAll('link[rel="alternate"]'))
-      .filter(link => link['hreflang'])
-      .map(link => link['hreflang']);
-    const langList = lang.supportedLanguages.filter(
-      lang => languageVersions.includes(lang));
+    const languageVersions = Array.from(
+      document.querySelectorAll('link[rel="alternate"]'),
+    )
+      .filter((link) => link['hreflang'])
+      .map((link) => link['hreflang']);
+    const langList = lang.supportedLanguages.filter((lang) =>
+      languageVersions.includes(lang),
+    );
     if (!langList.length) {
       return '';
     }

--- a/src/site/_includes/partials/translation-disclaimer.njk
+++ b/src/site/_includes/partials/translation-disclaimer.njk
@@ -8,8 +8,8 @@
     <!-- Must be an absolute url to enforce language reload.  -->
     <a href="/en{{ canonicalUrl }}" target="_blank">the original post</a>.
     {% endif %}
-    {% if gitlocalizeUrl %}
+    {# {% if gitlocalizeUrl %}
     Consider improving it by [contributing your translation]({{ gitlocalizeUrl }}).
-    {% endif %}
+    {% endif %} #}
 {% endBanner %}
 {% endif %}

--- a/src/site/_includes/partials/translation-disclaimer.njk
+++ b/src/site/_includes/partials/translation-disclaimer.njk
@@ -1,15 +1,9 @@
 {% set gitlocalizeUrl =  page.inputPath | gitlocalizeLink(lang) %}
-{% if translated %}
-{% Banner 'neutral' %}
-    {% if translated === 'none' %}
-    This page is not translated yet.
-    {% else %}
-    This article was translated from
-    <!-- Must be an absolute url to enforce language reload.  -->
-    <a href="/en{{ canonicalUrl }}" target="_blank">the original post</a>.
-    {% endif %}
-    {# {% if gitlocalizeUrl %}
-    Consider improving it by [contributing your translation]({{ gitlocalizeUrl }}).
-    {% endif %} #}
-{% endBanner %}
+{% if translated === 'none' %}
+  {% Banner 'neutral' %}
+  This page is not translated yet.
+  {# {% if gitlocalizeUrl %}
+  Consider improving it by [contributing your translation]({{ gitlocalizeUrl }}).
+  {% endif %} #}
+  {% endBanner %}
 {% endif %}

--- a/src/site/content/es/es.11tydata.js
+++ b/src/site/content/es/es.11tydata.js
@@ -23,6 +23,7 @@ module.exports = function () {
   return {
     lang: lang.lang,
     locale: lang.locale,
+    translated: 'none',
     home: {
       paths,
     },

--- a/src/site/content/es/vitals/index.md
+++ b/src/site/content/es/vitals/index.md
@@ -224,5 +224,3 @@ Los **Core Web Vitals** son relevantes para todas las páginas web y aparecen en
 Los otros Web Vitals suelen ser específicos del contexto o de la herramienta, y pueden ser más experimentales que los Core Web Vitals. Sus definiciones y umbrales pueden cambiar con mayor frecuencia.
 
 Para todos los Web Vitals, los cambios se documentarán de manera clara en este [REGISTRO DE CAMBIOS](http://bit.ly/chrome-speed-metrics-changelog) público.
-
-<web-feedback></web-feedback>

--- a/src/site/content/es/vitals/index.md
+++ b/src/site/content/es/vitals/index.md
@@ -12,6 +12,7 @@ tags:
   - metrics
   - performance
   - web-vitals
+translated: 2021-05-05
 ---
 
 Asegurar una calidad de experiencia de usuario óptima es clave para el éxito a largo plazo de cualquier sitio web. Tanto para un propietario de un negocio, especialista de marketing o desarrollador, Web Vitals pueden ayudarle a cuantificar la experiencia de su sitio e identificar oportunidades para mejorar.


### PR DESCRIPTION
Fixes #5443 

This PR attempts to show only languages that are available for the given page, and hide the rest. If only the English language is available, the switcher is not rendered.