### PR TITLE
[Courses] "Coming Soon" Styles

### DIFF
--- a/src/scss/blocks/_stack-nav.scss
+++ b/src/scss/blocks/_stack-nav.scss
@@ -70,6 +70,11 @@
   }
 }
 
+// Smaller font size for placeholder meta
+.is-placeholder .stack-nav__meta {
+  font-size: 0.7em;
+}
+
 .stack-nav__heading {
   font-size: get-size('size-2');
   padding-inline-start: $global-gutter-narrow;

--- a/src/scss/pages/_course.scss
+++ b/src/scss/pages/_course.scss
@@ -32,6 +32,11 @@ $course-side-vert-space: 20px;
     }
   }
 
+  // Placeholder items have slightly dimmed look and feel
+  .is-placeholder span {
+    @include apply-utility('color', 'mid-text');
+  }
+
   // Allows the sidebar elements to place and flex themselves
   web-navigation-drawer > * {
     display: flex;

--- a/src/site/_filters/navigation.js
+++ b/src/site/_filters/navigation.js
@@ -69,6 +69,8 @@ function mapPagesToTree(collection, map) {
       title: item.data.title,
       description: item.data.description,
       date: item.data.date,
+      // @ts-ignore
+      placeholder: item.data.placeholder,
     };
   }
 }

