### PR TITLE
Don't lazy load hero images. Improves LCP

### DIFF
--- a/src/site/_includes/components/Hero.js
+++ b/src/site/_includes/components/Hero.js
@@ -28,5 +28,8 @@ module.exports = ({hero, alt, heroPosition, heroFit = 'cover'}) => {
     sizes: '100vw',
     class: className,
     decoding: 'auto',
+    // Don't lazy load hero images
+    // https://github.com/GoogleChrome/web.dev/issues/5813
+    loading: false,
   });
 };


### PR DESCRIPTION
Fixes #5813

We should make this change on d.c.c. as well.

Changes proposed in this pull request:

- Don't lazy load above the fold images as it hurts LCP