### PR TITLE
Theme switcher

### DIFF
--- a/src/lib/components/ThemeToggle/index.js
+++ b/src/lib/components/ThemeToggle/index.js
@@ -1,0 +1,93 @@
+class ThemeToggle extends HTMLElement {
+  constructor() {
+    super();
+
+    this.STORAGE_KEY = 'user-color-scheme';
+    this.COLOR_MODE_KEY = '--color-mode';
+  }
+
+  connectedCallback() {
+    // Allows --flow-space to work and we
+    // only want that to happen when it's
+    // wired up
+    this.style.display = 'block';
+
+    this.render();
+  }
+
+  getCSSCustomProp(propKey) {
+    let response = getComputedStyle(document.documentElement).getPropertyValue(
+      propKey,
+    );
+
+    // Tidy up the string if there’s something to work with
+    if (response.length) {
+      response = response.replace(/'|"/g, '').trim();
+    }
+
+    // Gorko will probably set this as a `var()` reference,
+    // we need to strip that stuff out
+    return response.replace('var(--color-').replace(')');
+  }
+
+  applySetting(passedSetting) {
+    // Attempts to load the setting from local storage
+    const currentSetting =
+      passedSetting || localStorage.getItem(this.STORAGE_KEY);
+
+    if (currentSetting) {
+      this.setStatus(currentSetting);
+      window.applyThemeSetting(currentSetting);
+    } else {
+      // Loads the value based on the CSS custom property value instead, with a fallback of light
+      const customPropValue =
+        this.getCSSCustomProp(this.COLOR_MODE_KEY) || 'light';
+      this.setStatus(customPropValue);
+      window.applyThemeSetting(customPropValue);
+    }
+  }
+
+  setStatus(currentSetting) {
+    // Loop the buttons and set aria-pressed (active) state depending on current theme
+    this.buttons.forEach((button) => {
+      button.setAttribute(
+        'aria-pressed',
+        currentSetting === button.getAttribute('data-theme') ? 'true' : 'false',
+      );
+    });
+  }
+
+  render() {
+    this.innerHTML = `
+      <div class="theme-toggle" aria-label="Change display theme">
+        <button class="button" data-theme="light">Light</button>
+        <button class="button" data-theme="dark">Dark</button>
+      </div>
+    `;
+
+    this.afterRender();
+  }
+
+  afterRender() {
+    this.buttons = this.querySelectorAll('[data-theme]');
+
+    // Loop each button to attach the toggle event
+    this.buttons.forEach((button) => {
+      button.addEventListener('click', (evt) => {
+        evt.preventDefault();
+
+        const setting = button.getAttribute('data-theme');
+        this.applySetting(setting);
+        localStorage.setItem(this.STORAGE_KEY, setting);
+      });
+    });
+
+    this.applySetting();
+  }
+}
+
+if ('customElements' in window) {
+  customElements.define('theme-toggle', ThemeToggle);
+}
+
+export default ThemeToggle;

--- a/src/lib/components/ThemeToggle/index.js
+++ b/src/lib/components/ThemeToggle/index.js
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Element that allows a user to toggle the current theme.
+ * @extends {HTMLElement}
+ * @final
+ */
 class ThemeToggle extends HTMLElement {
   constructor() {
     super();

--- a/src/lib/components/ThemeToggle/index.js
+++ b/src/lib/components/ThemeToggle/index.js
@@ -28,12 +28,25 @@ class ThemeToggle extends HTMLElement {
   }
 
   connectedCallback() {
-    // Allows --flow-space to work and we
-    // only want that to happen when it's
-    // wired up
-    this.style.display = 'block';
+    this.toggleSwitch = this.querySelector('[role="switch"]');
 
-    this.render();
+    if (this.toggleSwitch) {
+      this.applySetting();
+
+      // Allows --flow-space to work and we
+      // only want that to happen when it's
+      // ready to go
+      this.style.display = 'block';
+      this.toggleSwitch.style.visibility = 'visible';
+
+      // On change, calculate the new setting, toggle state changes and store in storage
+      this.toggleSwitch.addEventListener('change', () => {
+        const setting = this.toggleSwitch.checked ? 'dark' : 'light';
+
+        this.applySetting(setting);
+        localStorage.setItem(this.STORAGE_KEY, setting);
+      });
+    }
   }
 
   getCSSCustomProp(propKey) {
@@ -57,53 +70,25 @@ class ThemeToggle extends HTMLElement {
       passedSetting || localStorage.getItem(this.STORAGE_KEY);
 
     if (currentSetting) {
-      this.setStatus(currentSetting);
+      this.setToggleSwitchStatus(currentSetting);
       window.applyThemeSetting(currentSetting);
     } else {
       // Loads the value based on the CSS custom property value instead, with a fallback of light
       const customPropValue =
         this.getCSSCustomProp(this.COLOR_MODE_KEY) || 'light';
-      this.setStatus(customPropValue);
+      this.setToggleSwitchStatus(customPropValue);
       window.applyThemeSetting(customPropValue);
     }
   }
 
-  setStatus(currentSetting) {
-    // Loop the buttons and set aria-pressed (active) state depending on current theme
-    this.buttons.forEach((button) => {
-      button.setAttribute(
-        'aria-pressed',
-        currentSetting === button.getAttribute('data-theme') ? 'true' : 'false',
-      );
-    });
-  }
-
-  render() {
-    this.innerHTML = `
-      <div class="theme-toggle" aria-label="Change display theme">
-        <button class="button" data-theme="light">Light</button>
-        <button class="button" data-theme="dark">Dark</button>
-      </div>
-    `;
-
-    this.afterRender();
-  }
-
-  afterRender() {
-    this.buttons = this.querySelectorAll('[data-theme]');
-
-    // Loop each button to attach the toggle event
-    this.buttons.forEach((button) => {
-      button.addEventListener('click', (evt) => {
-        evt.preventDefault();
-
-        const setting = button.getAttribute('data-theme');
-        this.applySetting(setting);
-        localStorage.setItem(this.STORAGE_KEY, setting);
-      });
-    });
-
-    this.applySetting();
+  // Sets the correct aria checked role and checked state
+  setToggleSwitchStatus(currentSetting) {
+    const isDarkMode = currentSetting === 'dark';
+    this.toggleSwitch.setAttribute(
+      'aria-checked',
+      isDarkMode ? 'true' : 'false',
+    );
+    this.toggleSwitch.checked = isDarkMode;
   }
 }
 

--- a/src/lib/components/base.js
+++ b/src/lib/components/base.js
@@ -9,5 +9,6 @@ import './Header';
 import './LanguageSelect';
 import './NavigationDrawer';
 import './SnackbarContainer';
+import './ThemeToggle';
 import './Search';
 import './SearchResults';

--- a/src/scss/blocks/_theme-toggle.scss
+++ b/src/scss/blocks/_theme-toggle.scss
@@ -1,0 +1,20 @@
+/// THIS IS VERY MUCH A TEMPORARY
+/// BIT OF CSS UNTIL WE SLING SOME
+/// PROPER UI DESIGN ON THE THEME TOGGLE
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  button {
+    border: 2px solid var(--color-stroke);
+    padding: 0.5rem 1rem;
+
+    @include apply-utility('bg', 'action-bg');
+    @include apply-utility('color', 'action-text');
+  }
+
+  [aria-pressed='true'] {
+    border-color: get-color('core-primary-glare');
+  }
+}

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -276,6 +276,9 @@ a:active {
   background: var(--color-core-text);
 }
 
+/// BLOCK CLASSES
+@import 'blocks/theme-toggle';
+
 /// UTILITY CLASSES
 @import 'utilities/flow';
 @import 'utilities/focus-ring';

--- a/src/site/_data/design/themes.js
+++ b/src/site/_data/design/themes.js
@@ -94,13 +94,13 @@ module.exports = {
       {
         name: 'dark-toggle',
         key: 'prefix',
-        value: '[data-theme="dark"]',
+        value: '[data-user-theme="dark"]',
         tokens: this.getDark(),
       },
       {
         name: 'light-toggle',
         key: 'prefix',
-        value: '[data-theme="light"]',
+        value: '[data-user-theme="light"]',
         tokens: this.getLight(),
       },
     ];

--- a/src/site/_data/design/themes.js
+++ b/src/site/_data/design/themes.js
@@ -10,6 +10,7 @@
 */
 module.exports = {
   colorKeys: {
+    MODE: 'mode',
     CORE_TEXT: 'core-text',
     CORE_BG: 'core-bg',
     MID_TEXT: 'mid-text',
@@ -32,6 +33,7 @@ module.exports = {
   },
   getDark() {
     return {
+      MODE: 'dark',
       CORE_TEXT: 'shades-light',
       CORE_BG: 'shades-dim',
       MID_TEXT: 'shades-gray-glare',
@@ -55,6 +57,7 @@ module.exports = {
   },
   getLight() {
     return {
+      MODE: 'light',
       CORE_TEXT: 'shades-dark',
       CORE_BG: 'shades-light-bright',
       MID_TEXT: 'shades-gray',
@@ -93,6 +96,12 @@ module.exports = {
         key: 'prefix',
         value: '[data-theme="dark"]',
         tokens: this.getDark(),
+      },
+      {
+        name: 'light-toggle',
+        key: 'prefix',
+        value: '[data-theme="light"]',
+        tokens: this.getLight(),
       },
     ];
   },

--- a/src/site/_data/design/tokens.json
+++ b/src/site/_data/design/tokens.json
@@ -130,8 +130,8 @@
         },
         {
           "name": "Light",
-          "hex": "#f3f3f3",
-          "hsl": "hsl(0, 0%, 95%)"
+          "hex": "#f9f9f9",
+          "hsl": "hsl(0, 0%, 97%)"
         },
         {
           "name": "Light Bright",

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -2,6 +2,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 {% if CSS_ORIGIN === 'next' %}
+  <script>
+    // A global function that the theme toggle can use to apply the current theme.
+    window.applyThemeSetting = function(override) {
+      const currentSetting = override || localStorage.getItem('user-color-scheme');
+      const currentAttribute = document.documentElement.getAttribute('data-theme');
+
+      if (currentSetting && currentSetting !== currentAttribute) {
+        document.documentElement.setAttribute('data-theme', currentSetting);
+      }
+    };
+    window.applyThemeSetting();
+  </script>
   {# hashForProd() will cache bust the css in dev with a random string. #}
   <link rel="stylesheet" href="{{ helpers.hashForProd('/css/next.css') }}">
 {% else %}

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -6,10 +6,10 @@
     // A global function that the theme toggle can use to apply the current theme.
     window.applyThemeSetting = function(override) {
       const currentSetting = override || localStorage.getItem('user-color-scheme');
-      const currentAttribute = document.documentElement.getAttribute('data-theme');
+      const currentAttribute = document.documentElement.getAttribute('data-user-theme');
 
       if (currentSetting && currentSetting !== currentAttribute) {
-        document.documentElement.setAttribute('data-theme', currentSetting);
+        document.documentElement.setAttribute('data-user-theme', currentSetting);
       }
     };
     window.applyThemeSetting();

--- a/src/site/content/en/design-system/temp-styleguide.njk
+++ b/src/site/content/en/design-system/temp-styleguide.njk
@@ -4,10 +4,14 @@ permalink: '/design-system/temp-styleguide/index.html'
 ---
 
 <main class="wrapper flow">
+
   <h1>Global CSS Temp styleguide</h1>
   <p>This is just a temporary dumping ground for the Global CSS to save time, working with the design system which still relies on the old CSS.</p>
 
   <hr />
+
+  <h2>Toggle theme</h2>
+  <theme-toggle></theme-toggle>
 
   <h2>Headings</h2>
 

--- a/src/site/content/en/design-system/temp-styleguide.njk
+++ b/src/site/content/en/design-system/temp-styleguide.njk
@@ -11,7 +11,13 @@ permalink: '/design-system/temp-styleguide/index.html'
   <hr />
 
   <h2>Toggle theme</h2>
-  <theme-toggle></theme-toggle>
+  <theme-toggle>
+    <!-- As part of the patterns, we'll build out a switch block and use that here -->
+    <label for="theme-toggle">
+      Dark mode
+      <input type="checkbox" role="switch" id="theme-toggle" />
+    </label>
+  </theme-toggle>
 
   <h2>Headings</h2>
 


### PR DESCRIPTION
This is the theme switcher that toggles dark/light mode, overriding the initial `prefers-color-scheme` setting that is honoured by default. The setting is stored in and loaded from local storage.

In `head.njk`, the little snippet of JavaScript applies the setting _before_ the CSS is loaded to prevent a flash of incorrect theme, when a user has a setting stored in local storage. 

In terms of UI on the toggle itself, I've just applied some really basic CSS so it doesn't look rubbish. We need to work out how the toggle will look, globally, so I'll tag in @jimoong for some thoughts on that. It's using `<button>` elements to toggle right now, but we could also lean into an `<input type="checkbox" role="switch" />` to support something more "toggle"-like. 

I added it to the `base.js` because we will need it on every page, ongoing. I doubt it'll have much of an impact on overall weight on pages using the now old CSS stuff. 

For now, I've just applied it to the temp styleguide: https://deploy-preview-5908--web-dev-staging.netlify.app/design-system/temp-styleguide/