### PR TITLE
fixing url in A more private way to measure ad conversions, the Event Conversion Measurement API blog

### DIFF
--- a/src/site/content/en/blog/conversion-measurement/index.md
+++ b/src/site/content/en/blog/conversion-measurement/index.md
@@ -106,7 +106,7 @@ iteration** of the API. Things may change substantially in [future iterations](#
 
 This iteration of the API only supports **click-through conversion measurement**, but [view-through
 conversion
-measurement](https://github.com/WICG/conversion-measurement-api/blob/main/event_attribution_reporting.md) is under public incubation.
+measurement](https://github.com/WICG/conversion-measurement-api/blob/main/event_attribution_reporting_views.md) is under public incubation.
 
 ### How it works
 


### PR DESCRIPTION
… Conversion Measurement API blog

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
