### PR TITLE
Fix internal page link to be root-relative

### DIFF
--- a/src/site/content/en/learn/design/ui-patterns/index.md
+++ b/src/site/content/en/learn/design/ui-patterns/index.md
@@ -68,7 +68,7 @@ For narrow screens, display items in a row using flexbox. The row of items will 
 }
 ```
 
-The [`scroll-snap`](css-scroll-snap/) properties ensure that the items can be swiped in a way that feels smooth. Thanks to `scroll-snap-type: inline mandatory`, the items snap into place.
+The [`scroll-snap`](/css-scroll-snap/) properties ensure that the items can be swiped in a way that feels smooth. Thanks to `scroll-snap-type: inline mandatory`, the items snap into place.
 
 When the screen is large enough—wider than `50em` in this case—switch over to grid and display the items in rows and columns, without hiding anything.
 


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

- Fix typo in the related article link


Original link leads to https://web.dev/learn/design/ui-patterns/css-scroll-snap/
Actual expected target is https://web.dev/css-scroll-snap/