### PR TITLE
Change from window to document Event listener

### DIFF
--- a/src/site/content/en/blog/trusted-types/index.md
+++ b/src/site/content/en/blog/trusted-types/index.md
@@ -121,7 +121,7 @@ You can deploy a report collector
 or use one of the commercial equivalents.
 You can also debug the violations in the browser:
 ```js
-window.addEventListener('securitypolicyviolation',
+document.addEventListener('securitypolicyviolation',
     console.error.bind(console));
 ```
 


### PR DESCRIPTION
See Mozilla documentation:
https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent/sample

And this thread with problems `document.addEventListener('securitypolicyviolation'` has on safari:
https://twitter.com/jub0bs/status/1452267366289747969

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Usage of correct browser APIs

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
