### PR TITLE
Fix Russian language translation

### DIFF
--- a/shared/locale.js
+++ b/shared/locale.js
@@ -26,24 +26,8 @@ const supportedLocales = dirs.filter((dir) => localeCode.validate(dir));
 
 const isSupportedLocale = (locale) => supportedLocales.indexOf(locale) > -1;
 
-/**
- * A map of supported language codes to their full names.
- * @const
- */
-const languageNames = {
-  en: 'English',
-  pl: 'Polski',
-  es: 'Español',
-  ko: '한국어',
-  zh: '中文',
-  ru: 'Rусский',
-  pt: 'Português',
-  ja: '日本語',
-};
-
 module.exports = {
   defaultLocale,
   supportedLocales,
   isSupportedLocale,
-  languageNames,
 };

--- a/src/lib/utils/language.js
+++ b/src/lib/utils/language.js
@@ -14,7 +14,7 @@ const languageNames = {
   es: 'Español',
   ko: '한국어',
   zh: '中文',
-  ru: 'Rусский',
+  ru: 'Русский',
   pt: 'Português',
   ja: '日本語',
 };
@@ -40,7 +40,7 @@ function isValidLanguage(lang) {
   return supportedLanguages.indexOf(lang) > -1;
 }
 
-export default {
+module.exports = {
   languageNames,
   defaultLanguage,
   isValidLanguage,

--- a/src/site/_includes/components/LanguageList.js
+++ b/src/site/_includes/components/LanguageList.js
@@ -16,7 +16,7 @@
 const path = require('path');
 const {getTranslatedUrls, getDefaultUrl} = require('../../_filters/urls');
 const {i18n} = require('../../_filters/i18n');
-const {languageNames} = require('../../../../shared/locale');
+const {languageNames} = require('../../../lib/utils/language');
 
 module.exports = (url, lang) => {
   const langhrefs = getTranslatedUrls(url)


### PR DESCRIPTION
This PR fixes:
- Wrong Russian language name translation (first letter is incorrect now). I am a native speaker and it misleads me) You can check it in [Google Translate](https://translate.google.com/?hl=ru&sl=en&tl=ru&text=Russian%20language&op=translate)
- Removed duplicate language names lists