### PR TITLE
update metric thresholds for Lighthouse 8

### DIFF
--- a/src/site/content/en/lighthouse-performance/first-contentful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/first-contentful-paint/index.md
@@ -5,7 +5,7 @@ description: |
   Learn about Lighthouse's First Contentful Paint metric and
   how to measure and optimize it.
 date: 2019-05-02
-updated: 2019-10-10
+updated: 2021-06-04
 web_lighthouse:
   - first-contentful-paint
 ---
@@ -17,7 +17,7 @@ Each metric captures some aspect of page load speed.
 Lighthouse displays FCP in seconds:
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/Y8maVyZwGyS6gdyRjYWb.png", alt="A screenshot of the Lighthouse First Contentful Paint audit", width="800", height="588", class="w-screenshot" %}
+  {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/0zDaizn5WxE6QfToxVMG.png", alt="A screenshot of the Lighthouse First Contentful Paint audit", width="800", height="592", class="w-screenshot" %}
 </figure>
 
 ## What FCP measures
@@ -34,9 +34,10 @@ Your FCP score is a comparison of your page's FCP time
 and FCP times for real websites, based on
 [data from the HTTP Archive](https://httparchive.org/reports/loading-speed#fcp).
 For example, sites performing in the ninety-ninth percentile
-render FCP in about 1.5&nbsp;seconds.
-If your website's FCP is 1.5 seconds,
-your FCP score is 99.
+render FCP in about 1.2&nbsp;seconds.
+If your website's FCP is 1.2 seconds,
+your FCP score is 99. See [How metric scores are determined](/performance-scoring/#metric-scores)
+to learn how Lighthouse score thresholds are set.
 
 This table shows how to interpret your FCP score:
 
@@ -46,24 +47,20 @@ This table shows how to interpret your FCP score:
       <tr>
         <th>FCP time<br>(in seconds)</th>
         <th>Color-coding</th>
-        <th>FCP score<br>(HTTP Archive percentile)</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>0–2</td>
+        <td>0–1.8</td>
         <td>Green (fast)</td>
-        <td>75–100</td>
       </tr>
       <tr>
-        <td>2–4</td>
+        <td>1.8–3</td>
         <td>Orange (moderate)</td>
-        <td>50–74</td>
       </tr>
       <tr>
-        <td>Over 4</td>
+        <td>Over 3</td>
         <td>Red (slow)</td>
-        <td>0–49</td>
       </tr>
     </tbody>
   </table>
@@ -93,7 +90,8 @@ for more on collecting real-user metrics.
 ## Resources
 
 - [Source code for **First Contentful Paint** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/first-contentful-paint.js)
-- [Lighthouse v3 Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring)
+- [FCP Metric Guide](/fcp)
+- [Lighthouse Scoring Guide](/performance-scoring)
 - [Paint Timing specification](https://w3c.github.io/paint-timing)
 
 [metrics]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics

--- a/src/site/content/en/lighthouse-performance/interactive/index.md
+++ b/src/site/content/en/lighthouse-performance/interactive/index.md
@@ -5,7 +5,7 @@ description: |
   Learn about Lighthouse's Time to Interactive metric and
   how to measure and optimize it.
 date: 2019-05-02
-updated: 2019-10-10
+updated: 2021-06-04
 web_lighthouse:
   - interactive
 ---
@@ -23,7 +23,7 @@ nothing happens.
 Lighthouse displays TTI in seconds:
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/MOXhGOQxWpolq6nhBleq.png", alt="A screenshot of the Lighthouse Time to Interactive audit", width="800", height="588", class="w-screenshot" %}
+  {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/JtyY7nYUTCt2Q9oFYvEL.png", alt="A screenshot of the Lighthouse Time to Interactive audit", width="800", height="592", class="w-screenshot" %}
 </figure>
 
 ## What TTI measures
@@ -116,7 +116,7 @@ can be a good proxy for TTI.
 ## Resources
 
 - [Source code for **Time to Interactive** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/interactive.js)
-- [Lighthouse v3 Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring)
+- [Lighthouse Scoring Guide](/performance-scoring)
 - [First Interactive And Consistently Interactive](https://docs.google.com/document/d/1GGiI9-7KeY3TPqS3YT271upUVimo-XiL5mwWorDUD4c/edit)
 - [JavaScript Start-up Optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/javascript-startup-optimization/)
 - [Reduce JavaScript Payloads with Tree Shaking](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking/)

--- a/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
+++ b/src/site/content/en/lighthouse-performance/lighthouse-largest-contentful-paint/index.md
@@ -5,6 +5,7 @@ description: |
   Learn about Lighthouse's Largest Contentful Paint metric and
   how to measure and optimize it.
 date: 2020-01-10
+updated: 2021-06-04
 web_lighthouse:
   - largest-contentful-paint
 ---
@@ -16,7 +17,7 @@ Each metric captures some aspect of page load speed.
 Lighthouse displays LCP in seconds:
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ptlIzgrai0ufjmZQv5Gz.png", alt="A screenshot of the Lighthouse Largest Contentful Paint audit", width="800", height="594", class="w-screenshot" %}
+  {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/NcBzUBQFmSzhZaxshxLS.png", alt="A screenshot of the Lighthouse Largest Contentful Paint audit", width="800", height="592", class="w-screenshot" %}
 </figure>
 
 ## What LCP measures

--- a/src/site/content/en/lighthouse-performance/lighthouse-total-blocking-time/index.md
+++ b/src/site/content/en/lighthouse-performance/lighthouse-total-blocking-time/index.md
@@ -7,6 +7,7 @@ description: |
 web_lighthouse:
   - total-blocking-time
 date: 2019-10-09
+updated: 2021-06-04
 ---
 
 Total Blocking Time (TBT) is one of the metrics tracked in the **Performance** section
@@ -15,7 +16,7 @@ of the Lighthouse report. Each metric captures some aspect of page load speed.
 The Lighthouse report displays TBT in milliseconds:
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/5mK1Vac6rk9cJHMNfZh2.jpg", alt="A screenshot of the Lighthouse Total Blocking Time audit", width="800", height="556", class="w-screenshot" %}
+  {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/wk3OTIdxFPoUImDCnjic.png", alt="A screenshot of the Lighthouse Total Blocking Time audit", width="800", height="592", class="w-screenshot" %}
 </figure>
 
 ## What TBT measures
@@ -29,8 +30,9 @@ the blocking portion would be 20&nbsp;ms.
 
 ## How Lighthouse determines your TBT score
 
-Your TBT score is a comparison of your page's TBT time and TBT times for the top 10,000 sites
-when loaded on mobile devices. The top site data includes 404 pages.
+Your TBT score is a comparison of your page's TBT time and TBT times millions of real sites
+when loaded on mobile devices. See [How metric scores are determined](/performance-scoring/#metric-scores)
+to learn how Lighthouse score thresholds are set.
 
 This table shows how to interpret your TBT score:
 
@@ -44,11 +46,11 @@ This table shows how to interpret your TBT score:
     </thead>
     <tbody>
       <tr>
-        <td>0–300</td>
+        <td>0–200</td>
         <td>Green (fast)</td>
       </tr>
       <tr>
-        <td>300-600</td>
+        <td>200-600</td>
         <td>Orange (moderate)</td>
       </tr>
       <tr>
@@ -87,6 +89,7 @@ In general, the most common causes of long tasks are:
 
 - [Source code for **Total Blocking Time** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/total-blocking-time.js)
 - [Are long JavaScript tasks delaying your Time to Interactive?][long tasks]
+- [Optimize First Input Delay][optimize fid]
 - [First Contentful Paint][fcp]
 - [Time to Interactive][tti]
 - [Reduce JavaScript payloads with code splitting][split]
@@ -94,6 +97,7 @@ In general, the most common causes of long tasks are:
 - [Efficiently load third-party resources][3p]
 
 [long tasks]: /long-tasks-devtools
+[optimize fid]: /optimize-fid
 [fcp]: /first-contentful-paint/
 [tti]: /interactive/
 [split]: /reduce-javascript-payloads-with-code-splitting/

--- a/src/site/content/en/lighthouse-performance/performance-scoring/index.md
+++ b/src/site/content/en/lighthouse-performance/performance-scoring/index.md
@@ -5,7 +5,7 @@ description: |
   Learn how Lighthouse generates the overall Performance score for your page.
 subhead: How Lighthouse calculates your overall Performance score
 date: 2019-09-19
-updated: 2021-02-26
+updated: 2021-06-04
 ---
 
 In general, only [metrics](/lighthouse-performance/#metrics)
@@ -55,6 +55,45 @@ The metric scores are not visible in the report, but are calculated under the ho
   </figcaption>
 </figure>
 
+### Lighthouse 8
+
+<div class="w-table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Audit</th>
+        <th>Weight</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="/first-contentful-paint/">First Contentful Paint</a></td>
+        <td>10%</td>
+      </tr>
+      <tr>
+        <td><a href="/speed-index/">Speed Index</a></td>
+        <td>10%</td>
+      </tr>
+      <tr>
+        <td><a href="/lcp/">Largest Contentful Paint</a></td>
+        <td>25%</td>
+      </tr>
+      <tr>
+        <td><a href="/interactive/">Time to Interactive</a></td>
+        <td>10%</td>
+      </tr>
+      <tr>
+        <td><a href="/lighthouse-total-blocking-time/">Total Blocking Time</a></td>
+        <td>30%</td>
+      </tr>
+      <tr>
+        <td><a href="/cls/">Cumulative Layout Shift</a></td>
+        <td>15%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ### Lighthouse 6
 
 <div class="w-table-wrapper">
@@ -89,42 +128,6 @@ The metric scores are not visible in the report, but are calculated under the ho
       <tr>
         <td><a href="/cls/">Cumulative Layout Shift</a></td>
         <td>5%</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-
-### Lighthouse 5
-
-<div class="w-table-wrapper">
-  <table>
-    <thead>
-      <tr>
-        <th>Audit</th>
-        <th>Weight</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a href="/first-contentful-paint/">First Contentful Paint</a></td>
-        <td>20%</td>
-      </tr>
-      <tr>
-        <td><a href="/speed-index/">Speed Index</a></td>
-        <td>27%</td>
-      </tr>
-      <tr>
-        <td><a href="/first-meaningful-paint/">First Meaningful Paint</a></td>
-        <td>7%</td>
-      </tr>
-      <tr>
-        <td><a href="/interactive/">Time to Interactive</a></td>
-        <td>33%</td>
-      </tr>
-      <tr>
-        <td><a href="/first-cpu-idle/">First CPU Idle</a></td>
-        <td>13%</td>
       </tr>
     </tbody>
   </table>
@@ -178,6 +181,41 @@ In the Lighthouse report, the **Opportunities** section has detailed suggestions
 <!--
 We don't think users care about the historical scoring rubrics, but we'd still prefer to keep them around because X
 ## Historical versions
+
+### Lighthouse 5
+
+<div class="w-table-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th>Audit</th>
+        <th>Weight</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="/first-contentful-paint/">First Contentful Paint</a></td>
+        <td>20%</td>
+      </tr>
+      <tr>
+        <td><a href="/speed-index/">Speed Index</a></td>
+        <td>27%</td>
+      </tr>
+      <tr>
+        <td><a href="/first-meaningful-paint/">First Meaningful Paint</a></td>
+        <td>7%</td>
+      </tr>
+      <tr>
+        <td><a href="/interactive/">Time to Interactive</a></td>
+        <td>33%</td>
+      </tr>
+      <tr>
+        <td><a href="/first-cpu-idle/">First CPU Idle</a></td>
+        <td>13%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 ### Lighthouse 3 and 4
 

--- a/src/site/content/en/lighthouse-performance/speed-index/index.md
+++ b/src/site/content/en/lighthouse-performance/speed-index/index.md
@@ -4,7 +4,7 @@ title: Speed Index
 description: |
   Learn about Lighthouse's Speed Index metric and how to optimize it.
 date: 2019-05-02
-updated: 2019-10-10
+updated: 2021-06-04
 web_lighthouse:
   - speed-index
 ---
@@ -16,7 +16,7 @@ Each metric captures some aspect of page load speed.
 Lighthouse displays Speed Index in seconds:
 
 <figure class="w-figure">
-  {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ksKnQH9tGEzIXsrVoUHR.png", alt="A screenshot of the Lighthouse Speed Index audit", width="800", height="588", class="w-screenshot" %}
+  {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/LFN6FPQ2uQ4LnwcHiZWq.png", alt="A screenshot of the Lighthouse Speed Index audit", width="800", height="592", class="w-screenshot" %}
 </figure>
 
 ## What Speed Index measures
@@ -29,17 +29,14 @@ to generate the Speed Index score.
 
 {% Aside %}
 Speedline is based on the same principles as the
-[original speed index introduced by WebpageTest.org](https://github.com/WPO-Foundation/webpagetest-docs/blob/master/user/Metrics/SpeedIndex.md),
-but it computes the visual progression between frames using the
-[structural similarity (SSIM) index](https://en.wikipedia.org/wiki/Structural_similarity)
-instead of the histogram distance.
+[original speed index introduced by WebpageTest.org](https://github.com/WPO-Foundation/webpagetest-docs/blob/main/src/metrics/SpeedIndex.md).
 {% endAside %}
 
 ## How Lighthouse determines your Speed Index score
 
 Your Speed Index score is a comparison of your page's speed index
 and the speed indices of real websites, based on
-[data from the HTTP Archive](https://bigquery.cloud.google.com/table/httparchive:lighthouse.2019_03_01_mobile?pli=1).
+[data from the HTTP Archive](/performance-scoring/#metric-scores).
 
 This table shows how to interpret your Speed Index score:
 
@@ -49,24 +46,20 @@ This table shows how to interpret your Speed Index score:
       <tr>
         <th>Speed Index<br>(in seconds)</th>
         <th>Color-coding</th>
-        <th>Speed Index score</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>0–4.3</td>
+        <td>0–3.4</td>
         <td>Green (fast)</td>
-        <td>75–100</td>
       </tr>
       <tr>
-        <td>4.4–5.8</td>
+        <td>3.4–5.8</td>
         <td>Orange (moderate)</td>
-        <td>50–74</td>
       </tr>
       <tr>
         <td>Over 5.8</td>
         <td>Red (slow)</td>
-        <td>0–49</td>
       </tr>
     </tbody>
   </table>
@@ -90,6 +83,6 @@ should have a particularly big impact:
 ## Resources
 
 - [Source code for **Speed Index** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/speed-index.js)
-- [Lighthouse v3 Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring)
+- [Lighthouse Scoring Guide](/performance-scoring)
 - [Speedline](https://github.com/paulirish/speedline)
-- [WebPagetest Speed Index](https://github.com/WPO-Foundation/webpagetest-docs/blob/master/user/Metrics/SpeedIndex.md)
+- [WebPagetest Speed Index](https://github.com/WPO-Foundation/webpagetest-docs/blob/main/src/metrics/SpeedIndex.md)


### PR DESCRIPTION
Lighthouse 8 was just [released](https://github.com/GoogleChrome/lighthouse/releases/tag/v8.0.0) and brought new score thresholds for `total-blocking-time` and `first-contentful-paint` and a re-weighting of the overall performance score.

I also noticed that the `speed-index` thresholds were incorrect and the screenshots were out of date (showing old metrics), so I updated those and a few random obsolete links.

This isn't the full revamp some of these articles need, but that can wait for the migration to d.c.c (or whatever we decide to do there).