### PR TITLE
Defer Reporting API content to the new article

### DIFF
--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -17,7 +17,7 @@ authors:
 hero: image/admin/Rv8gOTwZwxr2Z7b13Ize.jpg
 alt: An illustration of a person browsing a website that has a popup, an iframe, and an image.
 date: 2020-04-13
-updated: 2021-11-22
+updated: 2021-11-26
 tags:
   - blog
   - security
@@ -358,9 +358,8 @@ isolated.
 The [Reporting API](/reporting-api) is another mechanism through which you can
 detect various issues. You can configure the Reporting API to instruct your
 users' browser to send a report whenever COEP blocks the loading of a resource
-or COOP isolates a pop-up window. Chrome has supported the
-[`Report-To`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
-header since version 69 for a variety of uses including COEP and COOP.
+or COOP isolates a pop-up window. Chrome has supported the Reporting API since
+version 69 for a variety of uses including COEP and COOP.
 
 {% Aside %}
 
@@ -371,8 +370,9 @@ transitioning to a new version of the Reporting API, which replaces `Report-To` 
 
 {% endAside %}
 
-To learn how to set up a server to receive reports, see [Decide where reports should
-be sent](/reporting-api/#decide-where-reports-should-be-sent).
+To learn how to configure the Reporting API and set up a server to receive
+reports, head over to [Using the Reporting
+API](/reporting-api/#using-the-reporting-api).
 
 #### Example COEP report
 

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -365,7 +365,7 @@ header since version 69 for a variety of uses including COEP and COOP.
 {% Aside %}
 
 Are you already using the Reporting API with the `Report-To` header? Chrome is
-transitioning to a new version of the Reporting API, which replaces `Report-to` with
+transitioning to a new version of the Reporting API, which replaces `Report-To` with
 `Reporting-Endpoints`; consider migrating to the new version. Check out
 [Migrate to Reporting API v1](/reporting-api-migration) for details.
 

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -358,20 +358,20 @@ isolated.
 The [Reporting API](/reporting-api) is another mechanism through which you can
 detect various issues. You can configure the Reporting API to instruct your
 users' browser to send a report whenever COEP blocks the loading of a resource
-or COOP isolates a popup window. Chrome has supported the
+or COOP isolates a pop-up window. Chrome has supported the
 [`Report-To`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
 header since version 69 for a variety of uses including COEP and COOP.
 
 {% Aside %}
 
 Are you already using the Reporting API with the `Report-To` header? Chrome is
-transitioning to a new version of the Reporting API, based on
-`Reporting-Endpoints`; consider migrating to this new version. Head over
+transitioning to a new version of the Reporting API, which replaces `Report-to` with
+`Reporting-Endpoints`; consider migrating to the new version. Check out
 [Migrate to Reporting API v1](/reporting-api-migration) for details.
 
 {% endAside %}
 
-Learn how to set up a server to receive reports at [Decide where reports should
+To learn how to set up a server to receive reports, see [Decide where reports should
 be sent](/reporting-api/#decide-where-reports-should-be-sent).
 
 #### Example COEP report
@@ -405,7 +405,7 @@ eventually](https://github.com/whatwg/html/pull/5848).
 
 An example [COOP
 report](https://html.spec.whatwg.org/multipage/origin.html#reporting) payload
-when a popup window is opened isolated looks like this:
+when a pop-up window is opened isolated looks like this:
 
 ```json
 [{

--- a/src/site/content/en/blog/coop-coep/index.md
+++ b/src/site/content/en/blog/coop-coep/index.md
@@ -17,7 +17,7 @@ authors:
 hero: image/admin/Rv8gOTwZwxr2Z7b13Ize.jpg
 alt: An illustration of a person browsing a website that has a popup, an iframe, and an image.
 date: 2020-04-13
-updated: 2021-09-28
+updated: 2021-11-22
 tags:
   - blog
   - security
@@ -57,8 +57,6 @@ and Desktop Chrome
   precision.
 - **February 19, 2021**: Added a note about feature policy
   `allow="cross-origin-isolated"` and debugging functionality on DevTools.
-- **February 9, 2021**: Added an instruction [how to set up a reporting
-  endpoint](#set-up-reporting-endpoint).
 - **October 15, 2020**: `self.crossOriginIsolated` is available from Chrome 87.
   Reflecting that, `document.domain` is immutable when
   `self.crossOriginIsolated` returns `true`.
@@ -357,121 +355,26 @@ isolated.
 
 ### Observe issues using the Reporting API
 
-The [Reporting
-API](https://developers.google.com/web/updates/2018/09/reportingapi) is another
-mechanism through which you can detect various issues. You can configure the
-Reporting API to instruct your users' browser to send a report whenever COEP
-blocks the loading of a resource or COOP isolates a popup window. Chrome has
-supported the
+The [Reporting API](/reporting-api) is another mechanism through which you can
+detect various issues. You can configure the Reporting API to instruct your
+users' browser to send a report whenever COEP blocks the loading of a resource
+or COOP isolates a popup window. Chrome has supported the
 [`Report-To`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
 header since version 69 for a variety of uses including COEP and COOP.
 
 {% Aside %}
-The Reporting API is undergoing transition to [a new
-](https://w3c.github.io/reporting/)version. Chrome is planning to release it
-soon, but will leave the older API in place for some time.
-Firefox is also [considering the new
-API](https://bugzilla.mozilla.org/show_bug.cgi?id=1620573). You may want to use
-both APIs during the transition.
+
+Are you already using the Reporting API with the `Report-To` header? Chrome is
+transitioning to a new version of the Reporting API, based on
+`Reporting-Endpoints`; consider migrating to this new version. Head over
+[Migrate to Reporting API v1](/reporting-api-migration) for details.
+
 {% endAside %}
 
-#### Set up a server to receive reports {: #set-up-reporting-endpoint}
+Learn how to set up a server to receive reports at [Decide where reports should
+be sent](/reporting-api/#decide-where-reports-should-be-sent).
 
-A server with reporting endpoints needs to be set up in order to receive reports
-from your COOP/COEP. There are two options:
-
-* Use a solution that accepts reports.
-* Build your own server that accepts reports.
-
-##### Use a solution that accepts reports
-
-There are a couple of solutions that accept reports from the browser's COOP/COEP
-reporting functionality:
-
-* [https://report-uri.com](https://report-uri.com)
-* [https://uriports.com](https://uriports.com)
-
-If there are any other solutions that accept reports, [let us know to
-update this post](https://github.com/GoogleChrome/web.dev).
-
-##### Build your own server that accepts reports
-
-Building your own server that receives reports isn't that trivial. We have [a
-lightweight sample implementation of a reporting endpoint on
-glitch.com](https://reporting-endpoint.glitch.me/). ["Remix Project" to
-clone](https://glitch.com/edit/#!/reporting-endpoint) and customize for your own
-purposes.
-
-<figure class="w-figure">
-  {% Img src="image/admin/8Fh5mUULtCRK5K0738Ss.png", alt="Build your own reporting endpoint by forking a lightweight sample implementation on glitch.com.", width="800", height="496", class="w-screenshot w-screenshot--filled" %}
-</figure>
-
-All you have to do is to put the URL indicated in the page as the reporting
-endpoint of COOP and COEP. See below to learn how to configure.
-
-#### `Report-To`
-
-To specify where the browser should send reports, append the `Report-To` HTTP
-header to any document that is served with a COEP or COOP HTTP header. The
-`Report-To` header also supports a few extra parameters to configure the
-reports. For example:
-
-```http
-Report-To: { group: 'coep_report', max_age: 86400, endpoints: [{ url: 'https://reporting-endpoint.glitch.me/post'}]},{ group: 'coop_report', max_age: 86400, endpoints: [{ url: 'https://reporting-endpoint.glitch.me/post'}]}
-```
-
-The parameters object has three properties:
-
-#### `group`
-
-The `group` property names your various reporting endpoints. Use these names to
-direct a subset of your reports. For instance, in the
-`Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` directives you
-can specify the relevant endpoint by providing the group name to `report-to=`.
-For example:
-
-```http
-Cross-Origin-Embedder-Policy: require-corp; report-to="coep_report"
-Cross-Origin-Opener-Policy: same-origin; report-to="coop_report"
-```
-When the browser encounters this, it will cross reference the `report-to` value
-with the `group` property on the `Report-To` header to look up the endpoint.
-This example cross references `coep_report` and `coop_report` to find the
-endpoint `https://first-party-test.glitch.me/report`.
-
-If you prefer to receive reports without blocking any embedded content or
-without isolating a popup window, append `-Report-Only` to respective headers:
-i.e. `Cross-Origin-Embedder-Policy-Report-Only` and
-`Cross-Origin-Opener-Policy-Report-Only`. For example:
-
-```http
-Cross-Origin-Embedder-Policy-Report-Only: require-corp; report-to="coep_report"
-Cross-Origin-Opener-Policy-Report-Only: same-origin; report-to="coop_report"
-```
-
-By doing this, when the browser detects cross origin resources that don't have
-CORP or CORS, it sends a report using the Reporting API without actually
-blocking those resources because of COEP.
-
-Similarly, when the browser opens a cross-origin popup window, it sends a report
-without actually isolating the window because of COOP. It also reports when
-different browsing context groups try to access each other, but only in
-"report-only" mode.
-
-#### `max_age`
-
-The `max_age` property specifies the time in seconds after which unsent reports
-are to be dropped. The browser doesn't send the reports right away. Instead, it
-transmits them out-of-band whenever there aren't any other higher priority
-tasks. The `max_age` prevents the browser from sending reports that are too
-stale to be useful. For example, `max_age: 86400` means that reports older than
-twenty-four hours will not be sent.
-
-#### `endpoints`
-
-The `endpoints` property specifies the URLs of one or more reporting endpoints.
-The endpoint must accept CORS if it's hosted on a different origin. The browser
-will send reports with a Content-Type of `application/reports+json`.
+#### Example COEP report
 
 An example [COEP
 report](https://html.spec.whatwg.org/multipage/origin.html#coep-report-type)
@@ -497,6 +400,8 @@ payload when cross-origin resource is blocked looks like this:
 `blocked-url` is there for backward compatibility only and [will be removed
 eventually](https://github.com/whatwg/html/pull/5848).
 {% endAside %}
+
+#### Example COOP report
 
 An example [COOP
 report](https://html.spec.whatwg.org/multipage/origin.html#reporting) payload


### PR DESCRIPTION
Based on @maudnals 's suggestion, removed many Reporting API related content and defer to [the new Reporting API dedicated article](https://web.dev/reporting-api/).