### PR TITLE
Fix meta viewport tag content

### DIFF
--- a/src/site/content/en/learn/design/intro/index.md
+++ b/src/site/content/en/learn/design/intro/index.md
@@ -214,7 +214,7 @@ If you're using responsive design you need to tell the browser not to do that sc
 You can do that with a `meta` element in the `head` of the web page:
 
 ```html
-<meta name="viewport" value="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 ```
 
 There are two values, separated by commas. 

--- a/src/site/content/en/learn/design/media-queries/media-queries.assess.yml
+++ b/src/site/content/en/learn/design/media-queries/media-queries.assess.yml
@@ -43,7 +43,7 @@ questions:
         rationale: "Try again!"
       - content: "`font-size: 200%`"
         rationale: "Try again!"
-      - content: '`<meta name="viewport" value="width=device-width, initial-scale=1">`'
+      - content: '`<meta name="viewport" content="width=device-width, initial-scale=1">`'
         rationale: "🎉"
       - content: "Media Queries"
         rationale: "Try again!"


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7105

Changes proposed in this pull request:

- Fix meta viewport code samples to use the correct attribute: "content"
- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attributes
