### PR TITLE
docs(learn-css): correct reserved area keywords (#5581)

### DIFF
--- a/src/site/content/en/learn/css/grid/index.md
+++ b/src/site/content/en/learn/css/grid/index.md
@@ -644,7 +644,7 @@ footer {
 }
 ```
 
-The name can be anything you like other than the keyword `span`.
+The name can be anything you like other than the keywords `auto` and `span`.
 Once all of your items are named,
 use the
 [`grid-template-areas`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)


### PR DESCRIPTION
Additionally mention the keyword `auto` as being unavailable as a custom
grid area name, because `auto` is a keyword with special semantics.

For further details please refer to:

- https://drafts.csswg.org/css-grid/#named-lines

Fixes #5581

Changes proposed in this pull request:

- The first sentence of the paragraph about reserved area keywords would be changed to
  > The name can be anything you like other than the keywords `auto` and `span`.
