### PR TITLE
Milestone updates for AppCache removal

### DIFF
--- a/src/site/content/en/blog/appcache-removal/index.md
+++ b/src/site/content/en/blog/appcache-removal/index.md
@@ -5,8 +5,7 @@ authors:
   - jeffposnick
 description: Details of Chrome's and other browsers' plans to remove AppCache.
 date: 2020-05-18
-updated: 2021-02-01
-scheduled: true
+updated: 2021-08-23
 tags:
   - appcache
   - blog
@@ -74,7 +73,7 @@ A "deprecated" feature still exists, but logs warning messages discouraging use.
     <tr>
     <td>Complete removal from secure contexts for everyone, with completion of origin trial
     </td>
-    <td>Chrome 93 (<a href="https://chromiumdash.appspot.com/schedule">estimated October 2021</a>)
+    <td>Chrome 95 (<a href="https://chromiumdash.appspot.com/schedule">estimated October 2021</a>)
     </td>
     </tr>
   </table>
@@ -86,7 +85,7 @@ This timeline applies to Chrome on **all platforms other than iOS**. There is al
 
 ## Origin trial
 
-The timeline lists two upcoming milestones for removal. Beginning with Chrome 85, AppCache will no longer be available in Chrome by default. Developers who require additional time to migrate off of AppCache can [sign up](https://developers.chrome.com/origintrials/#/register_trial/1776670052997660673) for a "reverse" [origin trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md) to extend the availability of AppCache for their web apps. The origin trial will start in Chrome 84 (in advance of the default removal in Chrome 85), and will be active through Chrome 89. Starting with Chrome 90, AppCache will be fully removed for everyone, even those who had signed up for the origin trial.
+The timeline lists two upcoming milestones for removal. Beginning with Chrome 85, AppCache will no longer be available in Chrome by default. Developers who require additional time to migrate off of AppCache can [sign up](https://developers.chrome.com/origintrials/#/register_trial/1776670052997660673) for a "reverse" [origin trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md) to extend the availability of AppCache for their web apps. The origin trial will start in Chrome 84 (in advance of the default removal in Chrome 85), and will be active through Chrome 94. Starting with Chrome 95, AppCache will be fully removed for everyone, even those who had signed up for the origin trial.
 
 {% Aside %}
 Why are we calling this a "reverse" origin trial? Normally, an origin trial allows developers to opt-in to early access to new functionality before it has shipped by default in Chrome. In this case, we're allowing developers to opt-in to using legacy technology even after it's been removed from Chrome, but only temporarily.


### PR DESCRIPTION
This reflects the updated timeline for AppCache removal, given the new 4 week release cycle.

See https://bugs.chromium.org/p/chromium/issues/detail?id=582750#c109