### PR TITLE
Exempts the content label from being processed by stalebot.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,7 @@ exemptLabels:
   - accepted
   - Epic
   - bug
+  - content
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Changes proposed in this pull request:

- The stalebot is a useful tool for identifying what issues have gone stale, but the tech writers team has decided that it is not a prudent tool for issues with the "content" label, as some content-related issues have an arc over a long period of time, and may be mistakenly marked "stale" when they are actively in development (but their respective issues have not been touched for a while).