### PR TITLE
Heading text changes

### DIFF
--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -49,7 +49,7 @@ renderData:
       {% endif %}
     </div>
     <div class="w-path-intro__learn">
-      <h2 class="w-headline--three no-link">What you'll learn</h2>
+      <h2 class="w-headline--three no-link">Table of Contents</h2>
       <ul class="w-icon-list">
         {% for topic in topics %}
           <li class="w-icon-list__item w-icon-list__item--check">


### PR DESCRIPTION
Changed heading text from 'What you'll learn' to 'Table of Contents'

Fixes #5670

Changes proposed in this pull request:

- Changed heading text 

Current Behaviour - 
![image](https://user-images.githubusercontent.com/61384771/124381946-a3936e80-dce2-11eb-83c8-35b5d4a4e47f.png)

Proposed Behaviour -
![image](https://user-images.githubusercontent.com/61384771/124381963-ba39c580-dce2-11eb-8852-a487592e40df.png)

