### PR TITLE
Remove the auto dark mode for now

### DIFF
--- a/src/scss/blocks/_prose.scss
+++ b/src/scss/blocks/_prose.scss
@@ -2,11 +2,9 @@
 /// https://web.dev/design-system/pattern/prose
 .prose {
   @extend .flow;
+  @extend .wrapper;
 
   --flow-space: #{get-space('size-1')};
-
-  margin-inline: auto;
-  width: max-content;
 
   /// Add more space to elements that follow figures etc
   pre + *,

--- a/src/site/_data/design/themes.js
+++ b/src/site/_data/design/themes.js
@@ -188,12 +188,6 @@ module.exports = {
         tokens: this.getLight(),
       },
       {
-        name: 'dark',
-        key: 'prefers-color-scheme',
-        value: 'dark',
-        tokens: this.getDark(),
-      },
-      {
         name: 'dark-toggle',
         key: 'prefix',
         value: '[data-user-theme="dark"]',


### PR DESCRIPTION
To keep the rollout process simple, the media query-based dark mode will no longer work _but_ we can still toggle modes on and off for testing. 