### PR TITLE
Include command for CMD in Media Application Basics

### DIFF
--- a/src/site/content/en/media/media-application-basics/index.md
+++ b/src/site/content/en/media/media-application-basics/index.md
@@ -203,6 +203,14 @@ provided the instructions to get you set up quickly.
     docker run -w /media -v ${PWD}/media:/media -it --rm media-tools
     /media #
     ```
+    
+    If you are using Windows Command Prompt, use the following command instead:
+    
+    ```bash
+    docker run -w /media -v %cd%/media:/media -it --rm media-tools
+    /media #
+    ```
+    
 
 {% Aside 'gotchas' %}
 Make sure you run the previous `docker` commands from inside the `media-tools`


### PR DESCRIPTION
Windows command prompt does not understand `${PWD}`.
Changing that section of the 5th instruction to `%cd%` made the command work as expected in CMD.

Fixes #6056 

Changes proposed in this pull request:

- Added command for command prompt users
