### PR TITLE
docs(learn-css): reduce allowed properties for ::selection (#5677)

### DIFF
--- a/src/site/content/en/learn/css/pseudo-elements/index.md
+++ b/src/site/content/en/learn/css/pseudo-elements/index.md
@@ -245,10 +245,8 @@ p:nth-of-type(2)::selection {
 
 As with other pseudo-elements, only a subset of CSS properties are allowed:
 
-- `color` and `caret-color`
+- `color`
 - `background-color` but **not** `background-image`
-- `cursor`
-- `outline`
 - `text` properties
 
 ## `::placeholder`


### PR DESCRIPTION
In the [section about the ::selection pseudo-element in chapter 13 of the "Learn CSS" course](https://web.dev/learn/css/pseudo-elements/#::selection) the supported properties contain `carret-color`, `cursor` and `outline`, which I could neither find in the [referenced MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection#allowable_properties), nor the [official specification](https://drafts.csswg.org/css-pseudo-4/#highlight-styling).

Fixes #5677

Changes proposed in this pull request:

- Remove `carret-color`, `cursor` and `outline` from the list of supported CSS properties for the `::selection` pseudo-element
