### PR TITLE
[Web.dev Doc] : Checkbox attribute changed from selected to checked

### DIFF
--- a/src/site/content/en/learn/forms/form-fields/index.md
+++ b/src/site/content/en/learn/forms/form-fields/index.md
@@ -97,7 +97,7 @@ different validation rules, and more. Let's see how to change the type.
 
 By using `type="checkbox"` the browser now renders a checkbox instead of a text field.
 The checkbox also comes with additional attributes.
-You can set the `selected` attribute, to show it as selected.
+You can set the `checked` attribute, to show it as selected.
 
 {% Aside %}
 The default value for `type` is `text`. This means that if you simply want a text `<input>`, you can 

--- a/src/site/content/en/learn/forms/form-fields/index.md
+++ b/src/site/content/en/learn/forms/form-fields/index.md
@@ -97,7 +97,7 @@ different validation rules, and more. Let's see how to change the type.
 
 By using `type="checkbox"` the browser now renders a checkbox instead of a text field.
 The checkbox also comes with additional attributes.
-You can set the `checked` attribute, to show it as selected.
+You can set the `checked` attribute, to show it as checked.
 
 {% Aside %}
 The default value for `type` is `text`. This means that if you simply want a text `<input>`, you can 


### PR DESCRIPTION

Fixes [#6896](https://github.com/GoogleChrome/web.dev/issues/6896)

Change in this PR includes : 
- updation of  Checkbox wrong attribute from `selected` to `checked` in  [form-fields/#type](https://web.dev/learn/forms/form-fields/#type) page.
