### PR TITLE
fix(Subscribe): find correct elements in subscribe form, fixes #6663

### DIFF
--- a/src/lib/components/Subscribe/index.js
+++ b/src/lib/components/Subscribe/index.js
@@ -6,6 +6,9 @@ import {BaseElement} from '../BaseElement';
 import {trackError, trackEvent} from '../../analytics';
 import './_styles.scss';
 
+const pTagSelector = 'p.subscribe__error__message';
+const hiddenClass = 'hidden-yes';
+
 /**
  * Element that renders newsletter subscription form.
  *
@@ -34,10 +37,10 @@ class Subscribe extends BaseElement {
   connectedCallback() {
     super.connectedCallback();
     /** @type {HTMLFormElement} */
-    this.form = this.querySelector('.w-subscribe__form');
+    this.form = this.querySelector('form');
     /** @type HTMLElement */
-    this.subscribeError = this.querySelector('.w-subscribe__error');
-    this.subscribeMessage = this.querySelector('.w-subscribe__message');
+    this.subscribeError = this.querySelector('.subscribe__error');
+    this.subscribeMessage = this.querySelector('.subscribe__message');
     this.submissionUrl = this.form.action;
     if (!this.submissionUrl) {
       console.warn(`No submission URL found for subscribe element.`);
@@ -84,15 +87,12 @@ class Subscribe extends BaseElement {
       return;
     }
 
-    const pTag = document.createElement('p');
     const defaultError = new Error('Could not submit, please try again.');
-    this.subscribeError.textContent = '';
-
-    pTag.textContent = useDefault
+    this.subscribeError.querySelector(pTagSelector).textContent = useDefault
       ? defaultError.message
       : (error || defaultError).message;
 
-    this.subscribeError.appendChild(pTag);
+    this.subscribeError.classList.toggle(hiddenClass, false);
 
     trackError(error, 'Email form failed to submit because');
   }
@@ -129,7 +129,8 @@ class Subscribe extends BaseElement {
 
   onSuccess(isRobot = false) {
     this.submitted = true;
-    this.subscribeError.textContent = '';
+    this.subscribeError.classList.toggle(hiddenClass, true);
+    this.subscribeError.querySelector(pTagSelector).textContent = '';
     this.subscribeMessage.textContent = `Thank you! You're all signed up.`;
     this.form.removeEventListener('submit', this.onSubmit);
     this.form.parentElement.removeChild(this.form);

--- a/src/lib/components/Subscribe/index.js
+++ b/src/lib/components/Subscribe/index.js
@@ -6,7 +6,7 @@ import {BaseElement} from '../BaseElement';
 import {trackError, trackEvent} from '../../analytics';
 import './_styles.scss';
 
-const pTagSelector = 'p.subscribe__error__message';
+const pTagSelector = '.subscribe__error__message';
 const hiddenClass = 'hidden-yes';
 
 /**

--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -1,6 +1,8 @@
 ---
 layout: 'default-next'
 CSS_ORIGIN: 'next'
+pageScripts:
+  - '/js/home.js'
 ---
 {% from 'macros/icon.njk' import icon with context %}
 

--- a/src/site/_includes/partials/subscribe-next.njk
+++ b/src/site/_includes/partials/subscribe-next.njk
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <div class="headline all-center flow">
       <h2 class="headline__title">{{ subscribeTitle | default('Developer Newsletter', false) }}</h2>
-      <p>{{ subscribeNotes | default('Get the latest news, techniques and updates straight to your inbox.', false) }}</p>
+      <p class="subscribe__message">{{ subscribeNotes | default('Get the latest news, techniques and updates straight to your inbox.', false) }}</p>
     </div>
     <form class="flow gap-top-size-2" action="{{ site.subscribeForm }}" method="post">
       <div class="switcher">
@@ -66,6 +66,11 @@
       </div>
     </form>
     <div class="gap-top-size-2">
+      <div class="subscribe__error hidden-yes">
+        {% Aside 'warning' %}
+          <p class="subscribe__error__message"></p>
+        {% endAside %}
+      </div>
       <noscript>{% Aside 'warning' %}{{ 'i18n.subscribe.no_javascript' | i18n(locale) }}{% endAside %}</noscript>
     </div>
   </div>

--- a/src/site/_includes/partials/subscribe.njk
+++ b/src/site/_includes/partials/subscribe.njk
@@ -5,7 +5,7 @@
     </div>
     <div class="w-display--flex w-justify-content--center">
       <div class="w-subscribe--padded">
-        <p class="w-text--center w-mt--non w-subscribe__message">{{ subscribeNotes | default('Get the latest news, techniques and updates straight to your inbox.', false) }}</p>
+        <p class="w-text--center w-mt--non subscribe__message">{{ subscribeNotes | default('Get the latest news, techniques and updates straight to your inbox.', false) }}</p>
       </div>
     </div>
     <form class="w-subscribe__form" action="{{ site.subscribeForm }}" method="post">
@@ -73,7 +73,8 @@
         </button>
       </div>
     </form>
-    <div class="w-subscribe__error w-text--center w-mt--sm">
+    <div class="subscribe__error w-text--center w-mt--sm">
+      <p class="subscribe__error__message"></p>
       <noscript>{{ 'i18n.subscribe.no_javascript' | i18n(locale) }}</noscript>
     </div>
   </div>

--- a/src/styles/components/_subscribe.scss
+++ b/src/styles/components/_subscribe.scss
@@ -23,7 +23,7 @@ web-subscribe:not(:defined) {
   margin-top: 36px;
 }
 
-.w-subscribe__error {
+.subscribe__error {
   color: $WARNING_COLOR;
 }
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6663

Changes proposed in this pull request:

- Finds elements across `subscribe.njk` and `subscribe-next.njk` to attach onto and update.
- Attaches `pages/home.js` to home page
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
