### PR TITLE
Fixing Url in Deprecating Excalidraw Electron in favor of the web version blog

### DIFF
--- a/src/site/content/en/blog/deprecating-excalidraw-electron/index.md
+++ b/src/site/content/en/blog/deprecating-excalidraw-electron/index.md
@@ -259,7 +259,7 @@ enhancement strategy, we enjoy the latest and greatest wherever possible, but wi
 behind. Best viewed in _any_ browser.
 
 Electron has served us well, but in 2020 and beyond, we can live without it. Oh, and for that
-objective of [@vjeux](https://github/com/vjeux): since the Android Play Store now accepts PWAs in a
+objective of [@vjeux](https://github.com/vjeux): since the Android Play Store now accepts PWAs in a
 container format called [Trusted Web Activity](/using-a-pwa-in-your-android-app/) and
 since the
 [Microsoft Store supports PWAs](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-edgehtml/microsoft-store),


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
