### PR TITLE
allow more ram during build (seeing sometimes failures)

### DIFF
--- a/.cloudbuild/deploy.yaml
+++ b/.cloudbuild/deploy.yaml
@@ -20,6 +20,7 @@ steps:
     args: ['run', 'build']
     env:
     - 'ELEVENTY_ENV=prod'
+    - 'NODE_OPTIONS=--max_old_space_size=4096`
 
   - name: 'gcr.io/$PROJECT_ID/firebase'
     id: 'Deploy site to Firebase'


### PR DESCRIPTION
This matches what we've done for our Actions. Cloud Build's node is (sometimes) crashing without this.

Amusingly we request a huge instance yet Node still has a RAM limit here. Well, at least our CPU is faster for builds.