### PR TITLE
Typo in learn css grid section

### DIFF
--- a/src/site/content/en/learn/css/grid/index.md
+++ b/src/site/content/en/learn/css/grid/index.md
@@ -742,7 +742,7 @@ for example:
 
 ```css
 .container {
-    dislay: grid;
+    display: grid;
     grid: repeat(2, 80px) / auto-flow  120px;
 }
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix typo in "Learn CSS" -> "Grid" Section
