### PR TITLE
fix(measure): make styling more like previous measure page, fixes #6820

### DIFF
--- a/src/lib/components/LighthouseViewer/_styles.scss
+++ b/src/lib/components/LighthouseViewer/_styles.scss
@@ -6,7 +6,41 @@ web-lighthouse-viewer {
   min-height: 45px;
 
   .lh-root {
+    --font-size-small: 14px;
+    --font-size: 16px;
+    --font-weight-heavy: 700;
+
+    --link-color: var(--color-informative);
+    --metric-value-font-size: var(--font-size-small);
     --report-background-color: transparent;
+    --report-font-size-secondary: var(--font-size-small);
+
+    @media screen and (min-width: 464px) {
+      --gauge-circle-size: 80px;
+      --gauge-circle-size-big: 112px;
+      --gauge-label-font-size: 20px;
+      --gauge-label-font-size-big: 28px;
+      --gauge-label-line-height: 26px;
+      --gauge-label-line-height-big: 36px;
+      --gauge-wrapper-width: 148px;
+      --metric-value-font-size: var(--font-size);
+      --report-font-size: var(--font-size);
+      --report-font-size-secondary: var(--font-size);
+    }
+  }
+
+  .lh-audit-group__header {
+    color: var(--report-text-color);
+    font-weight: var(--font-weight-heavy);
+  }
+
+  .lh-audit-group__title {
+    font-weight: var(--font-weight-heavy);
+    text-transform: none;
+  }
+
+  .lh-category-header__description {
+    color: var(--report-text-color);
   }
 
   .lh-error-msg {
@@ -40,6 +74,19 @@ web-lighthouse-viewer {
     color: var(--color-pass);
   }
 
+  .lh-metric__description {
+    flex-grow: 0;
+  }
+
+  .lh-metric__innerwrap {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .lh-metric__title {
+    font-weight: var(--font-weight-heavy);
+  }
+
   /* unset a bunch of general styles applied by next.css */
   .lh-metricfilter__radio {
     width: 0;
@@ -57,12 +104,12 @@ web-lighthouse-viewer {
     line-height: unset;
 
     &::before,
-      &::after {
+    &::after {
       display: none;
     }
   }
 
-  details>*+* {
+  details > * + * {
     margin-top: 0;
   }
 

--- a/src/lib/components/LighthouseViewer/_styles.scss
+++ b/src/lib/components/LighthouseViewer/_styles.scss
@@ -20,7 +20,7 @@ web-lighthouse-viewer {
       --gauge-circle-size-big: 112px;
       --gauge-label-font-size: 20px;
       --gauge-label-font-size-big: 28px;
-      --gauge-label-line-height: 26px;
+      --gauge-label-line-height: 46px;
       --gauge-label-line-height-big: 36px;
       --gauge-wrapper-width: 148px;
       --metric-value-font-size: var(--font-size);
@@ -31,7 +31,6 @@ web-lighthouse-viewer {
 
   .lh-audit-group__header {
     color: var(--report-text-color);
-    font-weight: var(--font-weight-heavy);
   }
 
   .lh-audit-group__title {


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6820

Changes proposed in this pull request:

- CSS changes
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.

Here's what I'm aiming for

![image](https://user-images.githubusercontent.com/11811422/142255541-1129ec1d-6e6e-4768-a02a-a441686c45b0.png)

and this is what i was able to produce

![image](https://user-images.githubusercontent.com/11811422/142256188-b66923d8-a504-4910-bc3e-f7e041d936f5.png)


vs what it is now

![image](https://user-images.githubusercontent.com/11811422/142255652-822d05dc-eeb3-41df-a2fe-d5a64a7ceeea.png)
