### PR TITLE
fix(typo): s/fromtmatter/frontmatter

### DIFF
--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -63,7 +63,7 @@ Tags are used to categorize articles and also to generate [web.dev/tags](/tags/)
 The canonical list of tags is published in [tagsData.json](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_data/tagsData.json) on Github.
 
 - to add a new tag, add it first to `tagsData.json`
-- to use an existing tag, add it to your article's `fromtmatter`:
+- to use an existing tag, add it to your article's `frontmatter`:
 ```bash
 tags:
   - accessibility

--- a/src/site/content/en/patterns/example-set/full-html-demo/index.md
+++ b/src/site/content/en/patterns/example-set/full-html-demo/index.md
@@ -10,7 +10,7 @@ The HTML for the demo page can differ from the code samples displayed
 in the code pattern tabs. To achieve this, include the full HTML for the page
 in the demo.md file in the patterns directory, and ommit the layout property
 in the frontmatter. You still neeed to include the patternId in the
-fromtmatter.
+frontmatter.
 
 <!--
   Remove the following code if you're creating your own full HTML demo.


### PR DESCRIPTION
Found a typo while reading through the quick start section. `fromtmatter` -> `frontmatter`.
