### PR TITLE
Add DLC to Launch Handler migration info

### DIFF
--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -9,7 +9,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-19
-updated: 2021-12-21
+updated: 2021-12-22
 description: |
   Declarative Link Capturing is a proposal for a web app manifest property called
   "capture_links" that lets developers determine declaratively what should happen when the browser
@@ -36,12 +36,11 @@ Declarative Link Capturing API, you should
 Clicking links on the web can sometimes be a pleasant surprise. For example, clicking a web page
 link to YouTube on a mobile device opens the YouTube iOS or Android app, if it is installed. But
 when you install the [YouTube PWA](https://www.youtube.com/) on a desktop computer and click a link,
-it opens in… 🥁 a browser tab.
+it opens in a browser tab.
 
 But it gets more complex. What if the link appears not in a website, but in a chat message that you
-receive in one of Google's chat apps? On desktop operating systems that have the notion of separate
-app windows, if the app is open already, should a new window or tab be created for each link click
-that is captured? When you think about it, there are many ways links and navigations can be
+receive in one of Google's chat apps? On desktop operating systems, which have the notion of separate
+app windows, if the app is open already, should a new window or tab be created for each link click? When you think about it, there are many ways links and navigations can be
 captured, including, but not limited to, the following:
 
 - Clicked links from other web pages.
@@ -178,12 +177,12 @@ management settings page.
 {% Img src="image/ttTommHYbJXsEL29zNB1wXBvH4z1/WJ2KPqFUjqJABNYQUEN9.png", alt="Example of an installed app's settings page.", width="800", height="449" %}
 
 Link capturing is a Chrome&nbsp;OS-only feature for now; support for Windows, macOS, and Linux is
-still in progress.
+in progress.
 
 ### Launch Handler API
 
 The control of an incoming navigation is migrated to Launch Handler API, which allows web apps to
-decide how a web app launches at various situations, such as link capturing, share target or file
+decide how a web app launches in various situations such as link capturing, share target or file
 handling, etc. To migrate from the Declarative Link Capturing API to the Launch Handler API:
 
 1.  Register your site for the
@@ -191,18 +190,18 @@ handling, etc. To migrate from the Declarative Link Capturing API to the Launch 
     and place the origin trial key into your web app.
 1.  Add a `"launch_handler"` entry to your site's manifest.
 
-    - If you are using `"capture_links": "new-client"`, then
+    - To use `"capture_links": "new-client"`,
       add:`"launch_handler": { "route_to": "new-client" }`
-    - If you are using `"capture_links": "existing-client-navigate"`, then add:
+    - To use `"capture_links": "existing-client-navigate"`, add:
       `"launch_handler": { "route_to": "existing-client" }`
     - If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented
       in the Declarative Link Capturing origin trial), then add:
       `json { "launch_handler": { "route_to": "existing-client", "navigate_existing_client": "never" } } `
-            **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript via the `window.launchQueue.setConsumer()` API to enable navigation.
+            **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript by calling `window.launchQueue.setConsumer()` to enable navigation.
 
-1.  Keep the `capture_links` field and Declarative Link Capturing origin trial registration until
-    March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the
-    web app at a captured link.
+The `capture_links` field and Declarative Link Capturing origin trial registration are good until
+March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the
+web app at a captured link.
 
 For more details, check out [Control how your app is launched](/launch-handler/).
 

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -9,7 +9,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2021-05-19
-updated: 2021-12-20
+updated: 2021-12-21
 description: |
   Declarative Link Capturing is a proposal for a web app manifest property called
   "capture_links" that lets developers determine declaratively what should happen when the browser
