### PR TITLE
Tune up pullapprove groups

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,4 +1,19 @@
+# pullapprove lets you configure which individuals or teams should be able
+# to review and approve pull requests.
+#
+# If a user or team's name is prefixed with a ~ then they won't be assigned
+# as a reviewer, but they still have the power to approve. This helps cut
+# down on notification spam.
+
 version: 3
+
+# Global conditions that apply to all pull requests.
+# https://docs.pullapprove.com/config/pullapprove-conditions/
+pullapprove_conditions:
+# Don't tag in any reviewers if the PR is work in progress.
+- condition: "'WIP' not in title or not draft"
+  unmet_status: pending
+  explanation: "Work in progress"
 
 groups:
   # Learn CSS
@@ -13,7 +28,7 @@ groups:
       - ~web-dev-eng
       - ~web-dev-approvers
     reviews:
-      # Assign everyone on the content team for reviews.
+      # Assign all reviewers.
       request: 99
     conditions:
       - >
@@ -21,21 +36,30 @@ groups:
         glob('src/site/content/en/learn/css/**/*.yml') in files or
         glob('src/site/_data/courses/css/**/*.yml') in files
 
+  # Capabilities/Fugu
+  content:
+    reviewers:
+      users:
+      -  jpmedley
+      teams:
+      - ~web-dev-content
+      - ~web-dev-eng
+      - ~web-dev-approvers
+    conditions:
+      # Only fall through to this group if the review has not been handled by
+      # one of the prior teams.
+      - "'[Fugu]' in title or '[Capabilities]' in title or 'fugu' in labels or 'capabilities' in labels"
+
   # Content
   # Handles any changes related to site content.
   content:
     reviewers:
       teams:
-      - web-dev-content
-      # Prefix a username or team with ~ to include them in the reviewer pool
-      # but skip them when sending review requests.
+      - ~web-dev-content
       - ~web-dev-eng
       - ~web-dev-approvers
-    reviews:
-      # Assign everyone on the content team for reviews.
-      request: 99
     conditions:
-      # Only tag the content team if the review has not been handled by
+      # Only fall through to this group if the review has not been handled by
       # one of the prior teams.
       - 'len(groups.active) == 0'
       - >

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -37,18 +37,40 @@ groups:
         glob('src/site/_data/courses/css/**/*.yml') in files
 
   # Capabilities/Fugu
-  content:
+  capabilities:
     reviewers:
       users:
-      -  jpmedley
+      - jpmedley
       teams:
       - ~web-dev-content
       - ~web-dev-eng
       - ~web-dev-approvers
     conditions:
-      # Only fall through to this group if the review has not been handled by
-      # one of the prior teams.
-      - "'[Fugu]' in title or '[Capabilities]' in title or 'fugu' in labels or 'capabilities' in labels"
+      - '"[Fugu]" in title or "[Capabilities]" in title or "fugu" in labels or "capabilities" in labels'
+
+  # Vitals
+  vitals:
+    reviewers:
+      users:
+      - mihajlija
+      teams:
+      - ~web-dev-content
+      - ~web-dev-eng
+      - ~web-dev-approvers
+    conditions:
+      - '"[CWV]" in title or "[Vitals]" in title or "vitals" in labels'
+
+  # Privacy/Security
+  privacy_security:
+    reviewers:
+      users:
+      - mihajlija
+      teams:
+      - ~web-dev-content
+      - ~web-dev-eng
+      - ~web-dev-approvers
+    conditions:
+      - '"[Privacy]" in title or "[Security]" in title or "privacy/security" in labels'
 
   # Content
   # Handles any changes related to site content.


### PR DESCRIPTION
Changes proposed in this pull request:

- Don't tag in reviewers if a PR contains `WIP` in the title or is in draft mode.
- Auto-assign @jpmedley if the PR contains `[Fugu]` or `[Capabilities]` in the title, or if it uses the fugu or capabilities label.
- Auto-assign @mihajlija if the PR contains `[CWV]` or `[Vitals]` in the title, or if it uses the vitals label.
- Auto-assign @mihajlija if the PR contains `[Privacy]` or `[Security]` in the title, or if it uses the `privacy/security` label.
- Don't auto-assign reviews to the content team. This is to cut down on notification spam. Instead, we'll try to use a sheriff rotation to triage and assign reviewers.
