### PR TITLE
Mention @slightlyoff's blog posts for automating `contain-intrinsic-size`

### DIFF
--- a/src/site/content/en/blog/content-visibility/index.md
+++ b/src/site/content/en/blog/content-visibility/index.md
@@ -211,11 +211,11 @@ This means it will lay out as if it had a single child of "intrinsic-size"
 dimensions, ensuring that your unsized divs still occupy space.
 `contain-intrinsic-size` acts as a placeholder size in lieu of rendered content.
 
-As setting sizes for each element using `contain-intrinsic-size` is not easily 
-done, we can utilize a `IntersectionObserver` and `MutationObserver` to set
-the correct sizes inline. [Alex Russel](https://twitter.com/slightlylate) explains
-how this works in a [two](https://infrequently.org/2020/12/content-visibility-scroll-fix/)-[part](https://infrequently.org/2020/12/resize-resilient-deferred-rendering/) blog post series.
-
+{% Aside %}
+We can use `IntersectionObserver` and `MutationObserver` to set
+the correct sizes inline for each element. [Alex Russell](https://twitter.com/slightlylate) explains
+how this works in [`content-visibility` without jittery scrollbars](https://infrequently.org/2020/12/content-visibility-scroll-fix/), and [Resize-Resilient `content-visibility` Fixes](https://infrequently.org/2020/12/resize-resilient-deferred-rendering/).
+{% endAside %}
 ## Hiding content with `content-visibility: hidden`
 
 What if you want to keep the content unrendered regardless of whether or not it

--- a/src/site/content/en/blog/content-visibility/index.md
+++ b/src/site/content/en/blog/content-visibility/index.md
@@ -211,6 +211,11 @@ This means it will lay out as if it had a single child of "intrinsic-size"
 dimensions, ensuring that your unsized divs still occupy space.
 `contain-intrinsic-size` acts as a placeholder size in lieu of rendered content.
 
+As setting sizes for each element using `contain-intrinsic-size` is not easily 
+done, we can utilize a `IntersectionObserver` and `MutationObserver` to set
+the correct sizes inline. [Alex Russel](https://twitter.com/slightlylate) explains
+how this works in a [two](https://infrequently.org/2020/12/content-visibility-scroll-fix/)-[part](https://infrequently.org/2020/12/resize-resilient-deferred-rendering/) blog post series.
+
 ## Hiding content with `content-visibility: hidden`
 
 What if you want to keep the content unrendered regardless of whether or not it


### PR DESCRIPTION
In my opinion a major pain point of most blog posts is they give info about how to combat drawbacks of nice features (such as `content-visibility: auto` and the scrollbar problem, which is fixed by `contain-intrinsic-size`) but without mentioning how you can implement this in larger scale. 
It is very rare that a dev has time to add (and maintain!) sizes of elements. So, as @slightlyoff has created blog-posts about the topic already, I figured mentioning those (as they contain code that is ready to be implemented) gives developers an easer time implementing `contain-intrinsic-size` and `content-visibility: auto`.

Changes proposed in this pull request:

- Add a short sentence linking to @slightlyoff's blog posts about automatically setting `contain-intrinsic-size` by utilizing `IntersectionObserver` and `MutationObserver`

This is my first PR here, so I'm happy to get feedback on how to improve wording if needed :)
