### PR TITLE
Decrease margin on .w-stats container to get rid of CLS in the CLS article

### DIFF
--- a/src/styles/components/_stats.scss
+++ b/src/styles/components/_stats.scss
@@ -18,7 +18,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  margin: 32px -32px;
+  margin: 24px -24px;
   padding: 64px 32px;
   text-align: center;
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #5766 

Changes proposed in this pull request:

- Reduces margin for `.w-stats` container from `margin: 32px -32px` to `margin: 24px -24px`
- Note: Instead of jumping directly from 32px to 24px, a media query could be introduced to update the margin for mobile viewports as this is when things start to overflow.