### PR TITLE
Remove locale from mdn link

### DIFF
--- a/src/site/content/en/learn/forms/design-basics/index.md
+++ b/src/site/content/en/learn/forms/design-basics/index.md
@@ -166,7 +166,7 @@ for example, a mouse, using the  `pointer` CSS media feature.
 ```
 
 Learn more about the
-[`pointer` CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer).
+[`pointer` CSS media feature](https://developer.mozilla.org/docs/Web/CSS/@media/pointer).
 
 ### Show errors where they happen
 


### PR DESCRIPTION
This fixes an issue where other PRs can't be merged because of this lint warning.

```
> web.dev@3.0.0 lint:md /Users/fbeaufort/Documents/GitHub/web.dev
> remark -q -f .

src/site/content/en/learn/forms/design-basics/index.md
  169:1-169:95  warning  An MDN link contains a locale (/en-US). Please remove the locale from the link.  bad-urls  remark-lint

⚠ 1 warning
```