### PR TITLE
Add crossorigin attribute to preconnect hint on https://web.dev/css-web-vitals/

### DIFF
--- a/src/site/content/en/blog/css-web-vitals/index.md
+++ b/src/site/content/en/blog/css-web-vitals/index.md
@@ -357,7 +357,7 @@ Remove the following `@import` statement from your stylesheet:
 Add the following `<link>` tags to the `<head>` of the document:
 
 ```html
-<link rel="preconnect" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap" rel="stylesheet">
 ```
 


### PR DESCRIPTION
### What page(s) need to be updated?

https://web.dev/css-web-vitals/

### Why is this update needed?

The preconnect hint in the example does not have `crossorigin` attribute.
It is used to download fonts, according to MDN it should use `crossorigin` - https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#what_requests_use_cors
