### PR TITLE
feat(tags): automagically add `origin-trials` tag to posts, fixes #3311

### DIFF
--- a/src/site/content/content.11tydata.js
+++ b/src/site/content/content.11tydata.js
@@ -2,6 +2,20 @@ const outputPermalink = require('../../build/output-permalink');
 
 module.exports = {
   eleventyComputed: {
+    tags: (data) => {
+      // Add the following tags if necessary
+      const originTrials = 'origin-trials';
+
+      if (!Array.isArray(data.tags)) {
+        data.tags = [];
+      }
+
+      if (data.origin_trial && !data.tags.includes(originTrials)) {
+        data.tags.push(originTrials);
+      }
+
+      return data.tags;
+    },
     permalink: (data) => outputPermalink(data),
   },
 };

--- a/src/site/content/content.11tydata.js
+++ b/src/site/content/content.11tydata.js
@@ -6,7 +6,9 @@ module.exports = {
       // Add the following tags if necessary
       const originTrials = 'origin-trials';
 
-      if (!Array.isArray(data.tags)) {
+      if (typeof data.tags === 'string') {
+        data.tags = [data.tags];
+      } else if (!Array.isArray(data.tags)) {
         data.tags = [];
       }
 


### PR DESCRIPTION
Fixes #3311

Changes proposed in this pull request:

- Check all content for origin trial front matter and add origin trial tag if missing.
- 
- 
