### PR TITLE
add `siteRender` filter to render as close to site as possible

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -93,6 +93,7 @@ const getPaths = require('./src/site/_filters/get-paths');
 const navigation = require('./src/site/_filters/navigation');
 const {minifyJs} = require('./src/site/_filters/minify-js');
 const {cspHash, getHashList} = require('./src/site/_filters/csp-hash');
+const {siteRender} = require('./src/site/_filters/site-render');
 
 const disableLazyLoad = require('./src/site/_transforms/disable-lazy-load');
 const {purifyCss} = require('./src/site/_transforms/purify-css');
@@ -186,6 +187,7 @@ module.exports = function (config) {
   config.addFilter('isNewContent', isNewContent);
   config.addFilter('md', md);
   config.addFilter('navigation', navigation);
+  config.addNunjucksAsyncFilter('siteRender', siteRender);
   config.addFilter('pagedNavigation', pagedNavigation);
   config.addFilter('postsLighthouseJson', postsLighthouseJson);
   config.addFilter('prettyDate', prettyDate);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web.dev",
       "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -51,6 +52,7 @@
         "@types/markdown-it": "^12.0.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^14.11.2",
+        "@types/nunjucks": "^3.2.0",
         "@types/remove-markdown": "^0.1.1",
         "@types/resize-observer-browser": "^0.1.3",
         "ansi-colors": "^3.2.4",
@@ -4180,6 +4182,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.0.tgz",
+      "integrity": "sha512-1FM36Hm3EdidJmWlZZafkg/kZME0UZ/0vQ46JE8R7R0JqQafah0r+d4i6d/MJg5DnKxEeAOAeifEVkzo7fEvGg==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -36084,6 +36092,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/nunjucks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.0.tgz",
+      "integrity": "sha512-1FM36Hm3EdidJmWlZZafkg/kZME0UZ/0vQ46JE8R7R0JqQafah0r+d4i6d/MJg5DnKxEeAOAeifEVkzo7fEvGg==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/markdown-it": "^12.0.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^14.11.2",
+    "@types/nunjucks": "^3.2.0",
     "@types/remove-markdown": "^0.1.1",
     "@types/resize-observer-browser": "^0.1.3",
     "ansi-colors": "^3.2.4",

--- a/src/lib/patterns.js
+++ b/src/lib/patterns.js
@@ -24,20 +24,18 @@ const glob = require('fast-glob');
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
-const md = require('markdown-it')();
 
 const stripDot = /^\./;
 const basePath = path.join(__dirname, '../../src/site/content/en/patterns');
 const files = glob.sync(path.join(basePath, '**', 'index.md'));
 
-/** @type CodePatternSets */
+/** @type {CodePatternSets} */
 const allPatternSets = {};
 
-/** @type CodePatterns */
+/** @type {CodePatterns} */
 const allPatterns = files.reduce((patterns, file) => {
   const id = path.relative(basePath, path.dirname(file));
   const fileContents = matter(fs.readFileSync(file, 'utf-8'));
-  const content = md.render(fileContents.content);
   const suite = path.dirname(id);
 
   // This only reads front-matter from files, and doesn't inherit any data
@@ -48,11 +46,11 @@ const allPatterns = files.reduce((patterns, file) => {
       title: fileContents.data.title,
       description: fileContents.data.description,
       hero: fileContents.data.hero,
-      draft: fileContents.data.draft,
-      content,
+      draft: Boolean(fileContents.data.draft),
+      rawContent: fileContents.content,
       suite: suite !== '.' ? suite : null,
     };
-    /** @type CodePatternSet */
+    /** @type {CodePatternSet} */
     allPatternSets[id] = set;
   }
 
@@ -61,7 +59,7 @@ const allPatterns = files.reduce((patterns, file) => {
   }
 
   const assetsPaths = glob.sync(path.join(path.dirname(file), 'assets', '*'));
-  /** @type CodePatternAssets */
+  /** @type {CodePatternAssets} */
   const assets = assetsPaths.reduce((out, assetPath) => {
     const basename = path.basename(assetPath);
     const type = path.extname(assetPath).replace(stripDot, '');
@@ -78,17 +76,16 @@ const allPatterns = files.reduce((patterns, file) => {
   const demo =
     fileContents.data.demo || path.join('/', 'patterns', id, 'demo.html');
   const set = path.dirname(id);
-  /** @type CodePattern */
-  patterns[id] = {
+  patterns[id] = /** @type {CodePattern} */ ({
     id,
     ...fileContents.data,
-    content,
+    rawContent: fileContents.content,
     assets,
     demo,
     set,
-  };
+  });
   return patterns;
-}, {});
+}, /** @type {CodePatterns} */ ({}));
 
 module.exports = {
   patterns: function () {

--- a/src/site/_filters/minify-js.js
+++ b/src/site/_filters/minify-js.js
@@ -23,22 +23,21 @@ const {minify} = require('terser');
  * https://www.11ty.dev/docs/quicktips/inline-js/
  * @param {string} code
  */
-async function minifyJs(code, callback) {
+function minifyJs(code, callback) {
   if (process.env.ELEVENTY_ENV !== 'prod') {
     callback(null, code);
     return;
   }
 
-  try {
-    const minified = await minify(code);
-    callback(null, minified.code);
-    return;
-  } catch (err) {
-    console.error('Terser error: ', err);
-    // Fail gracefully.
-    callback(null, code);
-    return;
-  }
+  minify(code)
+    .then((result) => {
+      callback(result.code);
+    })
+    .catch((err) => {
+      console.error('Terser error: ', err);
+      // Fail gracefully.
+      callback(null, code);
+    });
 }
 
 module.exports = {minifyJs};

--- a/src/site/_filters/site-render.js
+++ b/src/site/_filters/site-render.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const md = require('../_plugins/markdown');
+
+// Imported just for types.
+// eslint-disable-next-line no-unused-vars
+const {Environment} = require('nunjucks');
+
+/**
+ * Renders content with Nunjucks _then_ with Markdown. This emulates rendering actual page content.
+ *
+ * This relies on the shape of the Nunjucks `this` object, which has a Nunjucks `Environment`.
+ *
+ * @this {{env: Environment, ctx: Object}}
+ * @param {string} raw
+ * @param {(err: Error?, result: string?) => void} callback
+ */
+function siteRender(raw, callback) {
+  const env = this.env;
+
+  // This renders Nunjucks, then we apply Markdown to the output.
+  // We use the async callback in case Nunjucks itself calls further async code (otherwise it will
+  // throw using the sync call).
+  env.renderString(raw, this.ctx, (err, result) => {
+    if (err) {
+      callback(err, null);
+      return;
+    }
+
+    const markdownResult = md.render(result);
+    callback(null, markdownResult);
+  });
+}
+
+module.exports = {siteRender};

--- a/src/site/_includes/pattern-set.njk
+++ b/src/site/_includes/pattern-set.njk
@@ -106,8 +106,7 @@ pageScripts:
       {% for patternSetId, patternSet in patterns.sets %}
         {% if patternSet.suite == patternSuite.id %}
           <h2 class="w-headline--two">{{ patternSet.title }}</h2>
-          {# This will not render any shortcodes within the patternset content! #}
-          {{ patternSet.content | safe }}
+          {{ patternSet.rawContent | siteRender | safe }}
           {% for patternId, pattern in patterns.patterns %}
             {% if pattern.set == patternSetId %}
               {{ codePattern(pattern) }}

--- a/types/site/_data/patterns.d.ts
+++ b/types/site/_data/patterns.d.ts
@@ -27,11 +27,12 @@ declare global {
     layout: string;
     title: string;
     description: string;
-    content: string;
     assets: CodePatternAssets;
     demo: string;
     suite: string;
     height: number;
+    rawContent: string;
+    set: string;
   }
   export interface CodePatterns {
     [key: string]: CodePattern;
@@ -40,7 +41,9 @@ declare global {
     id: string;
     title: string;
     description: string;
-    content: string;
+    hero: string;
+    draft: boolean;
+    rawContent: string;
     suite: string;
   }
   export interface CodePatternSets {


### PR DESCRIPTION
This improves on e.g., the `md` filter, because it'll run Nunjucks code too.

Used for Patterns cc @una 

Fixes #6603

Demo, although I took this change out:

<img width="929" alt="Screen Shot 2021-11-02 at 11 39 43" src="https://user-images.githubusercontent.com/119184/139768333-ce5066f0-f958-41b7-a136-ababd3a3c977.png">