@@ -157,23 +157,23 @@ site to navigate an existing window to a new page, overriding the default HTML n
 ## Migrate to Launch Handler API {: #migration }
 
 The Declarative Link Capturing API [origin trial](https://developer.chrome.com/origintrials/#/view_trial/4285175045443026945)
-is set to [expire on March 30, 2022](https://groups.google.com/a/chromium.org/g/blink-dev/c/2c4bul4V3GQ/m/Anluh1txBQAJ)
-for Chrome M97 and below. It will be replaced by a set of [new features and APIs](https://docs.google.com/document/d/1w9qHqVJmZfO07kbiRMd9lDQMW15DeK5o-p-rZyL7twk/edit)
-in Chrome 98 and above, which includes user-enabled link capturing and [Launch Handler API](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
+is set to [expire on March&nbsp;30, 2022](https://groups.google.com/a/chromium.org/g/blink-dev/c/2c4bul4V3GQ/m/Anluh1txBQAJ)
+for Chromium&nbsp;97 and below. It will be replaced by a set of [new features and APIs](https://docs.google.com/document/d/1w9qHqVJmZfO07kbiRMd9lDQMW15DeK5o-p-rZyL7twk/edit)
+in Chromium&nbsp;98 and above, which includes user-enabled link capturing and [Launch Handler API](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
 
 ### Link Capturing
 
-In Chrome 98, automatic link capturing is now a user opt-in behaviour rather than granted at install
+In Chromium&nbsp;98, automatic link capturing is now a user opt-in behavior rather than granted at install
 time to a web app. To enable link capturing, a user needs to launch an installed app from the browser
-using “Open with” and choose “Remember my choice”:
+using **Open with** and choose **Remember my choice**.
 
 {% Img src="image/ttTommHYbJXsEL29zNB1wXBvH4z1/rbFk5LtzHMlN3zRVpekf.png", alt="Example of an installed app's 'Open with' setting with the 'Remember my choice' option enabled.", width="385", height="277" %}
 
-Alternatively, users can switch link capturing on or off for a specific web app in the app management settings page:
+Alternatively, users can switch link capturing on or off for a specific web app in the app management settings page.
 
 {% Img src="image/ttTommHYbJXsEL29zNB1wXBvH4z1/WJ2KPqFUjqJABNYQUEN9.png", alt="Example of an installed app's settings page.", width="800", height="449" %}
 
-Link capturing is a Chrome OS only feature for now; support for Windows/Mac/Linux is still in progress.
+Link capturing is a Chrome&nbsp;OS-only feature for now; support for Windows, macOS, and Linux is still in progress.
 
 ### Launch Handler API
 
@@ -182,20 +182,22 @@ how a web app launches at various situations, such as link capturing, share targ
 To migrate from the Declarative Link Capturing API to the Launch Handler API:
 
 1. Register your site for the [Launch Handler origin trial](https://developer.chrome.com/origintrials/#/view_trial/2978005253598740481) and place the origin trial key into your web app.
-1. Add a `"launch_handler"` entry to your site’s manifest.
-   -  If you are using `"capture_links": "new-client"` then add:`"launch_handler": { "route_to": "new-client" }`
-   -  If you are using `"capture_links": "existing-client-navigate"` then add: `"launch_handler": { "route_to": "existing-client" }`
-   -  If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented in the Declarative Link Capturing origin trial) then add:
+1. Add a `"launch_handler"` entry to your site's manifest.
+   -  If you are using `"capture_links": "new-client"`, then add:`"launch_handler": { "route_to": "new-client" }`
+   -  If you are using `"capture_links": "existing-client-navigate"`, then add: `"launch_handler": { "route_to": "existing-client" }`
+   -  If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented in the Declarative Link Capturing origin trial), then add:
       ```json
-      "launch_handler": {
-        "route_to": "existing-client",
-        "navigate_existing_client": "never",
-      } 
+{
+   "launch_handler": {
+     "route_to": "existing-client",
+     "navigate_existing_client": "never"
+   }
+} 
       ```
       
       **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript via the `window.launchQueue.setConsumer()` API to enable navigation.
 
-1. Keep the `capture_links` field and Declarative Link Capturing origin trial registration until March 30, 2022. This will ensure users on Chrome 97 and below can still launch the web app at a captured link.
+1. Keep the `capture_links` field and Declarative Link Capturing origin trial registration until March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the web app at a captured link.
 
 For more details, check out [Control how your app is launched](/launch-handler/).
  

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -197,7 +197,7 @@ To migrate from the Declarative Link Capturing API to the Launch Handler API:
 
 1. Keep the `capture_links` field and Declarative Link Capturing origin trial registration until March 30, 2022. This will ensure users on Chrome 97 and below can still launch the web app at a captured link.
 
-For more details, check out [Control how your app is launched](http://localhost:8080/launch-handler/).
+For more details, check out [Control how your app is launched](/launch-handler/).
  
 ## Feedback {: #feedback }
 

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -25,25 +25,24 @@ tags:
 ---
 
 {% Aside 'caution' %} Declarative Link Capturing was part of the
-[capabilities project](/fugu-status/).
-The engineering team has decided that Declarative Link Capturing will _not_
-launch with its current design. Instead, the feature has been redesigned as
-described in [Control how your app is launched](/launch-handler/). If your
-app implements the Declarative Link Capturing API, you should
-[transition to the replacement Launch Handler API](#migration).
-{% endAside %}
+[capabilities project](/fugu-status/). The engineering team has decided that Declarative Link
+Capturing will _not_ launch with its current design. Instead, the feature has been redesigned as
+described in [Control how your app is launched](/launch-handler/). If your app implements the
+Declarative Link Capturing API, you should
+[transition to the replacement Launch Handler API](#migration). {% endAside %}
 
 ## What is Declarative Link Capturing? {: #what }
 
-Clicking links on the web can sometimes be a pleasant surprise. For example, clicking a web page link to YouTube on a mobile device opens the YouTube iOS or Android app, if it is installed.
-But when you install the [YouTube PWA](https://www.youtube.com/) on a desktop computer and click a
-link, it opens in… 🥁 a browser tab.
+Clicking links on the web can sometimes be a pleasant surprise. For example, clicking a web page
+link to YouTube on a mobile device opens the YouTube iOS or Android app, if it is installed. But
+when you install the [YouTube PWA](https://www.youtube.com/) on a desktop computer and click a link,
+it opens in… 🥁 a browser tab.
 
 But it gets more complex. What if the link appears not in a website, but in a chat message that you
-receive in one of Google's chat apps? On desktop operating systems that have the notion of
-separate app windows, if the app is open already, should a new window or tab be created for each
-link click that is captured? When you think about it, there are many ways links and navigations can
-be captured, including, but not limited to, the following:
+receive in one of Google's chat apps? On desktop operating systems that have the notion of separate
+app windows, if the app is open already, should a new window or tab be created for each link click
+that is captured? When you think about it, there are many ways links and navigations can be
+captured, including, but not limited to, the following:
 
 - Clicked links from other web pages.
 - URL launches from a platform-specific app in the operating system.
@@ -53,18 +52,18 @@ be captured, including, but not limited to, the following:
 - Navigations caused by the [Share Target API](/web-share-target/).
 - …and others.
 
-Declarative Link Capturing is a proposal for a web app manifest property called
-`"capture_links"` that lets developers determine declaratively what should happen when the browser
-is asked to navigate to a URL that is within the application's navigation scope, from a context
-outside of the navigation scope. This proposal does not apply if the user is already within the
-navigation scope (for instance, if the user has a browser tab open that is within scope, and clicks
-an internal link).
+Declarative Link Capturing is a proposal for a web app manifest property called `"capture_links"`
+that lets developers determine declaratively what should happen when the browser is asked to
+navigate to a URL that is within the application's navigation scope, from a context outside of the
+navigation scope. This proposal does not apply if the user is already within the navigation scope
+(for instance, if the user has a browser tab open that is within scope, and clicks an internal
+link).
 
-{% Aside 'key-term' %} The [navigation scope](https://web.dev/add-manifest/#scope) of a web
-app manifest is the `"scope"` item of a processed manifest. The navigation scope restricts
-the set of URLs to which an application context can be navigated while the manifest is applied. If
-the `"scope"` member is not present in the manifest, it defaults to the parent path of the
-`"start_url"` member. {% endAside %}
+{% Aside 'key-term' %} The [navigation scope](https://web.dev/add-manifest/#scope) of a web app
+manifest is the `"scope"` item of a processed manifest. The navigation scope restricts the set of
+URLs to which an application context can be navigated while the manifest is applied. If the
+`"scope"` member is not present in the manifest, it defaults to the parent path of the `"start_url"`
+member. {% endAside %}
 
 Some special conditions like middle-clicking a link (or right-clicking and then "open in new tab")
 would typically not trigger the link capturing behavior. Whether a link is `target=_self` or
@@ -106,26 +105,27 @@ To experiment with Declarative Link Capturing locally, without an origin trial t
 ## How to use Declarative Link Capturing? {: #use }
 
 Developers can declaratively determine how links should be captured by leveraging the additional web
-app manifest field `"capture_links"`. It takes a string or a an array of strings as its
-value. If an array of strings is given, the user agent chooses the first supported item in the list,
-defaulting to `"none"`. The following values are supported:
+app manifest field `"capture_links"`. It takes a string or a an array of strings as its value. If an
+array of strings is given, the user agent chooses the first supported item in the list, defaulting
+to `"none"`. The following values are supported:
 
 - `"none"` (the default): No link capturing; links clicked leading to this PWA scope navigate as
   normal without opening a PWA window.
 - `"new-client"`: Each clicked link opens a new PWA window at that URL.
-- `"existing-client-navigate"`: The clicked link opens in an existing PWA window, if one is available, or in a new window if it is not. If more than one PWA
-  window exists, the browser may choose one arbitrarily. This behaves like `"new-client"` if no
-  window is currently open. 🚨 Careful! This option potentially leads to data loss, as pages can be
-  arbitrarily navigated away from. Sites should be aware that they are opting into such behavior by
-  choosing this option. This option works best for "read-only" sites that do not hold user data in
-  memory, such as music players. If the page being navigated away from has a
+- `"existing-client-navigate"`: The clicked link opens in an existing PWA window, if one is
+  available, or in a new window if it is not. If more than one PWA window exists, the browser may
+  choose one arbitrarily. This behaves like `"new-client"` if no window is currently open. 🚨
+  Careful! This option potentially leads to data loss, as pages can be arbitrarily navigated away
+  from. Sites should be aware that they are opting into such behavior by choosing this option. This
+  option works best for "read-only" sites that do not hold user data in memory, such as music
+  players. If the page being navigated away from has a
   [`beforeunload` event](https://developer.mozilla.org/docs/Web/API/WindowEventHandlers/onbeforeunload),
   the user would see the prompt before the navigation completes.
 
-{% Aside %} There is discussion about adding options that do not open
-a window at all, but instead fire a `launch` event in a chosen foreground window or the service
-worker. See the [`launch` event explainer](https://github.com/WICG/sw-launch/blob/main/explainer.md)
-for details, and, more specifically, the sections on
+{% Aside %} There is discussion about adding options that do not open a window at all, but instead
+fire a `launch` event in a chosen foreground window or the service worker. See the
+[`launch` event explainer](https://github.com/WICG/sw-launch/blob/main/explainer.md) for details,
+and, more specifically, the sections on
 [`existing-client-event`](https://github.com/WICG/sw-launch/blob/main/declarative_link_capturing.md#:~:text=completes-,existing-client-event,-when)
 and
 [`service-worker`](https://github.com/WICG/sw-launch/blob/main/declarative_link_capturing.md#:~:text=future-,serviceworker,-doesn).
@@ -138,9 +138,9 @@ The demo for Declarative Link Capturing actually consists of two demos that inte
 1. [https://continuous-harvest-tomato.glitch.me/](https://continuous-harvest-tomato.glitch.me/)
 1. [https://hill-glitter-tree.glitch.me/](https://hill-glitter-tree.glitch.me/)
 
-The screencast below shows how the two interact. They show two different behaviors,
-`"new-client"` and `"existing-client-navigate"`. Be sure to test the apps in different states,
-running in a tab or as an installed PWA, to see the difference in behavior.
+The screencast below shows how the two interact. They show two different behaviors, `"new-client"`
+and `"existing-client-navigate"`. Be sure to test the apps in different states, running in a tab or
+as an installed PWA, to see the difference in behavior.
 
 {% Video src="video/8WbTDNrhLsU0El80frMBGE4eMCD3/pj3ehpntEg50WcnA2khM.webm", autoplay=true, muted=true, playsinline=true, loop=true %}
 
@@ -156,51 +156,56 @@ site to navigate an existing window to a new page, overriding the default HTML n
 
 ## Migrate to Launch Handler API {: #migration }
 
-The Declarative Link Capturing API [origin trial](https://developer.chrome.com/origintrials/#/view_trial/4285175045443026945)
-is set to [expire on March&nbsp;30, 2022](https://groups.google.com/a/chromium.org/g/blink-dev/c/2c4bul4V3GQ/m/Anluh1txBQAJ)
-for Chromium&nbsp;97 and below. It will be replaced by a set of [new features and APIs](https://docs.google.com/document/d/1w9qHqVJmZfO07kbiRMd9lDQMW15DeK5o-p-rZyL7twk/edit)
-in Chromium&nbsp;98 and above, which includes user-enabled link capturing and [Launch Handler API](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
+The Declarative Link Capturing API
+[origin trial](https://developer.chrome.com/origintrials/#/view_trial/4285175045443026945) is set to
+[expire on March&nbsp;30, 2022](https://groups.google.com/a/chromium.org/g/blink-dev/c/2c4bul4V3GQ/m/Anluh1txBQAJ)
+for Chromium&nbsp;97 and below. It will be replaced by a set of
+[new features and APIs](https://docs.google.com/document/d/1w9qHqVJmZfO07kbiRMd9lDQMW15DeK5o-p-rZyL7twk/edit)
+in Chromium&nbsp;98 and above, which includes user-enabled link capturing and
+[Launch Handler API](https://github.com/WICG/sw-launch/blob/main/launch_handler.md).
 
 ### Link Capturing
 
-In Chromium&nbsp;98, automatic link capturing is now a user opt-in behavior rather than granted at install
-time to a web app. To enable link capturing, a user needs to launch an installed app from the browser
-using **Open with** and choose **Remember my choice**.
+In Chromium&nbsp;98, automatic link capturing is now a user opt-in behavior rather than granted at
+install time to a web app. To enable link capturing, a user needs to launch an installed app from
+the browser using **Open with** and choose **Remember my choice**.
 
 {% Img src="image/ttTommHYbJXsEL29zNB1wXBvH4z1/rbFk5LtzHMlN3zRVpekf.png", alt="Example of an installed app's 'Open with' setting with the 'Remember my choice' option enabled.", width="385", height="277" %}
 
-Alternatively, users can switch link capturing on or off for a specific web app in the app management settings page.
+Alternatively, users can switch link capturing on or off for a specific web app in the app
+management settings page.
 
 {% Img src="image/ttTommHYbJXsEL29zNB1wXBvH4z1/WJ2KPqFUjqJABNYQUEN9.png", alt="Example of an installed app's settings page.", width="800", height="449" %}
 
-Link capturing is a Chrome&nbsp;OS-only feature for now; support for Windows, macOS, and Linux is still in progress.
+Link capturing is a Chrome&nbsp;OS-only feature for now; support for Windows, macOS, and Linux is
+still in progress.
 
 ### Launch Handler API
 
-The control of an incoming navigation is migrated to Launch Handler API, which allows web apps to decide
-how a web app launches at various situations, such as link capturing, share target or file handling, etc.
-To migrate from the Declarative Link Capturing API to the Launch Handler API:
+The control of an incoming navigation is migrated to Launch Handler API, which allows web apps to
+decide how a web app launches at various situations, such as link capturing, share target or file
+handling, etc. To migrate from the Declarative Link Capturing API to the Launch Handler API:
 
-1. Register your site for the [Launch Handler origin trial](https://developer.chrome.com/origintrials/#/view_trial/2978005253598740481) and place the origin trial key into your web app.
-1. Add a `"launch_handler"` entry to your site's manifest.
-   -  If you are using `"capture_links": "new-client"`, then add:`"launch_handler": { "route_to": "new-client" }`
-   -  If you are using `"capture_links": "existing-client-navigate"`, then add: `"launch_handler": { "route_to": "existing-client" }`
-   -  If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented in the Declarative Link Capturing origin trial), then add:
-      ```json
-{
-   "launch_handler": {
-     "route_to": "existing-client",
-     "navigate_existing_client": "never"
-   }
-} 
-      ```
-      
-      **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript via the `window.launchQueue.setConsumer()` API to enable navigation.
+1.  Register your site for the
+    [Launch Handler origin trial](https://developer.chrome.com/origintrials/#/view_trial/2978005253598740481)
+    and place the origin trial key into your web app.
+1.  Add a `"launch_handler"` entry to your site's manifest.
 
-1. Keep the `capture_links` field and Declarative Link Capturing origin trial registration until March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the web app at a captured link.
+    - If you are using `"capture_links": "new-client"`, then
+      add:`"launch_handler": { "route_to": "new-client" }`
+    - If you are using `"capture_links": "existing-client-navigate"`, then add:
+      `"launch_handler": { "route_to": "existing-client" }`
+    - If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented
+      in the Declarative Link Capturing origin trial), then add:
+      `json { "launch_handler": { "route_to": "existing-client", "navigate_existing_client": "never" } } `
+            **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript via the `window.launchQueue.setConsumer()` API to enable navigation.
+
+1.  Keep the `capture_links` field and Declarative Link Capturing origin trial registration until
+    March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the
+    web app at a captured link.
 
 For more details, check out [Control how your app is launched](/launch-handler/).
- 
+
 ## Feedback {: #feedback }
 
 The Chromium team wants to hear about your experiences with Declarative Link Capturing.
@@ -242,12 +247,13 @@ and let us know where and how you are using it.
 Declarative Link Capturing was specified by [Matt Giuca](https://twitter.com/mgiuca) with input from
 Alan Cutter and [Dominick Ng](https://twitter.com/dominickng). The API was implemented by Alan
 Cutter. This article was reviewed by [Joe Medley](https://github.com/jpmedley), Matt Giuca, Alan
-Cutter, and [Shunya Shishido](https://github.com/sisidovski).
-Hero image by [Zulmaury Saavedra](https://unsplash.com/@zulmaury) on
+Cutter, and [Shunya Shishido](https://github.com/sisidovski). Hero image by
+[Zulmaury Saavedra](https://unsplash.com/@zulmaury) on
 [Unsplash](https://unsplash.com/photos/zh0J32MrJfA).
 
 [explainer]: https://github.com/WICG/sw-launch/blob/main/declarative_link_capturing.md
 [issues]: https://github.com/WICG/sw-launch/issues/
 [spec]: https://github.com/w3c/manifest/issues/764
-[powerful-apis]: https://chromium.googlesource.com/chromium/src/+/lkgr/docs/security/permissions-for-powerful-web-platform-features.md
+[powerful-apis]:
+  https://chromium.googlesource.com/chromium/src/+/lkgr/docs/security/permissions-for-powerful-web-platform-features.md
 [cr-dev-twitter]: https://twitter.com/ChromiumDev

--- a/src/site/content/en/blog/declarative-link-capturing/index.md
+++ b/src/site/content/en/blog/declarative-link-capturing/index.md
@@ -191,13 +191,15 @@ handling, etc. To migrate from the Declarative Link Capturing API to the Launch 
 1.  Add a `"launch_handler"` entry to your site's manifest.
 
     - To use `"capture_links": "new-client"`,
-      add:`"launch_handler": { "route_to": "new-client" }`
+      add:`"launch_handler": { "route_to": "new-client" }`.
     - To use `"capture_links": "existing-client-navigate"`, add:
-      `"launch_handler": { "route_to": "existing-client" }`
-    - If you wanted to use `"capture_links": "existing-client-event"` (which was never implemented
-      in the Declarative Link Capturing origin trial), then add:
-      `json { "launch_handler": { "route_to": "existing-client", "navigate_existing_client": "never" } } `
-            **Note**: With this option, pages in your app scope will no longer navigate automatically when a link navigation is captured. You must handle the `LaunchParams` in JavaScript by calling `window.launchQueue.setConsumer()` to enable navigation.
+      `"launch_handler": { "route_to": "existing-client" }`.
+    - To use `"capture_links": "existing-client-event"` (which was never implemented
+      in the Declarative Link Capturing origin trial), add:
+      `{ "launch_handler": { "route_to": "existing-client", "navigate_existing_client": "never" } }`.
+      With this option, pages in your app scope will no longer navigate automatically when a link
+      navigation is captured. You must handle the `LaunchParams` in JavaScript by calling
+      `window.launchQueue.setConsumer()` to enable navigation.
 
 The `capture_links` field and Declarative Link Capturing origin trial registration are good until
 March&nbsp;30, 2022. This will ensure users on Chromium&nbsp;97 and below can still launch the


### PR DESCRIPTION
Changes proposed in this pull request:

- Add information for migrating from Declarative Link Handling to Launch Handler API
- Introduces new Link Capturing user-enabled feature in Chrome


