### PR TITLE
fix(assessment): display full question in mobile, fixes #7219

### DIFF
--- a/src/lib/components/AssessmentQuestion/_styles.scss
+++ b/src/lib/components/AssessmentQuestion/_styles.scss
@@ -9,7 +9,7 @@ web-question {
 
 .web-question__content {
   display: block;
-  flex: 1 1 0;
+  flex: 1;
   height: 0; // Lets content match viewport height minus assessment header/footer
   padding: 0 1.5rem 1.5rem;
   overflow-y: auto;


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7219

Changes proposed in this pull request:

- Set flex to `1` so on mobile it takes up space
-
-

[See here for demo](https://threadit.app/thread/tnlgi4mjsnjb07mj2bzp/message/r4tphgib90dl0d2990ht8lwq?utm_medium=referral-link)

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
