### PR TITLE
Fix DEMO link and capture_links values

### DIFF
--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -146,11 +146,11 @@ and
 
 The demo for Declarative Link Capturing actually consists of two demos that interact together:
 
-1. [https://continuous-harvest-tomato.glitch.me/](https://hill-glitter-tree.glitch.me/)
+1. [https://continuous-harvest-tomato.glitch.me/](https://continuous-harvest-tomato.glitch.me/)
 1. [https://hill-glitter-tree.glitch.me/](https://hill-glitter-tree.glitch.me/)
 
 The screencast below shows how the two interact. They show two different behaviors,
-`"new_client"` and `"existing_client_navigate"`. Be sure to test the apps in different states,
+`"new-client"` and `"existing-client-navigate"`. Be sure to test the apps in different states,
 running in a tab or as an installed PWA, to see the difference in behavior.
 
 {% Video src="video/8WbTDNrhLsU0El80frMBGE4eMCD3/pj3ehpntEg50WcnA2khM.webm", autoplay=true, muted=true, playsinline=true, loop=true %}

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -9,7 +9,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-19
-updated: 2021-05-28
+updated: 2021-06-18
 description: |
   Declarative Link Capturing is a proposal for a web app manifest property called
   "capture_links" that lets developers determine declaratively what should happen when the browser
@@ -205,8 +205,9 @@ and let us know where and how you are using it.
 
 Declarative Link Capturing was specified by [Matt Giuca](https://twitter.com/mgiuca) with input from
 Alan Cutter and [Dominick Ng](https://twitter.com/dominickng). The API was implemented by Alan
-Cutter. This article was reviewed by [Joe Medley](https://github.com/jpmedley), Matt Giuca, and Alan
-Cutter. Hero image by [Zulmaury Saavedra](https://unsplash.com/@zulmaury) on
+Cutter. This article was reviewed by [Joe Medley](https://github.com/jpmedley), Matt Giuca, Alan
+Cutter, and [Shunya Shishido](https://github.com/sisidovski).
+Hero image by [Zulmaury Saavedra](https://unsplash.com/@zulmaury) on
 [Unsplash](https://unsplash.com/photos/zh0J32MrJfA).
 
 [explainer]: https://github.com/WICG/sw-launch/blob/main/declarative_link_capturing.md


### PR DESCRIPTION
I noticed the DEMO link URL is wrong and `capture_links` values here are written with snake case. https://web.dev/declarative-link-capturing/
@tomayac Could you take a look at this?