### PR TITLE
Update web-vitals to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "strip-comments": "^2.0.1",
         "terser": "^5.9.0",
         "unistore": "^3.4.1",
-        "web-vitals": "^2.1.3",
+        "web-vitals": "^2.1.4",
         "webdev-infra": "^1.0.28",
         "wicg-inert": "^3.0.1"
       },
@@ -31860,9 +31860,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.3.tgz",
-      "integrity": "sha512-+ijpniAzcnQicXaXIN0/eHQAiV/jMt1oHGHTmz7VdAJPPkzzDhmoYPSpLgJTuFtUh+jCjxCoeTZPg7Ic+g8o7w=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
+      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "node_modules/webdev-infra": {
       "version": "1.0.28",
@@ -58476,9 +58476,9 @@
       }
     },
     "web-vitals": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.3.tgz",
-      "integrity": "sha512-+ijpniAzcnQicXaXIN0/eHQAiV/jMt1oHGHTmz7VdAJPPkzzDhmoYPSpLgJTuFtUh+jCjxCoeTZPg7Ic+g8o7w=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
+      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "webdev-infra": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "strip-comments": "^2.0.1",
     "terser": "^5.9.0",
     "unistore": "^3.4.1",
-    "web-vitals": "^2.1.3",
+    "web-vitals": "^2.1.4",
     "webdev-infra": "^1.0.28",
     "wicg-inert": "^3.0.1"
   },

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -52,7 +52,7 @@ module.exports = {
       TRACKING_VERSION: 'dimension5',
       NAVIGATION_TYPE: 'dimension6',
     },
-    version: 6,
+    version: 7,
   },
   firebase: {
     prod: {


### PR DESCRIPTION
This PR updates the web-vitals JS library to address an issue fixed in https://github.com/GoogleChrome/web-vitals/issues/201.

This change should have no effect on the functionality of the site, but it'll address an issue with the accuracy of the TTFB data we're reporting to Google Analytics.