### PR TITLE
[Learn Responsive Design] change `lang` to `hreflang` in the Internationalization article

### DIFF
--- a/src/site/content/en/learn/design/internationalization/index.md
+++ b/src/site/content/en/learn/design/internationalization/index.md
@@ -171,7 +171,7 @@ Here, the text "Deutsche Version" is marked up as being in the German language, 
 You can also use the `hreflang` attribute on the `link` element. This goes in the `head` of your document:
 
 ```html
-<link href="/path/to/german/version" rel="alternate" lang="de">
+<link href="/path/to/german/version" rel="alternate" hreflang="de">
 ```
 But unlike the `lang` attribute, which can go on any element, `hreflang` can only be applied to `a` and `link` elements.
 


### PR DESCRIPTION
in https://web.dev/learn/design/internationalization/#identify-a-linked-document's-language there's a paragraph saying

> You can also use the `hreflang` attribute on the `link` element. This goes in the `head` of your document:

but the following code uses `lang`. this patch fixes it.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
