### PR TITLE
refactor(post): remove `post-old.njk` layout

### DIFF
--- a/src/site/_includes/post-old.njk
+++ b/src/site/_includes/post-old.njk
@@ -1,9 +1,0 @@
----
-layout: default
-permalink: "/{{lang}}/{{page.fileSlug}}/index.html"
-tags:
-  - post
-pageScripts:
-  - '/js/content.js'
----
-{% include 'partials/post.njk' %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Delete `post-old.njk` layout, not used anymore
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
