### PR TITLE
Little reword to the "fun fact" in USB article

### DIFF
--- a/src/site/content/en/blog/porting-libusb-to-webusb/index.md
+++ b/src/site/content/en/blog/porting-libusb-to-webusb/index.md
@@ -19,7 +19,7 @@ In [a previous post](/asyncify/), I showed how to port apps using filesystem API
 I'll show how apps that communicate with USB devices can be ported to the web by porting [libusb](https://libusb.info/)—a popular USB library written in C—to WebAssembly (via [Emscripten](https://emscripten.org/)), Asyncify and [WebUSB](/usb/).
 
 {% Aside %}
-Fun fact: On many platforms, Chromium implementation of WebUSB also uses libusb under the hood. So what the port achieves is, in fact, one libusb, compiled to WebAssembly, talking to another libusb, shipped as part of the browser, through an intermediate layer. Isn't the web fun?
+Fun fact: On some platforms, implementation of WebUSB also uses libusb under the hood. So what the port achieves is, in fact, one libusb, compiled to WebAssembly, talking to another libusb, shipped as part of the browser, through an intermediate layer. Isn't the web fun?
 {% endAside %}
 
 ## First things first: a demo


### PR DESCRIPTION
1) Looks like more platforms migrated away from libusb since I wrote this, so "some" is more accurate than "many".
2) When talking about "some platforms", "Chromium" clarification is unnecessary.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Follow-up to #7151 

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
