### PR TITLE
fix(offline-cookbook): Push API broken link

### DIFF
--- a/src/site/content/en/reliable/offline-cookbook/index.md
+++ b/src/site/content/en/reliable/offline-cookbook/index.md
@@ -260,7 +260,7 @@ This is very similar to HTTP's [stale-while-revalidate](https://www.mnot.net/blo
   <figcaption class="w-figcaption">On push message.</figcaption>
 </figure>
 
-The [Push API](/web/fundamentals/push-notifications) is another feature built on top of
+The [Push API](https://developers.google.com/web/fundamentals/push-notifications) is another feature built on top of
 Service Worker. This allows the Service Worker to be awoken in response to a message from the OS's
 messaging service. This happens even when the user doesn't have a tab open to your site. Only the
 Service Worker is woken up. You request permission to do this from a page and the user will be


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



Changes proposed in this pull request:

Push API link currently points to https://web.dev/web/fundamentals/push-notifications which is broken.
Correct link is https://developers.google.com/web/fundamentals/push-notifications/

Another instance of this broken link also exists at https://github.com/GoogleChrome/web.dev/blame/main/src/site/content/en/blog/push-notifications-overview/index.md#L247 but that reference-style link is not referred anywhere in that article. Let me know if I should also remove that link.

