### PR TITLE
Update content-visibilty to fix typo

### DIFF
--- a/src/site/content/en/blog/content-visibility/index.md
+++ b/src/site/content/en/blog/content-visibility/index.md
@@ -216,6 +216,7 @@ We can use `IntersectionObserver` and `MutationObserver` to set
 the correct sizes inline for each element. [Alex Russell](https://twitter.com/slightlylate) explains
 how this works in [`content-visibility` without jittery scrollbars](https://infrequently.org/2020/12/content-visibility-scroll-fix/), and [Resize-Resilient `content-visibility` Fixes](https://infrequently.org/2020/12/resize-resilient-deferred-rendering/).
 {% endAside %}
+
 ## Hiding content with `content-visibility: hidden`
 
 What if you want to keep the content unrendered regardless of whether or not it


### PR DESCRIPTION
This will (hopefully) fix a rendering issue leading to the `## Hiding content with `content-visibility: hidden` header being rendered wrong at https://web.dev/content-visibility/.