### PR TITLE
fix(BaseResponseElement): scroll to selected option when option is correct, fixes #6463

### DIFF
--- a/src/lib/components/BaseResponseElement/index.js
+++ b/src/lib/components/BaseResponseElement/index.js
@@ -15,6 +15,7 @@
  */
 
 import {BaseElement} from '../BaseElement';
+import {debounce} from '../../utils/debounce';
 import './_styles.scss';
 
 /**
@@ -41,6 +42,7 @@ export class BaseResponseElement extends BaseElement {
     this.enforceCardinality = this.enforceCardinality.bind(this);
     this.submitResponse = this.submitResponse.bind(this);
     this.reset = this.reset.bind(this);
+    this.scrollToOption = debounce(this.scrollToOption.bind(this), 100);
   }
 
   /**
@@ -172,10 +174,24 @@ export class BaseResponseElement extends BaseElement {
     return correctAnswersArr.every((val) => selections.includes(val));
   }
 
+  /**
+   * @param {HTMLElement} option HTML ELement to scroll to.
+   */
+  scrollToOption(option) {
+    const {top, height} = option.getBoundingClientRect();
+
+    this.parentElement.scrollTo({
+      top: top - height * 2.5,
+      left: 0,
+      behavior: 'smooth',
+    });
+  }
+
   // Updates option states when response component is submitted.
   // NOTE: Assumes client components have a deselectOption() method.
   // (Necessary because selection mechanisms will vary by response type.)
   submitResponse() {
+    /** @type {NodeListOf<HTMLElement>} */
     const options = this.querySelectorAll('[data-role=option]');
 
     for (const option of options) {
@@ -199,6 +215,7 @@ export class BaseResponseElement extends BaseElement {
       } else if (this.state === 'answeredCorrectly') {
         this.disableOption(option);
         if (isSelected) {
+          this.scrollToOption(option);
           option.setAttribute('data-submitted', '');
         }
       }

--- a/src/lib/components/BaseResponseElement/index.js
+++ b/src/lib/components/BaseResponseElement/index.js
@@ -178,10 +178,12 @@ export class BaseResponseElement extends BaseElement {
    * @param {HTMLElement} option HTML ELement to scroll to.
    */
   scrollToOption(option) {
-    const {top, height} = option.getBoundingClientRect();
-
+    const paddingTop = parseFloat(
+      window.getComputedStyle(option, null).getPropertyValue('padding-top'),
+    );
     this.parentElement.scrollTo({
-      top: top - height * 2.5,
+      // Deduct offset of parent from top from element's offset and add padding.
+      top: option.offsetTop - this.parentElement.offsetTop - paddingTop,
       left: 0,
       behavior: 'smooth',
     });


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6463

Changes proposed in this pull request:

- Add method to scroll to selected, correct, option
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
