### PR TITLE
Add media attribute support for meta[name=theme-color]

### DIFF
--- a/src/site/content/en/blog/prefers-color-scheme/index.md
+++ b/src/site/content/en/blog/prefers-color-scheme/index.md
@@ -4,7 +4,7 @@ subhead: Overhyped or necessity? Learn everything about dark mode and how to sup
 authors:
   - thomassteiner
 date: 2019-06-27
-updated: 2020-06-09
+updated: 2020-06-21
 hero: image/admin/dgDcIJUyuWB5xNn9CODd.jpg
 hero_position: bottom
 alt: |
@@ -463,6 +463,18 @@ in order to see the theme color and favicon changes, open the
     const darkModeOn = e.matches;
     console.log(`Dark mode is ${darkModeOn ? '🌒 on' : '☀️ off'}.`);
   });
+```
+
+In Chrome&nbsp;93, you can adjust the color based on a media query with the
+`media` attribute of the `meta` theme color element. The first one that matches
+will be picked. For example, you could have one color for light mode and another
+one for dark mode. At the time of writing, you can't define those in your
+manifest. See [w3c/manifest#975 GitHub
+issue](https://github.com/w3c/manifest/issues/975).
+
+```html
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
+<meta name="theme-color" media="(prefers-color-scheme: dark)"  content="black">
 ```
 
 ## Debugging and testing dark mode

--- a/src/site/content/en/blog/prefers-color-scheme/index.md
+++ b/src/site/content/en/blog/prefers-color-scheme/index.md
@@ -465,11 +465,11 @@ in order to see the theme color and favicon changes, open the
   });
 ```
 
-In Chrome&nbsp;93, you can adjust the color based on a media query with the
-`media` attribute of the `meta` theme color element. The first one that matches
-will be picked. For example, you could have one color for light mode and another
-one for dark mode. At the time of writing, you can't define those in your
-manifest. See [w3c/manifest#975 GitHub
+As of Chromium&nbsp;93 and Safari&nbsp;15, you can adjust the color based on a
+media query with the `media` attribute of the `meta` theme color element. The
+first one that matches will be picked. For example, you could have one color for
+light mode and another one for dark mode. At the time of writing, you can't
+define those in your manifest. See [w3c/manifest#975 GitHub
 issue](https://github.com/w3c/manifest/issues/975).
 
 ```html

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -6,7 +6,7 @@ authors:
   - beaufortfrancois
   - thomassteiner
 date: 2018-11-05
-updated: 2021-03-30
+updated: 2021-06-14
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile
@@ -253,6 +253,18 @@ the app's preview in task switchers. The `theme_color` should match the
 <figure class="w-figure">
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/8mkBdT3O0FZLo0PUppvv.png", alt="An example of a PWA window with custom theme_color.", width="800", height="196", class="w-screenshot" %}
 </figure>
+
+In Chrome&nbsp;93, you can adjust this color based on a media query with the
+`media` attribute of the `meta` theme color element. The first one that matches
+will be picked. For example, you could have one color for light mode and another
+one for dark mode. At the time of writing, you can't define those in your
+manifest. See [w3c/manifest#975 GitHub
+issue](https://github.com/w3c/manifest/issues/975).
+
+```html
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
+<meta name="theme-color" media="(prefers-color-scheme: dark)"  content="black">
+```
 
 #### `shortcuts` {: #shortcuts }
 

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -254,11 +254,11 @@ the app's preview in task switchers. The `theme_color` should match the
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/8mkBdT3O0FZLo0PUppvv.png", alt="An example of a PWA window with custom theme_color.", width="800", height="196", class="w-screenshot" %}
 </figure>
 
-In Chrome&nbsp;93, you can adjust this color based on a media query with the
-`media` attribute of the `meta` theme color element. The first one that matches
-will be picked. For example, you could have one color for light mode and another
-one for dark mode. At the time of writing, you can't define those in your
-manifest. See [w3c/manifest#975 GitHub
+As of Chromium&nbsp;93 and Safari&nbsp;15, you can adjust this color based on a
+media query with the `media` attribute of the `meta` theme color element. The
+first one that matches will be picked. For example, you could have one color for
+light mode and another one for dark mode. At the time of writing, you can't
+define those in your manifest. See [w3c/manifest#975 GitHub
 issue](https://github.com/w3c/manifest/issues/975).
 
 ```html

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -6,7 +6,7 @@ authors:
   - beaufortfrancois
   - thomassteiner
 date: 2018-11-05
-updated: 2021-06-14
+updated: 2021-06-21
 description: |
   The web app manifest is a simple JSON file that tells the browser about your
   web application and how it should behave when installed on the user's mobile


### PR DESCRIPTION
This PR adds upcoming "media" attribute support for `meta[name=theme-color]` to the "Add a web app manifest" article.
See https://groups.google.com/a/chromium.org/g/blink-dev

Live preview: https://deploy-preview-5620--web-dev-staging.netlify.app/add-manifest/#theme-color