### PR TITLE
✏️ Fix typo in Cascade lesson

### DIFF
--- a/src/site/content/en/learn/css/the-cascade/index.md
+++ b/src/site/content/en/learn/css/the-cascade/index.md
@@ -93,7 +93,7 @@ This means it gets more specificity than the <code>&lt;style&gt;</code> element<
 An inline `style` attribute with CSS declared in it will override all other CSS,
 regardless of its position, unless a declaration has `!important` defined.
 
-Position also applies in the order of your in a CSS rule.
+Position also applies to the order *inside* a CSS rule.
 In this example, the element will have a purple background because `background: purple` was declared last.
 Because the green background was declared before the purple background, it is now ignored by the browser.
 

--- a/src/site/content/en/learn/css/the-cascade/index.md
+++ b/src/site/content/en/learn/css/the-cascade/index.md
@@ -93,7 +93,7 @@ This means it gets more specificity than the <code>&lt;style&gt;</code> element<
 An inline `style` attribute with CSS declared in it will override all other CSS,
 regardless of its position, unless a declaration has `!important` defined.
 
-Position also applies to the order *inside* a CSS rule.
+Position also applies in the order of your CSS rule.
 In this example, the element will have a purple background because `background: purple` was declared last.
 Because the green background was declared before the purple background, it is now ignored by the browser.
 


### PR DESCRIPTION
"order of your in a CSS rule" is poor wording.  Change to "order inside a CSS rule" for more clarity

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
