### PR TITLE
Clarifications about baseURLs when using URLPattern 

### DIFF
--- a/src/site/content/en/blog/urlpattern/index.md
+++ b/src/site/content/en/blog/urlpattern/index.md
@@ -4,6 +4,7 @@ subhead: An approach to standardizing common pattern matching use cases.
 authors:
   - jeffposnick
 date: 2021-07-22
+updated: 2021-08-04
 description: An approach to standardizing common pattern matching use cases.
 thumbnail: image/FNkVSAX8UDTTQWQkKftSgGe9clO2/YWhOUaN06kzk4mu93a1v.jpg
 tags:
@@ -137,6 +138,10 @@ const p = new URLPattern({
   baseURL: 'https://example.com',
 });
 ```
+
+{% Aside %}
+When passing a `baseURL` to the constructor, any aspects of the URL that are not provided are treated as if they were set to an empty string, _not_ as a `'*'` wildcard. For instance, `new URLPattern({baseURL: 'https://example.com/'})` will create a `URLPattern` with `search`, `hash`, and other unspecified properties set to `''`.
+{% endAside %}
 
 All of these examples assume that your use case involves matching origins. If
 you're only interested in matching on the other portions of the URL, excluding

--- a/src/site/content/en/blog/urlpattern/index.md
+++ b/src/site/content/en/blog/urlpattern/index.md
@@ -140,7 +140,11 @@ const p = new URLPattern({
 ```
 
 {% Aside %}
-When passing a `baseURL` to the constructor, any aspects of the URL that are not provided are treated as if they were set to an empty string, _not_ as a `'*'` wildcard. For instance, `new URLPattern({baseURL: 'https://example.com/'})` will create a `URLPattern` with `search`, `hash`, and other unspecified properties set to `''`.
+When passing a `baseURL` to the constructor, any aspects of the URL
+that are not provided are treated as if they were set to an empty string, _not_
+as a `'*'` wildcard. For instance,
+`new URLPattern({baseURL: 'https://example.com/'})` will create a `URLPattern`
+with `search`, `hash`, and other unspecified properties set to `''`.
 {% endAside %}
 
 All of these examples assume that your use case involves matching origins. If


### PR DESCRIPTION
This addresses some developer feedback raised in https://github.com/WICG/urlpattern/issues/63 about how the `baseURL` property affects the constructed `URLPattern`.

CC: @wanderview