### PR TITLE
LearnCSS: Transitions -> update devtools image

### DIFF
--- a/src/site/content/en/learn/css/transitions/index.md
+++ b/src/site/content/en/learn/css/transitions/index.md
@@ -79,7 +79,7 @@ Our [module on CSS Animation](/learn/css/animations/#animation-timing-function) 
 
 You can use [DevTools](https://developer.chrome.com/docs/devtools/css/animations/) to experiment with different timing functions in real-time.
 
-{% Img src="image/eiKy1JcjHqPp3gaedjAQWjPJ8YK2/G06SHV4Dra1HqTAL9d6t.png", alt="Chrome DevTools visual transition timing editor.", width="264", height="359" %}
+{% Img src="image/eiKy1JcjHqPp3gaedjAQWjPJ8YK2/dRwKg0RIsy5wWVzkUFUA.png", alt="Chrome DevTools visual transition timing editor.", width="800", height="418" %}
 
 ### transition-delay
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes issue where dev tools image in "transition-timing-function" section was too large

Changes proposed in this pull request:

- Update dev-tools image to a wider image

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
