### PR TITLE
refactor(CodelabsCallout): remove old callout HTML and fix layout

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,9 @@ const Banner = require('./src/site/_includes/components/Banner');
 const Blockquote = require('./src/site/_includes/components/Blockquote');
 const Breadcrumbs = require('./src/site/_includes/components/Breadcrumbs');
 const BrowserCompat = require('./src/site/_includes/components/BrowserCompat');
-const CodelabsCallout = require('./src/site/_includes/components/CodelabsCallout');
+const {
+  CodelabsCallout,
+} = require('./src/site/_includes/components/CodelabsCallout');
 const CodePattern = require('./src/site/_includes/components/CodePattern');
 const Codepen = require('./src/site/_includes/components/Codepen');
 const Compare = require('./src/site/_includes/components/Compare');

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,9 +32,7 @@ const Banner = require('./src/site/_includes/components/Banner');
 const Blockquote = require('./src/site/_includes/components/Blockquote');
 const Breadcrumbs = require('./src/site/_includes/components/Breadcrumbs');
 const BrowserCompat = require('./src/site/_includes/components/BrowserCompat');
-const {
-  CodelabsCallout,
-} = require('./src/site/_includes/components/CodelabsCallout');
+const CodelabsCallout = require('./src/site/_includes/components/CodelabsCallout');
 const CodePattern = require('./src/site/_includes/components/CodePattern');
 const Codepen = require('./src/site/_includes/components/Codepen');
 const Compare = require('./src/site/_includes/components/Compare');

--- a/src/component-library/callout/callout.njk
+++ b/src/component-library/callout/callout.njk
@@ -12,7 +12,7 @@
       <h2 class="callout__title">{{ data.title }}</h2>
       <p>{{ data.summary }}</p>
     </div>
-    <nav class="callout__links" aria-label="{{ data.title }} links">
+    <nav class="callout__links repel" aria-label="{{ data.title }} links">
       <ul role="list">
         {% for item in data.links %}
           <li>

