### PR TITLE
fix(share-action): corrupted hover style

### DIFF
--- a/src/lib/components/ShareAction/_styles.scss
+++ b/src/lib/components/ShareAction/_styles.scss
@@ -6,7 +6,7 @@ share-action {
   color: var(--color-mid-text);
 
   &:hover {
-    filter: invert(0.5);
+    filter: invert(0.05);
   }
 
   svg {


### PR DESCRIPTION
share-action hover style sets filter to 0.5 results with corrupted style
![image](https://user-images.githubusercontent.com/15140652/139587081-4cf478f4-aaa6-4271-b1f5-8beaa18bfb2b.png)

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
