### PR TITLE
Remove JS Self Profiling from translations in cross-origin isolation guide article

### DIFF
--- a/src/site/content/es/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/es/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-Esta guía le muestra cómo habilitar el aislamiento de origen cruzado. Se requiere aislamiento de origen cruzado si desea utilizar [`SharedArrayBuffer`](/monitor-total-page-memory-usage/), [`performance.measureUserAgentSpecificMemory()`](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/), [high resolution timer with better precision](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/), o la API de autoperfilado de JS.
+Esta guía le muestra cómo habilitar el aislamiento de origen cruzado. Se requiere aislamiento de origen cruzado si desea utilizar [`SharedArrayBuffer`](/monitor-total-page-memory-usage/), [`performance.measureUserAgentSpecificMemory()`](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/) o [high resolution timer with better precision](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/).
 
 Si tiene la intención de habilitar el aislamiento de origen cruzado, evalúe el impacto que esto tendrá en otros recursos de origen cruzado en su sitio web, como la ubicación de anuncios.
 

--- a/src/site/content/ja/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/ja/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-このガイドでは、Cross-Origin Isolation (クロスオリジンアイソレーション) を有効にする方法を説明します。クロスオリジンアイソレーションは、[`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) や [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/)、[高精度の高解像度タイマー](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/)、JS Self-Profiling API を使用する場合に必要となります。
+このガイドでは、Cross-Origin Isolation (クロスオリジンアイソレーション) を有効にする方法を説明します。クロスオリジンアイソレーションは、[`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) や [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/)、[高精度の高解像度タイマー](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/)を使用する場合に必要となります。
 
 クロスオリジンアイソレーションを有効にする場合は、広告の配置など、ウェブサイト上の他のクロスオリジンリソースに与える影響を評価してください。
 

--- a/src/site/content/ko/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/ko/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-이 가이드에서는 출처 간 격리를 이용하는 방법을 보여줍니다. [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/), [높은 정밀도의 고해상도 타이머](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/) 또는 JS Self-Profiling API를 사용하려면 출처 간 격리가 필요합니다.
+이 가이드에서는 출처 간 격리를 이용하는 방법을 보여줍니다. [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/) 또는 [높은 정밀도의 고해상도 타이머](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/)를 사용하려면 출처 간 격리가 필요합니다.
 
 출처 간 격리를 이용하려는 경우, 이것이 광고 배치와 같은 웹사이트의 다른 출처 간 리소스에 미치는 영향을 평가하세요.
 

--- a/src/site/content/pt/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/pt/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-Este guia mostra como habilitar o isolamento de origem cruzada. O isolamento de origem cruzada é necessário se você deseja usar [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/), [cronômetro de alta resolução com melhor precisão](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/) ou a API JS Self-Profiling.
+Este guia mostra como habilitar o isolamento de origem cruzada. O isolamento de origem cruzada é necessário se você deseja usar [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/) ou [cronômetro de alta resolução com melhor precisão](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/).
 
 Se você pretende ativar o isolamento de origem cruzada, avalie o impacto que isso terá em outros recursos de origem cruzada em seu site, como canais de anúncios.
 

--- a/src/site/content/ru/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/ru/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-В этом руководстве показано, как включить межсайтовую изоляцию, которая необходима для использования [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/), [высокоточного таймера](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/) и JS Self-Profiling API.
+В этом руководстве показано, как включить межсайтовую изоляцию, которая необходима для использования [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), [`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/) и [высокоточного таймера](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/).
 
 Прежде чем включать межсайтовую изоляцию, оцените, как она повлияет на рекламные места и другие межсайтовые ресурсы на вашем сайте.
 

--- a/src/site/content/zh/secure/cross-origin-isolation-guide/index.md
+++ b/src/site/content/zh/secure/cross-origin-isolation-guide/index.md
@@ -11,7 +11,7 @@ tags:
   - security
 ---
 
-本篇指南将向您展示跨域隔离的启用方式。如果您想使用[`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)、[`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/)、[更精确的高精度计时器](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/)或 JS Self-Profiling API，就会需要跨域隔离。
+本篇指南将向您展示跨域隔离的启用方式。如果您想使用[`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)、[`performance.measureUserAgentSpecificMemory()`](/monitor-total-page-memory-usage/)或 [更精确的高精度计时器](https://developer.chrome.com/blog/cross-origin-isolated-hr-timers/)，就会需要跨域隔离。
 
 如果您打算启用跨域隔离，请评估这对您网站上的其他跨域资源（例如广告展示位置）将产生的影响。
 


### PR DESCRIPTION
This patch removes "JS Self-Profiling API" from outdated translations in cross-origin isolation guide article