### PR TITLE
Pattterns copy edit, remove draft status

### DIFF
--- a/src/site/content/en/patterns/layout/aspect-ratio-image-card/demo.md
+++ b/src/site/content/en/patterns/layout/aspect-ratio-image-card/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/aspect-ratio-image-card
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/aspect-ratio-image-card/index.md
+++ b/src/site/content/en/patterns/layout/aspect-ratio-image-card/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Aspect Ratio Image Card
+title: Aspect ratio image card
 description: Maintains the aspect ratio of an image in a card, while letting you resize the card.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -12,7 +11,7 @@ draft: true
   </video>
 </figure>
 
-With the `aspect-ratio` property, as you resize the card, the green visual block maintains this 16 x 9 aspect ratio. We are respecting the aspect ratio with `aspect-ratio: 16 / 9`.
+With the [`aspect-ratio`](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio) property, as you resize the card, the green visual block maintains this 16 x 9 aspect ratio. We are respecting the aspect ratio with `aspect-ratio: 16 / 9`.
 
 ```css/1
 .video {

--- a/src/site/content/en/patterns/layout/clamping-card/demo.md
+++ b/src/site/content/en/patterns/layout/clamping-card/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/clamping-card
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/clamping-card/index.md
+++ b/src/site/content/en/patterns/layout/clamping-card/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Clamping Card
+title: Clamping card
 description: Sets an absolute min and max size, and an actual size for the card.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -12,7 +11,7 @@ draft: true
   </video>
 </figure>
 
-In this demo, you are setting the width using clamp like so: `width: clamp(<min>, <actual>, <max>)`.
+In this demo, you are setting the width using `clamp()` like so: `width: clamp(<min>, <actual>, <max>)`.
 
 This sets an absolute min and max size, and an actual size. With values, that can look like:
 
@@ -24,8 +23,8 @@ This sets an absolute min and max size, and an actual size. With values, that ca
 
 The minimum size here is `23ch` or 23 character units, and the maximum size is `46ch`, 46 characters. [Character width units](https://meyerweb.com/eric/thoughts/2018/06/28/what-is-the-css-ch-unit/) are based on the font size of the element (specifically the width of the `0` glyph). The 'actual' size is 50%, which represents 50% of this element's parent width.
 
-What the `clamp()` function is doing here is enabling this element to retain a 50% width *until* 50% is either greater than `46ch` (on wider viewports), or smaller than `23ch` (on smaller viewports). You can see that as I stretch and shrink the parent size, the width of this card increases to its clamped maximum point and decreases to its clamped minimum. It then stays centered in the parent since we've applied additional properties to center it. This enables more legible layouts, as the text won't be too wide (above `46ch`) or too squished and narrow (less than `23ch`).
+What the `clamp()` function is doing here is enabling this element to retain a 50% width *until* 50% is either greater than `46ch` (on wider viewports), or smaller than `23ch` (on smaller viewports). In the video, watch how the width of this card increases to its clamped maximum point and decreases to its clamped minimum as the parent stretches and shrinks. It then stays centered in the parent using additional properties to center it. This enables more legible layouts, as the text won't be too wide (above `46ch`) or too squished and narrow (less than `23ch`).
 
-This is also a great way to implement responsive typography. For example, you could write: `font-size: clamp(1.5rem, 20vw, 3rem)`. In this case, the font-size of a headline would always stay clamped between `1.5rem` and `3rem` but would grow and shrink based on the `20vw` actual value to fit the width of of the viewport.
+You can use this technique to implement responsive typography. For example: `font-size: clamp(1.5rem, 20vw, 3rem)`. In this case, the font-size of a headline would always stay clamped between `1.5rem` and `3rem` but would grow and shrink based on the `20vw` actual value to fit the width of of the viewport.
 
 This is a great technique to ensure legibility with a minimum and maximum size value, but remember it is not supported in all modern browsers so make sure you have fallbacks and do your testing.

--- a/src/site/content/en/patterns/layout/container-query-card/demo.md
+++ b/src/site/content/en/patterns/layout/container-query-card/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/container-query-card
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/container-query-card/index.md
+++ b/src/site/content/en/patterns/layout/container-query-card/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Container Query Card ⚠️
-description: Card that intrinsicly owns its independent style logic and is styled based on its parent's inline width.
-date: 2021-10-20
-draft: true
+title: Container query card ⚠️
+description: Card that owns its independent style logic and is styled based on its parent's inline width.
+date: 2021-11-03
 height: 500
 ---
 

--- a/src/site/content/en/patterns/layout/container-query-card/index.md
+++ b/src/site/content/en/patterns/layout/container-query-card/index.md
@@ -7,7 +7,7 @@ height: 500
 ---
 
 {% Aside 'warning' %}
-This demo uses an experimental web technology that is not currently supported in all browsers. To try it out, open Chrome Canary and enable the #enable-container-queries flag.
+This demo uses an experimental web technology that is not currently supported in all browsers. To try it out, open Chrome Canary and enable the `#enable-container-queries` flag.
 {% endAside %}
 
 This demo uses [container queries](https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries) to create an intrinsic, responsive card. The card goes from a single-column layout at more narrow sizes to a two-column layout when it is at wider sizes.

