### PR TITLE
simulate a mobile device in /measure tool

### DIFF
--- a/src/lib/psi-service.js
+++ b/src/lib/psi-service.js
@@ -19,6 +19,7 @@ export async function runPsi(url) {
     'SEO',
   ];
   const params = new URLSearchParams();
+  params.append('strategy', 'MOBILE');
   params.append('url', url);
   params.append('key', API_KEY);
   for (const category of categories) {


### PR DESCRIPTION
Fixes #6694

To match the old /measure which simulated a mobile-device-load, the PSI API needs an explicit `strategy=MOBILE` or it defaults to desktop.