### PR TITLE
Bug/learn css logical properties minor corrections

### DIFF
--- a/src/site/content/en/learn/css/logical-properties/index.md
+++ b/src/site/content/en/learn/css/logical-properties/index.md
@@ -204,7 +204,7 @@ using shorthand versions of the margin and padding properties.
   padding-block: 2em;
   margin-inline: 2em 0;
   position: relative;
-  inset: 0.2em 0 0 0;
+  inset-block: 0.2em 0;
 }
 ```
 

--- a/src/site/content/en/learn/css/logical-properties/index.md
+++ b/src/site/content/en/learn/css/logical-properties/index.md
@@ -117,8 +117,8 @@ write a rule like this:
 }
 ```
 
-The flow-relative equivalents are `max-block-size` and `min-block-size`.
-You can also use `max-inline-size` and `min-inline-size` instead of `max-width` and `min-width`.
+The flow-relative equivalents are `max-inline-size` and `max-block-size`.
+You can also use `min-block-size` and `min-inline-size` instead of `min-height` and `min-width`.
 
 With logical properties,
 that max width and height rule would look like this:


### PR DESCRIPTION
This pull request is about two possible minor issues within [chapter 11 of the "Learn CSS" course](https://web.dev/learn/css/logical-properties/):

- The first commit of the associated pull requests slightly reformulates the [section about sizing](https://web.dev/learn/css/logical-properties/#sizing), because the CSS properties mentioned in the text are introduced as the flow-relative equivalents of the corresponding example, which strictly speaking, by my understanding they are not, eg. the equivalent of `max-width` would be `max-inline-size`. However, this might be a misunderstanding of the text from my side and if you wish, I can simply drop this commit.
- The second commit changes the last example of the [section about spacing and positioning regarding shorthands](https://web.dev/learn/css/logical-properties/#spacing-and-positioning), because the shorthand `inset` used in the example does not consider logical properties and would therefore change the semantics. I opted for `inset-block` in the correction, because it is explicitly referred to in the text. Still, I am not sure, whether this would be the change you want, because while it demonstrates the shorthand `inset-block` for `inset-block-start`, it also requires setting `inset-block-end` to `0` with the second value for `inset-block`.

Fixes #5600

Changes proposed in this pull request:

- Minor reformulating of the [section about sizing](https://web.dev/learn/css/logical-properties/#sizing)
- Changing the shorthand property in the last example of the [section about spacing and positioning regarding shorthands](https://web.dev/learn/css/logical-properties/#spacing-and-positioning)
