### PR TITLE
JavaScript Eventing Deep Dive: Fix 2 live demo links to match the text

### DIFF
--- a/src/site/content/en/blog/eventing-deepdive/index.md
+++ b/src/site/content/en/blog/eventing-deepdive/index.md
@@ -360,7 +360,7 @@ output:
 You can interactively play with this in the live demo below. Click on the `#C` element in the live demo and observe the console output.
 
 <div style="height: 680px; width: 100%;">
-  <iframe src="https://silicon-brawny-cardinal.glitch.me/stop-propagation-capturing-C.html" loading="lazy" style="height: 100%; width: 100%; border: 0;"></iframe>
+  <iframe src="https://silicon-brawny-cardinal.glitch.me/stop-propagation-bubbling-A.html" loading="lazy" style="height: 100%; width: 100%; border: 0;"></iframe>
 </div>
 
 One more, just for fun. What happens if we call `stopPropagation()` in the _target phase_ for `#C`?
@@ -390,7 +390,7 @@ event's propagation will cease.
 You can interactively play with this in the live demo below. Click on the `#C` element in the live demo and observe the console output.
 
 <div style="height: 680px; width: 100%;">
-  <iframe src="https://silicon-brawny-cardinal.glitch.me/stop-propagation-bubbling-A.html" loading="lazy" style="height: 100%; width: 100%; border: 0;"></iframe>
+  <iframe src="https://silicon-brawny-cardinal.glitch.me/stop-propagation-capturing-C.html" loading="lazy" style="height: 100%; width: 100%; border: 0;"></iframe>
 </div>
 
 In any of these live demos, I encourage you to play around. Try clicking on the `#A` element only or


### PR DESCRIPTION
Thanks for a great article.
I understand propagation/capture/bubble so much better now!
I just think two of the live demo links may be out of sync with their surrounding text though, see below:

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fix live demo link for stopping propagation at `#A` in the bubbling phase
- Fix live demo link for `stopPropagation()` in the _target phase_ for `#C`
