### PR TITLE
fix dead PWA install link for FF

### DIFF
--- a/src/site/content/en/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/en/progressive-web-apps/install-criteria/index.md
@@ -68,7 +68,7 @@ Other browsers have similar criteria for installation, though there may be
 minor differences. Check the respective sites for full details:
 
 * [Edge](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps#requirements)
-* [Firefox](https://developer.mozilla.org/Apps/Progressive/Add_to_home_screen#How_do_you_make_an_app_A2HS-ready)
+* [Firefox](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Installable_PWAs)
 * [Opera](https://dev.opera.com/articles/installable-web-apps/)
 * [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
 * [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)

--- a/src/site/content/en/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/en/progressive-web-apps/install-criteria/index.md
@@ -68,7 +68,7 @@ Other browsers have similar criteria for installation, though there may be
 minor differences. Check the respective sites for full details:
 
 * [Edge](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps#requirements)
-* [Firefox](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Installable_PWAs)
+* [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 * [Opera](https://dev.opera.com/articles/installable-web-apps/)
 * [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
 * [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)


### PR DESCRIPTION
Apparently the install docs for FF are a 404 now. I couldn't find a language agnostic one so I went for `en-US`.
