### PR TITLE
Bug/learn css spacing minor corrections

### DIFF
--- a/src/site/content/en/learn/css/spacing/index.md
+++ b/src/site/content/en/learn/css/spacing/index.md
@@ -312,12 +312,12 @@ will only apply the directional values when it is in its docked/stuck state.
 } %}
 
 In the [logical properties](/learn/css/logical-properties) module,
-you learn about the `inset` property,
-which allows you to set directional values that honor writing mode.
+you learn about the `inset-block` and `inset-inline` properties,
+which allow you to set directional values that honor writing mode.
 
-The `inset` order of properties is the same as TRouBLe with `margin` and `padding`
-but instead of `top`, `right`, `bottom` and `left`,
-it is `block-start`, `inline-end`, `block-end` and `inline-start`
+Both properties are shorthands combining the `start` and `end` values
+and as such accept either one value to be set for `start` and `end` or
+two individual values.
 
 ## Grid and flexbox
 

--- a/src/site/content/en/learn/css/spacing/index.md
+++ b/src/site/content/en/learn/css/spacing/index.md
@@ -348,8 +348,8 @@ to help you create a consistent user interface that has good flow and rhythm.
 A good way to achieve this is use consistent measures for your spacing.
 
 For example, you could commit to using `20px`
-as a consistent measure for all gaps between elements—
-known as gutters—so all layouts look and feel consistent.
+as a consistent measure for all gaps between elements—known as gutters—so
+all layouts look and feel consistent.
 You could also decide to use `1em` as the vertical spacing between flow content,
 which would achieve consistent spacing based on the element's `font-size`.
 Whatever you choose,

--- a/src/site/content/en/learn/css/spacing/index.md
+++ b/src/site/content/en/learn/css/spacing/index.md
@@ -32,15 +32,15 @@ each with its own strengths and caveats.
 ## HTML spacing
 
 HTML itself provides some methods to space elements.
-The `<br />` and `<hr />` elements allow you to space elements in the block direction,
+The `<br>` and `<hr>` elements allow you to space elements in the block direction,
 which if you are in a latin-based language,
 is top-to-bottom.
 
-If you use a `<br />` element,
+If you use a `<br>` element,
 it will create a line-break,
 just like if you were to press your enter key in a word processor.
 
-The `<hr />` creates a horizontal line with space either-side, known as `margin`.
+The `<hr>` creates a horizontal line with space either-side, known as `margin`.
 
 {% Codepen {
   user: 'web-dot-dev',


### PR DESCRIPTION
This pull request is about three possible minor issues within [chapter 12 of the "Learn CSS" course](https://web.dev/learn/css/spacing/):

- The [first commit](https://github.com/GoogleChrome/web.dev/pull/5619/commits/3f79058d3e9282193e0a3c02701be19b5ba2d3f8) of the associated pull request removes the solidi in the HTML examples to be consistent with the aside further down in the document, the MDN HTML tutorial referenced in [chapter 0](https://web.dev/learn/css/#welcome-to-learn-css!) as well as [(probably retired) Google HTML styleguide](https://google.github.io/styleguide/htmlcssguide.html#Document_Type). Note that if this commit is kept as it is, the [related CodePen](https://codepen.io/web-dot-dev/pen/dyNRJQg) should be adjusted as well.
- The [second commit](https://github.com/GoogleChrome/web.dev/pull/5619/commits/c6dd561a4e6ded5eec1d69a08bba36003645f7b0) changes the inset property to its logical counterparts, analogous to the [second commit](https://github.com/GoogleChrome/web.dev/pull/5601/commits/35566b42b5fe79978acd066206acb790e30362cd) of the already closed issue #5600.
- The [last commit](https://github.com/GoogleChrome/web.dev/pull/5619/commits/99f9e67fa690e64a2077090eac8aefc89979d4bd) fixes a probably unintended word split causing a typo. Please note that I am unfamiliar with the typographic guidelines used on this website, which is why I am not sure, whether the dashes should be separated with spaces. Assuming that the intended result is em dashes, I opted to go without spaces, because this seems to be more common.

Fixes #5618

Changes proposed in this pull request:

- Removal of solidi in HTML element examples
- Change of `inset` shorthand to its logical counterparts `inset-block` and `inset-inline`
- Fix of a typo introduced by a probably unintended word split
