### PR TITLE
fix(newsletter): use zh-TW for Taiwan, fixes #6193

### DIFF
--- a/src/site/_data/countries.js
+++ b/src/site/_data/countries.js
@@ -297,7 +297,7 @@ module.exports = [
     'ST: S\u00e3o Tom\u00e9 and Pr\u00edncipe',
     'S\u00e3o Tom\u00e9 and Pr\u00edncipe',
   ],
-  ['TW: Taiwan', 'Taiwan (\u53f0\u6e7e)'],
+  ['TW: Taiwan', 'Taiwan (\u53f0\u7063)'],
   [
     'TJ: Tajikistan',
     'Tajikistan (\u062a\u0627\u062c\u06cc\u06a9\u0633\u062a\u0627\u0646)',


### PR DESCRIPTION
Fixes #6193.

Changes proposed in this pull request:

- Use the correct locale (zh-TW) for the display name of Taiwan in Newsletter page.
