### PR TITLE
Fix default scope description to match spec

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -236,7 +236,7 @@ to the `<a>` tag. On Android, links with `target="_blank"` will open in a
 A few other notes on `scope`:
 
 * If you don't include a `scope` in your manifest, then the default implied
-  `scope` is the directory that your web app manifest is served from.
+  `scope` is the parent directory of your `start_url`.
 * The `scope` attribute can be a relative path (`../`), or any higher level
   path (`/`) which would allow for an increase in coverage of navigations
   in your web app.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fix default scope description to match spec: https://www.w3.org/TR/appmanifest/#scope-member
