### PR TITLE
Adding head and body tags in examples.

### DIFF
--- a/src/site/content/en/blog/aurora-resource-inlining/index.md
+++ b/src/site/content/en/blog/aurora-resource-inlining/index.md
@@ -154,7 +154,6 @@ Let's look at an example:
 ```html
 <head>
    <link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
-  ...
 </head>
 <body>
   <section>

--- a/src/site/content/en/blog/aurora-resource-inlining/index.md
+++ b/src/site/content/en/blog/aurora-resource-inlining/index.md
@@ -153,10 +153,14 @@ Let's look at an example:
 {% Compare 'worse', 'Example before inlining' %}
 ```html
 <head>
-<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
-<section>
- <button class="primary"></button>
-</section>
+   <link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
+  ...
+</head>
+<body>
+  <section>
+    <button class="primary"></button>
+  </section>
+</body>
 ```
 
 ```css
@@ -177,16 +181,18 @@ Finally critters will inline the corresponding styles in the `<head>` of the pag
 {% Compare 'better', 'Example after inlining' %}
 ```html
 <head>
-<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
-<style>
-section button.primary {
-  /* ... */
-}
-</style>
+  <link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
+  <style>
+  section button.primary {
+    /* ... */
+  }
+  </style>
 </head>
-<section>
- <button class="primary"></button>
-</section>
+<body>
+  <section>
+    <button class="primary"></button>
+  </section>
+</body>
 ```
 {% endCompare %}
 


### PR DESCRIPTION
Related issue: https://github.com/GoogleChrome/web.dev/issues/5876

Changes proposed in this pull request:

- Adding head and body tags in examples.
