### PR TITLE
WIP: prototype rendering new design system components without disturbing older stuff

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -157,14 +157,12 @@ module.exports = function (config) {
   // CSS_ORIGIN set to 'next'. This allows shortcodes to determine if we
   // are in a design system context or a legacy context
   config.addCollection('designSystemGlobals', (collection) => {
-    global.__designSystemPaths = [
-      ...new Set(
-        collection
-          .getAll()
-          .filter(({data}) => data.CSS_ORIGIN === 'next')
-          .map(({filePathStem}) => filePathStem),
-      ),
-    ];
+    global.__designSystemPaths = new Set(
+      collection
+        .getAll()
+        .filter(({data}) => data.CSS_ORIGIN === 'next')
+        .map(({filePathStem}) => filePathStem),
+    );
 
     return global.__designSystemPaths;
   });

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -166,8 +166,6 @@ module.exports = function (config) {
       ),
     ];
 
-    global.__designSystemComponents = require('./src/site/_data/design/components');
-
     return global.__designSystemPaths;
   });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -153,6 +153,24 @@ module.exports = function (config) {
     return memoize(collection.getAll());
   });
 
+  // Filters through all collection items and finds content that has
+  // CSS_ORIGIN set to 'next'. This allows shortcodes to determine if we
+  // are in a design system context or a legacy context
+  config.addCollection('designSystemGlobals', (collection) => {
+    global.__designSystemPaths = [
+      ...new Set(
+        collection
+          .getAll()
+          .filter(({data}) => data.CSS_ORIGIN === 'next')
+          .map(({filePathStem}) => filePathStem),
+      ),
+    ];
+
+    global.__designSystemComponents = require('./src/site/_data/design/components');
+
+    return global.__designSystemPaths;
+  });
+
   // ----------------------------------------------------------------------------
   // FILTERS
   // ----------------------------------------------------------------------------

