### PR TITLE
Leverage prettier and regex to improve output formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.10",
+    "prettier": "^2.3.2",
     "prismjs": "^1.24.1",
     "proxyquire": "^2.1.3",
     "puppeteer": "^5.2.1",

--- a/src/pattern-library/patterns/aside/aside.njk
+++ b/src/pattern-library/patterns/aside/aside.njk
@@ -7,5 +7,5 @@
     <strong>{{ data.title }}</strong>
   </p> 
   {% endif %}
-  <p class="{{ data.utilities.body }}">{{ data.content | md | safe }}</p>
+  <div class="{{ data.utilities.body }}">{{ data.content | md | safe }}</div>
 </div>

--- a/src/site/_data/design/patterns.js
+++ b/src/site/_data/design/patterns.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const nunjucks = require('nunjucks');
 const fs = require('fs');
 const path = require('path');
+const prettier = require('prettier');
 
 // Pull in filters
 const md = require('../../_filters/md');
@@ -116,9 +117,20 @@ module.exports = {
         );
       }
 
-      response.rendered = nunjucksEnv.renderString(response.markup, {
-        data: response.data.context || {},
-      });
+      // Render the pattern with nunjucks and then run it through
+      // prettier so format it correctly to make copy/paste easier
+      response.rendered = prettier
+        .format(
+          nunjucksEnv.renderString(response.markup, {
+            data: response.data.context || {},
+          }),
+          {
+            useTabs: false,
+            tabWidth: 2,
+            parser: 'html',
+          },
+        )
+        .replace(/^\s*\n/gm, ''); // Gets rid of blank lines (https://stackoverflow.com/q/16369642)
 
       if (fs.existsSync(path.resolve(patternPath, `${patternName}.md`))) {
         response.docs = fs.readFileSync(


### PR DESCRIPTION
The output HTML was a touch ropey in the design system patterns (soon to be renamed components) which will affect copy and paste:

![Badly formatted output HTML](https://user-images.githubusercontent.com/8672583/130220141-29c91300-30db-4cab-ae78-9ce946d72847.jpg)

This mini PR leverages `prettier` and a little regex to remove blank lines to assist with that:

![Nicely formatted output HTML](https://user-images.githubusercontent.com/8672583/130220289-b342510f-f694-42ad-94e9-ee3af313e694.jpg)


