### PR TITLE
refactor(course-cards-next): use carousel

### DIFF
--- a/src/lib/components/Carousel/index.js
+++ b/src/lib/components/Carousel/index.js
@@ -44,6 +44,7 @@ class Carousel extends BaseElement {
 
     this.next = this.next.bind(this);
     this.previous = this.previous.bind(this);
+    this._onKeyup = this._onKeyup.bind(this);
     this._onScroll = this._onScroll.bind(this);
   }
 
@@ -60,8 +61,6 @@ class Carousel extends BaseElement {
       ...this._carouselTrack.children,
     ]);
 
-    this._items.forEach((v, i) => v.setAttribute('data-index', '' + i));
-
     this._previousButton = this.querySelector('button[data-direction="prev"]');
     this._previousButton.addEventListener('click', this.previous);
     this._nextButton = this.querySelector('button[data-direction="next"]');
@@ -71,8 +70,9 @@ class Carousel extends BaseElement {
       e.addEventListener('focusin', () => this.moveSlide(i - this._index)),
     );
 
-    this._carouselTrack.addEventListener('scroll', this._onScroll);
-
+    this._carouselTrack.addEventListener('keyup', this._onKeyup);
+    this._carouselTrack.addEventListener('touchmove', this._onScroll);
+    this._carouselTrack.addEventListener('wheel', this._onScroll);
     this.moveSlide(0, false);
   }
 
