### PR TITLE
feat: Copying a heading copies the link to the clipboard

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -5,6 +5,7 @@ import lang from './utils/language';
 import {localStorage} from './utils/storage';
 import cookies from 'js-cookie';
 import {trackEvent} from './analytics';
+import './copy';
 
 export const clearSignedInState = store.action(() => {
   const {isSignedIn} = store.getState();

--- a/src/lib/components/Snackbar/index.js
+++ b/src/lib/components/Snackbar/index.js
@@ -78,11 +78,27 @@ class Snackbar extends BaseElement {
     `;
   }
 
+  get copiedTemplate() {
+    setTimeout(() => {
+      this.removeAttribute('open');
+      this.removeAttribute('type');
+    }, 3000);
+
+    return html`
+      <div class="web-snackbar__label" role="status">
+        Link copied to clipboard.
+      </div>
+    `;
+  }
+
   render() {
     let template;
     switch (this.type) {
       case 'cookies':
         template = this.cookiesTemplate;
+        break;
+      case 'copied':
+        template = this.copiedTemplate;
         break;
       default:
         break;

--- a/src/lib/copy.js
+++ b/src/lib/copy.js
@@ -1,0 +1,21 @@
+if ('clipboard' in navigator && 'writeText' in navigator.clipboard) {
+  document.addEventListener('click', async (event) => {
+    if (
+      // @ts-ignore
+      !event.target.classList ||
+      // @ts-ignore
+      !event.target.classList.contains('w-headline-link')
+    ) {
+      return;
+    }
+    event.preventDefault();
+    try {
+      await navigator.clipboard.writeText(event.target.href);
+      const snackbar = document.querySelector('web-snackbar');
+      snackbar.setAttribute('type', 'copied');
+      snackbar.setAttribute('open', 'open');
+    } catch (err) {
+      console.warn('Failed to copy: ', err);
+    }
+  });
+}

--- a/src/lib/copy.js
+++ b/src/lib/copy.js
@@ -1,9 +1,7 @@
 if ('clipboard' in navigator && 'writeText' in navigator.clipboard) {
   document.addEventListener('click', async (event) => {
     if (
-      // @ts-ignore
-      !event.target.classList ||
-      // @ts-ignore
+      !(event.target instanceof Element) ||
       !event.target.classList.contains('w-headline-link')
     ) {
       return;


### PR DESCRIPTION
This is the successor to #4570.

This now uses the `web-snackbar`.