### PR TITLE
Prevent carousel buttons showing on small viewports

### DIFF
--- a/src/scss/blocks/_carousel.scss
+++ b/src/scss/blocks/_carousel.scss
@@ -1,12 +1,8 @@
 /// COMPONENT LIBRARY LOCATION
 /// https://web.dev/design-system/component/carousel
 .carousel {
-  display: grid;
-  grid-template-columns: 2rem 1fr 2rem;
-  gap: $global-gutter-narrow;
-  align-items: center;
-
   .icon-button {
+    display: none;
     height: 36px;
     width: 36px;
 
@@ -63,6 +59,19 @@
   // E.G cards will all be the same height in a carousel
   > * > * {
     height: 100%;
+  }
+}
+
+@include media-query('md') {
+  .carousel {
+    display: grid;
+    grid-template-columns: 2rem 1fr 2rem;
+    gap: $global-gutter-narrow;
+    align-items: center;
+
+    .icon-button {
+      display: inline-block;
+    }
   }
 }
 

--- a/src/site/_data/design/themes.js
+++ b/src/site/_data/design/themes.js
@@ -85,7 +85,7 @@ module.exports = {
       ACTION_BG: 'shades-dim',
       ACTION_BG_ALT: 'shades-dim',
       ACTION_BG_PRIMARY: 'core-primary-dim',
-      ACTION_BG_HOVER: 'shades-gray',
+      ACTION_BG_HOVER: 'shades-gray-glare',
       ACTION_TEXT: 'core-primary-glare',
       ACTION_TEXT_PRIMARY: 'core-primary-bright',
       ACTION_TEXT_ALT: 'shades-light',


### PR DESCRIPTION
It takes up way too much space and results in half-cards being rendered.