@@ -82,7 +82,9 @@ class Carousel extends BaseElement {
     this._nextButton?.removeEventListener('click', this.next);
     window.clearTimeout(this._timeout);
     this._items.forEach((e) => e.removeChild(e));
-    this._carouselTrack?.removeEventListener('scroll', this._onScroll);
+    this._carouselTrack?.removeEventListener('keyup', this._onKeyup);
+    this._carouselTrack?.removeEventListener('touchmove', this._onScroll);
+    this._carouselTrack?.removeEventListener('wheel', this._onScroll);
   }
 
   /**
@@ -129,21 +131,35 @@ class Carousel extends BaseElement {
   }
 
   /**
+   * Event listener function that listens for key presses to see if user is switching elements.
+   *
+   * @param {KeyboardEvent} e The keyboard event.
+   */
+  _onKeyup(e) {
+    switch (e.key) {
+      case 'ArrowLeft':
+        return this.previous();
+      case 'ArrowRight':
+        return this.next();
+      default:
+        break;
+    }
+  }
+
+  /**
    * Event listener function that determines which element a user has scrolled to.
    */
   _onScroll() {
-    for (const item of this._items) {
+    for (let i = 0; i < this._items.length; i++) {
+      const item = this._items[i];
       const overflow =
-        (this._carouselTrack.parentElement.clientWidth -
-          this._carouselTrack.clientWidth) /
-        2;
-
+        this._carouselTrack.parentElement.clientWidth -
+        this._carouselTrack.clientWidth;
       if (
         this._carouselTrack.scrollLeft + overflow <=
         item.offsetLeft + item.offsetWidth
       ) {
-        const index = parseInt(item.getAttribute('data-index'), 10);
-        return this.moveSlide(index - this._index, false);
+        return this.moveSlide(i - this._index, false);
       }
     }
   }

--- a/src/lib/components/Carousel/index.js
+++ b/src/lib/components/Carousel/index.js
@@ -23,7 +23,7 @@ class Carousel extends BaseElement {
     /** @type {HTMLElement} */
     this._carouselTrack = undefined;
     /** @type {number} */
-    this._index = -1;
+    this._index = 0;
     /** @type {HTMLElement[]} */
     this._items = [];
     /** @type {HTMLButtonElement} */
@@ -56,11 +56,9 @@ class Carousel extends BaseElement {
     this._nextButton.addEventListener('click', this._next);
 
     this._items.forEach((e, i) =>
-      e.addEventListener('focusin', () => this._moveSlide(i - this._index)),
+      e.addEventListener('focusin', () => this._setIndex(i - this._index)),
     );
     this._carouselTrack.addEventListener('keyup', this._onKeyup);
-
-    this._moveSlide(0);
   }
 
   disconnectedCallback() {
@@ -69,25 +67,6 @@ class Carousel extends BaseElement {
     this._nextButton?.removeEventListener('click', this._next);
     this._items.forEach((e) => e.removeChild(e));
     this._carouselTrack?.removeEventListener('keyup', this._onKeyup);
-  }
-
-  /**
-   * Sets the new current slide index and scrolls to it.
-   *
-   * @param {number} increment How many items to move by.
-   */
-  _moveSlide(increment) {
-    this._index = this._index + increment;
-
-    if (this._index < 0) {
-      this._index = 0;
-    } else if (this._index >= this._items.length) {
-      this._index = this._items.length - 1;
-    }
-
-    const active = this._items[this._index];
-    active.focus({preventScroll: true});
-    this._carouselTrack.scrollTo(active.offsetLeft, 0);
   }
 
   /**
@@ -105,9 +84,9 @@ class Carousel extends BaseElement {
   _onKeyup(e) {
     switch (e.key) {
       case 'ArrowLeft':
-        return this._moveSlide(-1);
+        return this._setIndex(-1);
       case 'ArrowRight':
-        return this._moveSlide(1);
+        return this._setIndex(1);
       default:
         break;
     }
@@ -143,6 +122,25 @@ class Carousel extends BaseElement {
         return this._carouselTrack.scrollTo(scrollTo.offsetLeft, 0);
       }
     }
+  }
+
+  /**
+   * Sets the new current slide index and scrolls to it.
+   *
+   * @param {number} increment How many items to move by.
+   */
+  _setIndex(increment) {
+    this._index = this._index + increment;
+
+    if (this._index < 0) {
+      this._index = 0;
+    } else if (this._index >= this._items.length) {
+      this._index = this._items.length - 1;
+    }
+
+    const active = this._items[this._index];
+    active.focus({preventScroll: true});
+    this._carouselTrack.scrollTo(active.offsetLeft, 0);
   }
 }
 

--- a/src/lib/pages/home.js
+++ b/src/lib/pages/home.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for Home page.
  */
 
+import '../components/Carousel';
 import '../components/Subscribe';
 
 import '../components/base';

--- a/src/lib/pages/learn.js
+++ b/src/lib/pages/learn.js
@@ -2,6 +2,7 @@
  * @fileoveriew Entrypoint for Learn page.
  */
 
+import '../components/Carousel';
 import '../components/LearnFilter';
 
 import '../components/base';

--- a/src/site/_includes/partials/course-cards-next.njk
+++ b/src/site/_includes/partials/course-cards-next.njk
@@ -1,27 +1,37 @@
 {% from 'macros/icon.njk' import svg with context %}
 
-<nav class="reel scrollbar" aria-label="available courses">
-  {# Convert the courses object into an array of objects. #}
-  {% set coursesArr = helpers.values(courses) %}
-  {# Sort courses by descending date order (most recent comes first) #}
-  {% for course in coursesArr|sort(true, false, 'meta.date') %}
-    {% if course.meta and not course.meta.draft %}
-      <a href="{{ course.meta.url }}" class="card" data-style="branded">
-        <h3 class="visually-hidden">{{ course.meta.title }}</h3>
-        <div class="card__header repel">
-          <p class="color-mid-text">Course</p>
-          <div class="counter t-bg-core-primary t-color-shades-light-bright">
-            {% set pages = collections.all | navigation(course.toc) %}
-            <span class="counter__content" aria-label="{{ pages.list.length }} {{ 'i18n.learn.resources' | i18n(locale) }}">{{ pages.list.length }}</span>
-            {{ icon('mortarboard') }}
-          </div>
-        </div>
-        <img src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
-        <div class="card__content flow">
-          <p class="text-size-0">{{ course.meta.description | i18n(locale) }}</p>
-        </div>
-      </a>
-    {% endif %}
-  {% endfor %}
-</nav>
+<web-carousel>
+  <div class="carousel">
+    <button class="icon-button" data-direction="prev" aria-label="back">
+      {% include "icons/carat-back.svg" %}
+    </button>
+    <div class="carousel__track reel" data-scroll="snap" aria-label="available courses">
+      {# Convert the courses object into an array of objects. #}
+      {% set coursesArr = helpers.values(courses) %}
+      {# Sort courses by descending date order (most recent comes first) #}
+      {% for course in coursesArr|sort(true, false, 'meta.date') %}
+        {% if course.meta and not course.meta.draft %}
+          <a href="{{ course.meta.url }}" class="card" data-style="branded">
+            <h3 class="visually-hidden">{{ course.meta.title }}</h3>
+            <div class="card__header repel">
+              <p class="color-mid-text">Course</p>
+              <div class="counter t-bg-core-primary t-color-shades-light-bright">
+                {% set pages = collections.all | navigation(course.toc) %}
+                <span class="counter__content" aria-label="{{ pages.list.length }} {{ 'i18n.learn.resources' | i18n(locale) }}">{{ pages.list.length }}</span>
+                {{ icon('mortarboard') }}
+              </div>
+            </div>
+            <img src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
+            <div class="card__content flow">
+              <p class="text-size-0">{{ course.meta.description | i18n(locale) }}</p>
+            </div>
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+    <button class="icon-button" data-direction="next" aria-label="forward">
+      {% include "icons/carat-forward.svg" %}
+    </button>
+  </div>
+</web-carousel>
 

--- a/src/site/_includes/partials/course-cards-next.njk
+++ b/src/site/_includes/partials/course-cards-next.njk
@@ -5,7 +5,7 @@
     <button class="icon-button" data-direction="prev" aria-label="back">
       {% include "icons/carat-back.svg" %}
     </button>
-    <div class="carousel__track reel" data-scroll="snap" aria-label="available courses">
+    <div class="carousel__track reel scrollbar" data-scroll="snap" aria-label="available courses">
       {# Convert the courses object into an array of objects. #}
       {% set coursesArr = helpers.values(courses) %}
       {# Sort courses by descending date order (most recent comes first) #}


### PR DESCRIPTION
Changes proposed in this pull request:

- Update course cards partial to use carousel
- Carousel tracks active card when tabbing and using arrow keys.
- Carousel scrolls when using forward/back buttons.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
