### PR TITLE
Fix grammar - Remove misplaced "is"

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -32,7 +32,7 @@ and the Samsung browser. Safari has partial support.
 The manifest file can have any name, but is commonly named `manifest.json` and
 served from the root (your website's top-level directory). The specification
 suggests the extension should be `.webmanifest`, but browsers also support
-`.json` extensions, which is may be easier for developers to understand.
+`.json` extensions, which may be easier for developers to understand.
 
 ```json
 {


### PR DESCRIPTION
Fixes #7144 

Changes proposed in this pull request:

- Remove an un-grammatical "is" in the "Add a web app manifest" article at the url https://web.dev/add-manifest/

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