--- a/src/site/_includes/partials/course-index.njk
+++ b/src/site/_includes/partials/course-index.njk
@@ -3,12 +3,18 @@
 {%- for item in pageNavigation.list -%}
   {#- Skip the first item so we don't show an entry for the current page. -#}
   {%- if not loop.first -%}
-    {%- set title = item.data.title or '' -%}
-    {%- if item.title -%}
-      {%- set title = item.title | i18n(locale) -%}
-    {%- endif -%}
-
-    <h3><a href="{{ item.url }}">{{ title }}</a></h3>
-    <p>{{ item.data.description }}</p>
+      {%- set title = item.data.title or '' -%}
+      {%- if item.title -%}
+        {%- set title = item.title | i18n(locale) -%}
+      {%- endif -%}
+      {%- if not item.data.placeholder -%}
+        <h3><a href="{{ item.url }}">{{ title }}</a></h3>
+        <p>{{ item.data.description }}</p>
+      {%- endif -%}
+      {# Don't link to placeholder items #}
+      {%- if item.data.placeholder -%}
+        <h3>{{ title }}</h3>
+        <p>{{ item.data.description }}</p>
+      {%- endif -%}
   {%- endif -%}
 {%- endfor -%}

--- a/src/site/_includes/partials/navigation-drawer-course.njk
+++ b/src/site/_includes/partials/navigation-drawer-course.njk
@@ -10,6 +10,7 @@
   {% if item.url %}
     {# The isNew flag is used to display a 'NEW' badge next to content. #}
     {% set isNew = false %}
+    {% set isPlaceholder= false %}
     {# Check to make sure the content was published after the course's #}
     {# initial launch date (so everything doesn't say 'NEW' when we #}
     {# first launch a course). #}
@@ -17,7 +18,11 @@
       {# Only show the 'NEW' badge if content is less than thirty days old. #}
       {% set isNew = item.data.date | isNewContent %}
     {% endif %}
-    <a class="repel" href="{{ item.url }}" {% if item.url == page.url %}aria-current="page"{% endif %}>
+    {% if item.data.placeholder %}
+      {# Set disabled style #}
+      {% set isDisabledClass = 'is-placeholder' %}
+    {% endif %}
+    <a class="repel {{isDisabledClass}}" {% if item.url == page.url %}aria-current="page"{% endif %} {% if item.data.placeholder != true %} href="{{ item.url }}" {% endif %}>
       <span class="cluster">
         <span class="stack-nav__meta">{{ item.counter }}</span>
         <span>{{ title }}</span>
@@ -25,6 +30,9 @@
       <span class="cluster">
         {% if isNew %}
           <span class="stack-nav__meta tt-upper color-action-text">{{ 'i18n.common.new' | i18n(locale) }}</span>
+        {% endif %}
+        {% if item.data.placeholder %}
+          <span class="stack-nav__meta tt-upper color-action-text">{{ 'Coming Soon' }}</span>
         {% endif %}
         {{ icon('done') }}
       </span>

--- a/src/site/content/en/learn/design/accessibility/index.md
+++ b/src/site/content/en/learn/design/accessibility/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/icons/index.md
+++ b/src/site/content/en/learn/design/icons/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/interaction/index.md
+++ b/src/site/content/en/learn/design/interaction/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/media-features/index.md
+++ b/src/site/content/en/learn/design/media-features/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/picture-element/index.md
+++ b/src/site/content/en/learn/design/picture-element/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/screen-configurations/index.md
+++ b/src/site/content/en/learn/design/screen-configurations/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/theming/index.md
+++ b/src/site/content/en/learn/design/theming/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/typography/index.md
+++ b/src/site/content/en/learn/design/typography/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/design/ui-patterns/index.md
+++ b/src/site/content/en/learn/design/ui-patterns/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - adactio
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/app-design/index.md
+++ b/src/site/content/en/learn/pwa/app-design/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/architecture/index.md
+++ b/src/site/content/en/learn/pwa/architecture/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/assets-and-data/index.md
+++ b/src/site/content/en/learn/pwa/assets-and-data/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/caching/index.md
+++ b/src/site/content/en/learn/pwa/caching/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/capabilities/index.md
+++ b/src/site/content/en/learn/pwa/capabilities/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/complexity/index.md
+++ b/src/site/content/en/learn/pwa/complexity/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/conclusion/index.md
+++ b/src/site/content/en/learn/pwa/conclusion/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/detection/index.md
+++ b/src/site/content/en/learn/pwa/detection/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/enhancements/index.md
+++ b/src/site/content/en/learn/pwa/enhancements/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/experimental/index.md
+++ b/src/site/content/en/learn/pwa/experimental/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/installation-prompt/index.md
+++ b/src/site/content/en/learn/pwa/installation-prompt/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/installation/index.md
+++ b/src/site/content/en/learn/pwa/installation/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/offline-data/index.md
+++ b/src/site/content/en/learn/pwa/offline-data/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/os-integration/index.md
+++ b/src/site/content/en/learn/pwa/os-integration/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/service-workers/index.md
+++ b/src/site/content/en/learn/pwa/service-workers/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/serving/index.md
+++ b/src/site/content/en/learn/pwa/serving/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/tools-and-debug/index.md
+++ b/src/site/content/en/learn/pwa/tools-and-debug/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/update/index.md
+++ b/src/site/content/en/learn/pwa/update/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/web-app-manifest/index.md
+++ b/src/site/content/en/learn/pwa/web-app-manifest/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/windows/index.md
+++ b/src/site/content/en/learn/pwa/windows/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/src/site/content/en/learn/pwa/workbox/index.md
+++ b/src/site/content/en/learn/pwa/workbox/index.md
@@ -5,6 +5,7 @@ description: >
 authors:
   - firt
 date: 2021-11-03
+placeholder: true
 ---
 
 Coming soon!

--- a/types/navigation/navigation-item.d.ts
+++ b/types/navigation/navigation-item.d.ts
@@ -23,6 +23,7 @@ declare global {
       title: string,
       description: string,
       date: Date,
+      placeholder: string,
     },
     prev?: NavigationItem | null,
     next?: NavigationItem | null,


### PR DESCRIPTION
Changes in this PR:
- Apply differentiated "coming soon" styles to placeholder content for courses in sidebar
- Update partials to not render links to placeholder content
- Adds `placeholder: true` to Learn Design courses

If we're happy with this solution, I can replicate on Learn PWA

---

![Screen Shot 2021-11-02 at 12 16 11 PM](https://user-images.githubusercontent.com/1693164/139903715-077e3ab4-840f-49bf-a05e-4046bb53cb6a.png)


