### PR TITLE
Let authors use markdown in course titles and descriptions.

### DIFF
--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -55,8 +55,8 @@ inlineScripts:
             <div class="course-index font-mono">{{ loop.index0 | padStart(3, '0') }}</div>
           {% endif %}
         {% endfor %}
-        <h1 class="course-headline">{{ title }}</h1>
-        <p class="course-description">{{ description }}</p>
+        <h1 class="course-headline">{{ title | md }}</h1>
+        <p class="course-description">{{ description | md }}</p>
         {% include 'partials/toc-inner.njk' %}
         <div class="course-copy flow">
           {% if audio %}

--- a/src/site/_includes/course.njk
+++ b/src/site/_includes/course.njk
@@ -55,8 +55,12 @@ inlineScripts:
             <div class="course-index font-mono">{{ loop.index0 | padStart(3, '0') }}</div>
           {% endif %}
         {% endfor %}
-        <h1 class="course-headline">{{ title | md }}</h1>
-        <p class="course-description">{{ description | md }}</p>
+        <h1 class="course-headline">{{ title | md | safe }}</h1>
+        <p class="course-description">
+          {# If authors use backticks in their description markdown we don't #}
+          {# want the code to have any border or background color. #}
+          <span class="unstyled-code">{{ description | md | safe }}</span>
+        </p>
         {% include 'partials/toc-inner.njk' %}
         <div class="course-copy flow">
           {% if audio %}

--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -80,16 +80,21 @@ pre code {
 
 // It's not uncommon to have code in markdown headings.
 // In these cases we should remove the border.
+// There is also a utility class, .unstyled-code, that can be used
+// if we're using <code> blocks in new contexts.
+// For example: <span class="unstyled-code">{{ description | md | safe }}</span>
 h1 code,
 h2 code,
 h3 code,
 h4 code,
 h5 code,
-h6 code {
+h6 code,
+.unstyled-code code {
   background: transparent;
   border: 0;
   color: inherit;
   font-size: inherit;
+  font-style: inherit;
   margin: 0;
   padding: 0;
   white-space: normal;


### PR DESCRIPTION
Previously you could not use markdown backticks in the titles or descriptions for course content. This already works for regular blog posts, but it didn't for courses.

This also adds an `.unstyled-code` class which can be used as an exception to disable most of our code styles.

Before:
![image](https://user-images.githubusercontent.com/1066253/131723618-2c06f5a3-b18b-4771-870d-be2d80df148e.png)

After:
![image](https://user-images.githubusercontent.com/1066253/131723628-93b03858-8be7-448f-bd94-11f3bac5e074.png)
