### PR TITLE
feat(learn): add localized pages for `/learn`, fixes #7168

### DIFF
--- a/src/site/_includes/learn-page.njk
+++ b/src/site/_includes/learn-page.njk
@@ -4,7 +4,6 @@ title: Learn
 description: |
   Learn best practices for the modern web and hone your skills with hands-on
   codelabs.
-date: 2021-10-29
 pageScripts:
   - '/js/learn.js'
 ---

--- a/src/site/content/en/learn/index.md
+++ b/src/site/content/en/learn/index.md
@@ -1,0 +1,5 @@
+---
+layout: learn-page
+title: Learn
+date: 2021-10-29
+---

--- a/src/site/content/es/accessible/index.md
+++ b/src/site/content/es/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/es/angular/index.md
+++ b/src/site/content/es/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/es/animations/index.md
+++ b/src/site/content/es/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/es/devices/index.md
+++ b/src/site/content/es/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/es/discoverable/index.md
+++ b/src/site/content/es/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/es/fast/index.md
+++ b/src/site/content/es/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/es/identity/index.md
+++ b/src/site/content/es/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/es/learn-web-vitals/index.md
+++ b/src/site/content/es/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/es/learn/index.md
+++ b/src/site/content/es/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: Aprender
+---

--- a/src/site/content/es/learn/learn.11tydata.js
+++ b/src/site/content/es/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/es/lighthouse-accessibility/index.md
+++ b/src/site/content/es/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/es/lighthouse-best-practices/index.md
+++ b/src/site/content/es/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/es/lighthouse-performance/index.md
+++ b/src/site/content/es/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/es/lighthouse-pwa/index.md
+++ b/src/site/content/es/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/es/lighthouse-seo/index.md
+++ b/src/site/content/es/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/es/media/index.md
+++ b/src/site/content/es/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/es/metrics/index.md
+++ b/src/site/content/es/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/es/mini-apps/index.md
+++ b/src/site/content/es/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/es/payments/index.md
+++ b/src/site/content/es/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/es/progressive-web-apps/index.md
+++ b/src/site/content/es/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/es/react/index.md
+++ b/src/site/content/es/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/es/reliable/index.md
+++ b/src/site/content/es/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/es/secure/index.md
+++ b/src/site/content/es/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/es/secure/index.njk
+++ b/src/site/content/es/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----

--- a/src/site/content/ja/accessible/index.md
+++ b/src/site/content/ja/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/ja/angular/index.md
+++ b/src/site/content/ja/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/ja/animations/index.md
+++ b/src/site/content/ja/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/ja/devices/index.md
+++ b/src/site/content/ja/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/ja/discoverable/index.md
+++ b/src/site/content/ja/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/ja/fast/index.md
+++ b/src/site/content/ja/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/ja/identity/index.md
+++ b/src/site/content/ja/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/ja/learn-web-vitals/index.md
+++ b/src/site/content/ja/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/ja/learn/index.md
+++ b/src/site/content/ja/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: 学び
+---

--- a/src/site/content/ja/learn/learn.11tydata.js
+++ b/src/site/content/ja/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/ja/lighthouse-accessibility/index.md
+++ b/src/site/content/ja/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/ja/lighthouse-best-practices/index.md
+++ b/src/site/content/ja/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/ja/lighthouse-performance/index.md
+++ b/src/site/content/ja/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/ja/lighthouse-pwa/index.md
+++ b/src/site/content/ja/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/ja/lighthouse-seo/index.md
+++ b/src/site/content/ja/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/ja/media/index.md
+++ b/src/site/content/ja/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/ja/metrics/index.md
+++ b/src/site/content/ja/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/ja/mini-apps/index.md
+++ b/src/site/content/ja/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/ja/payments/index.md
+++ b/src/site/content/ja/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/ja/progressive-web-apps/index.md
+++ b/src/site/content/ja/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/ja/react/index.md
+++ b/src/site/content/ja/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/ja/reliable/index.md
+++ b/src/site/content/ja/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/ja/secure/index.md
+++ b/src/site/content/ja/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/ja/secure/index.njk
+++ b/src/site/content/ja/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----

--- a/src/site/content/ko/accessible/index.md
+++ b/src/site/content/ko/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/ko/angular/index.md
+++ b/src/site/content/ko/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/ko/animations/index.md
+++ b/src/site/content/ko/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/ko/devices/index.md
+++ b/src/site/content/ko/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/ko/discoverable/index.md
+++ b/src/site/content/ko/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/ko/fast/index.md
+++ b/src/site/content/ko/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/ko/identity/index.md
+++ b/src/site/content/ko/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/ko/learn-web-vitals/index.md
+++ b/src/site/content/ko/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/ko/learn/index.md
+++ b/src/site/content/ko/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: 배우다
+---

