### PR TITLE
Hotfix: Add missing 'worse' compare box treatment to two compare blocks in CSS Backgrounds module

### DIFF
--- a/src/site/content/en/learn/css/backgrounds/index.md
+++ b/src/site/content/en/learn/css/backgrounds/index.md
@@ -203,7 +203,7 @@ background-position: right bottom 88%;
 
 {% endCompare %}
 
-{% Compare 'better' %}
+{% Compare 'worse' %}
 
 ```css
 background-position: 88% bottom right;
@@ -232,7 +232,7 @@ background-position: right 33% bottom 88%;
 {% endCompare %}
 
 
-{% Compare 'better' %}
+{% Compare 'worse' %}
 
 ```css
 background-position: 88% 33% bottom left;


### PR DESCRIPTION
Changes proposed in this pull request:

-  Hotfix: Add missing 'worse' compare box treatment to two compare blocks in CSS Backgrounds module

**Before**
<img width="881" alt="Screen Shot 2021-12-02 at 6 57 54 AM" src="https://user-images.githubusercontent.com/1223224/144447991-d3a6bb1c-e0bf-41de-81a5-c453042a0613.png">

**After**
<img width="909" alt="Screen Shot 2021-12-02 at 6 58 37 AM" src="https://user-images.githubusercontent.com/1223224/144448038-155eb5d7-74a8-4ebd-acc9-abe9ec66b7df.png">


