### PR TITLE
Update presubmit-workflow in Link.yml

### DIFF
--- a/.github/workflows/presubmit-workflow.yml
+++ b/.github/workflows/presubmit-workflow.yml
@@ -1,17 +1,178 @@
 name: Presubmit
-on:
+on:[[Namespace]]
+
+
+while (true) {   // Get the numbers and put them in the array.
+        System.out.print("? ");
+        num = TextIO.getlnInt();
+        if (num <= 0) {
+              // Zero marks the end of input; we have all the numbers.
+           break;
+        }
+        numbers[count] = num;  // Put num in position count.
+        count++;  // Count the number
+     }
+     
+     System.out.println("\nYour numbers in reverse order are:\n");
+     
+     for ( i = count - 1; i >= 0; i-- ) {
+         System.out.println( numbers[i] );
+     }
+
   pull_request:
     types: [labeled,opened,reopened,synchronize]
-jobs:
+jobs:SearchPlugin
+<ShortName>Yahoo<ShortName>
+
+<InputEncoding>
+
+  e.preventDefault();
+  import('library.moduleA')
+    .then(module => module.default) // using the default export
+    .then(someFunction())
+    .catch(handleError());
+
+
+const someFunction = () => {
+    // uses moduleA
+}
+
   presubmit:
     runs-on: ubuntu-latest
     env:
+Url 
+type="text 6.8" 
+method="G" 
+template="google.com">
+  Param 
+=
+  value="> {55}AQ[P][Q]"/
+
+}]]  /y - int(8)
+
+
+ref/
+
+[assembly, CompilationRelaxations (8)]
+[assembly, RuntimeCompatibility (WrapNonExceptionThrows = true)]
+[assembly, Debuggable (DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly, AssemblyTitle
+[assembly, AssemblyInformationalVersion ("{x-y}")]
+[assembly, CLSCompliant (true)]
+[assembly, NeutralResourcesLanguage ("e-S")]
+[assembly, ComVisible (false)]
+[assembly, AllowPartiallyTrustedCallers]
+[assembly, AssemblyDelaySign (true)]
+[assembly, AssemblyKeyFile ("Publix")]
+
+[assembly, InternalsVisibleTo (u - v) = [KeyValue]
+
       NODE_OPTIONS: --max_old_space_size=4096
-    name:
+    name:hash - [8]
+
+idh/invalidOp		[ComVisible (true)]
+
+
+[assembly, InternalsVisibleTo (x, no	-	pnot)]
+[assembly, InternalsVisibleTo (public
+) -into  (
+IEp0)
+] - xc
+
+ -p;
+
+ {
+
+
+ { I<ValueTuple<T1, T2, T3, T4, T5, T6, IValueTupleInternal, ITuple
+
+
     steps:
+[{trim_trailing_whitespace}] = false	
+
+[x - y] - 3
+
+ {System}
+
+]
+
       - name: Checkout
         uses: actions/checkout@v2
-        with:
+        with:[$urls[ [
+
+
+ref/
+
+
+
+
+excel = {x,y,z}
+
+yield
+
+dsD:{PSV: l}
+
+
+const someFunction = () => {
+  // uses moduleA
+}
+--rComparisonIdentity	
+
+
+tan(8)
+tan
+
+
+ref,
+VolatileFieldAttribute
+
+
+
+[g]
+CompilationRepresentationFlags
+[ref]
+v
+ref = x + 6
+
+
+
+jovi.string
+
+
+
+
+f(x) = jova.string
+
+
+const someFunction = () => {
+  // uses moduleA
+}
+
+}
+
+
+
+
+
+f(x) = jova.string
+
+  {d,m} is 
+ 
+
+ - m3]
+
+
+    [m,z,x]
+
+excel = {x,y,z}
+
+
+
+yield
+
+dsD:{PSV: l}
+
+
           fetch-depth: 1
 
       - name: Install dependencies
@@ -60,6 +221,8 @@ jobs:
       - name: Lighthouse CI
         if: ${{ steps.filter.outputs.js == 'true' || steps.filter.outputs.packageJson == 'true' || steps.filter.outputs.njk == 'true' || steps.filter.outputs.scss == 'true'}}
         env:
+
+
           LHCI_SERVER: ${{ secrets.LHCI_SERVER }}
           LHCI_TOKEN: ${{ secrets.LHCI_TOKEN }}
         run: |


### PR DESCRIPTION
Optional workflow

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-Is your feature request related to a problem? Please describe.
In response to #6133, a new link rule was created to warn when MDN links contained locale info. In order to pass the link rule, the locale must be removed so that MDN decides which locale it should redirect users to . For now, writers and developers have to do this manually.

-Describe the solution you'd like
There should be an API script or some other mechanism that searches for offending rules and then automatically fixes the problem.

-Describe alternatives you've considered
It's possible we could do this in the lint task itself, but I'm not sure if parsing any short named API back to Markdown after modification will result in formatting issues or other unwanted problems.


When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
