### PR TITLE
Remove double parentheses in link  

### DIFF
--- a/src/site/content/en/blog/payment-and-address-form-best-practices/index.md
+++ b/src/site/content/en/blog/payment-and-address-form-best-practices/index.md
@@ -559,7 +559,7 @@ Address line 2 (optional)
 You can try this out by remixing and editing the demo embedded below.
 
 {% Aside 'caution' %}
-Research shows that [**Address line 2** may be problematic for users]((https://baymard.com/blog/address-line-2)).
+Research shows that [**Address line 2** may be problematic for users](https://baymard.com/blog/address-line-2).
 Bear this in mind when designing address forms—you should consider alternatives such as using a
 single `textarea` (see below) or other options.
 {% endAside %}


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


Changes proposed in this pull request:

- Remove double parentheses around link, they were linking to https://web.dev/payment-and-address-form-best-practices/%28https:/baymard.com/blog/address-line-2%29 instead of https://baymard.com/blog/address-line-2

