### PR TITLE
[i18n] Localize string in `Instruction.js`

### DIFF
--- a/src/site/_data/i18n/instruction.yml
+++ b/src/site/_data/i18n/instruction.yml
@@ -1,0 +1,53 @@
+devtools:
+  en: DevTools
+
+network:
+  en: Network
+  ru: Сеть
+
+elements:
+  en: Elements
+  ru: Элементы
+
+console:
+  en: Console
+  ru: Консоль
+
+sources:
+  en: Sources
+  ru: Источники
+  
+performance:
+  en: Performance
+  ru: Производительность
+
+memory:
+  en: memory
+  ru: память
+
+application:
+  en: Application
+  ru: Приложение
+
+security:
+  en: Security
+  ru: Защита
+
+lighthouse:
+  en: Lighthouse
+
+disable_cache:
+  en: Select the **Disable cache** checkbox.
+  ru: Установите флажок **Отключить кеш**.
+
+reload_page:
+  en: Reload the page.
+  ru: Перезагрузите страницу.
+
+devtools_click:
+  en: Click the **$0** tab.
+  ru: Перейдите на вкладку **$0**.
+
+devtools_shared:
+  en: Press \`Control+Shift+J\` (or \`Command+Option+J\` on Mac) to open DevTools.
+  ru: Откройте DevTools, нажав `Control+Shift+J` (или `Command+Option+J`, если у вас Mac).

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -15,6 +15,8 @@
  */
 
 const {html} = require('common-tags');
+const {i18n} = require('../../_filters/i18n');
+const {defaultLocale} = require('../../../../shared/locale');
 const capitalize = require('../../_filters/capitalize');
 
 /**
@@ -25,7 +27,7 @@ const capitalize = require('../../_filters/capitalize');
  * @param {string} listStyle The list style to use. Defaults to 'ul'.
  * @return {string} A list of instructions.
  */
-module.exports = (type, listStyle = 'ul') => {
+module.exports = (type, listStyle = 'ul', locale = defaultLocale) => {
   let instruction;
   let substitution;
   let bullet;
@@ -51,7 +53,7 @@ module.exports = (type, listStyle = 'ul') => {
 
   // Common phrases shared across multiple instructions.
   const shared = {
-    devtools: `${bullet}Press \`Control+Shift+J\` (or \`Command+Option+J\` on Mac) to open DevTools.`,
+    devtools: `${bullet}${i18n('i18n.instruction.devtools_shared', locale)}`,
   };
 
   switch (type) {
@@ -99,7 +101,10 @@ module.exports = (type, listStyle = 'ul') => {
       break;
 
     case 'disable-cache':
-      instruction = html`${bullet}Select the **Disable cache** checkbox.`;
+      instruction = html`${bullet}${i18n(
+        'i18n.instruction.disable_cache',
+        locale,
+      )}`;
       break;
 
     case 'reload-app':
@@ -107,7 +112,10 @@ module.exports = (type, listStyle = 'ul') => {
       break;
 
     case 'reload-page':
-      instruction = html`${bullet}Reload the page.`;
+      instruction = html`${bullet}${i18n(
+        'i18n.instruction.reload_page',
+        locale,
+      )}`;
       break;
 
     case 'start-profiling':
@@ -141,10 +149,15 @@ module.exports = (type, listStyle = 'ul') => {
       instruction = html`${shared.devtools}`;
       substitution = type.substring('devtools-'.length);
       if (substitution) {
+        const tab = i18n(`i18n.instruction.${substitution}`, locale);
+        const step = i18n('i18n.instruction.devtools_click', locale).replace(
+          '$0',
+          `${tab}`,
+        );
         // prettier-ignore
         instruction = html`
           ${instruction}
-          ${bullet}Click the **${capitalize(substitution)}** tab.
+          ${bullet}${step}
         `;
       }
       break;

--- a/src/site/_includes/components/Instruction.js
+++ b/src/site/_includes/components/Instruction.js
@@ -15,19 +15,21 @@
  */
 
 const {html} = require('common-tags');
-const {i18n} = require('../../_filters/i18n');
-const {defaultLocale} = require('../../../../shared/locale');
+const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
 const capitalize = require('../../_filters/capitalize');
 
 /**
  * A component to help DRY up common lists of instructions.
  * This helps ensure consistency in our docs and makes it easy
  * to respond when Glitch changes their UI.
+ * @this {EleventyPage}
  * @param {string} type The type of instruction to print.
  * @param {string} listStyle The list style to use. Defaults to 'ul'.
  * @return {string} A list of instructions.
  */
-module.exports = (type, listStyle = 'ul', locale = defaultLocale) => {
+module.exports = function (type, listStyle = 'ul') {
+  const locale = getLocaleFromPath(this.page && this.page.filePathStem);
+
   let instruction;
   let substitution;
   let bullet;


### PR DESCRIPTION
Fixes #6982 

Add an optional `locale` param in the `Instruction` shortcode. Can use that like below in any article, especially translated one.

```js
{% Instruction 'devtools-network', 'li', locale %}
```

Preferably able to access to `@this {EleventyPage}` object like the `components/Aside.js`, then we can eliminate this additional `locale` param. However, I couldn't get that work.
