### PR TITLE
PWA summit, registration banner.

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -32,8 +32,8 @@ module.exports = {
   subscribeForm:
     'https://services.google.com/fb/submissions/591768a1-61a6-4f16-8e3c-adf1661539da/',
   thumbnail: 'image/tcFciHGuF3MxnTr1y5ue01OGLBn2/vU99HKzIf5EUPnzGVPf1.png',
-  isBannerEnabled: false,
-  banner: '',
+  isBannerEnabled: true,
+  banner: 'PWA Summit: a virtual conference to help everyone succeed with PWAs is on Oct 6 & 7. Get your [free ticket](https://pwasummit.org/register) today!',
   areCoursesEnabled: true,
   paginationCount: PAGINATION_COUNT,
   imgixDomain: 'web-dev.imgix.net',

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -33,7 +33,8 @@ module.exports = {
     'https://services.google.com/fb/submissions/591768a1-61a6-4f16-8e3c-adf1661539da/',
   thumbnail: 'image/tcFciHGuF3MxnTr1y5ue01OGLBn2/vU99HKzIf5EUPnzGVPf1.png',
   isBannerEnabled: true,
-  banner: 'PWA Summit: a virtual conference to help everyone succeed with PWAs is on Oct 6 & 7. Get your [free ticket](https://pwasummit.org/register) today!',
+  banner:
+    'PWA Summit: a virtual conference to help everyone succeed with PWAs is on Oct 6 & 7. Get your [free ticket](https://pwasummit.org/register) today!',
   areCoursesEnabled: true,
   paginationCount: PAGINATION_COUNT,
   imgixDomain: 'web-dev.imgix.net',


### PR DESCRIPTION
Changes proposed in this pull request:

- Adding a PWA banner with a link to the registration

My idea is to have this banner until Oct 7, when I'll change the banner to link to the livestream, so people can join, and I'll remove the banner by EOD oct 7th.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
