### PR TITLE
lighthouse-user-flows: fix URL in the warm-load example

### DIFF
--- a/src/site/content/en/blog/lighthouse-user-flows/index.md
+++ b/src/site/content/en/blog/lighthouse-user-flows/index.md
@@ -96,7 +96,7 @@ async function captureReport() {
   const browser = await puppeteer.launch({headless: false});
   const page = await browser.newPage();
 
-  const testUrl = 'https://pptr.dev/';
+  const testUrl = 'https://web.dev/performance-scoring/';
   const flow = await startFlow(page, {name: 'Cold and warm navigations'});
   await flow.navigate(testUrl, {
     stepName: 'Cold navigation'


### PR DESCRIPTION
[Lighthouse user flows](https://web.dev/lighthouse-user-flows/#capturing-a-warm-load)

the `testUrl` was set to https://pptr.dev/ in code but the preceding paragraph and the screenshot points to https://web.dev/performance-scoring/

Changes proposed in this pull request:

- change `testUrl` value in the "Capturing a warm load" section to https://web.dev/performance-scoring/
