### PR TITLE
docs(learn-css): extend supported properties for ::marker (#5668)

### DIFF
--- a/src/site/content/en/learn/css/pseudo-elements/index.md
+++ b/src/site/content/en/learn/css/pseudo-elements/index.md
@@ -202,6 +202,7 @@ Only a small subset of CSS properties are supported for `::marker`:
 - `content`
 - `white-space`
 - `font` properties
+- `animation` and `transition` properties
 
 You can change the marker symbol, using the `content` property. You can use this to set a plus and minus symbol for the closed and empty states of a `<summary>` element, for example.
 


### PR DESCRIPTION
In the [section about the ::marker pseudo-element within chapter 13 of the Learn CSS course](https://web.dev/learn/css/pseudo-elements/#::marker), the supported CSS properties neither include the `animation` nor the `transition` properties, which, by my understanding of the [specification](https://www.w3.org/TR/css-lists-3/#marker-properties) and the [linked MDN article](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker#allowable_properties), they should.

Fixes #5668

Changes proposed in this pull request:

- Extend the supported properties for `::marker` by mentioning the `animation` and `transition` properties as well.
