### PR TITLE
Mention command line flag to test updates

### DIFF
--- a/src/site/content/en/progressive-web-apps/manifest-updates/index.md
+++ b/src/site/content/en/progressive-web-apps/manifest-updates/index.md
@@ -78,8 +78,8 @@ and can help you understand when the manifest was last updated, how often
 it's updated, and more.
 
 To manually force Chrome to check for an updated manifest, you can either launch
-Chrome with the command line flag `--disable-manifest-update-throttle` or
-restart Chrome (use `about://restart`), this resets the timer so that Chrome
+Chrome with the [command line flag][flag] `--disable-manifest-update-throttle`
+or restart Chrome (use `about://restart`), this resets the timer so that Chrome
 will check for an updated manifest when the PWA is next launched. Then launch
 the PWA. After closing the PWA, it should be updated with the new manifest
 properties.
@@ -145,5 +145,6 @@ The PWA usually updates within a few minutes, once the update has completed,
 
 * [`UpdateReason` enum][update-enum] for Chrome on Android
 
+[flag]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
 [updatable-manifest-doc]: https://docs.google.com/document/d/1twU_yAoTDp4seZMmqrDzJFQtrM7Z60jXHkXjMIO2VpM/preview
 [update-enum]: https://cs.chromium.org/chromium/src/chrome/browser/android/webapk/webapk.proto?l=35


### PR DESCRIPTION
This PR mentions the  `--disable-manifest-update-throttle` command line flag as an easy way to test manifest updates.