--- a/src/scss/blocks/_callout.scss
+++ b/src/scss/blocks/_callout.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.callout__links {
+  justify-content: end;
+}
+
 .callout__links [role='list'] {
   margin-block: 0;
   padding: 0;

--- a/src/site/_filters/find-by-url.js
+++ b/src/site/_filters/find-by-url.js
@@ -16,6 +16,7 @@
 
 const {defaultLocale} = require('../_data/site');
 const defaultLocaleRegExp = new RegExp(`^/${defaultLocale}`);
+/** @type {{[url: string]: EleventyCollectionItem}} */
 let memo;
 
 /**
@@ -25,9 +26,9 @@ let memo;
  *
  * Memoize an eleventy collection into a hash for faster lookups.
  * Important: Memoization assumes that all post urls are unique.
- * @param {Array<Object>} collection An eleventy collection.
+ * @param {EleventyCollectionItem[]} collection An eleventy collection.
  * Typically collections.all
- * @return {Array<Object>} The original collection. We return this to make
+ * @return {EleventyCollectionItem[]} The original collection. We return this to make
  * eleventy.addCollection happy since it expects a collection of some kind.
  * @see {@link https://github.com/11ty/eleventy/issues/399}
  */
@@ -52,7 +53,7 @@ const memoize = (collection) => {
  * Look up a post by its url.
  * Requires that the collection the post lives in has already been memoized.
  * @param {string} url The post url (in a form of "lang/slug") to look up.
- * @return {Object} An eleventy collection item.
+ * @return {EleventyCollectionItem} An eleventy collection item.
  */
 const findByUrl = (url) => {
   if (!url) {

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -19,6 +19,33 @@ const {findByUrl} = require('../../_filters/find-by-url');
 const md = require('../../_filters/md');
 
 /**
+ *
+ * @param {EleventyCollectionItem} codelab
+ * @returns {string}
+ */
+function renderCodelab(codelab) {
+  return html`
+    <li>
+      <a href="${codelab.url}">
+        <span>${md(codelab.data.title)}</span>
+        <!-- icons/carat-forward.svg -->
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
+          />
+        </svg>
+      </a>
+    </li>
+  `;
+}
+
+/**
  * Generates codelab links HTML.
  *
  * @param {string[]|string} slugs
@@ -35,33 +62,6 @@ function CodelabsCallout(slugs, lang) {
 
   if (!codelabs.length) {
     return;
-  }
-
-  /**
-   *
-   * @param {EleventyCollectionItem} codelab
-   * @returns {string}
-   */
-  function renderCodelab(codelab) {
-    return html`
-      <li>
-        <a href="${codelab.url}">
-          <span>${md(codelab.data.title)}</span>
-          <!-- icons/carat-forward.svg -->
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
-            />
-          </svg>
-        </a>
-      </li>
-    `;
   }
 
   return `
@@ -86,4 +86,4 @@ function CodelabsCallout(slugs, lang) {
     `;
 }
 
-module.exports = CodelabsCallout;
+module.exports = {CodelabsCallout, renderCodelab};

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -17,19 +17,15 @@
 const {html} = require('common-tags');
 const {findByUrl} = require('../../_filters/find-by-url');
 const md = require('../../_filters/md');
-const isDesignSystemContext = require('../../../lib/utils/is-design-system-context');
 
-/* NOTE: This component is in a transition period to support both new design system contexts
-and the existing system. Once the new design system has been *fully* rolled out, this component
-can be cleaned up with the following:
-
-1. The isDesignSystemContext conditional can be removed and code in that block should run as normal
-2. Everything from the '/// DELETE THIS WHEN ROLLOUT COMPLETE' comment *downwards* can be removed
-*/
-
-/* eslint-disable require-jsdoc */
-
-function CodelabCallout(slugs, lang) {
+/**
+ * Generates codelab links HTML.
+ *
+ * @param {string[]|string} slugs
+ * @param {string} lang
+ * @returns {string}
+ */
+function CodelabsCallout(slugs, lang) {
   // Coerce slugs to Array just in case someone pasted in a single slug string.
   slugs = slugs instanceof Array ? slugs : [slugs];
 
@@ -41,12 +37,36 @@ function CodelabCallout(slugs, lang) {
     return;
   }
 
-  /// UN-FENCE CODE IN THIS BLOCK WHEN ROLLOUT COMPLETE
-  // prettier-ignore
-  if (isDesignSystemContext(this.page.filePathStem)) {
-    return `
+  /**
+   *
+   * @param {EleventyCollectionItem} codelab
+   * @returns {string}
+   */
+  function renderCodelab(codelab) {
+    return html`
+      <li>
+        <a href="${codelab.url}">
+          <span>${md(codelab.data.title)}</span>
+          <!-- icons/carat-forward.svg -->
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
+            />
+          </svg>
+        </a>
+      </li>
+    `;
+  }
+
+  return `
       <aside class="callout bg-quaternary-box-bg color-quaternary-box-text">
-        <div class="repel">
+        <div class="auto-grid">
           <div class="callout__content flow">
             <div class="callout__branding cluster gutter-base">
               <!-- icons/code.svg -->
@@ -58,50 +78,12 @@ function CodelabCallout(slugs, lang) {
           </div>
           <nav class="callout__links" aria-label="Codelabs links">
             <ul role="list">
-              ${codelabs.map(codelab => html`
-                <li>
-                  <a href="${codelab.url}">
-                    <span>${md(codelab.data.title)}</span>
-                    <!-- icons/carat-forward.svg -->
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"/></svg>
-                  </a>
-                </li>
-              `).join('')}
+              ${codelabs.map(renderCodelab).join('')}
             </ul>
           </nav>
         </div>
       </aside>
-    `
-  }
-
-  /// DELETE THIS WHEN ROLLOUT COMPLETE
-  function renderCodelab(codelab) {
-    return html`
-      <li class="w-callout__listitem">
-        <a
-          class="w-callout__link w-callout__link--codelab"
-          href="${codelab.url}"
-        >
-          ${md(codelab.data.title)}
-        </a>
-      </li>
     `;
-  }
-
-  return html`
-    <div class="w-callout w-callout--2col">
-      <div class="w-callout__header">
-        <h2 class="w-callout__lockup w-callout__lockup--codelab">Codelabs</h2>
-        <div class="w-callout__headline">See it in action</div>
-        <div class="w-callout__blurb">
-          Learn more and put this guide into action.
-        </div>
-      </div>
-      <ul class="w-unstyled-list w-callout__list">
-        ${codelabs.map(renderCodelab)}
-      </ul>
-    </div>
-  `;
 }
 
-module.exports = CodelabCallout;
+module.exports = CodelabsCallout;

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -49,7 +49,7 @@ function CodelabsCallout(slugs, lang) {
             <h2 class="callout__title">See it in action</h2>
             <p>Learn more and put this guide into action.</p>
           </div>
-          <nav class="callout__links" aria-label="Codelabs links">
+          <nav class="callout__links repel" aria-label="Codelabs links">
             <ul role="list">
               ${codelabs.map(CodelabsCallout.renderCodelab).join('')}
             </ul>

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -19,33 +19,6 @@ const {findByUrl} = require('../../_filters/find-by-url');
 const md = require('../../_filters/md');
 
 /**
- *
- * @param {EleventyCollectionItem} codelab
- * @returns {string}
- */
-function renderCodelab(codelab) {
-  return html`
-    <li>
-      <a href="${codelab.url}">
-        <span>${md(codelab.data.title)}</span>
-        <!-- icons/carat-forward.svg -->
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
-          />
-        </svg>
-      </a>
-    </li>
-  `;
-}
-
-/**
  * Generates codelab links HTML.
  *
  * @param {string[]|string} slugs
@@ -78,7 +51,7 @@ function CodelabsCallout(slugs, lang) {
           </div>
           <nav class="callout__links" aria-label="Codelabs links">
             <ul role="list">
-              ${codelabs.map(renderCodelab).join('')}
+              ${codelabs.map(CodelabsCallout.renderCodelab).join('')}
             </ul>
           </nav>
         </div>
@@ -86,4 +59,30 @@ function CodelabsCallout(slugs, lang) {
     `;
 }
 
-module.exports = {CodelabsCallout, renderCodelab};
+/**
+ * @param {EleventyCollectionItem} codelab
+ * @returns {string}
+ */
+CodelabsCallout.renderCodelab = function (codelab) {
+  return html`
+    <li>
+      <a href="${codelab.url}">
+        <span>${md(codelab.data.title)}</span>
+        <!-- icons/carat-forward.svg -->
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
+          />
+        </svg>
+      </a>
+    </li>
+  `;
+};
+
+module.exports = CodelabsCallout;

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -64,22 +64,20 @@ function CodelabsCallout(slugs, lang) {
  * @returns {string}
  */
 CodelabsCallout.renderCodelab = function (codelab) {
+  const svg = html`<svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z" />
+  </svg>`;
   return html`
     <li>
       <a href="${codelab.url}">
         <span>${md(codelab.data.title)}</span>
-        <!-- icons/carat-forward.svg -->
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m8 7.34 4.58 4.365L8 16.07l1.41 1.34 6-5.705L9.41 6 8 7.34Z"
-          />
-        </svg>
+        ${svg}
       </a>
     </li>
   `;

--- a/src/site/content/en/lighthouse-seo/http-status-code/index.md
+++ b/src/site/content/en/lighthouse-seo/http-status-code/index.md
@@ -7,6 +7,8 @@ date: 2019-05-02
 updated: 2019-08-21
 web_lighthouse:
   - http-status-code
+codelabs:
+  - codelab-fix-sneaky-404
 ---
 
 Servers provide a three-digit [HTTP status code](https://developer.mozilla.org/docs/Web/HTTP/Status)
@@ -56,5 +58,3 @@ complicated. Learn how to [fix sneaky 404s in an Express application](/codelab-f
 
 - [Source code for **Page has unsuccessful HTTP status code** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/seo/http-status-code.js)
 - [HTTP response status codes](https://developer.mozilla.org/docs/Web/HTTP/Status)
-
-{% CodelabsCallout 'codelab-fix-sneaky-404', lang %}

--- a/test/unit/src/site/_filters/find-by-url.js
+++ b/test/unit/src/site/_filters/find-by-url.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {expect} = require('chai');
+const {
+  memoize,
+  findByUrl,
+} = require('../../../../../src/site/_filters/find-by-url');
+
+const collectionAll = /** @type {EleventyCollectionItem[]} */ ([
+  {url: '/en/foo/bar/', data: {title: 'foobar'}},
+  {url: '/en/foo-bar/', data: {title: 'foobar'}},
+  {url: '/en/foobar/', data: {title: 'foobar'}},
+  {url: '/es/fizzbuzz/', data: {title: 'fizzbuzz'}},
+]);
+
+describe('find-by-url', function () {
+  describe('memoize', function () {
+    it('creates memo when there are no duplicates', async function () {
+      expect(() => memoize(collectionAll)).not.to.throw();
+    });
+
+    it('throws error when duplicate URLs provided', async function () {
+      const duplicates = [...collectionAll, ...collectionAll];
+      expect(() => memoize(duplicates)).to.throw();
+    });
+
+    it("throws error when an array isn't passed in", async function () {
+      ['foobar', 2, true, {}, Date].forEach((i) => {
+        //@ts-ignore
+        expect(() => memoize(i)).to.throw();
+      });
+    });
+  });
+
+  describe('findByUrl', function () {
+    it('returns url in memo', async function () {
+      memoize(collectionAll);
+      expect(findByUrl(collectionAll[0].url)).to.deep.equal(collectionAll[0]);
+    });
+
+    it('throws error when no URL provided', async function () {
+      //@ts-ignore
+      expect(() => findByUrl()).to.throw();
+    });
+
+    it('returns `undefined` when url not found', async function () {
+      expect(findByUrl('pop/foo-bar')).to.deep.equal(undefined);
+    });
+  });
+});

--- a/test/unit/src/site/_filters/index.js
+++ b/test/unit/src/site/_filters/index.js
@@ -1,6 +1,7 @@
 describe('_filters', function () {
   require('./algolia-item');
   require('./capitalize');
+  require('./find-by-url');
   require('./is-new-content');
   require('./is-live');
 });

--- a/test/unit/src/site/_includes/components/CodelabsCallout.js
+++ b/test/unit/src/site/_includes/components/CodelabsCallout.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {expect} = require('chai');
+const cheerio = require('cheerio');
+const {memoize} = require('../../../../../../src/site/_filters/find-by-url');
+const {
+  CodelabsCallout,
+  renderCodelab,
+} = require('../../../../../../src/site/_includes/components/CodelabsCallout');
+
+const collectionAll = /** @type {EleventyCollectionItem[]} */ ([
+  {url: '/en/foo/bar/', data: {title: 'foobar'}},
+  {url: '/en/foo-bar/', data: {title: 'foobar'}},
+  {url: '/en/foobar/', data: {title: 'foobar'}},
+  {url: '/es/fizzbuzz/', data: {title: 'fizzbuzz'}},
+]);
+
+describe('CodelabsCallout', function () {
+  describe('CodelabsCallout', function () {
+    it('returns call out with correct links', async function () {
+      memoize(collectionAll);
+      const html = CodelabsCallout(
+        collectionAll.map((i) =>
+          i.url.replace(/^\/([a-z]{2})\//, '').replace(/\/$/, ''),
+        ),
+        'en',
+      );
+      const $ = cheerio.load(html);
+      const li = $('li');
+      expect(li.length).to.equal(3);
+    });
+
+    it('returns nothing if URLs not found', async function () {
+      const html = CodelabsCallout(
+        collectionAll.map((i) => i.url + '/pop'),
+        'en',
+      );
+      expect(html).to.equal(undefined);
+    });
+  });
+
+  describe('renderCodelab', function () {
+    it('creates links for codelabs', async function () {
+      collectionAll.forEach((item) => {
+        const html = renderCodelab(item);
+        const $ = cheerio.load(html);
+        expect($('a').attr('href')).to.equal(item.url);
+        expect($('span').text()).to.equal(item.data.title);
+      });
+    });
+  });
+});

--- a/test/unit/src/site/_includes/components/CodelabsCallout.js
+++ b/test/unit/src/site/_includes/components/CodelabsCallout.js
@@ -18,10 +18,7 @@
 const {expect} = require('chai');
 const cheerio = require('cheerio');
 const {memoize} = require('../../../../../../src/site/_filters/find-by-url');
-const {
-  CodelabsCallout,
-  renderCodelab,
-} = require('../../../../../../src/site/_includes/components/CodelabsCallout');
+const CodelabsCallout = require('../../../../../../src/site/_includes/components/CodelabsCallout');
 
 const collectionAll = /** @type {EleventyCollectionItem[]} */ ([
   {url: '/en/foo/bar/', data: {title: 'foobar'}},
@@ -54,10 +51,10 @@ describe('CodelabsCallout', function () {
     });
   });
 
-  describe('renderCodelab', function () {
+  describe('CodelabsCallout.renderCodelab', function () {
     it('creates links for codelabs', async function () {
       collectionAll.forEach((item) => {
-        const html = renderCodelab(item);
+        const html = CodelabsCallout.renderCodelab(item);
         const $ = cheerio.load(html);
         expect($('a').attr('href')).to.equal(item.url);
         expect($('span').text()).to.equal(item.data.title);

--- a/test/unit/src/site/_includes/components/index.js
+++ b/test/unit/src/site/_includes/components/index.js
@@ -1,4 +1,5 @@
 describe('components', function () {
   require('./Author');
   require('./AuthorsDate');
+  require('./CodelabsCallout');
 });


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove old HTML.
- Fix layout of links to message so they're side by side like old design.
- Add some typings to functions for code quality.
- Add tests.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
