### PR TITLE
fix(frontend-learn-css): link to the animate lesson

### DIFF
--- a/src/site/content/en/learn/css/functions/index.md
+++ b/src/site/content/en/learn/css/functions/index.md
@@ -416,7 +416,7 @@ along with `perspective-origin-x` and `perspective-origin-y` properties to creat
 
 ## Animation functions, gradients and filters
 
-CSS also provides functions that help you [animate](/learn/css/animation) elements,
+CSS also provides functions that help you [animate](/learn/css/animations) elements,
 apply [gradients](/learn/css/gradients) to them and use graphical [filters](/learn/css/filters) to manipulate how they look.
 To keep this module as concise as possible,
 they are covered in the linked modules.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fixes a typo of the link to the Animation lesson: `/learn/css/animation` -> `/learn/css/animations `
