### PR TITLE
Add caution about null GPU adapter

### DIFF
--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-updated: 2021-09-02
+updated: 2021-09-03
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 description: |
@@ -110,7 +110,7 @@ if ("gpu" in navigator) {
 ```
 
 {% Aside 'caution' %}
-The GPU adapter returned by `navigator.gpu.requestAdapter()` may be null.
+The GPU adapter returned by `navigator.gpu.requestAdapter()` may be `null`.
 {% endAside %}
 
 ### Get started {: #get-started }

--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-#updated: 2021-08-26
+updated: 2021-09-02
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 description: |
@@ -108,6 +108,10 @@ if ("gpu" in navigator) {
   // WebGPU is supported! 🎉
 }
 ```
+
+{% Aside 'caution' %}
+The GPU adapter returned by `navigator.gpu.requestAdapter()` may be null.
+{% endAside %}
 
 ### Get started {: #get-started }
 


### PR DESCRIPTION
This PR adds a caution about GPU adapter being null which may cause confusion. See https://github.com/mrdoob/three.js/pull/22482/files