### PR TITLE
Fix image styling on design course

### DIFF
--- a/src/site/content/en/learn/design/internationalization/index.md
+++ b/src/site/content/en/learn/design/internationalization/index.md
@@ -63,7 +63,7 @@ Likewise, in a language like English where the text is written from top to botto
 `block-start` corresponds to "top" and `block-end` corresponds to "bottom."
 
 {% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/9EcUvMxy9T10EzY4U95b.webp", 
-alt="Latin, Hebrew and Japanese are shown rendering placeholder text within a device frame. Arrows and colors follow the text to help associate the 2 directions of block and inline.", width="800", height="577" %}
+alt="Latin, Hebrew and Japanese are shown rendering placeholder text within a device frame. Arrows and colors follow the text to help associate the 2 directions of block and inline.", width="800", height="577", class="w-screenshot" %}
 
 If you use logical properties in your CSS, you can use the same stylesheet for translations of your pages. 
 Even if your pages are translated into languages written from right to left or bottom to top, your design will adjust accordingly. 

--- a/src/site/content/en/learn/design/intro/index.md
+++ b/src/site/content/en/learn/design/intro/index.md
@@ -31,7 +31,7 @@ not like the flat liquid crystal displays we have now.
 <figure class="w-figure">
 {% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/0a8vHe4LgChVZvaZQfYs.png", 
 alt="The Microsoft website with two simple columns of text plus a navbar.", 
-width="640", height="480" %}
+width="640", height="480", class="w-screenshot" %}
   <figcaption class="w-figcaption">The Microsoft website in the late 90s designed for a width of 640 pixels. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 
@@ -43,7 +43,7 @@ Before long, most screens had dimensions of 800 by 600 pixels.
 Web designs changed accordingly. Designers and developers started assuming that 800 pixels was a safe default.
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/C88van0yWyvbz5l746pB.png", alt="The Microsoft website using a three-column, mostly text-based design.", width="800", height="600" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/C88van0yWyvbz5l746pB.png", alt="The Microsoft website using a three-column, mostly text-based design.", width="800", height="600", class="w-screenshot" %}
 <figcaption class="w-figcaption">The Microsoft website in the learly 2000s designed for a width of 800 pixels. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 
@@ -51,7 +51,7 @@ Then the screens got bigger again. 1024 by 768 became the default.
 It felt like an arms race between web designers and hardware manufacturers.
 
 ​​<figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/nuHSqBVgInTvLti73Qz2.png", alt="The Microsoft website with a more complex design using images as well as text.", width="800", height="600" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/nuHSqBVgInTvLti73Qz2.png", alt="The Microsoft website with a more complex design using images as well as text.", width="800", height="600", class="w-screenshot" %}
 <figcaption class="w-figcaption">The Microsoft website in the mid 2000s designed for a width of 1024 pixels. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 
@@ -65,7 +65,7 @@ You can center the content of your pages to distribute that space more evenly
 (instead of having empty space on one side) but you still wouldn't be taking full advantage of the available space.
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/t0Zd1eGEJeeqMO8ItsqK.png", alt="A narrow layour with a lot of white space around it.", width="800", height="320" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/t0Zd1eGEJeeqMO8ItsqK.png", alt="A narrow layour with a lot of white space around it.", width="800", height="320", class="w-screenshot" %}
 <figcaption class="w-figcaption">The Yahoo website from the early 2000s as experienced in a browser that's wider than the site's 800 pixel wide design. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 
@@ -74,7 +74,7 @@ then your content won't fit horizontally.
 The browser generates a crawlbar—the horizontal equivalent of a scrollbar—and the user has to move the whole page left and right to see all the content.
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/bnh7fDiGjFhdBHTD5CJ8.png", alt="A website that appears cut-off to the right due to being too wide for the viewport.", width="420", height="640" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/bnh7fDiGjFhdBHTD5CJ8.png", alt="A website that appears cut-off to the right due to being too wide for the viewport.", width="420", height="640", class="w-screenshot" %}
 <figcaption class="w-figcaption">The Yahoo website from the early 2000s as experienced in a browser that's narrower than the site's 800 pixel wide design. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 
@@ -98,12 +98,12 @@ On a wide screen the layout looks stretched.
 On a narrow screen the layout looks squashed. Both scenarios aren't ideal.
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/oBAbgP2JCt2zVENHVCnc.png", alt="A layout that is squashed into a narrow window.", width="420", height="640" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/oBAbgP2JCt2zVENHVCnc.png", alt="A layout that is squashed into a narrow window.", width="420", height="640", class="w-screenshot" %}
 <figcaption class="w-figcaption">Wikipedia's liquid layout from the mid 2000s as experienced in a narrow browser window. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 ​​
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/zRBSmS1xCgYPTueUBMd9.png", alt="A layout stretched horizontally with very long line lengths.", width="800", height="320" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/zRBSmS1xCgYPTueUBMd9.png", alt="A layout stretched horizontally with very long line lengths.", width="800", height="320", class="w-screenshot" %}
 <figcaption class="w-figcaption">Wikipedia's liquid layout from the mid 2000s as experienced in a wide browser window. Screenshot from <a href="https://archive.org">archive.org</a></figcaption>
 </figure>
 

--- a/src/site/content/en/learn/design/micro-layouts/index.md
+++ b/src/site/content/en/learn/design/micro-layouts/index.md
@@ -60,8 +60,8 @@ h1::after {
 } %}
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/mNjoV2ri3HmsPeRoTpTh.png", alt="Developer tools in Firefox showing a grid overlay.", width="800", height="644" %}
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/7A1UYerc4KNuuWmp3IMJ.png", alt="Developer tools in Chrome showing a grid overlay.", width="800", height="644" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/mNjoV2ri3HmsPeRoTpTh.png", alt="Developer tools in Firefox showing a grid overlay.", width="800", height="644", class="w-screenshot" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/7A1UYerc4KNuuWmp3IMJ.png", alt="Developer tools in Chrome showing a grid overlay.", width="800", height="644", class="w-screenshot" %}
  <figcaption class="w-figcaption">
    Desktop browsers like Firefox and Chrome have developer tools that can show you grid lines and areas overlaid on your design. 
  </figcaption>
@@ -101,8 +101,8 @@ But the image never gets larger than 200 pixels.
 } %}
 
 <figure class="w-figure">
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/9xyxPbFU4EUtnPGsKdQI.png", alt="Developer tools in Firefox showing a flexbox overlay.", width="800", height="644" %}
-{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/R7Ucm4OvYLbXGD0I3rw2.png", alt="Developer tools in Chrome showing a flexbox overlay.", width="800", height="644" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/9xyxPbFU4EUtnPGsKdQI.png", alt="Developer tools in Firefox showing a flexbox overlay.", width="800", height="644", class="w-screenshot" %}
+{% Img src="image/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/R7Ucm4OvYLbXGD0I3rw2.png", alt="Developer tools in Chrome showing a flexbox overlay.", width="800", height="644", class="w-screenshot" %}
  <figcaption class="w-figcaption">
    The developer tools in Firefox and Chrome can help you visualize the shape of your flexbox components. 
  </figcaption>


### PR DESCRIPTION
This PR tries adding screenshot styles to a bunch of images.

Problem:
Apparently `w-screenshot` class doesn't work on courses. @devnook @andy-piccalilli 
See: https://deploy-preview-6715--web-dev-staging.netlify.app/learn/design/intro/

Expected: 
Borders around images, like here: https://web.dev/whats-new-pagespeed-insights/#clear-separation-of-field-and-lab-data

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
