### PR TITLE
Add guidance on article structure

### DIFF
--- a/src/site/content/en/handbook/writing-blog-posts/index.md
+++ b/src/site/content/en/handbook/writing-blog-posts/index.md
@@ -85,8 +85,8 @@ Also, see the tips below and consider whether you are over-explaining basic conc
 ### Article content
 
 Your article should follow a standard rhetorical structure.
-The introduction should introduce the concepts to be discussed, establish the context of your article, and alude to required background knowledge.
-The body should epxlain the most import aspects of you subject.
+The introduction should introduce the concepts to be discussed, establish the context of your article, and allude to required background knowledge.
+The body should explain the most import aspects of you subject.
 Conclusions vary, but the may include a recapitulation of your subject, calls to action, or requests for feedback.
 
 ## Working with an editor

--- a/src/site/content/en/handbook/writing-blog-posts/index.md
+++ b/src/site/content/en/handbook/writing-blog-posts/index.md
@@ -2,6 +2,7 @@
 layout: handbook
 title: How to write blog posts for web.dev and developer.chrome.com
 date: 2021-10-11
+update: 2021-10-27
 description: |
   Practical information and writing tips to get you started.
 ---
@@ -80,6 +81,13 @@ If you find that you are writing much more than that,
 it might be that the article can be split into two or more pieces dealing with various parts of the topic. 
 Ask your editor for advice on this. 
 Also, see the tips below and consider whether you are over-explaining basic concepts.
+
+### Article content
+
+Your article should follow a standard rhetorical structure.
+The introduction should introduce the concepts to be discussed, establish the context of your article, and alude to required background knowledge.
+The body should epxlain the most import aspects of you subject.
+Conclusions vary, but the may include a recapitulation of your subject, calls to action, or requests for feedback.
 
 ## Working with an editor
 


### PR DESCRIPTION
This is probably something we should add as part of expectation setting. This is something I _always_ cover in the initial 1:1 with new contributors. I want to make it clear before a single word is written that 'blog' does not mean 'anything goes'.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
