### PR TITLE
Content edit of image cdn outro

### DIFF
--- a/src/site/content/en/fast/image-cdns/index.md
+++ b/src/site/content/en/fast/image-cdns/index.md
@@ -100,4 +100,4 @@ Third-party image CDNs provide image CDNs as a service. Just as cloud providers 
 
 There are many good options for image CDNs. Some will have more features than others, but all of them will probably help you save bytes on your images and therefore load your pages faster. Besides feature sets, other factors to consider when choosing an image CDN are cost, support, documentation, and ease of setup or migration.
 
-Trying them out yourself before making a decision can also be helpful. Below you can find codelabs with instructions on how to quickly get started with several image CDNs.
+Trying them out yourself before making a decision can also be helpful.


### PR DESCRIPTION
Changes proposed in this pull request:

https://web.dev/image-cdns/#choosing-an-image-cdn

- This removes a line to look at the codelab below, the codelab described is no longer there. The only codelab relates to a previous paragraph about self-managed image cdns

Note how it says "several" while the codelab is only about the single self-hosted option.
![Screen Shot 2021-06-09 at 10 08 49 AM](https://user-images.githubusercontent.com/77058599/121370425-b8126000-c90a-11eb-96f8-f9b87a5ff82a.png)


I don't think this is the ideal content edit, the article now ends abruptly. 
Please advise.
