### PR TITLE
fix(frontend-learn-css): typo in functions chapter

### DIFF
--- a/src/site/content/en/learn/css/functions/index.md
+++ b/src/site/content/en/learn/css/functions/index.md
@@ -196,7 +196,7 @@ You can also pass custom properties in a `var()` function as part of an expressi
 The [`min()`](https://developer.mozilla.org/en-US/docs/Web/CSS/min())
 function returns the smallest computed value of the one or more passed arguments.
 The [`max()`](https://developer.mozilla.org/en-US/docs/Web/CSS/max())
-function does the opposite: get the largest value of the one ore more passed arguments.
+function does the opposite: get the largest value of the one or more passed arguments.
 
 ```css
 .my-element {


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #5583

Changes proposed in this pull request:

-  Fixes a typo: `ore` -> `or`
