### PR TITLE
@devnook Add patterns that do not have a parent PatternSet to the pattern-set page

### DIFF
--- a/src/site/_data/i18n/patterns.yml
+++ b/src/site/_data/i18n/patterns.yml
@@ -1,3 +1,7 @@
 all_patterns:
   en: All patterns
   es: Todos los patrones
+
+other_patterns:
+  en: Other patterns
+  es: Otros patrones

--- a/src/site/_includes/pattern-set.njk
+++ b/src/site/_includes/pattern-set.njk
@@ -124,11 +124,13 @@ pageScripts:
       {% endfor %}
 
       {# Patterns that belong directly to the pattern suite #}
+      {% set first = true %}
       {% for patternId, pattern in patterns.patterns %}
         {% if pattern.set == patternSuite.id %}
-          {% if loop.first %}
-            <h2> Other patterns</h2>
+          {% if first %}
+            <h2>{{ "i18n.patterns.other_patterns" | i18n(locale) }}</h2>
           {% endif %}
+          {% set first = false %}
           <div>
             <h3 id="{{pattern.id}}"><a href="/patterns/{{pattern.id}}">{{pattern.title}}</a></h3>
             {{ pattern.content | safe }}

--- a/src/site/_includes/pattern-set.njk
+++ b/src/site/_includes/pattern-set.njk
@@ -127,7 +127,7 @@ pageScripts:
       {% for patternId, pattern in patterns.patterns %}
         {% if pattern.set == patternSuite.id %}
           {% if loop.first %}
-            <h2> Other patterns vv </h2>
+            <h2> Other patterns</h2>
           {% endif %}
           <div>
             <h3 id="{{pattern.id}}"><a href="/patterns/{{pattern.id}}">{{pattern.title}}</a></h3>

--- a/src/site/_includes/pattern-set.njk
+++ b/src/site/_includes/pattern-set.njk
@@ -106,6 +106,7 @@ pageScripts:
 
     {% else %}
 
+      {# Patterns in PatternSets that belong to the current suite #}
       {% for patternSetId, patternSet in patterns.sets %}
         {% if patternSet.suite == patternSuite.id %}
           <h2> {{ patternSet.title }} </h2>
@@ -119,6 +120,20 @@ pageScripts:
               </div>
             {% endif %}
           {% endfor %}
+        {% endif %}
+      {% endfor %}
+
+      {# Patterns that belong directly to the pattern suite #}
+      {% for patternId, pattern in patterns.patterns %}
+        {% if pattern.set == patternSuite.id %}
+          {% if loop.first %}
+            <h2> Other patterns vv </h2>
+          {% endif %}
+          <div>
+            <h3 id="{{pattern.id}}"><a href="/patterns/{{pattern.id}}">{{pattern.title}}</a></h3>
+            {{ pattern.content | safe }}
+            {% CodePattern pattern.id %}
+          </div>
         {% endif %}
       {% endfor %}
 


### PR DESCRIPTION
Some patterns might belong directly to the pattern suite (/patterns/PatternSuite/Pattern) instead of a PatternSet (/patterns/PatternSuite/PatternSet/Pattern). They are displayed under "other patterns" heading in the pattern suite page.