### PR TITLE
don't index design-system

### DIFF
--- a/src/site/content/en/design-system/design-system.11tydata.json
+++ b/src/site/content/en/design-system/design-system.11tydata.json
@@ -1,4 +1,5 @@
 {
+  "noindex": true,
   "CSS_ORIGIN": "next",
   "sideLinks": [
     {


### PR DESCRIPTION
We're showing up all these pages in search results, e.g.:
<img width="796" alt="Screen Shot 2021-10-14 at 15 00 51" src="https://user-images.githubusercontent.com/119184/137249529-2cfb2899-5205-4a54-b53b-2fd223ca07cc.png">

...don't ask me why "boat" was the first thing that came to mind, and for some reason it returns results 🤔 ⛵ 
