### PR TITLE
fix(i18n): display i18n titles of courses in paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -66,7 +66,7 @@ const tags = require('./src/site/_collections/tags');
 // Filters
 const consoleDump = require('./src/site/_filters/console-dump');
 const {i18n} = require('./src/site/_filters/i18n');
-const {getRelativePath} = require('./src/site/_filters/urls');
+const {getDefaultUrl, getRelativePath} = require('./src/site/_filters/urls');
 const {memoize, findByUrl} = require('./src/site/_filters/find-by-url');
 const pathSlug = require('./src/site/_filters/path-slug');
 const algoliaIndexable = require('./src/site/_filters/algolia-indexable');
@@ -170,8 +170,9 @@ module.exports = function (config) {
   // ----------------------------------------------------------------------------
   config.addFilter('consoleDump', consoleDump);
   config.addFilter('i18n', i18n);
-  config.addFilter('getRelativePath', getRelativePath);
   config.addFilter('findByUrl', findByUrl);
+  config.addFilter('getDefaultUrl', getDefaultUrl);
+  config.addFilter('getRelativePath', getRelativePath);
   config.addFilter('pathSlug', pathSlug);
   config.addFilter('algoliaIndexable', algoliaIndexable);
   config.addFilter('algoliaItem', algoliaItem);

--- a/src/site/_includes/partials/item.njk
+++ b/src/site/_includes/partials/item.njk
@@ -1,13 +1,11 @@
 {% for pathItem in section.pathItems %}
-  {% set url = ['', lang, pathItem, ''] | join('/') %}
+  {% set url = ['', 'i18n', lang, pathItem, ''] | join('/') %}
   {% set item = url | findByUrl %}
-
   {# Add a default language fallback in case the article is not translated. #}
   {% if not item %}
     {% set url = ['', 'en', pathItem, ''] | join('/') %}
     {% set item = url | findByUrl %}
   {% endif %}
-
   {% if pathItem.url %}
     <li>
       <a href="{{ pathItem.url }}">
@@ -17,7 +15,7 @@
   {% elif item %}
     {% if not item.data.draft %}
       <li>
-        <a href="{{ item.url }}">
+        <a href="{{ item.url | getDefaultUrl }}">
           {{ item.data.title | trim | md({linkify: false}) | safe }}
         </a>
       </li>


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Related to #7225

Fixes only titles, links fixed in #7283

Changes proposed in this pull request:

- Add `i18n` to urls used to display paths' items' links


When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