--- a/src/site/content/en/patterns/layout/deconstructed-pancake/demo.md
+++ b/src/site/content/en/patterns/layout/deconstructed-pancake/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/deconstructed-pancake
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/deconstructed-pancake/index.md
+++ b/src/site/content/en/patterns/layout/deconstructed-pancake/index.md
@@ -1,20 +1,19 @@
 ---
 layout: pattern
-title: Deconstructed Pancake
+title: Deconstructed pancake
 description: Create a layout that stretches to fit the space, and snaps to the next line at a minimum size.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 This is a common layout for marketing sites, for example, which may have a row of three items, usually with an image, title, and then some text, describing some features of a product. On smaller screens, you'll want those to stack nicely, and expand as you increase the screen size.
 
-By using Flexbox for this effect, you won't need media queries to adjust the placement of these elements when the screen resizes.
+By using flexbox for this effect, you won't need media queries to adjust the placement of these elements when the screen resizes.
 
 The [flex](https://developer.mozilla.org/docs/Web/CSS/flex) shorthand stands for: `flex: <flex-grow> <flex-shrink> <flex-basis>`.
 
 ## `flex-grow` Stretching
 
-If you want the boxes to stretch and fill the space as they wrap to the next line, set the <flex-grow> to 1, so it would look like:
+If you want the boxes to stretch and fill the space as they wrap to the next line, set the value of `<flex-grow>` to 1, for example:
 
 ```css/5
 .parent {
@@ -32,11 +31,11 @@ If you want the boxes to stretch and fill the space as they wrap to the next lin
   </video>
 </figure>
 
-Now, as you increase or decrease the screen size,  these flex items both shrink and grow.
+Now, as you increase or decrease the screen size, these flex items both shrink and grow.
 
-## No Stretching
+## No stretching
 
-If you want your boxes to fill out to their `<flex-basis>` size, shrink on smaller sizes, but not stretch to fill any additional space, write: `flex: 0 1 <flex-basis>`. In this case, your `<flex-basis>` is 150px so it looks like:
+If you want your boxes to fill out to their `<flex-basis>` size, shrink on smaller sizes, but not stretch to fill any additional space, write: `flex: 0 1 <flex-basis>`. In this case, your `<flex-basis>` is 150px:
 
 ```css/5
 .parent {

--- a/src/site/content/en/patterns/layout/holy-grail/demo.md
+++ b/src/site/content/en/patterns/layout/holy-grail/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/holy-grail
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/holy-grail/index.md
+++ b/src/site/content/en/patterns/layout/holy-grail/index.md
@@ -15,7 +15,7 @@ For this classic holy grail layout, there is a header, footer, left sidebar, rig
 
 To write this entire grid using a single line of code, use the `grid-template` property. This enables you to set both the rows and columns at the same time.
 
-The property and value pair is: `grid-template: auto 1fr auto / auto 1fr auto`. The slash in between the first and second space-separated lists is the break between rows and columns.
+The property and value pair is: `grid-template: auto 1fr auto / auto 1fr auto`. The slash between the first and second space-separated lists is the break between rows and columns.
 
 ```css/2
 .parent {

--- a/src/site/content/en/patterns/layout/holy-grail/index.md
+++ b/src/site/content/en/patterns/layout/holy-grail/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Holy Grail Layout
+title: Holy grail layout
 description: Classic layout with a header, footer, and two sidebars flanking a main content area.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>

--- a/src/site/content/en/patterns/layout/index.md
+++ b/src/site/content/en/patterns/layout/index.md
@@ -1,12 +1,12 @@
 ---
 layout: pattern-set
-title: Layout Patterns
-description: A collection of common layout patterns using CSS Grid and Flexbox.
+title: Layout patterns
+description: A collection of layout patterns built using modern CSS APIs that will help you build common interfaces such as cards, dynamic grid areas, and full-page layouts.
 hero: image/HodOHWjMnbNw56hvNASHWSgZyAf2/PRyD1Ad1GtT6IZLqWtu1.svg
-draft: true
 ---
 
-Welcome to our growing collection of CSS layout patterns. Most of these patterns use CSS grid and flexbox to help you achieve common UX patterns such as cards, flexible grids, and full-page layouts, and are supported on all modern browsers.
+Welcome to our growing collection of CSS layout patterns. Most of these patterns use CSS [grid](/learn/css/grid) and [flexbox](/learn/css/flexbox) to help you achieve common UI patterns such as cards, dynamic grid areas, and full-page layouts, and are supported on all modern browsers.
 
-**⚠️ Warning:**
-This collection also includes some more experimental patterns, denoted by a yellow warning icon (⚠️). These patterns use experimental web technologies that are not currently supported in stable browsers.
+{% Aside 'caution' %}
+This collection also includes some experimental patterns that use [container queries](https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries). These patterns are denoted by a yellow warning icon (⚠️), and are not currently supported in stable browsers.
+{% endAside %}

--- a/src/site/content/en/patterns/layout/line-up/demo.md
+++ b/src/site/content/en/patterns/layout/line-up/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/line-up
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/line-up/index.md
+++ b/src/site/content/en/patterns/layout/line-up/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Line Up
+title: Line up
 description: A layout where the sidebar is given a minimum and maximum safe area size, and the rest of the content fills the available space.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -12,9 +11,9 @@ draft: true
   </video>
 </figure>
 
-For the next layout, the main point to demonstrate here is `justify-content: space-between`, which places the first and last child elements at the edges of their bounding box, with the remaining space evenly distributed between the elements. For these cards, they are placed in a Flexbox display mode, with the direction being set to column using `flex-direction: column`.
+The main point demonstrated here is the use of `justify-content: space-between`, which places the first and last child elements at the edges of their bounding box, with the remaining space evenly distributed between the elements. For these cards, they are placed in a flexbox display mode, with the direction being set to column using `flex-direction: column`.
 
-This places the title, description, and image block in a vertical column inside of the parent card. Then, applying `justify-content: space-between` anchors the first (title) and last (image block) elements to the edges of the flexbox, and the descriptive text in between those gets placed with equal spacing to each endpoint.
+This places the title, description, and image block in a vertical column inside of the parent card. Then, applying `justify-content: space-between` anchors the first (title) and last (image block) elements to the edges of the flex container, and the descriptive text in between those gets placed with equal spacing to each endpoint.
 
 ```css/3
 .container {

--- a/src/site/content/en/patterns/layout/pancake-stack/demo.md
+++ b/src/site/content/en/patterns/layout/pancake-stack/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/pancake-stack
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/pancake-stack/index.md
+++ b/src/site/content/en/patterns/layout/pancake-stack/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Pancake Stack
+title: Pancake stack
 description: Commonly referred to as a sticky footer, this layout is often used for both websites and apps.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -12,7 +11,7 @@ draft: true
   </video>
 </figure>
 
-Unlike the Deconstructed Pancake, this example does not wrap its children when the screen size changes. Commonly referred to as a [sticky footer](https://developer.mozilla.org/docs/Web/CSS/Layout_cookbook/Sticky_footers), this layout is often used for both websites and apps, across mobile applications (the footer is commonly a toolbar), and websites (single page applications often use this global layout).
+Unlike the [deconstructed pancake](/patterns/layout/deconstructed-pancake), this example does not wrap its children when the screen size changes. Commonly referred to as a [sticky footer](https://developer.mozilla.org/docs/Web/CSS/Layout_cookbook/Sticky_footers), this layout is used for both websites and apps, across mobile applications (the footer is commonly a toolbar), and websites—in particular single page applications.
 
 Adding `display: grid` to the component will give you a single column grid, however the main area will only be as tall as the content with the footer below it.
 
@@ -25,4 +24,4 @@ To make the footer stick to the bottom,  add:
 }
 ```
 
-This sets the header and footer content to automatically take the size of its children, and applies the remaining space (`1fr`) to the main area, while the `auto` sized row will take the size of the minimum content of its children, so as that content increases in size, the row itself will grow to adjust.
+This sets the header and footer content to automatically take the size of their children, and applies the remaining space (`1fr`) to the main area, while the `auto` sized row will take the size of the minimum content of its children, so as that content increases in size, the row itself will grow to adjust.

--- a/src/site/content/en/patterns/layout/repeat-auto-minmax/demo.md
+++ b/src/site/content/en/patterns/layout/repeat-auto-minmax/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/repeat-auto-minmax
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/repeat-auto-minmax/index.md
+++ b/src/site/content/en/patterns/layout/repeat-auto-minmax/index.md
@@ -2,8 +2,7 @@
 layout: pattern
 title: RAM (Repeat, Auto, Minmax)
 description: A responsive layout with automatically-placed and flexible children.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -23,9 +22,9 @@ All together, it looks like:
 }
 ```
 
-You are using repeat again, but this time, using the `auto-fit` keyword instead of an explicit numeric value. This enables auto-placement of these child elements. These children also have a base minimum value of `150px` with a maximum value `1fr`, meaning on smaller screens, they will take up the full `1fr` width, and as they reach `150px` wide each, they will start to flow onto the same line.
+You are using `repeat()` again, but this time, using the `auto-fit` keyword instead of an explicit numeric value. This enables auto-placement of these child elements. These children have a base minimum value of `150px` with a maximum value `1fr`, meaning on smaller screens, they will take up the full `1fr` width, and as they reach `150px` wide each, they will start to flow onto the same line.
 
-With `auto-fit`, the boxes will stretch as their horizontal size exceeds 150px to fill the entire remaining space. However, if you change this to `auto-fill`, they will not stretch when their base size in the minmax function is exceeded:
+With `auto-fit`, any completely empty tracks will collapse to `0` and the filled tracks will grow to take up their space. However, if you change this to `auto-fill`, empty tracks will take up the same amount of space they would do if filled:
 
 <figure class='w-figure'>
   <video controls autoplay loop muted playsinline class='w-screenshot'>

--- a/src/site/content/en/patterns/layout/sidebar-says/demo.md
+++ b/src/site/content/en/patterns/layout/sidebar-says/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/sidebar-says
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/sidebar-says/index.md
+++ b/src/site/content/en/patterns/layout/sidebar-says/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Sidebar Says
+title: Sidebar says
 description: A layout where the sidebar is given a minimum and maximum safe area size, and the rest of the content fills the available space.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 <figure class='w-figure'>
@@ -12,9 +11,9 @@ draft: true
   </video>
 </figure>
 
-This demo takes advantage of the [minmax](https://developer.mozilla.org/docs/Web/CSS/minmax) function for grid layouts. What we're doing here is setting the minimum sidebar size to be `100px`, but on larger screens, letting that stretch out to `25%`. The sidebar will always take up `25%` of its parent's horizontal space until that `25%` becomes smaller than `100px`.
+This demo takes advantage of the [minmax()](https://developer.mozilla.org/docs/Web/CSS/minmax) function for grid layouts. In the demo this function is used to set the minimum sidebar size to `100px`, but on larger screens, letting that stretch out to `25%`. The sidebar will always take up `25%` of its parent's horizontal space until that `25%` becomes smaller than `100px`.
 
-Add this as a value of grid-template-columns with the following value:
+Add this by using the `grid-template-columns` property with the following value:
 `minmax(100px, 25%) 1fr`. The item in the first column (the sidebar in this case) gets a `minmax` of `100px` at `25%`, and the second item (the `main` section here) takes up the rest of the space as a single `1fr` track.
 
 ```css/2

--- a/src/site/content/en/patterns/layout/super-centered/demo.md
+++ b/src/site/content/en/patterns/layout/super-centered/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/super-centered
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/super-centered/index.md
+++ b/src/site/content/en/patterns/layout/super-centered/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: Super Centered
+title: Super centered
 description: Centering a child div in one line of code
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 ---
 
 Use `place-items: center` to center an element within its parent.

--- a/src/site/content/en/patterns/layout/twelve-span-grid/demo.md
+++ b/src/site/content/en/patterns/layout/twelve-span-grid/demo.md
@@ -1,6 +1,5 @@
 ---
 patternId: layout/twelve-span-grid
-draft: true
 layout: demo
 ---
 

--- a/src/site/content/en/patterns/layout/twelve-span-grid/index.md
+++ b/src/site/content/en/patterns/layout/twelve-span-grid/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pattern
-title: 12-Span Grid
+title: 12-span grid
 description: A grid broken up into 12 segments where you can place areas onto the tracks evenly.
-date: 2021-10-20
-draft: true
+date: 2021-11-03
 height: 400
 ---
 
@@ -26,7 +25,7 @@ Another classic: the 12-span grid. You can quickly write grids in CSS with the `
 }
 ```
 
-Now you have a 12 column track grid, we can place our children on the grid. One way to do this would be to place them using grid lines. For example, `grid-column: 1 / 13` would span all the way from the first line to the last (13th) and span 12 columns. `grid-column: 1 / 5;` would span the first four.
+Now you have a 12 column track grid, you can place child elements on the grid. One way to do this would be to place them using grid lines. For example, `grid-column: 1 / 13` would span all the way from the first line to the last (13th) and span 12 columns. `grid-column: 1 / 5;` would span the first four.
 
 <figure class='w-figure'>
   <video controls autoplay loop muted playsinline class='w-screenshot'>

--- a/src/site/content/en/patterns/web-vitals-patterns/carousels/index.md
+++ b/src/site/content/en/patterns/web-vitals-patterns/carousels/index.md
@@ -7,12 +7,12 @@ date: 2021-08-10
 
 A carousel is a UX component that displays content in a slideshow-like manner.
 Large, above-the-fold carousels often contain a page's [Largest Contentful Paint
-(LCP) element](https://web.dev/lcp/#what-elements-are-considered), and therefore
-can have a significant impact on [LCP](https://web.dev/lcp). In addition, a
+(LCP) element](/lcp/#what-elements-are-considered), and therefore
+can have a significant impact on [LCP](/lcp). In addition, a
 surprising number of carousels use [non-composited
-animations](https://web.dev/non-composited-animations/) that can contribute to
-[Cumulative Layout Shift (CLS)](https://web.dev/cls). On pages with autoplaying
+animations](/non-composited-animations/) that can contribute to
+[Cumulative Layout Shift (CLS)](/cls). On pages with autoplaying
 carousels, this has the potential to cause infinite layout shifts.
 
 To learn about performance and UX best practices for carousels, see
-[Carousel Best Practices](https://web.dev/carousel-best-practices/).
+[Carousel Best Practices](/carousel-best-practices/).

--- a/src/site/content/en/patterns/web-vitals-patterns/fonts/index.md
+++ b/src/site/content/en/patterns/web-vitals-patterns/fonts/index.md
@@ -7,11 +7,11 @@ date: 2021-08-17
 
 If a web font has not been loaded, browsers typically delay rendering any text
 that uses the web font. In many situations, this delays [First Contentful Paint
-(FCP)](https://web.dev/fcp). In some situations, this delays [Largest Contentful
-Paint (LCP)](https://web.dev/lcp).
+(FCP)](/fcp). In some situations, this delays [Largest Contentful
+Paint (LCP)](/lcp).
 
 In addition, fonts can cause [layout
-shifts](https://web.dev/debug-layout-shifts). These layout shifts occur when a
+shifts](/debug-layout-shifts). These layout shifts occur when a
 web font and its fallback font take up different amounts of space on the page.
 
-For more information, see [Best practices for fonts](https://web.dev/font-best-practices/).
+For more information, see [Best practices for fonts](/font-best-practices/).

--- a/src/site/content/en/patterns/web-vitals-patterns/infinite-scroll/index.md
+++ b/src/site/content/en/patterns/web-vitals-patterns/infinite-scroll/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pattern-set
-title: Infinite Scroll
+title: Infinite scroll
 description: Avoid layout shifts when using infinite scroll
 date: 2021-08-20
 updated: 2021-08-20
@@ -9,4 +9,4 @@ height: 500
 
 Infinite scroll is a UX pattern where content is continuously added to the page
 as a user scrolls. Some implementations of infinite scroll can be a source of
-[layout shifts](https://web.dev/debugging-layout-shifts/).
+[layout shifts](/debugging-layout-shifts/).

--- a/src/site/content/en/patterns/web-vitals-patterns/notices-pattern-set/index.md
+++ b/src/site/content/en/patterns/web-vitals-patterns/notices-pattern-set/index.md
@@ -7,4 +7,4 @@ date: 2021-08-17
 
 Banners and notices are a common source of layout shifts. Inserting a banner into the DOM after the surrounding page has already been rendered pushes the page elements below it further down the page.
 
-For more information, see [Best practices for cookie notices](https://web.dev/cookie-notice-best-practices/).
+For more information, see [Best practices for cookie notices](/cookie-notice-best-practices/).

--- a/src/site/content/en/patterns/web-vitals-patterns/video/index.md
+++ b/src/site/content/en/patterns/web-vitals-patterns/video/index.md
@@ -6,6 +6,6 @@ date: 2021-08-17
 ---
 
 Video can impact Web Vitals by being a source of [layout
-shifts](https://web.dev/debug-layout-shifts/). In addition, in some scenarios
+shifts](/debug-layout-shifts/). In addition, in some scenarios
 large video files can delay LCP by monopolizing network resources and delaying
 the loading of other page resources.


### PR DESCRIPTION
Copyedits for the patterns, I also made the changes in Una's draft PR #6617 as that was ending up in a tangle of merge conflicts.

@una I had one query, I don't really understand what you are saying here in the aspect ratio example:

> "To maintain a 16 x 9 aspect ratio without this property, you'd need to use a [`padding-top` hack](https://css-tricks.com/aspect-ratio-boxes/) and give it a padding of `56.25%` to set a top-to-width ratio. We will soon have a property for this to avoid the hack and the need to calculate the percentage. You can make a square with `1 / 1` ratio, a 2 to 1 ratio with `2 / 1`, and really just anything you need for this image to scale with a set size ratio."

This makes it sound like you can't do a 1/1 aspect ratio, which you can, with the `aspect-ratio` property just demonstrated.

I also fixed the description of auto-fill/auto-fit as it wasn't correct. It's not to do with growing, it's to do with collapsing. The description made it sound like the items don't stretch at all.
