### PR TITLE
Add note re about:// instead of chrome:// to handbook.

### DIFF
--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -259,6 +259,7 @@ To copy, press `Control+C` (or `Command+C` on Mac).
 Use _pane_ to refer to the content areas associated with tabs—unless you're referring to an area in DevTools; then use _panel_.
 
 Use `about://` instead of `chrome://` for built-in URLs in web.dev articles. This generalizes these URLs to all Chromium forks. Typing `about://` in such a browser will be rewritten to a browser-specific scheme. For example typing `about://` in Microsoft Edge will be rewritten to `edge://`.
+For more background on this rule, see the article [How to set browser flags in Chromium](https://developer.chrome.com/blog/browser-flags/).
 
 <div class="w-columns">
 {% Compare 'worse' %}

--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -2,6 +2,7 @@
 layout: handbook
 title: Grammar, mechanics, and usage
 date: 2019-06-26
+updated: 2021-06-04
 description: |
   A list of grammar, mechanics, and usage rules for web.dev, followed by a list of style and usage references.
 ---
@@ -256,6 +257,18 @@ To copy, press `Control+C` (or `Command+C` on Mac).
 </div>
 
 Use _pane_ to refer to the content areas associated with tabs—unless you're referring to an area in DevTools; then use _panel_.
+
+Use `about://` instead of `chrome://` for built-in URLs in web.dev articles. This generalizes these URLs to all Chromium forks. Typing `about://` in such a browser will redirect to a browser-specific page. For example typing `about://` in Microsoft Edge will redirect to `edge://`.
+
+<div class="w-columns">
+{% Compare 'worse' %}
+`chrome://`
+{% endCompare %}
+
+{% Compare 'better' %}
+`about://`
+{% endCompare %}
+</div>
 
 ## Units
 Use _KB_ for kilobytes, _kb_ for kilobits.

--- a/src/site/content/en/handbook/grammar/index.md
+++ b/src/site/content/en/handbook/grammar/index.md
@@ -258,7 +258,7 @@ To copy, press `Control+C` (or `Command+C` on Mac).
 
 Use _pane_ to refer to the content areas associated with tabs—unless you're referring to an area in DevTools; then use _panel_.
 
-Use `about://` instead of `chrome://` for built-in URLs in web.dev articles. This generalizes these URLs to all Chromium forks. Typing `about://` in such a browser will redirect to a browser-specific page. For example typing `about://` in Microsoft Edge will redirect to `edge://`.
+Use `about://` instead of `chrome://` for built-in URLs in web.dev articles. This generalizes these URLs to all Chromium forks. Typing `about://` in such a browser will be rewritten to a browser-specific scheme. For example typing `about://` in Microsoft Edge will be rewritten to `edge://`.
 
 <div class="w-columns">
 {% Compare 'worse' %}


### PR DESCRIPTION

Fixes #5384 

Changes proposed in this pull request:

- 
- 
- 
