### PR TITLE
add flex-direction to web-assessment__content

### DIFF
--- a/src/lib/components/Assessment/_styles.scss
+++ b/src/lib/components/Assessment/_styles.scss
@@ -78,6 +78,7 @@ web-assessment {
 
 .web-assessment__content {
   display: flex;
+  flex-direction: column;
   flex: 1;
 }
 


### PR DESCRIPTION
add flex-direction to web-assessment__content  class

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7184

Changes proposed in this pull request:

- add `flex-direction: column` to `web-assessment__content` class

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
