### PR TITLE
Add user gesture requirement

### DIFF
--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -4,7 +4,7 @@ subhead: The Web Serial API allows websites to communicate with serial devices.
 authors:
   - beaufortfrancois
 date: 2020-08-12
-updated: 2021-08-18
+updated: 2021-11-18
 hero: image/admin/PMOws2Au6GPLq9sXSSqw.jpg
 thumbnail: image/admin/8diipQ5aHdP03xNuFNp7.jpg
 alt: |
@@ -97,13 +97,15 @@ received at any time, requiring a way to listen to it.
 
 To open a serial port, first access a `SerialPort` object. For this, you can
 either prompt the user to select a single serial port by calling
-`navigator.serial.requestPort()`, or pick one from `navigator.serial.getPorts()`
-which returns a list of serial ports the website has been granted access to
-previously.
+`navigator.serial.requestPort()` in response to a user gesture such as touch
+or mouse click, or pick one from `navigator.serial.getPorts()` which returns
+a list of serial ports the website has been granted access to previously.
 
 ```js
-// Prompt user to select any serial port.
-const port = await navigator.serial.requestPort();
+document.querySelector('button').addEventListener('click', async () => {
+  // Prompt user to select any serial port.
+  const port = await navigator.serial.requestPort();
+});
 ```
 
 ```js

--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -99,7 +99,7 @@ To open a serial port, first access a `SerialPort` object. For this, you can
 either prompt the user to select a single serial port by calling
 `navigator.serial.requestPort()` in response to a user gesture such as touch
 or mouse click, or pick one from `navigator.serial.getPorts()` which returns
-a list of serial ports the website has been granted access to previously.
+a list of serial ports the website has been granted access to.
 
 ```js
 document.querySelector('button').addEventListener('click', async () => {


### PR DESCRIPTION
This PR adds explicitly the user gesture requirement to the Serial API to help developers that may not understand the error message.
Context: https://stackoverflow.com/questions/70007274/how-to-use-the-chrome-web-serial-api/70017650#70017650