### PR TITLE
Bug/learn css pseudo element typos

### DIFF
--- a/src/site/content/en/learn/css/pseudo-elements/index.md
+++ b/src/site/content/en/learn/css/pseudo-elements/index.md
@@ -83,7 +83,7 @@ Once a `::before` or `::after` element has been created,
 you can style it however you want with no limits.
 You can only insert a `::before` or `::after` element to an element that will accept child elements
 ([elements with a document tree](https://www.w3.org/TR/CSS21/generate.html)),
-so elements such as `<img />`, `<video>`, `<button`> and `<input>` won't work.
+so elements such as `<img />`, `<video>`, `<button>` and `<input>` won't work.
 
 {% Codepen {
   user: 'web-dot-dev',

--- a/src/site/content/en/learn/css/pseudo-elements/pseudo-elements.assess.yml
+++ b/src/site/content/en/learn/css/pseudo-elements/pseudo-elements.assess.yml
@@ -23,7 +23,7 @@ questions:
   - type: multiple-choice
     cardinality: "1"
     correctAnswers: "1"
-    stem: Psuedo-elements can be found in an HTML file.
+    stem: Pseudo-elements can be found in an HTML file.
     options:
       - content: "True"
         rationale: "While DevTools may show pseudo-elements in the Elements


### PR DESCRIPTION
There may be two minor typos in [chapter 13 of the "Learn CSS" course](https://web.dev/learn/css/pseudo-elements/)

* [In the section about ::before and ::after](https://web.dev/learn/css/pseudo-elements/#::before-and-::after), the `<button>` element is missing the closing angle bracket within the Markdown code span.
* In the quiz question 2 the text starts with
  > Psuedo-elements
  <!-- --> 
  instead of "Pseudo-elements"

Fixes #5666

Changes proposed in this pull request:

- Fixes for the two typos mentioned above.
