### PR TITLE
Spotted a typo in the feedback section

### DIFF
--- a/src/site/content/en/blog/responsiveness/index.md
+++ b/src/site/content/en/blog/responsiveness/index.md
@@ -297,7 +297,7 @@ new PerformanceObserver((entries) => {
 
 ## Feedback
 
-We want to encourage developers to try out these new layout shift metrics on
+We want to encourage developers to try out these new responsiveness metrics on
 their sites, and let us know if you discover any issue.
 
 Please also email any general feedback on the approaches outlined here to the


### PR DESCRIPTION
Mentioned layout shift metrics instead of responsive metrics

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
