### PR TITLE
Fix typo in code example

### DIFF
--- a/src/site/content/en/blog/building-a-breadcrumbs-component/index.md
+++ b/src/site/content/en/blog/building-a-breadcrumbs-component/index.md
@@ -469,7 +469,7 @@ const preventedKeys = new Set(['ArrowUp', 'ArrowDown'])
 
 // watch crumbs for changes,
 // ensures it's a full value change, not a user exploring options via keyboard
-crumb.forEach(nav => {
+crumbs.forEach(nav => {
   let ignoreChange = false
 
   nav.addEventListener('change', e => {


### PR DESCRIPTION
Changes proposed in this pull request:

- I think it should be `crumbs.forEach` instead of `crumb.forEach`.

