### PR TITLE
add includeRaw shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,7 @@ const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const yaml = require('js-yaml');
 const fs = require('fs');
+const path = require('path');
 
 const toc = require('eleventy-plugin-toc');
 const markdown = require('./src/site/_plugins/markdown');
@@ -215,6 +216,10 @@ module.exports = function (config) {
   config.addShortcode('Tooltip', Tooltip);
   config.addShortcode('Video', Video);
   config.addShortcode('YouTube', YouTube);
+  config.addShortcode('includeRaw', (arg) => {
+    const p = path.join(__dirname, 'src/site/_includes', arg);
+    return fs.readFileSync(p, 'utf-8');
+  });
 
   // This table is used for the web.dev/LIVE event, and should be taken down
   // when the event is over or we no longer use it.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,7 +19,6 @@ const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const yaml = require('js-yaml');
 const fs = require('fs');
-const path = require('path');
 
 const toc = require('eleventy-plugin-toc');
 const markdown = require('./src/site/_plugins/markdown');
@@ -43,6 +42,7 @@ const DetailsSummary = require('./src/site/_includes/components/DetailsSummary')
 const EventTable = require('./src/site/_includes/components/EventTable');
 const Glitch = require('./src/site/_includes/components/Glitch');
 const Hero = require('./src/site/_includes/components/Hero');
+const includeRaw = require('./src/site/_includes/components/includeRaw');
 const IFrame = require('./src/site/_includes/components/IFrame');
 const {Img, generateImgixSrc} = require('./src/site/_includes/components/Img');
 const Instruction = require('./src/site/_includes/components/Instruction');
@@ -216,10 +216,7 @@ module.exports = function (config) {
   config.addShortcode('Tooltip', Tooltip);
   config.addShortcode('Video', Video);
   config.addShortcode('YouTube', YouTube);
-  config.addShortcode('includeRaw', (arg) => {
-    const p = path.join(__dirname, 'src/site/_includes', arg);
-    return fs.readFileSync(p, 'utf-8');
-  });
+  config.addShortcode('includeRaw', includeRaw);
 
   // This table is used for the web.dev/LIVE event, and should be taken down
   // when the event is over or we no longer use it.

--- a/src/lib/components/CourseLinks/index.js
+++ b/src/lib/components/CourseLinks/index.js
@@ -47,7 +47,7 @@ class CourseLinks extends HTMLElement {
    * Get the user's overall course progress from localstorage.
    * This returns an object where each string key represents a different course.
    * Example: {css: {pages: ['intro', ...], percent: 10}, pwa: {...}}
-   * @returns {Object.<string, Course>}
+   * @returns {{[courseName: string]: Course}}
    */
   getProgress = () => {
     let progress;

--- a/src/site/_includes/components/includeRaw.js
+++ b/src/site/_includes/components/includeRaw.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// The path to the _includes folder inside web.dev.
+const includesPath = path.join(__dirname, '../');
+
+/**
+ * @param {string} arg
+ * @return {string}
+ */
+module.exports = (arg) => {
+  const p = path.join(includesPath, arg);
+  return fs.readFileSync(p, 'utf-8');
+};

--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -3,7 +3,7 @@ layout: base
 pageScripts:
   - '/js/course.js'
 inlineScripts:
-  - '../../../lib/components/CourseLinks/index.js'
+  - '../../lib/components/CourseLinks/index.js'
 ---
 
 {% from 'macros/audio-fab.njk' import audioFab %}

--- a/src/site/_includes/design-system.njk
+++ b/src/site/_includes/design-system.njk
@@ -24,7 +24,7 @@
       <div class="sidebar flex-auto">
         <nav class="flow bg-mid-bg pad-block-size-1" aria-label="design system">
           <div class="brand cluster pad-inline-size-1">
-            {{ svg('../../../images/lockup.svg', {label: 'web.dev'}) }}
+            {{ svg('../../images/lockup.svg', {label: 'web.dev'}) }}
             <p class="brand__byline">Design System</p>
           </div>
           <div class="pad-inline-size-1">

--- a/src/site/_includes/macros/icon.njk
+++ b/src/site/_includes/macros/icon.njk
@@ -13,7 +13,7 @@
 #}
 {% macro svg(path, options) %}
 {% set rawSvg -%}
-  {% include path %}
+  {% includeRaw path %}
 {%- endset %}
 {{ rawSvg | updateSvgForInclude(options) | safe }}
 {% endmacro %}

--- a/src/site/_includes/partials/course-app-bar.njk
+++ b/src/site/_includes/partials/course-app-bar.njk
@@ -2,7 +2,7 @@
 <nav class="course-app-bar app-bar" aria-label="breadcrumbs">
   <ul class="app-bar__list">
     <li class="app-bar__item">
-      <a href="/">{{ svg('../../../images/lockup.svg', {label: 'web.dev', className: 'course-app-bar__logo'}) }}</a>
+      <a href="/">{{ svg('../../images/lockup.svg', {label: 'web.dev', className: 'course-app-bar__logo'}) }}</a>
     </li>
     <li class="app-bar__item">
       <a href="/learn/">{{ 'i18n.header.learn' | i18n(locale) }}</a>

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -42,12 +42,9 @@
 {# Include the GA object so we can start queuing events. #}
 {% include 'partials/analytics.njk' %}
 
-{# Warning: Inlined script can't contain double curly braces (like in a JSDoc
-object comment), or any other nunjucks syntax. Otherwise nunjucks will fail the
-include. #}
 {% for item in inlineScripts %}
   {% set inlineScript %}
-    {% include item %}
+    {% includeRaw item %}
   {% endset %}
   <script>{{ inlineScript | minifyJs | cspHash | safe }}</script>
 {% endfor %}

--- a/src/site/_includes/partials/header-course.njk
+++ b/src/site/_includes/partials/header-course.njk
@@ -11,7 +11,7 @@
       {# The course logo is stored in src/images, but the svg macro uses
       Nunjuck's include syntax. So we need to give it a relative path from
       src/site/_includes to src/images. #}
-      {% set logo = helpers.join('../../..', courseData.meta.logo) %}
+      {% set logo = helpers.join('../..', courseData.meta.logo) %}
       {{ svg(logo, {label: courseData.meta.title | i18n(locale)}) }}
     {% endif %}
   </div>

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -15,7 +15,7 @@
             {# The course logo is stored in src/images, but the svg macro uses
             Nunjuck's include syntax. So we need to give it a relative path from
             src/site/_includes to src/images. #}
-            {% set logo = helpers.join('../../..', courseData.meta.logo) %}
+            {% set logo = helpers.join('../..', courseData.meta.logo) %}
             {{ svg(logo, {label: courseData.meta.title | i18n(locale)}) }}
           {% endif %}
         </div>


### PR DESCRIPTION
This follows-up from @robdodson 's PR #5964 and adds an `includeRaw` helper.

Very confusingly, all the previous includes that go outside "src/site/_includes" seem to have needed "../../.." and yet somehow still end up in "src/site" as the base path. I can't explain it, but I think Nunjucks' include function must do something different or special here.

So I've simplified that here.