### PR TITLE
test(presubmit): build a staging version of site to speed up HTML and CSS transforms

### DIFF
--- a/.github/workflows/presubmit-workflow.yml
+++ b/.github/workflows/presubmit-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run a production build of site
         run: npm run build
         env:
-          ELEVENTY_ENV: prod
+          ELEVENTY_ENV: staging
 
       # Checks to see if any files in the PR match one of the listed file types.
       # We can use this filter to decide whether or not to run linters or tests.

--- a/.github/workflows/presubmit-workflow.yml
+++ b/.github/workflows/presubmit-workflow.yml
@@ -23,7 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           is_presubmit: ${{ contains(github.event.pull_request.labels.*.name, '$-presubmit') }}
 
-      - name: Run a production build of site
+      - name: Run a staging build of site
         run: npm run build
         env:
           ELEVENTY_ENV: staging

--- a/src/site/_collections/hooks/utils.js
+++ b/src/site/_collections/hooks/utils.js
@@ -29,7 +29,7 @@ const filterByLang = require('../../_filters/filter-by-lang');
 const feed = (items) => {
   const filteredFeed = [];
 
-  if (process.env.ELEVENTY_ENV !== 'prod') {
+  if (!['prod', 'staging'].includes(process.env.ELEVENTY_ENV)) {
     return filteredFeed;
   }
 

--- a/src/site/_transforms/minify-html.js
+++ b/src/site/_transforms/minify-html.js
@@ -15,9 +15,21 @@
  */
 
 const minify = require('html-minifier').minify;
+const path = require('path');
+const {URL} = require('url');
+const stagingUrls =
+  require('../../../tools/lhci/lighthouserc').ci.collect.url.map((url) =>
+    path.join('dist', new URL(url).pathname, 'index.html'),
+  );
+
+const isProd = process.env.ELEVENTY_ENV === 'prod';
+const isStaging = process.env.ELEVENTY_ENV === 'staging';
 
 const minifyHtml = (content, outputPath) => {
-  if (outputPath && outputPath.endsWith('.html')) {
+  if (
+    (isProd && outputPath && outputPath.endsWith('.html')) ||
+    (isStaging && stagingUrls.includes(outputPath))
+  ) {
     try {
       content = minify(content, {
         removeAttributeQuotes: true,


### PR DESCRIPTION
Changes proposed in this pull request:

- Change build command in presubmit to staging environment
- Update `purify-css` and `minify-html` to run on LHCI urls when in staging
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
