### PR TITLE
fix: content overflow of code-pattern.scss component

### DIFF
--- a/src/styles/components/_code-pattern.scss
+++ b/src/styles/components/_code-pattern.scss
@@ -26,6 +26,7 @@
 
   .code-pattern__assets {
     border: 1px solid $BORDER_COLOR;
+    overflow: scroll;
 
     @include bp(md) {
       max-width: 426px; // Fix width to prevent the grid blowout (in Chrome 93)


### PR DESCRIPTION
Fix bug of content overflow in all the code components within [web.dev/patterns](url)

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7088 , #7063,

Changes proposed in this pull request:

- Fix content overflow in contents that uses code-pattern component.
- Add `overflow: scroll` property to .code-pattern__content class

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
