### PR TITLE
Append a note that Payment Request `show()` requires a user activation.

### DIFF
--- a/src/site/content/en/payments/how-payment-request-api-works/index.md
+++ b/src/site/content/en/payments/how-payment-request-api-works/index.md
@@ -111,10 +111,10 @@ interface.
 
 {% Aside 'warning' %}
 
-Calling `show()` method requires [a user
+To call the `show()` method, you must add a [user
 activation](https://developers.google.com/web/updates/2019/01/user-activation).
-This means the call must be encapsurated inside an event listener such as
-'click'. Note that Chrome currently bypasses this constraint, but will enforce
+This means the call must be inside an event listener, such as
+`click`. Note that Chrome currently bypasses this constraint, but plans to enforce
 it sometime in the future.
 
 {% endAside %}

--- a/src/site/content/en/payments/how-payment-request-api-works/index.md
+++ b/src/site/content/en/payments/how-payment-request-api-works/index.md
@@ -6,7 +6,7 @@ subhead: |
 authors:
   - agektmr
 date: 2018-09-10
-updated: 2021-10-12
+updated: 2022-01-31
 description: |
   Learn how the Payment Request API works at a high level.
 tags:
@@ -108,6 +108,15 @@ Learn more about [PaymentRequest.canMakePayment() on MDN](https://developer.mozi
 After setting the two parameters and creating the `request` object as shown
 above, you can call the `show()` method, which displays the payment app user
 interface.
+
+{% Aside 'warning' %}
+
+Starting from version 99, Chrome requires [a user
+activation](https://developers.google.com/web/updates/2019/01/user-activation)
+before calling `show()` method. This means the call must be encapsurated inside
+an event listener such as 'click'.
+
+{% endAside %}
 
 ```javascript
 request.show().then(response => {

--- a/src/site/content/en/payments/how-payment-request-api-works/index.md
+++ b/src/site/content/en/payments/how-payment-request-api-works/index.md
@@ -111,10 +111,11 @@ interface.
 
 {% Aside 'warning' %}
 
-Starting from version 99, Chrome requires [a user
-activation](https://developers.google.com/web/updates/2019/01/user-activation)
-before calling `show()` method. This means the call must be encapsurated inside
-an event listener such as 'click'.
+Calling `show()` method requires [a user
+activation](https://developers.google.com/web/updates/2019/01/user-activation).
+This means the call must be encapsurated inside an event listener such as
+'click'. Note that Chrome currently bypasses this constraint, but will enforce
+it sometime in the future.
 
 {% endAside %}
 


### PR DESCRIPTION
Requires user activation before calling `show()`.
