### PR TITLE
[Window Controls Overlay article] Rename to `titlebarAreaRect`

### DIFF
--- a/src/site/content/en/blog/window-controls-overlay/index.md
+++ b/src/site/content/en/blog/window-controls-overlay/index.md
@@ -297,7 +297,7 @@ const debounce = (func, wait) => {
 
 if ('windowControlsOverlay' in navigator) {
   navigator.windowControlsOverlay.ongeometrychange = debounce((e) => {
-    span.hidden = e.boundingRect.width < 800;
+    span.hidden = e.titlebarAreaRect.width < 800;
   }, 250);
 }
 ```
@@ -310,7 +310,7 @@ Rather than assigning a function to `ongeometrychange`, you can also add an even
 navigator.windowControlsOverlay.addEventListener(
   'geometrychange',
   debounce((e) => {
-    span.hidden = e.boundingRect.width < 800;
+    span.hidden = e.titlebarAreaRect.width < 800;
   }, 250),
 );
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

- Rename to `titlebarAreaRect`.