### PR TITLE
Purge CSS implementation for next.css

### DIFF
--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -1,29 +1,14 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-{# ONCE THE ROLLOUT IS COMPLETE, THIS CONDITION CAN BE REMOVED #}
-{% if CSS_ORIGIN === 'next' %}
-  {% include "partials/theme-script.njk" %}
+{% include "partials/theme-script.njk" %}
 
-  {% if process.env.ELEVENTY_ENV === 'prod' %}
-    {# CSS will be injected by purify-css transform. #}
-    <!-- __PURGECSS_INJECT -->
-  {% else %}
-    {# hashForProd() will cache bust the css in dev with a random string. #}
-    <link rel="stylesheet" href="{{ helpers.hashForProd('/css/next.css') }}">
-  {% endif %}
-
-{# ONCE THE ROLLOUT IS COMPLETE, THIS FALLBACK CAN BE REMOVED #}
+{% if process.env.ELEVENTY_ENV === 'prod' %}
+  {# CSS will be injected by purify-css transform. #}
+  <!-- __PURGECSS_INJECT -->
 {% else %}
-  {% if process.env.ELEVENTY_ENV === 'prod' %}
-    {# CSS will be injected by purify-css transform. #}
-    <!-- __PURGECSS_INJECT -->
-  {% else %}
-    {# hashForProd() will cache bust the css in dev with a random string. #}
-    <link rel="stylesheet" href="{{ helpers.hashForProd('/css/main.css') }}">
-  {% endif %}
-
-  <link rel="preload" as="font" crossorigin href="/fonts/material-icons/regular.woff2">
+  {# hashForProd() will cache bust the css in dev with a random string. #}
+  <link rel="stylesheet" href="{{ helpers.hashForProd('/css/next.css') }}">
 {% endif %}
 
 <link rel="preload" as="font" crossorigin href="/fonts/google-sans/regular/latin.woff2">

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -1,12 +1,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+{# ONCE THE ROLLOUT IS COMPLETE, THIS CONDITION CAN BE REMOVED #}
 {% if CSS_ORIGIN === 'next' %}
   {% include "partials/theme-script.njk" %}
-  {# hashForProd() will cache bust the css in dev with a random string. #}
-  <link rel="stylesheet" href="{{ helpers.hashForProd('/css/next.css') }}">
-  <link rel="stylesheet" href="{{ helpers.hashForProd('/css/legacy-rollout.css') }}">
-  <link rel="preload" as="font" crossorigin href="/fonts/material-icons/regular.woff2">
+
+  {% if process.env.ELEVENTY_ENV === 'prod' %}
+    {# CSS will be injected by purify-css transform. #}
+    <!-- __PURGECSS_INJECT -->
+  {% else %}
+    {# hashForProd() will cache bust the css in dev with a random string. #}
+    <link rel="stylesheet" href="{{ helpers.hashForProd('/css/next.css') }}">
+  {% endif %}
+
+{# ONCE THE ROLLOUT IS COMPLETE, THIS FALLBACK CAN BE REMOVED #}
 {% else %}
   {% if process.env.ELEVENTY_ENV === 'prod' %}
     {# CSS will be injected by purify-css transform. #}

--- a/src/site/_transforms/purify-css.js
+++ b/src/site/_transforms/purify-css.js
@@ -24,7 +24,7 @@ const stagingUrls =
   require('../../../tools/lhci/lighthouserc').ci.collect.url.map((url) =>
     path.join('dist', new URL(url).pathname, 'index.html'),
   );
-const pathToCss = 'dist/css/main.css';
+const pathToCss = 'dist/css/next.css';
 const isProd = process.env.ELEVENTY_ENV === 'prod';
 const isStaging = process.env.ELEVENTY_ENV === 'staging';
 


### PR DESCRIPTION
**Important** if—[as outlined in the wiki](https://github.com/GoogleChrome/web.dev/wiki/Design-system-rollout-and-removal-of-old-system#nextscss-to-be-name-changed)—the `next.css` name is changed to `main.css`, this implementation will need to be updated.

Fixes #6996 

Old PR