### PR TITLE
Added vanilla-lazyload alongside lozad

### DIFF
--- a/src/site/content/en/fast/lazy-loading-video/index.md
+++ b/src/site/content/en/fast/lazy-loading-video/index.md
@@ -150,7 +150,11 @@ and you can lazy-load that content.
 
 The following libraries can help you to lazy-load video:
 
-- [lozad.js](https://github.com/ApoorvSaxena/lozad.js) is a super lightweight
+- [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) and 
+[lozad.js](https://github.com/ApoorvSaxena/lozad.js) are super lightweight options 
+that uses Intersection Observer only. As such, they are highly performant, but
+will need to be polyfilled before you can use it on older browsers.
+-  is a super lightweight
 option that uses Intersection Observer only. As such, it's highly performant,
 but will need to be polyfilled before you can use it on older browsers.
 - [yall.js](https://github.com/malchata/yall.js) is a library that uses

--- a/src/site/content/en/fast/lazy-loading-video/index.md
+++ b/src/site/content/en/fast/lazy-loading-video/index.md
@@ -153,7 +153,7 @@ The following libraries can help you to lazy-load video:
 - [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) and 
 [lozad.js](https://github.com/ApoorvSaxena/lozad.js) are super lightweight options 
 that use Intersection Observer only. As such, they are highly performant, but
-will need to be polyfilled before you can use it on older browsers.
+will need to be polyfilled before you can use them on older browsers.
 - [yall.js](https://github.com/malchata/yall.js) is a library that uses
 Intersection Observer and falls back to event handlers. It's compatible with IE11
 and major browsers.

--- a/src/site/content/en/fast/lazy-loading-video/index.md
+++ b/src/site/content/en/fast/lazy-loading-video/index.md
@@ -152,11 +152,8 @@ The following libraries can help you to lazy-load video:
 
 - [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) and 
 [lozad.js](https://github.com/ApoorvSaxena/lozad.js) are super lightweight options 
-that uses Intersection Observer only. As such, they are highly performant, but
+that use Intersection Observer only. As such, they are highly performant, but
 will need to be polyfilled before you can use it on older browsers.
--  is a super lightweight
-option that uses Intersection Observer only. As such, it's highly performant,
-but will need to be polyfilled before you can use it on older browsers.
 - [yall.js](https://github.com/malchata/yall.js) is a library that uses
 Intersection Observer and falls back to event handlers. It's compatible with IE11
 and major browsers.


### PR DESCRIPTION
Both libraries work with video loading. vanilla-lazyload can be used to lazyload also images, background images and iframes.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

Changes proposed in this pull request:

- Adds vanilla-lazyload alongside lozad as both libraries can be used to lazyload videos, and vanilla-lazyload also works also with background images.