### PR TITLE
docs(frontend): correct unpacking of `flex: 1` (#5537)

### DIFF
--- a/src/site/content/en/learn/css/flexbox/index.md
+++ b/src/site/content/en/learn/css/flexbox/index.md
@@ -317,12 +317,12 @@ as the space that is shared between the items is shared out _after_ each item is
 max-content size.
 So a large item will gain more space.
 To force all of the items to be a consistent size and ignore the size of the content change
-`flex:auto` to `flex: 1`. in the demo.
+`flex:auto` to `flex: 1` in the demo.
 
 This unpacks to:
 
 - `flex-grow: 1`: items can grow larger than their `flex-basis`.
-- `flex-shrink: 0`: items can't shrink smaller than their `flex-basis`.
+- `flex-shrink: 1`: items can shrink smaller than their `flex-basis`.
 - `flex-basis: 0`: items have a base size of `0`.
 
 Using `flex: 1` says that all items have zero size,


### PR DESCRIPTION
Change the unpacking of `flex: 1` with respect to `flex-shrink` to
`flex-shrink: 1` to be consistent with the specification and fix wording
of the sentence referring to the list detailing the unpacked values.

For further details please refer to:

- https://drafts.csswg.org/css-flexbox-1/#flex-common
- https://developer.mozilla.org/en-US/docs/Web/CSS/flex#syntax

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #5537

Changes proposed in this pull request:

- Changing the explanation of the `flex: 1` unpacking from `flex-shrink: 0` to `flex-shrink: 1`.
- Rewording the sentence explaining the unpacking of `flex: 1`.
