### PR TITLE
fix(lists): fix order and styling of embedded lists, fixes #7044

### DIFF
--- a/src/scss/blocks/_prose.scss
+++ b/src/scss/blocks/_prose.scss
@@ -53,7 +53,7 @@
   details > * {
     --flow-space: #{get-space('size-1')};
   }
-    
+
   :not([class]) li {
     @extend .flow;
 
@@ -62,11 +62,11 @@
 
   /// Modidifies the custom list style positions to
   /// work with the larger line heights
-  ul li::before {
+  ul > li::before {
     inset: 1.2ex 0 0 0;
   }
 
-  ol li::before {
+  ol > li::before {
     line-height: 1.1;
     inset: 0.25ex 0 0 0;
   }

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -120,7 +120,7 @@ ul:not([class]) {
   list-style: none;
   padding-inline-start: 1rem;
 
-  li::before {
+  > li::before {
     content: '';
     display: block;
     position: absolute;
@@ -131,7 +131,7 @@ ul:not([class]) {
     background: currentColor;
   }
 
-  li {
+  > li {
     padding-inline-start: 2ch;
   }
 }
@@ -140,7 +140,7 @@ ol:not([class]) {
   counter-reset: ol-list;
   padding-inline-start: 0.5rem;
 
-  li::before {
+  > li::before {
     content: counter(ol-list);
     display: flex;
     flex-direction: column;
@@ -158,7 +158,7 @@ ol:not([class]) {
     @include apply-utility('weight', 'medium');
   }
 
-  li {
+  > li {
     counter-increment: ol-list;
     padding-inline-start: 2.5rem;
   }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7044

Changes proposed in this pull request:
- Only apply `li` styles to the `ol` or `ul` that they are inside of.

Before:
![image](https://user-images.githubusercontent.com/11811422/146129550-643c523d-caf8-4d86-b043-2314e6a68d14.png)

You're seeing `<ul>` lists embedded inside of a `<li>` inside of a `<ol>`, and it looks like an embedded `<ol>`, which isn't right...

After:
![image](https://user-images.githubusercontent.com/11811422/146314751-0b84d09f-6770-4c7d-a597-ca702ab45705.png)