--- a/src/site/content/ko/learn/learn.11tydata.js
+++ b/src/site/content/ko/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/ko/lighthouse-accessibility/index.md
+++ b/src/site/content/ko/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/ko/lighthouse-best-practices/index.md
+++ b/src/site/content/ko/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/ko/lighthouse-performance/index.md
+++ b/src/site/content/ko/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/ko/lighthouse-pwa/index.md
+++ b/src/site/content/ko/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/ko/lighthouse-seo/index.md
+++ b/src/site/content/ko/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/ko/media/index.md
+++ b/src/site/content/ko/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/ko/metrics/index.md
+++ b/src/site/content/ko/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/ko/mini-apps/index.md
+++ b/src/site/content/ko/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/ko/payments/index.md
+++ b/src/site/content/ko/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/ko/progressive-web-apps/index.md
+++ b/src/site/content/ko/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/ko/react/index.md
+++ b/src/site/content/ko/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/ko/reliable/index.md
+++ b/src/site/content/ko/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/ko/secure/index.md
+++ b/src/site/content/ko/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/ko/secure/index.njk
+++ b/src/site/content/ko/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----

--- a/src/site/content/pl/accessible/index.md
+++ b/src/site/content/pl/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/pl/angular/index.md
+++ b/src/site/content/pl/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/pl/animations/index.md
+++ b/src/site/content/pl/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/pl/devices/index.md
+++ b/src/site/content/pl/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/pl/discoverable/index.md
+++ b/src/site/content/pl/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/pl/fast/index.md
+++ b/src/site/content/pl/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/pl/identity/index.md
+++ b/src/site/content/pl/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/pl/learn-web-vitals/index.md
+++ b/src/site/content/pl/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/pl/learn/index.md
+++ b/src/site/content/pl/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: Uczyć się
+---

--- a/src/site/content/pl/learn/learn.11tydata.js
+++ b/src/site/content/pl/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/pl/lighthouse-accessibility/index.md
+++ b/src/site/content/pl/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/pl/lighthouse-best-practices/index.md
+++ b/src/site/content/pl/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/pl/lighthouse-performance/index.md
+++ b/src/site/content/pl/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/pl/lighthouse-pwa/index.md
+++ b/src/site/content/pl/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/pl/lighthouse-seo/index.md
+++ b/src/site/content/pl/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/pl/media/index.md
+++ b/src/site/content/pl/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/pl/metrics/index.md
+++ b/src/site/content/pl/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/pl/mini-apps/index.md
+++ b/src/site/content/pl/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/pl/payments/index.md
+++ b/src/site/content/pl/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/pl/progressive-web-apps/index.md
+++ b/src/site/content/pl/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/pl/react/index.md
+++ b/src/site/content/pl/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/pl/reliable/index.md
+++ b/src/site/content/pl/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/pl/secure/index.md
+++ b/src/site/content/pl/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/pt/accessible/index.md
+++ b/src/site/content/pt/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/pt/angular/index.md
+++ b/src/site/content/pt/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/pt/animations/index.md
+++ b/src/site/content/pt/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/pt/devices/index.md
+++ b/src/site/content/pt/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/pt/discoverable/index.md
+++ b/src/site/content/pt/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/pt/fast/index.md
+++ b/src/site/content/pt/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/pt/identity/index.md
+++ b/src/site/content/pt/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/pt/learn-web-vitals/index.md
+++ b/src/site/content/pt/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/pt/learn/index.md
+++ b/src/site/content/pt/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: Aprender
+---

--- a/src/site/content/pt/learn/learn.11tydata.js
+++ b/src/site/content/pt/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/pt/lighthouse-accessibility/index.md
+++ b/src/site/content/pt/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/pt/lighthouse-best-practices/index.md
+++ b/src/site/content/pt/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/pt/lighthouse-performance/index.md
+++ b/src/site/content/pt/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/pt/lighthouse-pwa/index.md
+++ b/src/site/content/pt/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/pt/lighthouse-seo/index.md
+++ b/src/site/content/pt/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/pt/media/index.md
+++ b/src/site/content/pt/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/pt/metrics/index.md
+++ b/src/site/content/pt/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/pt/mini-apps/index.md
+++ b/src/site/content/pt/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/pt/payments/index.md
+++ b/src/site/content/pt/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/pt/progressive-web-apps/index.md
+++ b/src/site/content/pt/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/pt/react/index.md
+++ b/src/site/content/pt/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/pt/reliable/index.md
+++ b/src/site/content/pt/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/pt/secure/index.md
+++ b/src/site/content/pt/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/pt/secure/index.njk
+++ b/src/site/content/pt/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----

--- a/src/site/content/ru/accessible/index.md
+++ b/src/site/content/ru/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/ru/angular/index.md
+++ b/src/site/content/ru/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/ru/animations/index.md
+++ b/src/site/content/ru/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/ru/devices/index.md
+++ b/src/site/content/ru/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/ru/discoverable/index.md
+++ b/src/site/content/ru/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/ru/fast/index.md
+++ b/src/site/content/ru/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/ru/identity/index.md
+++ b/src/site/content/ru/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/ru/learn-web-vitals/index.md
+++ b/src/site/content/ru/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/ru/learn/index.md
+++ b/src/site/content/ru/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: Учиться
+---

