### PR TITLE
fix(algolia): add landing pages and prioritize them, fixes #4027

### DIFF
--- a/algolia.js
+++ b/algolia.js
@@ -124,7 +124,9 @@ async function index() {
 
   // When indexing data we mark these two fields as fields that can be filtered by.
   await index.setSettings({
+    searchableAttributes: ['title', 'content', 'description'],
     attributesForFaceting: ['locales', 'tags'],
+    customRanking: ['desc(priority)'],
   });
 
   // Update algolia index with new data

--- a/src/site/_filters/algolia-item.js
+++ b/src/site/_filters/algolia-item.js
@@ -36,6 +36,7 @@ function algoliaItem(post) {
     locale: data.lang || defaultLocale,
     locales: [],
     objectID: md5(post.url),
+    priority: data.algolia_priority ?? 1,
     tags: data.tags && Array.isArray(data.tags) ? data.tags : [],
     title: data.renderData?.title || data.title,
     updatedOn: data.updated,

--- a/src/site/_includes/base.njk
+++ b/src/site/_includes/base.njk
@@ -1,5 +1,6 @@
 ---
 show_banner: true
+algolia_priority: 1
 tags: []
 ---
 

--- a/src/site/_includes/blog.njk
+++ b/src/site/_includes/blog.njk
@@ -1,5 +1,6 @@
 ---
 layout: landing-page
+algolia_priority: 0.9
 eleventyComputed:
   noindex: "{{ paged.index > 0 }}"
 ---

--- a/src/site/_includes/index-page.njk
+++ b/src/site/_includes/index-page.njk
@@ -1,5 +1,6 @@
 ---
 layout: landing-page
+algolia_priority: 0.9
 eleventyComputed:
   noindex: "{{ paged.index > 0 }}"
 ---

--- a/src/site/_includes/item-page.njk
+++ b/src/site/_includes/item-page.njk
@@ -1,5 +1,6 @@
 ---
 layout: default-next
+algolia_priority: 0.9
 eleventyComputed:
   noindex: "{{ paged.index > 0 }}"
 ---

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -1,6 +1,7 @@
 ---
 layout: default
-renderData:
+algolia_priority: 1.1
+eleventyComputed:
   title: "{{paths[pathName].title | i18n(locale)}}"
   description: "{{paths[pathName].description | i18n(locale)}}"
   hero: "{{paths[pathName].cover}}"

--- a/types/eleventy/collection-item.d.ts
+++ b/types/eleventy/collection-item.d.ts
@@ -108,6 +108,10 @@ declare global {
        * If the post should be excluded from /tags/ pages.
        */
       excludeFromTags?: boolean;
+      /**
+       * How Algolia should prioritize a page. 1 is average, higher is better.
+       */
+      algolia_priority: number;
     };
     /**
      * The rendered content of this template. This does not include layout wrappers.

--- a/types/utils/algolia.d.ts
+++ b/types/utils/algolia.d.ts
@@ -30,6 +30,7 @@ declare global {
      * ID of item used to update existing entry.
      */
     objectID: string;
+    priority: number;
     tags: string[];
     /**
      * Title of a post.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #4027

Changes proposed in this pull request:

- Limit search to just title, description and content. (Things like the URL could have been false positives with the inclusion of "web")
- Add custom ranking sort on new `priority` field.
- Default pages to algolia priority of `1`.
- Set paginated pages algolia priority to `0.9`.
- Set path pages algolia priority to `1.1`.
- Set path pages to use `eleventyComputed` instead of `renderData` for title and what not. (When using `renderData` posts don't have a title, and therefore fail to be indexed by algolia)

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
