### PR TITLE
Remove call to deprecated createBufferMapped

### DIFF
--- a/src/site/content/en/blog/gpu-compute/index.md
+++ b/src/site/content/en/blog/gpu-compute/index.md
@@ -6,7 +6,7 @@ subhead: |
 authors:
   - beaufortfrancois
 date: 2019-08-28
-updated: 2021-09-06
+updated: 2021-10-18
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/AwjccGqafT2OOWqLGdDX.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/AwjccGqafT2OOWqLGdDX.jpeg
 description: |


### PR DESCRIPTION
While following the WebGPU compute tutorial (https://web.dev/gpu-compute/) I got an error running the code as given. This is because it uses `device.createBufferMapped` which is deprecated and seems to now throw an error. Looks like it was deprecated July 2020 or earlier (see https://github.com/gpuweb/gpuweb/pull/896). 

I don't think any other change is necessary since this call to `device.createBuffer` is done with `mappedAtCreation: true` which should have the desired behavior in this snippet.

I have an individual CLA signed with the name "Omar Shehata". 