### PR TITLE
throw on missing i18n string

### DIFF
--- a/src/site/_filters/i18n.js
+++ b/src/site/_filters/i18n.js
@@ -69,10 +69,14 @@ const data = {i18n: walk(path.join(__dirname, '..', '_data', 'i18n'))};
 const i18n = (path, locale = defaultLocale) => {
   locale = locale.split('_')[0];
   try {
-    return get(data, path)[locale] || get(data, path)[defaultLocale];
+    const out = get(data, path)[locale] ?? get(data, path)[defaultLocale];
+    if (out !== undefined) {
+      return out;
+    }
   } catch (err) {
-    throw new Error(`Could not find i18n result for ${path}`);
+    // ignore, throw below
   }
+  throw new Error(`Could not find i18n result for: ${path}`);
 };
 
 /**

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -1,9 +1,10 @@
 {% from 'macros/icon.njk' import icon, svg with context %}
 
 {% macro renderItem(item, depth) %}
-  {%- set title = item.data.title or '' -%}
   {%- if item.title -%}
-    {%- set title = item.title | i18n(locale) -%}
+    {%- set title = (item.title | i18n(locale)) or '' -%}
+  {%- else -%}
+    {%- set title = item.data.title or '' -%}
   {%- endif -%}
 
   {% if item.url %}


### PR DESCRIPTION
I found strange (probably intended?) behavior in Nunjucks, that it was falling back to the previous `{{ title }}` when the result of calling the i18n filter was `undefined`.

Anyway, the solution here is to actually barf on missing i18n strings. This was hitting us when a user tried to access a string like "i18n.courses.foo", when strings "i18n.courses.foo.bar" was actually defined (since the parent object existed, it just has no 'en' prop).