### PR TITLE
fix(building-a-toast-component): Fix broken link

### DIFF
--- a/src/site/content/en/blog/building-a-toast-component/index.md
+++ b/src/site/content/en/blog/building-a-toast-component/index.md
@@ -58,7 +58,7 @@ Toasts are more passive than other notice strategies.
 ## Markup
 
 The
-[`<output>`](​​https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element)
+[`<output>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element)
 element is a good choice for the toast because it is announced to screen
 readers. Correct HTML provides a safe base for us to enhance with JavaScript and
 CSS, and there will be lots of JavaScript. 


### PR DESCRIPTION
Fixed the link by removing the two zero width spaces ([\u200B](https://www.fileformat.info/info/unicode/char/200b/index.htm)) in the URL.
Before this change the `<output>` in the articles [markup paragraph](https://web.dev/building-a-toast-component/#markup) pointed to a 404 page.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- fix broken link in [building-a-toast-component article](https://web.dev/building-a-toast-component)

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
