### PR TITLE
fix(anchor): remove outline on `<a>` on active, fixes #5671

### DIFF
--- a/src/styles/generic/_links.scss
+++ b/src/styles/generic/_links.scss
@@ -23,8 +23,7 @@ a,
     text-decoration: underline;
   }
 
-  &:focus,
-  &:active {
+  &:focus {
     outline: 1px solid $FOCUS_COLOR;
   }
 }


### PR DESCRIPTION
Fixes #5671

Changes proposed in this pull request:

- remove outline on `<a>` on active
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
