### PR TITLE
fixing url in Virtual reality comes to the web, part II blog

### DIFF
--- a/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
+++ b/src/site/content/en/blog/vr-comes-to-the-web-pt-ii/index.md
@@ -38,7 +38,7 @@ a WebXR App. Fortunately many frameworks provide a layer of abstraction on top
 of WebGL and WebGL2. Such frameworks include [three.js](https://threejs.org/),
 [babylonjs](https://www.babylonjs.com/), and
 [PlayCanvas](https://playcanvas.com/), while [A-Frame](https://aframe.io/) and
-[React 360](https://facebook.github.io/react-360/) are designed for interacting
+[React 360](https://github.com/facebookarchive/react-360) was designed for interacting
 with WebXR.
 
 This article is neither a WebGL nor a framework tutorial. It explains basics of


### PR DESCRIPTION
https://github.com/mdn/content/pull/8719#issue-728506061 - Facebook has stopped supporting the React 360 project since 2018 but it is still available to view and use.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
