### PR TITLE
Update the web-vitals library and metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web.dev",
       "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -28,7 +29,7 @@
         "strip-comments": "^2.0.1",
         "terser": "^5.9.0",
         "unistore": "^3.4.1",
-        "web-vitals": "^0.2.4",
+        "web-vitals": "^2.1.3",
         "webdev-infra": "^1.0.28",
         "wicg-inert": "^3.0.1"
       },
@@ -31859,9 +31860,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
-      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.3.tgz",
+      "integrity": "sha512-+ijpniAzcnQicXaXIN0/eHQAiV/jMt1oHGHTmz7VdAJPPkzzDhmoYPSpLgJTuFtUh+jCjxCoeTZPg7Ic+g8o7w=="
     },
     "node_modules/webdev-infra": {
       "version": "1.0.28",
@@ -58475,9 +58476,9 @@
       }
     },
     "web-vitals": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
-      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.3.tgz",
+      "integrity": "sha512-+ijpniAzcnQicXaXIN0/eHQAiV/jMt1oHGHTmz7VdAJPPkzzDhmoYPSpLgJTuFtUh+jCjxCoeTZPg7Ic+g8o7w=="
     },
     "webdev-infra": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "strip-comments": "^2.0.1",
     "terser": "^5.9.0",
     "unistore": "^3.4.1",
-    "web-vitals": "^0.2.4",
+    "web-vitals": "^2.1.3",
     "webdev-infra": "^1.0.28",
     "wicg-inert": "^3.0.1"
   },

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,4 +1,4 @@
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {getCLS, getFCP, getFID, getLCP, getTTFB} from 'web-vitals';
 import {dimensions} from 'webdev_analytics';
 import {store} from './store';
 
@@ -114,5 +114,7 @@ store.subscribe(({isSignedIn}) => {
 });
 
 getCLS(sendToGoogleAnalytics);
+getFCP(sendToGoogleAnalytics);
 getFID(sendToGoogleAnalytics);
 getLCP(sendToGoogleAnalytics);
+getTTFB(sendToGoogleAnalytics);


### PR DESCRIPTION
This PR updates the version of the [web-vitals](https://github.com/GoogleChrome/web-vitals/) library used on web.dev. It also adds two additional metrics (FCP and TTFB) that we can use to help debug performance issues.

I have a few additional performance improvement PRs that I plan to submit shortly, but I'd like to get this PR merged first so we can compare the before and after results.
