### PR TITLE
fix(typo): fix GitHub casing

### DIFF
--- a/src/site/content/en/blog/asyncify/index.md
+++ b/src/site/content/en/blog/asyncify/index.md
@@ -361,7 +361,7 @@ WebAssembly code. Again, in the C / C++ case this would be included by Emscripte
 custom JavaScript glue code that would handle arbitrary WebAssembly files. We've created a library
 just for that.
 
-You can find it on Github at
+You can find it on GitHub at
 [https://github.com/GoogleChromeLabs/asyncify](https://github.com/GoogleChromeLabs/asyncify) or npm
 under the name [`asyncify-wasm`](https://www.npmjs.com/package/asyncify-wasm).
 

--- a/src/site/content/en/blog/building-a-switch-component/index.md
+++ b/src/site/content/en/blog/building-a-switch-component/index.md
@@ -891,4 +891,4 @@ to the community remixes section below!
 ### Resources
 
 Find the `.gui-switch` [source code on
-  Github](https://github.com/argyleink/gui-challenges).
+  GitHub](https://github.com/argyleink/gui-challenges).

--- a/src/site/content/en/blog/compress-images-avif/index.md
+++ b/src/site/content/en/blog/compress-images-avif/index.md
@@ -351,5 +351,5 @@ and optimizations and tooling integrations are actively being developed.
 If you have questions, comments, or feature requests,
 reach out on the
 [av1-discuss mailing list](https://groups.google.com/a/aomedia.org/g/av1-discuss),
-[AOM Github community](https://github.com/AOMediaCodec/community/wiki), and
+[AOM GitHub community](https://github.com/AOMediaCodec/community/wiki), and
 [AVIF wiki](https://github.com/AOMediaCodec/av1-avif/wiki).

--- a/src/site/content/en/blog/introducing-model-viewer/index.md
+++ b/src/site/content/en/blog/introducing-model-viewer/index.md
@@ -174,7 +174,7 @@ priority, so breaking changes will be avoided until version 2.0 is released.
 `<model-viewer>` version 1.0 includes the most-requested capabilities, but the
 team is not done yet. More features will be added, as will improvements in
 performance, stability, documentation, and tooling. If you have suggestions,
-file an [issue in Github](https://github.com/google/model-viewer/issues); also,
+file an [issue in GitHub](https://github.com/google/model-viewer/issues); also,
 PRs are always welcome. You can stay connected by following [`<model-viewer>` on
 Twitter](https://twitter.com/modelviewer) and checking out the [community chat
 on Spectrum](https://spectrum.chat/model-viewer?tab=posts).

--- a/src/site/content/en/blog/lighthouse-ci/index.md
+++ b/src/site/content/en/blog/lighthouse-ci/index.md
@@ -421,7 +421,7 @@ to display these results on each pull request.
     recent commit.
 
     <figure class="w-figure">
-      {% Img src="image/admin/ougavsYk6faiNidNxIGQ.png", alt="Screenshot of the Github 'Settings' tab", width="800", height="216", class="w-screenshot" %}
+      {% Img src="image/admin/ougavsYk6faiNidNxIGQ.png", alt="Screenshot of the GitHub 'Settings' tab", width="800", height="216", class="w-screenshot" %}
     </figure>
 
     You can navigate to the Lighthouse report corresponding to a particular commit
@@ -429,7 +429,7 @@ to display these results on each pull request.
     workflow step, then expand the results of the **run Lighthouse CI** step.
 
     <figure class="w-figure">
-      {% Img src="image/admin/aJF6FVHGOPpGNxKB3LjY.png", alt="Screenshot of the Github 'Settings' tab", width="800", height="366", class="w-screenshot" %}
+      {% Img src="image/admin/aJF6FVHGOPpGNxKB3LjY.png", alt="Screenshot of the GitHub 'Settings' tab", width="800", height="366", class="w-screenshot" %}
     </figure>
 
     You've just set up a GitHub Action to run Lighthouse CI. This will be most
@@ -443,7 +443,7 @@ typically includes information such as the results of a test or the success of a
 build.
 
 <figure class="w-figure">
-  {% Img src="image/admin/RZIfiOAPrst9Cxtxi9AX.png", alt="Screenshot of the Github 'Settings' tab", width="800", height="297", class="w-screenshot" %}
+  {% Img src="image/admin/RZIfiOAPrst9Cxtxi9AX.png", alt="Screenshot of the GitHub 'Settings' tab", width="800", height="297", class="w-screenshot" %}
 </figure>
 
 The steps below explain how to set up a status check for Lighthouse CI.
@@ -466,7 +466,7 @@ The steps below explain how to set up a status check for Lighthouse CI.
     repository, click **Secrets**, then click **Add a new secret**.
 
     <figure class="w-figure">
-      {% Img src="image/admin/ZYH9cOHehImZLI6vov1r.png", alt="Screenshot of the Github 'Settings' tab", width="800", height="375", class="w-screenshot" %}
+      {% Img src="image/admin/ZYH9cOHehImZLI6vov1r.png", alt="Screenshot of the GitHub 'Settings' tab", width="800", height="375", class="w-screenshot" %}
     </figure>
 
 6.  Set the **Name** field to `LHCI_GITHUB_APP_TOKEN` and set the **Value**

--- a/src/site/content/en/blog/lighthouse-whats-new-6.0/index.md
+++ b/src/site/content/en/blog/lighthouse-whats-new-6.0/index.md
@@ -314,7 +314,7 @@ At [CDS last November](/lighthouse-evolution-cds-2019/#lighthouse-ci-alpha-relea
 we announced [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci), the open source Node
 CLI and server that tracks Lighthouse results on every commit in your continuous integration
 pipeline, and we've come a long way since the alpha release. Lighthouse CI now has support
-for numerous CI providers including Travis, Circle, GitLab, and Github Actions. Ready-to-deploy
+for numerous CI providers including Travis, Circle, GitLab, and GitHub Actions. Ready-to-deploy
 [docker images](https://github.com/GoogleChrome/lighthouse-ci/tree/master/docs/recipes) make setup a
 breeze, and a comprehensive dashboard redesign now reveals trends across every category and metric
 in Lighthouse for detailed analysis.

--- a/src/site/content/en/blog/logical-property-shorthands/index.md
+++ b/src/site/content/en/blog/logical-property-shorthands/index.md
@@ -464,7 +464,7 @@ to see which matches your toolchain and overall site strategy.
 
 ## What's next
 More of CSS will offer logical properties, it's not done yet! There's one big missing
-set of shorthands though, and a resolution is still pending in this [Github issue](https://github.com/w3c/csswg-drafts/issues/1282).
+set of shorthands though, and a resolution is still pending in this [GitHub issue](https://github.com/w3c/csswg-drafts/issues/1282).
 There is a temporary solution [in a draft](https://drafts.csswg.org/css-logical/#logical-shorthand-keyword). What if you want to style all
 logical sides of a box with a shorthand?
 

--- a/src/site/content/en/blog/speculative-prerendering/index.md
+++ b/src/site/content/en/blog/speculative-prerendering/index.md
@@ -439,7 +439,7 @@ to a more sophisticated prerendering journey. Sign-up for
 the prerendering
 [origin trial](https://developer.chrome.com/origintrials/#/view_trial/1325184190353768449)
 and see how well it works for your specific use cases. If you have any feedback on the trial, submit an issue
-[to the Github repo](https://github.com/jeremyroman/alternate-loading-modes/issues).
+[to the GitHub repo](https://github.com/jeremyroman/alternate-loading-modes/issues).
 
 There is also an ongoing trial for using
 [Speculation Rules for Prefetch](https://developer.chrome.com/origintrials/#/view_trial/4576783121315266561).

--- a/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
+++ b/src/site/content/en/fast/codelab-extract-and-inline-critical-css/index.md
@@ -71,7 +71,7 @@ Error handling isn't mandatory, but it's an easy way to gauge the operation succ
 
 ### Configure Critical
 
-The table below contains some useful Critical options. You can check out all of the [available options on Github](https://github.com/addyosmani/critical#usage).
+The table below contains some useful Critical options. You can check out all of the [available options on GitHub](https://github.com/addyosmani/critical#usage).
 
 <table>
     <th>Option</th>

--- a/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
+++ b/src/site/content/en/fast/incorporate-performance-budgets-into-your-build-tools/index.md
@@ -118,9 +118,9 @@ Bundlesize outputs color-coded test results in one line.
 You'll get the most value out of bundlesize if you integrate it with a CI to automatically enforce size limits on pull requests. **If bundlesize test fails, that pull request is not merged.** It works for pull requests on GitHub with [Travis CI](https://travis-ci.org/), [CircleCI](https://circleci.com/), [Wercker](http://www.wercker.com/), and [Drone](http://readme.drone.io/).
 
 <figure class="w-figure">
-  {% Img src="image/admin/RKpNwfcXRoKZ34qDoxcO.jpg", alt="Bundlesize check status on Github", width="800", height="326", class="screenshot" %}
+  {% Img src="image/admin/RKpNwfcXRoKZ34qDoxcO.jpg", alt="Bundlesize check status on GitHub", width="800", height="326", class="screenshot" %}
   <figcaption class="w-figcaption">
-    Bundlesize check status on Github
+    Bundlesize check status on GitHub
   </figcaption>
 </figure>
 
@@ -158,9 +158,9 @@ after_success:
 If the scores for a pull request on GitHub fall below the threshold you've set, **Lighthouse Bot can prevent pull request from being merged**. ⛔
 
 <figure class="w-figure">
-  {% Img src="image/admin/nVDqJAA1DZDFqpOaQA9J.png", alt="Lighthouse Bot check status on Github", width="800", height="175", class="screenshot" %}
+  {% Img src="image/admin/nVDqJAA1DZDFqpOaQA9J.png", alt="Lighthouse Bot check status on GitHub", width="800", height="175", class="screenshot" %}
   <figcaption class="w-figcaption">
-    Lighthouse Bot check status on Github
+    Lighthouse Bot check status on GitHub
   </figcaption>
 </figure>
 

--- a/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
+++ b/src/site/content/en/fast/using-bundlesize-with-travis-ci/index.md
@@ -152,7 +152,7 @@ the homepage of the repository.
 
 You'll now see status checks in progress on the pull request page.
 
-{% Img src="image/admin/SrdHGr9z5QY1vEfBwNIY.png", alt="Github checks in progress", width="774", height="351" %}
+{% Img src="image/admin/SrdHGr9z5QY1vEfBwNIY.png", alt="GitHub checks in progress", width="774", height="351" %}
 
 It won't take long until all checks are done. Unfortunately, the cat voting app
 is a bit bloated and does not pass the performance budget check. The main bundle

--- a/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
+++ b/src/site/content/en/fast/using-lighthouse-bot-to-set-a-performance-budget/index.md
@@ -255,14 +255,14 @@ Travis log.
 To trigger the Lighthouse Bot test:
 
 1. Checkout a new branch
-2. Push it to Github
+2. Push it to GitHub
 3. Make a pull request
 
 Hang tight on that pull request page and wait for Lighthouse Bot to sing! 🎤
 
 {% Img src="image/admin/SmWHb70YqVfagXI3f03D.png", alt="Passing Lighthouse scores", width="586", height="329", class="w-screenshot" %}
 
-{% Img src="image/admin/ZrPGH5OGEY5Y4e9ntUBK.png", alt="Passing Github checks", width="462", height="189", class="w-screenshot" %}
+{% Img src="image/admin/ZrPGH5OGEY5Y4e9ntUBK.png", alt="Passing GitHub checks", width="462", height="189", class="w-screenshot" %}
 
 The performance score is great, the app is under budget, and the check has passed!
 

--- a/src/site/content/en/handbook/quick-start/index.md
+++ b/src/site/content/en/handbook/quick-start/index.md
@@ -60,7 +60,7 @@ If applicable, launch translation process for this content by emailing web.dev@.
 ### Tags
 
 Tags are used to categorize articles and also to generate [web.dev/tags](/tags/) pages.
-The canonical list of tags is published in [tagsData.json](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_data/tagsData.json) on Github.
+The canonical list of tags is published in [tagsData.json](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_data/tagsData.json) on GitHub.
 
 - to add a new tag, add it first to `tagsData.json`
 - to use an existing tag, add it to your article's `fromtmatter`:

--- a/src/site/content/en/handbook/writing-blog-posts/index.md
+++ b/src/site/content/en/handbook/writing-blog-posts/index.md
@@ -40,7 +40,7 @@ There are some technical differences in terms of components you have access to w
 
 Use Google docs initially, and write in Markdown. 
 Make a copy of this [template](https://docs.google.com/document/d/1lgaNIEnXZf-RB8_p9RK22QEgpXJqnu77pLWVWVy4nuw/edit?usp=sharing) as a starting point. 
-Your initial reviews will take place in the document as it is an easier place for structural changes than Github. 
+Your initial reviews will take place in the document as it is an easier place for structural changes than GitHub. 
 You can also share your document with any members of your team who need to sign off on the content before publication.
 
 ## The general procedure

--- a/src/site/content/en/lighthouse-seo/http-status-code/index.md
+++ b/src/site/content/en/lighthouse-seo/http-status-code/index.md
@@ -43,7 +43,7 @@ another URL.
 
 {% Aside %}
 If you're
-[using Github Pages to host a single-page app](https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/),
+[using GitHub Pages to host a single-page app](https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/),
 you'll likely need to serve valid content with a 404 status code.
 {% endAside %}
 

--- a/src/styles/generic/_code.scss
+++ b/src/styles/generic/_code.scss
@@ -107,7 +107,7 @@ cite code {
   font-size: .9em;
 }
 
-// Github-like theme for Prism.js
+// GitHub-like theme for Prism.js
 // @author Luke Askew http://github.com/lukeaskew
 
 // Token colors


### PR DESCRIPTION
GitHub should be written with a capital H. `Github` -> `GitHub`.