### PR TITLE
["Improve article" link] `main` is the new `master`

### DIFF
--- a/src/site/_filters/github-link.js
+++ b/src/site/_filters/github-link.js
@@ -24,6 +24,6 @@ module.exports = (inputPath) => {
       'inputPath passed to githubLink filter was undefined or null.',
     );
   }
-  const branch = 'master';
+  const branch = 'main';
   return `${repo}/${path.join('blob', branch, inputPath)}`;
 };


### PR DESCRIPTION
Changes proposed in this pull request:

- The old branch name is still surfaced in the `Improve article` links at the bottom of each article.