### PR TITLE
Fix environment variable usage on screen-configurations page

### DIFF
--- a/src/site/content/en/learn/design/screen-configurations/index.md
+++ b/src/site/content/en/learn/design/screen-configurations/index.md
@@ -132,7 +132,7 @@ For dual screens with a vertical hinge, set the first column to be the width of 
 ```css
 @media (horizontal-viewport-segments: 2) and (vertical-viewport-segments: 1) {
   main article {
-    flex: 1 1 env(viewport-segment-width 0 0);
+    flex: 1 1 env(viewport-segment-width, 0);
   }
   main aside {
     flex: 1;


### PR DESCRIPTION
Changes proposed in this pull request:

The https://web.dev/learn/design/screen-configurations/ page uses the environment variable in a wrong manner. [According to the syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/env()#syntax), it requires a variable and a fallback value. However, we were seeing `env(value fallback fallback)` which makes the browser unhappy about it.