### PR TITLE
Provide more specific link to Parcel docs

### DIFF
--- a/src/site/content/en/blog/bundling-non-js-resources/index.md
+++ b/src/site/content/en/blog/bundling-non-js-resources/index.md
@@ -106,7 +106,7 @@ Following bundlers support the `new URL` scheme already:
 
 -  [Webpack v5](https://webpack.js.org/guides/asset-modules/#url-assets)
 -  [Rollup](https://rollupjs.org/) (Achieved via plugins—[@web/rollup-plugin-import-meta-assets](https://modern-web.dev/docs/building/rollup-plugin-import-meta-assets/) for generic assets and [@surma/rollup-plugin-off-main-thread](https://github.com/surma/rollup-plugin-off-main-thread) for Workers specifically.)
--  [Parcel v2 (beta)](https://v2.parceljs.org/)
+-  [Parcel v2 (beta)](https://v2.parceljs.org/languages/javascript/#url-dependencies)
 -  [Vite](https://vitejs.dev/guide/assets.html#new-url-url-import-meta-url)
 
 #### WebAssembly


### PR DESCRIPTION
In response to my issue, Parcel has added a dedicated section in docs for this pattern, so changing the link to point right there.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
