### PR TITLE
Fix geometrychange event name

### DIFF
--- a/src/site/content/en/blog/virtualkeyboard/index.md
+++ b/src/site/content/en/blog/virtualkeyboard/index.md
@@ -81,7 +81,7 @@ You can programmatically show the virtual keyboard by calling its `show()` metho
 the focused element needs to be a form control (such as a `textarea` element), or be an editing host
 (for example, by using the
 [`contenteditable`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable)
-attribute). The method always returns `undefined` but triggers a `geometrychanged` event
+attribute). The method always returns `undefined` but triggers a `geometrychange` event
 if the virtual keyboard previously was not shown.
 
 ```js
@@ -89,7 +89,7 @@ navigator.virtualKeyboard.show();
 ```
 
 To hide the virtual keyboard, call the `hide()` method. The method always returns `undefined` but triggers
-a `geometrychanged` event if the virtual keyboard previously was shown.
+a `geometrychange` event if the virtual keyboard previously was shown.
 
 ```js
 navigator.virtualKeyboard.hide();
@@ -97,13 +97,13 @@ navigator.virtualKeyboard.hide();
 
 ### Being informed of geometry changes
 
-Whenever the virtual keyboard appears or disappears, the `geometrychanged` event is dispatched. The
+Whenever the virtual keyboard appears or disappears, the `geometrychange` event is dispatched. The
 event's `target` property contains the new geometry of the virtual keyboard inset as a
 [`DOMRect`](https://www.w3.org/TR/geometry-1/#domrect).
 The inset corresponds to the top, right, bottom, and/or left properties.
 
 ```js
-navigator.virtualKeyboard.addEventListener('geometrychanged', (event) => {
+navigator.virtualKeyboard.addEventListener('geometrychange', (event) => {
   const { x, y, width, height } = event.target;
   console.log('Virtual keyboard geometry changed:', x, y, width, height);
 });


### PR DESCRIPTION
The event name is `geometrychange`. The article incorrectly references `geometrychanged` a few times.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
