### PR TITLE
Correct link markup in Web Vitals Tools article

### DIFF
--- a/src/site/content/en/blog/vitals-tools-workflow/index.md
+++ b/src/site/content/en/blog/vitals-tools-workflow/index.md
@@ -451,7 +451,7 @@ This table will help you choose the right APIs to suit your needs.
         <td>Allows slicing of data in meaningful ways
         which can be joined with other public datasets
         like the
-        [HTTP Archive](https://httparchive.org/) for advanced insights.</td>
+          <a href="https://httparchive.org/">HTTP Archive</a> for advanced insights.</td>
         <td>RESTful access to CrUX data programmatically.
 More filtering possibilities and faster than PSI API (also higher quota).</td>
         <td>RESTful access to CrUX and Lighthouse data programmatically.</td>


### PR DESCRIPTION
Changes proposed in this pull request:

- Not rendering link. I presume because you can't use markdown in the middle of HTML table?

https://web.dev/vitals-tools-workflow/#:~:text=Allows%20slicing%20of%20data%20in%20meaningful%20ways%20which%20can%20be%20joined%20with%20other%20public%20datasets
