### PR TITLE
Add a wrap up section title to courses

### DIFF
--- a/src/site/_data/courses/forms/toc.yml
+++ b/src/site/_data/courses/forms/toc.yml
@@ -29,4 +29,5 @@
   - url: /learn/forms/identity
   - url: /learn/forms/payment
   - url: /learn/forms/address
-- url: /learn/forms/conclusion
+  - title: i18n.courses.wrap_up.title
+  - url: /learn/forms/conclusion

--- a/src/site/_data/i18n/courses.yml
+++ b/src/site/_data/i18n/courses.yml
@@ -62,6 +62,13 @@ form_types:
     en: Specific form types
   description:
     en: "to do."
+
+wrap_up:
+  title:
+    en: Wrap up
+  description:
+    en: "Title for the section with the conclusion of the course"
+
 learn_design:
   title:
     en: Learn Responsive Design!


### PR DESCRIPTION
This appears at the bottom of the sidebar TOC for courses with nesting (e.g. forms):
<img width="410" alt="Screenshot 2021-10-27 at 20 44 33" src="https://user-images.githubusercontent.com/1914261/139127572-84646bfa-0bb4-4f4b-a63e-1263a7e14796.png">

Please let me know if you're ok with the wording.


