### PR TITLE
Replace typo in JS snippet for responsiveness post

### DIFF
--- a/src/site/content/en/blog/better-responsiveness-metric/index.md
+++ b/src/site/content/en/blog/better-responsiveness-metric/index.md
@@ -495,7 +495,7 @@ const observer = new PerformanceObserver(list => {
     }
   });
 });
-observer.observe({type: "event", minDuration: 16, buffered: true});
+observer.observe({type: "event", durationThreshold: 16, buffered: true});
 // We can report maxTapDragDuration and maxKeyboardDuration when sending
 // metrics to analytics.
 ```


### PR DESCRIPTION
`minDuration` should have been `durationThreshold` (as per spec and local testing)