### PR TITLE
Update nginx.md

### DIFF
--- a/src/site/content/en/lighthouse-pwa/redirects-http/index.md
+++ b/src/site/content/en/lighthouse-pwa/redirects-http/index.md
@@ -40,6 +40,8 @@ make sure that all unsecure HTTP traffic to your site is redirected to HTTPS:
   * [Cloudflare](https://www.cloudflare.com/website-optimization/automatic-https-rewrite/)
   * [Microsoft IIS](https://serverfault.com/q/893315)
 
+Latest Guide for [HTTP traffic to HTTPS in NGINX](https://www.armanism.com/blog/install-free-ssl-on-nginx#:~:text=Step%204%20-%20Redirect%20HTTP%20to%20HTTPS%20in%20NGINX%20(Optionally))
+
 ## Resources
 - [Source code for **Does not redirect HTTP traffic to HTTPS** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/redirects-http.js)
 - [Does not use HTTPS](/is-on-https)


### PR DESCRIPTION
Added tutorial for HTTP to HTTPS redirection in NGINX because the old method is not working now. It occurs "ERR_TOO_MANY_REDIRECTS".

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
