### PR TITLE
Future-proof the reference to Chrome 93.

### DIFF
--- a/src/site/content/en/blog/sanitizer/index.md
+++ b/src/site/content/en/blog/sanitizer/index.md
@@ -8,6 +8,7 @@ description: |
 authors:
   - jackjey
 date: 2021-10-06
+updated: 2021-10-07
 hero: image/PV7xjXdOKHP8LWt9XhstsToJeK82/R2KGdIHv2lBRDS9vs8q1.jpg
 alt: Sanitizing a desk with Sanitizer
 tags:
@@ -279,7 +280,7 @@ Webkit: See the response on the [WebKit mailing list](https://lists.webkit.org/p
 
 #### Chrome
 
-Chrome is in the process of implementing the Sanitizer API, and when Chrome 93 is released, you can try out the behavior by enabling `about://flags/#enable-experimental-web-platform-features` flag. In earlier versions of Chrome Canary and Dev channel, you can enable it via `--enable-blink-features=SanitizerAPI` and try it out right now. Check out the [instructions for how to run Chrome with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags).
+Chrome is in the process of implementing the Sanitizer API. In Chrome 93 or later, you can try out the behavior by enabling `about://flags/#enable-experimental-web-platform-features` flag. In earlier versions of Chrome Canary and Dev channel, you can enable it via `--enable-blink-features=SanitizerAPI` and try it out right now. Check out the [instructions for how to run Chrome with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags).
 
 
 #### Firefox


### PR DESCRIPTION
Changes proposed in this pull request:

Articles like this are around long after the release of Chrome versions they mention. This article in particular, published yesterday, says "when Chrome 93 is released". Chrome 93 was released 36 days ago. This PR changes the phrase to use the words, "In Chrome 93 or later."