--- a/src/component-library/aside/aside.json
+++ b/src/component-library/aside/aside.json
@@ -17,6 +17,13 @@
   },
   "variants": [
     {
+      "name": "note",
+      "title": "Note",
+      "context": {
+        "content": "A note is just a standard aside."
+      }
+    },
+    {
       "name": "caution",
       "title": "Caution",
       "context": {

--- a/src/lib/utils/is-design-system-context.js
+++ b/src/lib/utils/is-design-system-context.js
@@ -1,0 +1,4 @@
+/* global __designSystemPaths */
+
+// Attempts to find passed path in generated design system compatible paths
+module.exports = (path) => __designSystemPaths.includes(path);

--- a/src/lib/utils/is-design-system-context.js
+++ b/src/lib/utils/is-design-system-context.js
@@ -1,4 +1,5 @@
 /* global __designSystemPaths */
 
-// Attempts to find passed path in generated design system compatible paths
-module.exports = (path) => __designSystemPaths.includes(path);
+// Attempts to find passed path in generated design system
+// compatible paths, which are a Set
+module.exports = (path) => __designSystemPaths.has(path);

--- a/src/scss/blocks/_prose.scss
+++ b/src/scss/blocks/_prose.scss
@@ -2,11 +2,9 @@
 /// https://web.dev/design-system/pattern/prose
 .prose {
   @extend .flow;
+  @extend .wrapper;
 
   --flow-space: #{get-space('size-1')};
-
-  margin-inline: auto;
-  width: max-content;
 
   /// Add more space to elements that follow figures etc
   pre + *,

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -26,7 +26,7 @@ $global-stroke: 1px solid get-utility-value('color', 'stroke');
 @import 'mixins/vertically-align-label';
 
 /// GLOBAL CSS
-/// Core CSS that is applicable to every page.
+/// Core CSS that is applicable to every page
 /// https://cube.fyi/css.html
 
 body {

--- a/src/site/_data/design/components.js
+++ b/src/site/_data/design/components.js
@@ -299,12 +299,7 @@ module.exports = {
     }
 
     // Passed data overwrites any context data.
-    // Regex removes whitespace and minifies: https://stackoverflow.com/a/59357436
     const renderData = {...item.data.context, ...data};
-    return nunjucksEnv
-      .renderString(item.markup, {data: renderData})
-      .replace(/\>[\r\n ]+\</g, '><')
-      .replace(/(<.*?>)|\s+/g, (m, $1) => ($1 ? $1 : ' '))
-      .trim();
+    return nunjucksEnv.renderString(item.markup, {data: renderData});
   },
 };

--- a/src/site/_data/design/components.js
+++ b/src/site/_data/design/components.js
@@ -20,6 +20,7 @@ const nunjucksEnv = new nunjucks.Environment(
   new nunjucks.FileSystemLoader(
     path.join(__basedir, 'src', 'site', '_includes'),
   ),
+  {autoescape: false},
 );
 
 nunjucksEnv.addFilter('md', md);
@@ -298,7 +299,12 @@ module.exports = {
     }
 
     // Passed data overwrites any context data.
+    // Regex: https://stackoverflow.com/a/59357436
     const renderData = {...item.data.context, ...data};
-    return nunjucksEnv.renderString(item.markup, {data: renderData});
+    return nunjucksEnv
+      .renderString(item.markup, {data: renderData})
+      .replace(/\>[\r\n ]+\</g, '><')
+      .replace(/(<.*?>)|\s+/g, (m, $1) => ($1 ? $1 : ' '))
+      .trim();
   },
 };

--- a/src/site/_data/design/components.js
+++ b/src/site/_data/design/components.js
@@ -299,7 +299,7 @@ module.exports = {
     }
 
     // Passed data overwrites any context data.
-    // Regex: https://stackoverflow.com/a/59357436
+    // Regex removes whitespace and minifies: https://stackoverflow.com/a/59357436
     const renderData = {...item.data.context, ...data};
     return nunjucksEnv
       .renderString(item.markup, {data: renderData})

--- a/src/site/_includes/components/Aside.js
+++ b/src/site/_includes/components/Aside.js
@@ -1,3 +1,5 @@
+/* global __designSystemComponents */
+
 /*
  * Copyright 2019 Google LLC
  *
@@ -14,6 +16,7 @@
  * limitations under the License.
  */
 const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
+const isDesignSystemContext = require('../../../lib/utils/is-design-system-context');
 
 /**
  * @this {EleventyPage}
@@ -22,6 +25,33 @@ function Aside(content, type = 'note') {
   const locale = getLocaleFromPath(this.page && this.page.filePathStem);
 
   let prefix;
+
+  // Renders the new aside
+  if (isDesignSystemContext(this.page.filePathStem)) {
+    switch (type) {
+      case 'codelab':
+        prefix = `${i18n(`i18n.common.try_it`, locale)}!`;
+        break;
+
+      case 'key-term':
+        prefix = i18n(`i18n.common.key_term`, locale);
+        break;
+
+      case 'note':
+        break;
+
+      default:
+        prefix = i18n(`i18n.common.${type}`, locale);
+        break;
+    }
+
+    return __designSystemComponents.render(`aside-${type}`, {
+      title: prefix,
+      content,
+    });
+  }
+
+  // Renders the old aside
   switch (type) {
     case 'note':
       prefix = '';

--- a/src/site/_includes/components/Aside.js
+++ b/src/site/_includes/components/Aside.js
@@ -1,5 +1,3 @@
-/* global __designSystemComponents */
-
 /*
  * Copyright 2019 Google LLC
  *
@@ -16,7 +14,6 @@
  * limitations under the License.
  */
 const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
-const isDesignSystemContext = require('../../../lib/utils/is-design-system-context');
 
 /**
  * @this {EleventyPage}
@@ -25,33 +22,6 @@ function Aside(content, type = 'note') {
   const locale = getLocaleFromPath(this.page && this.page.filePathStem);
 
   let prefix;
-
-  // Renders the new aside
-  if (isDesignSystemContext(this.page.filePathStem)) {
-    switch (type) {
-      case 'codelab':
-        prefix = `${i18n(`i18n.common.try_it`, locale)}!`;
-        break;
-
-      case 'key-term':
-        prefix = i18n(`i18n.common.key_term`, locale);
-        break;
-
-      case 'note':
-        break;
-
-      default:
-        prefix = i18n(`i18n.common.${type}`, locale);
-        break;
-    }
-
-    return __designSystemComponents.render(`aside-${type}`, {
-      title: prefix,
-      content,
-    });
-  }
-
-  // Renders the old aside
   switch (type) {
     case 'note':
       prefix = '';

--- a/src/site/_includes/design-system.njk
+++ b/src/site/_includes/design-system.njk
@@ -55,17 +55,14 @@
           </ul>
         </nav>
         <div class="pad-size-1">
-          <div class="wrapper flow">
+          <article class="prose">
             <h1>{{ pageTitle if pageTitle else title }}</h1>
             {% if summary %}
               {{ summary | md | safe }}
             {% endif %}
-
-            <div class="flow">
-              {% block inner %}
-              {% endblock %}
-            </div>
-          </div>
+            {% block inner %}
+            {% endblock %}
+          </article>
         </div>
       </div>
     </div>

--- a/src/site/content/en/design-system/css-methodology.md
+++ b/src/site/content/en/design-system/css-methodology.md
@@ -9,3 +9,11 @@ layout: 'design-system-documentation.njk'
 - CUBE CSS
 - SCSS structure
 - Best practice
+
+{% Aside %}
+A test aside **with markdown** to see if this strategy works.
+{% endAside %}
+
+{% Aside 'caution' %}
+A test caution aside **with markdown** to see if this strategy works.
+{% endAside %}


### PR DESCRIPTION
I recorded a screencast of this admittedly, questionable approach: https://www.loom.com/share/a5f832e2f84948d4a81b7ee86c6d1b1e

If we go down this route, the main problem will be how do we handle nested shortcodes. For example, how do we handle a `{% Img %}` being passed into an `{% Aside %}`? The markdown is processed using [our filter](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_filters/md.js).

Other than that and the frightening globals, this could have legs—especially as it is very temporary. 

Let me know ur thoughts and please, feel free to play around on this branch too! 

Example page that uses the new design system and an existing shortcode: https://github.com/GoogleChrome/web.dev/blob/prototype-shortcode-context/src/site/content/en/design-system/css-methodology.md