### PR TITLE
fix(feeds): trim RSS feed entries' content to just the first paragraph, fixes #5676 and fixes #5663

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -74,6 +74,7 @@ const pathSlug = require(`./${filtersDir}/path-slug`);
 const containsTag = require(`./${filtersDir}/contains-tag`);
 const expandAuthors = require(`./${filtersDir}/expand-authors`);
 const findTags = require(`./${filtersDir}/find-tags`);
+const firstParagraph = require(`./${filtersDir}/first-paragraph`);
 const githubLink = require(`./${filtersDir}/github-link`);
 const gitlocalizeLink = require(`./${filtersDir}/gitlocalize-link`);
 const htmlDateString = require(`./${filtersDir}/html-date-string`);
@@ -160,6 +161,7 @@ module.exports = function (config) {
   config.addFilter('i18n', i18n);
   config.addFilter('findByUrl', findByUrl);
   config.addFilter('findTags', findTags);
+  config.addFilter('firstParagraph', firstParagraph);
   config.addFilter('pathSlug', pathSlug);
   config.addFilter('containsTag', containsTag);
   config.addFilter('expandAuthors', expandAuthors);

--- a/src/site/_filters/first-paragraph.js
+++ b/src/site/_filters/first-paragraph.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const cheerio = require('cheerio');
+
+/**
+ * Extracts first paragraph (`<p>`) from a HTML string.
+ * @param {string} templateContent HTML string of content.
+ * @returns {string}
+ */
+module.exports = (templateContent) => {
+  const $ = cheerio.load(templateContent);
+  return $('p').first().html();
+};

--- a/src/site/_includes/feed.njk
+++ b/src/site/_includes/feed.njk
@@ -21,7 +21,7 @@
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+      <a href="absolutePostUrl" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/_includes/feed.njk
+++ b/src/site/_includes/feed.njk
@@ -21,7 +21,7 @@
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank">Read more...</a>
+      <a href="{{absolutePostUrl}}" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/_includes/feed.njk
+++ b/src/site/_includes/feed.njk
@@ -19,7 +19,10 @@
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html">
+      <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
+      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+    </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}
     <author>

--- a/src/site/content/en/authors/feed.njk
+++ b/src/site/content/en/authors/feed.njk
@@ -39,7 +39,7 @@ pagination:
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+      <a href="absolutePostUrl" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/content/en/authors/feed.njk
+++ b/src/site/content/en/authors/feed.njk
@@ -39,7 +39,7 @@ pagination:
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank">Read more...</a>
+      <a href="{{absolutePostUrl}}" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/content/en/authors/feed.njk
+++ b/src/site/content/en/authors/feed.njk
@@ -37,7 +37,10 @@ pagination:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html">
+      <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
+      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+    </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}
     <author>

--- a/src/site/content/en/tags/feed.njk
+++ b/src/site/content/en/tags/feed.njk
@@ -41,7 +41,7 @@ pagination:
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank">Read more...</a>
+      <a href="{{absolutePostUrl}}" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/content/en/tags/feed.njk
+++ b/src/site/content/en/tags/feed.njk
@@ -41,7 +41,7 @@ pagination:
     <id>{{ absolutePostUrl }}</id>
     <content type="html">
       <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
-      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+      <a href="absolutePostUrl" target="_blank">Read more...</a>
     </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}

--- a/src/site/content/en/tags/feed.njk
+++ b/src/site/content/en/tags/feed.njk
@@ -39,7 +39,10 @@ pagination:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html">
+      <p>{{ post.templateContent | firstParagraph | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</p>
+      <a href="absolutePostUrl" target="_blank" >Read more...</a>
+    </content>
     {% for entry in post.data.authors %}
     {%- set author =  collections.authors[entry] -%}
     <author>


### PR DESCRIPTION
Fixes #5676 and fixes #5663

Changes proposed in this pull request:

- Add filter that extracts just the first paragraph of HTML content and apply it to the RSS feeds.
