### PR TITLE
feat(subscribe): create subscribe FAB using new design system, fixes #6676

### DIFF
--- a/src/scss/blocks/_fab.scss
+++ b/src/scss/blocks/_fab.scss
@@ -15,17 +15,18 @@
 }
 
 .fab__label {
-  /// By default (small viewport), the
-  /// label is hidden
+  text-transform: uppercase;
+  // By default (small viewport), the
+  // label is hidden
   @extend .visually-hidden;
 
-  /// If this isn't a icon only context,
-  /// show the label where there is more space
+  // If this isn't a icon only context,
+  // show the label where there is more space
   @include media-query('md') {
     .fab:not([data-icon-only]) & {
-      clip: none;
-      position: static;
-      width: unset;
+      height: auto;
+      position: initial;
+      width: auto;
     }
   }
 }

--- a/src/site/_includes/partials/subscribe-action-next.njk
+++ b/src/site/_includes/partials/subscribe-action-next.njk
@@ -1,0 +1,4 @@
+<a class="fab gc-analytics-event" data-type="primary" data-docked data-category="web.dev" data-label="view-subscribe" data-action="click" href="/newsletter/">
+  {% include "icons/subscribe.svg" %}
+  <span class="fab__label">{{ 'i18n.subscribe.subscribe' | i18n(locale) }}</span>
+</a>


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6676

Changes proposed in this pull request:

- Creates new subscribe fab for new design system
- Fixes FAB label so it's shown in viewports medium and higher
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