--- a/src/site/content/ru/learn/learn.11tydata.js
+++ b/src/site/content/ru/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/ru/lighthouse-accessibility/index.md
+++ b/src/site/content/ru/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/ru/lighthouse-best-practices/index.md
+++ b/src/site/content/ru/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/ru/lighthouse-performance/index.md
+++ b/src/site/content/ru/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/ru/lighthouse-pwa/index.md
+++ b/src/site/content/ru/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/ru/lighthouse-seo/index.md
+++ b/src/site/content/ru/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/ru/media/index.md
+++ b/src/site/content/ru/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/ru/metrics/index.md
+++ b/src/site/content/ru/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/ru/mini-apps/index.md
+++ b/src/site/content/ru/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/ru/payments/index.md
+++ b/src/site/content/ru/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/ru/progressive-web-apps/index.md
+++ b/src/site/content/ru/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/ru/react/index.md
+++ b/src/site/content/ru/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/ru/reliable/index.md
+++ b/src/site/content/ru/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/ru/secure/index.md
+++ b/src/site/content/ru/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/ru/secure/index.njk
+++ b/src/site/content/ru/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----

--- a/src/site/content/zh/accessible/index.md
+++ b/src/site/content/zh/accessible/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: accessible
+---

--- a/src/site/content/zh/angular/index.md
+++ b/src/site/content/zh/angular/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: angular
+---

--- a/src/site/content/zh/animations/index.md
+++ b/src/site/content/zh/animations/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: animations
+---

--- a/src/site/content/zh/devices/index.md
+++ b/src/site/content/zh/devices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: devices
+---

--- a/src/site/content/zh/discoverable/index.md
+++ b/src/site/content/zh/discoverable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: discoverable
+---

--- a/src/site/content/zh/fast/index.md
+++ b/src/site/content/zh/fast/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: fast
+---

--- a/src/site/content/zh/identity/index.md
+++ b/src/site/content/zh/identity/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: identity
+---

--- a/src/site/content/zh/learn-web-vitals/index.md
+++ b/src/site/content/zh/learn-web-vitals/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: learn-web-vitals
+---

--- a/src/site/content/zh/learn/index.md
+++ b/src/site/content/zh/learn/index.md
@@ -1,0 +1,4 @@
+---
+layout: learn-page
+title: 学习
+---

--- a/src/site/content/zh/learn/learn.11tydata.js
+++ b/src/site/content/zh/learn/learn.11tydata.js
@@ -1,0 +1,9 @@
+// =============================================================================
+// LEARN OVERVIEW
+//
+// This is the context object for the learn page.
+// It helps layout cards featured on the learn page, and their ordering.
+//
+// =============================================================================
+
+module.exports = require('../../en/learn/learn.11tydata');

--- a/src/site/content/zh/lighthouse-accessibility/index.md
+++ b/src/site/content/zh/lighthouse-accessibility/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-accessibility
+---

--- a/src/site/content/zh/lighthouse-best-practices/index.md
+++ b/src/site/content/zh/lighthouse-best-practices/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-best-practices
+---

--- a/src/site/content/zh/lighthouse-performance/index.md
+++ b/src/site/content/zh/lighthouse-performance/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-performance
+---

--- a/src/site/content/zh/lighthouse-pwa/index.md
+++ b/src/site/content/zh/lighthouse-pwa/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-pwa
+---

--- a/src/site/content/zh/lighthouse-seo/index.md
+++ b/src/site/content/zh/lighthouse-seo/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: lighthouse-seo
+---

--- a/src/site/content/zh/media/index.md
+++ b/src/site/content/zh/media/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: media
+---

--- a/src/site/content/zh/metrics/index.md
+++ b/src/site/content/zh/metrics/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: metrics
+---

--- a/src/site/content/zh/mini-apps/index.md
+++ b/src/site/content/zh/mini-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: mini-apps
+---

--- a/src/site/content/zh/payments/index.md
+++ b/src/site/content/zh/payments/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: payments
+---

--- a/src/site/content/zh/progressive-web-apps/index.md
+++ b/src/site/content/zh/progressive-web-apps/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: progressive-web-apps
+---

--- a/src/site/content/zh/react/index.md
+++ b/src/site/content/zh/react/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: react
+---

--- a/src/site/content/zh/reliable/index.md
+++ b/src/site/content/zh/reliable/index.md
@@ -1,0 +1,5 @@
+---
+layout: path
+override:tags: []
+pathName: reliable
+---

--- a/src/site/content/zh/secure/index.md
+++ b/src/site/content/zh/secure/index.md
@@ -1,0 +1,7 @@
+---
+layout: path
+override:tags: []
+pathName: secure
+tags:
+  - security
+---

--- a/src/site/content/zh/secure/index.njk
+++ b/src/site/content/zh/secure/index.njk
@@ -1,8 +1,0 @@
----
-layout: path
-override:tags: []
-date: 2021-12-07
-pathName: secure
-tags:
-  - security
----


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7168

Changes proposed in this pull request:

- Abstract `/learn` page into it's own layout
- Create `/learn` pages in each language and extend template from new `learn-page.njk` and data from `en/learn/learn.11tydata.js`
- Copy/create `MD` files for each collection's landing page into each language.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
