### PR TITLE
Update OT timeline

### DIFF
--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-updated: 2021-09-06
+updated: 2021-11-05
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 description: |
@@ -87,11 +87,7 @@ To experiment with WebGPU locally, without an origin trial token, enable the
 ### Enabling support during the origin trial phase
 
 Starting in Chrome&nbsp;94, WebGPU is available as an origin trial in Chrome. The
-origin trial is expected to end in Chrome&nbsp;97 (Jan 26, 2022).
-
-{% Aside 'caution' %}
-Server-side A/B testing will be used to progressively rollout WebGPU in Chrome.
-{% endAside %}
+origin trial is expected to end in Chrome&nbsp;101 (May 18, 2022).
 
 {% include 'content/origin-trials.njk' %}
 


### PR DESCRIPTION
This PR updates the OT timeline for WebGPU now that it has been extended: https://developer.chrome.com/origintrials/#/view_trial/118219490218475521

FYI @kangz