### PR TITLE
[Declarative Link Capturing] Add OT not launching warning

### DIFF
--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -114,7 +114,7 @@ Chromium. The origin trial is expected to end in Chromium&nbsp;94 (October 13, 2
 
 {% Aside %}
 While you can still sign up for the origin trial, the engineering team has decided already
-that Declarative Link Capturing will _not_ launch in the present shape. Interested parties
+that Declarative Link Capturing will _not_ launch with the current design. Interested parties
 can check out and provide early feedback on the likely replacement feature called
 [Web App Launch Handling](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
 {% endAside %}

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -112,6 +112,13 @@ Chromium. The origin trial is expected to end in Chromium&nbsp;94 (October 13, 2
 
 ### Register for the origin trial {: #register-for-ot }
 
+{% Aside %}
+While you can still sign up for the origin trial, the engineering team has decided already
+that Declarative Link Capturing will _not_ launch in the present shape. Interested parties
+can check out and provide early feedback on the likely replacement feature called
+[Web App Launch Handling](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
+{% endAside %}
+
 {% include 'content/origin-trial-register.njk' %}
 
 ## How to use Declarative Link Capturing? {: #use }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add OT not launching warning.