### PR TITLE
fix: remove dead link

### DIFF
--- a/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
+++ b/src/site/content/en/lighthouse-best-practices/external-anchors-use-rel-noopener/index.md
@@ -77,6 +77,5 @@ post for more information.
 
 ## Resources
 
-- [Source code for **Links to cross-origin destinations are unsafe** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js)
 - [Share cross-origin resources safely](/cross-origin-resource-sharing/)
 - [Site isolation for web developers](https://developers.google.com/web/updates/2018/07/site-isolation)


### PR DESCRIPTION
Changes proposed in this pull request:

Lighthouse no longer checks for links with `target="_blank"` having the `rel="noopener"` attribute since `rel="noopener"` is implied already in all current evergreen browsers.
(maybe the content on this page needs further updates to note that?)