### PR TITLE
Add nested shadowRoot support to DSD pollyfill

### DIFF
--- a/src/site/content/en/blog/declarative-shadow-dom/index.md
+++ b/src/site/content/en/blog/declarative-shadow-dom/index.md
@@ -456,21 +456,15 @@ on their parent element. This process can be done once the document is ready, or
 specific events like Custom Element lifecycles.
 
 ```js
-(function() {
-  function attachShadowRoots(documentFragment) {
-    documentFragment
-      .querySelectorAll("template[shadowroot]")
-      .forEach(template => {
-        const mode = template.getAttribute("shadowroot");
-        const shadowRoot = template.parentNode.attachShadow({ mode });
-        shadowRoot.appendChild(template.content);
-        template.remove();
-        attachShadowRoots(shadowRoot);
-      });
-  }
-
-  attachShadowRoots(document);
-})();
+(function attachShadowRoots(root) {
+  root.querySelectorAll("template[shadowroot]").forEach(template => {
+    const mode = template.getAttribute("shadowroot");
+    const shadowRoot = template.parentNode.attachShadow({ mode });
+    shadowRoot.appendChild(template.content);
+    template.remove();
+    attachShadowRoots(shadowRoot);
+  });
+})(document);
 ```
 
 ## Further Reading {: #further-reading }

--- a/src/site/content/en/blog/declarative-shadow-dom/index.md
+++ b/src/site/content/en/blog/declarative-shadow-dom/index.md
@@ -456,12 +456,21 @@ on their parent element. This process can be done once the document is ready, or
 specific events like Custom Element lifecycles.
 
 ```js
-document.querySelectorAll('template[shadowroot]').forEach(template => {
-  const mode = template.getAttribute('shadowroot');
-  const shadowRoot = template.parentNode.attachShadow({ mode });
-  shadowRoot.appendChild(template.content);
-  template.remove();
-});
+(function() {
+  function attachShadowRoots(documentFragment) {
+    documentFragment
+      .querySelectorAll("template[shadowroot]")
+      .forEach(template => {
+        const mode = template.getAttribute("shadowroot");
+        const shadowRoot = template.parentNode.attachShadow({ mode });
+        shadowRoot.appendChild(template.content);
+        template.remove();
+        attachShadowRoots(shadowRoot);
+      });
+  }
+
+  attachShadowRoots(document);
+})();
 ```
 
 ## Further Reading {: #further-reading }


### PR DESCRIPTION
The prior Declarative Shadow DOM polyfill code does not work for nested custom elements. When an outer `template[shadowroot]` gets converted to a `shadowRoot`, any nested DSDs are no longer accessible on the `document`. Instead, we have to search any `shadowRoot`s we attach in order to find any nested DSDs.

Alternately, we might be able to process them in reverse order, in order to implicitly handle more deeply nested nodes before the nodes they're nested within, but that seems more fragile & magical.

See https://glitch.com/edit/#!/experienced-mint-wednesday for an example that requires this change.

Fixes #7107