### PR TITLE
fix(Snackbar): use new button classes for snackbar, fixes #6705

### DIFF
--- a/src/component-library/button/button.json
+++ b/src/component-library/button/button.json
@@ -28,6 +28,14 @@
       }
     },
     {
+      "name": "clear",
+      "title": "Clear",
+      "context": {
+        "text": "A clear button",
+        "type": "clear"
+      }
+    },
+    {
       "name": "disabled",
       "title": "Disabled",
       "context": {

--- a/src/lib/components/Snackbar/_styles.scss
+++ b/src/lib/components/Snackbar/_styles.scss
@@ -42,8 +42,9 @@ web-snackbar {
     align-items: center;
   }
 
-  .web-snackbar__action {
-    font-size: .875rem;
+  .web-snackbar__action,
+  .web-snackbar__action:link {
+    font-size: 0.875rem;
     color: $WEB_SECONDARY_COLOR;
     height: auto;
   }

--- a/src/lib/components/Snackbar/index.js
+++ b/src/lib/components/Snackbar/index.js
@@ -68,10 +68,15 @@ class Snackbar extends BaseElement {
       <div class="web-snackbar__actions">
         <a
           href="https://policies.google.com/technologies/cookies"
-          class="w-button web-snackbar__action"
+          class="w-button web-snackbar__action button"
+          data-type="clear"
           >More details</a
         >
-        <button @click=${this.action} class="w-button web-snackbar__action">
+        <button
+          @click=${this.action}
+          class="w-button web-snackbar__action button"
+          data-type="clear"
+        >
           OK
         </button>
       </div>

--- a/src/scss/mixins/_button-base-styles.scss
+++ b/src/scss/mixins/_button-base-styles.scss
@@ -60,6 +60,11 @@
     border: 1px solid get-utility-value('color', 'stroke');
   }
 
+  &[data-type='clear'] {
+    border: none;
+    background: none;
+  }
+
   /// DISABLED STATE
   /// All properties are !important because this
   /// state has to take priority in all cases

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -216,11 +216,3 @@
   text-transform: initial;
   letter-spacing: initial;
 }
-
-// A reset class that can be used to strip out the UA default button styles.
-.button {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  padding: 0;
-}

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -121,7 +121,7 @@
   justify-content: center;
   letter-spacing: 1px;
   outline: 0;
-  padding: 0 16px;
+  padding: 0 16px !important;
   position: relative;
   text-decoration: none;
   text-transform: uppercase;

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -121,7 +121,7 @@
   justify-content: center;
   letter-spacing: 1px;
   outline: 0;
-  padding: 0 16px !important;
+  padding: 0 16px !important; // `.button` from new design system removes padding, this keeps it.
   position: relative;
   text-decoration: none;
   text-transform: uppercase;

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -121,7 +121,7 @@
   justify-content: center;
   letter-spacing: 1px;
   outline: 0;
-  padding: 0 16px !important; // `.button` from new design system removes padding, this keeps it.
+  padding: 0 16px;
   position: relative;
   text-decoration: none;
   text-transform: uppercase;


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6705

Changes proposed in this pull request:

- Add clear button class.
- Add clear button class/attribute to snackbar buttons.


Before:
![image](https://user-images.githubusercontent.com/11811422/140830527-b61b70b2-eea1-430a-b407-ce0960ea8192.png)


After:
![image](https://user-images.githubusercontent.com/11811422/140831549-513325fb-f2d2-4ab3-a8d3-3c7fb5dc16d7.png)

This'll obviously need some love and attention if/when we remove the component level styling and the old SCSS.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
