### PR TITLE
Removing note about two different image uploaders

### DIFF
--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -28,12 +28,6 @@ Googlers access, so signing in with a personal account will fail.
 If you're not a Googler, reach out to your Google contact to see about getting
 access to the CDN.
 
-{% Aside 'caution' %}
-There are different uploaders for web.dev and developer.chrome.com:
-* [web.dev uploader](https://web-dev-uploads.web.app/uploader)
-* [developer.chrome.com uploader](https://chrome-gcs-uploader.web.app/)
-{% endAside %}
-
 ### Choose a file
 
 Upload a high quality image (jpg or png if you need alpha transparency). Our


### PR DESCRIPTION
The page at https://web.dev/handbook/markup-media/ still mentioned the two image uploaders, the dcc one now redirects to the web.dev one, therefore removing the note to save confusion.
