### PR TITLE
fix(hero): remove `loading="lazy"` from all images in `.hero` elements, fixes #6895

### DIFF
--- a/src/component-library/hero/hero.njk
+++ b/src/component-library/hero/hero.njk
@@ -15,7 +15,7 @@
         <a class="feature-card" href="{{ item.url }}" data-theme="{{ item.theme }}">
           <span class="feature-card__eyebrow">{{ item.eyebrow }}</span>
           <h3 class="{{ 'visually-hidden' if item.hiddenTitle else 'feature-card__title' }}">{{ item.title }}</h3>
-          <img class="feature-card__background" loading="lazy" alt="" aria-hidden="true" src="{{ item.background }}" />
+          <img class="feature-card__background" alt="" aria-hidden="true" src="{{ item.background }}" />
         </a>
         {% endfor %}
       </div>

--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -24,7 +24,7 @@ pageScripts:
           <a class="feature-card" href="{{ featureCard.url }}" data-theme="{{ featureCard.theme }}" data-treatment="illustration">
             <span class="feature-card__eyebrow">{{ featureCard.eyebrow }}</span>
             <h3 class="{{ 'visually-hidden' if featureCard.hiddenTitle else 'feature-card__title' }}">{{ featureCard.title }}</h3>
-            <img class="feature-card__background" loading="lazy" alt="" aria-hidden="true" src="{{ featureCard.background }}" />
+            <img class="feature-card__background" alt="" aria-hidden="true" src="{{ featureCard.background }}" />
           </a>
           {% include "partials/picked-case-study.njk" %}
         </div>


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6895

Changes proposed in this pull request:

- Remove `loading="lazy"` from all images in `.hero` elements
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
