### PR TITLE
refactor: clamp expressions can take math functions

### DIFF
--- a/src/site/content/en/learn/css/the-cascade/index.md
+++ b/src/site/content/en/learn/css/the-cascade/index.md
@@ -115,7 +115,7 @@ the initial declaration will be honored, and the font-size will be 1.5rem
 ```css
 .my-element {
   font-size: 1.5rem;
-  font-size: clamp(1.5rem, calc(1rem + 3vw), 2rem);
+  font-size: clamp(1.5rem, 1rem + 3vw, 2rem);
 }
 ```
 


### PR DESCRIPTION
Calc is already being used in clamp. Make clamp easier to read.

Fixes #6854 

