### PR TITLE
Remove value judgement from the recommendation

### DIFF
--- a/src/site/content/en/lighthouse-accessibility/heading-order/index.md
+++ b/src/site/content/en/lighthouse-accessibility/heading-order/index.md
@@ -64,7 +64,7 @@ You can also use tools like Microsoft's
 to visualize your page structure and catch out-of-order heading elements.
 
 {% Aside 'caution' %}
-Less experienced developers sometimes skip heading levels
+Developers sometimes skip heading levels
 to achieve a desired visual style.
 For example, they may use an `<h3>` element
 because they feel the `<h2>` text is too large.


### PR DESCRIPTION
For context, I'm maintaining [a guide](https://www.notion.so/mui-org/Technical-documentation-7e55b517ac2e489a9ddb6d0f6dd765de) with all the learnings we had at MUI to write great documentation. I have linked this section, but I don't feel great about people that would make this mistake and be categories as "less experienced".