### PR TITLE
Update CDN cache config

### DIFF
--- a/firebase.incl.json
+++ b/firebase.incl.json
@@ -19,11 +19,7 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "no-cache"
-          },
-          {
-            "key": "Surrogate-Control",
-            "value": "max-age=600"
+            "value": "max-age=0"
           }
         ]
       }

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -51,7 +51,7 @@ module.exports = {
       SIGNED_IN: 'dimension1',
       TRACKING_VERSION: 'dimension5',
     },
-    version: 4,
+    version: 5,
   },
   firebase: {
     prod: {


### PR DESCRIPTION
After a recent perf audit of web.dev, I noticed that HTML pages were not being cached on the CDN. For example, if you run:

```sh
curl -svo /dev/null https://web.dev/
```

The response headers always show a miss, no matter how many times you request the page from the same machine:

```
< x-cache: MISS
< x-cache-hits: 0
```

I reached out to the Firebase team to see if they could give me data on our cache hit rate, and this is what I found (broken down by content type):

![web-dev-cache-hit-by-type](https://user-images.githubusercontent.com/326742/149062685-2cbd5a88-d875-4b8e-9d8a-e660d48c726f.png)

This chart shows that the cache hit rate for subresources (JS, CSS, images, font) is actually pretty good, but the hit rate for documents is terrible. And this confirms my local testing. HTML pages are basically never being cached, despite the use of the [Surrogate-Control](https://developer.fastly.com/reference/http/http-headers/Surrogate-Control/) header (which should instruct Fastly to cache the pages in its edge nodes).

When I reported this issue to the Firebase team is turns out that Firebase Hosting actually overrides the `Surrogate-Control` header, so our setting it is pointless. In addition, it turns out that because we set `cache-control: no-cache`, Firebase actually **instructs Fastly to mark the resource as private and not cache it**. (Unfortunately neither of these are documented...)

So the best solution here if we don't want browsers to cache HTML documents but we _do_ want CDNs to cache them is to use `max-age: 0` instead of `no-cache`. (Note that Firebase automatically takes care of invalidating resources that change every time we re-deploy the site, so we don't need to worry about that fact that the CDN is caching these resources that might change in the future).

To measure the effects of this CDN change, I've also bumped the `TRACKING_VERSION` dimension in our analytics so we can compare TTFB before and after (as mentioned in #7153). So ideally we'll merge that PR first, and then wait a few days to merge this one so we can compare the difference (hence the "DO NOT MERGE" label).

