### PR TITLE
Correct element name to heading from header

### DIFF
--- a/src/site/content/en/blog/css-is-and-where/index.md
+++ b/src/site/content/en/blog/css-is-and-where/index.md
@@ -15,7 +15,7 @@ updated: 2021-05-27
 
 When writing CSS, you can sometimes end up with long selector lists to target
 multiple elements with the same style rules. For example, if you want to color
-adjust any `<b>` tags found inside a header element, you could write:
+adjust any `<b>` tags found inside a heading element, you could write:
 
 ```css
 h1 > b, h2 > b, h3 > b, h4 > b, h5 > b, h6 > b {


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes small typo in docs

Changes proposed in this pull request:

- `header` —> `heading` as name of h1, h2, etc. html elements 