### PR TITLE
feat(i18n): allow easy navigation in `/i18n/` directory, fixes #6669

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@
 .tmp/*
 dist/*
 types/*
+/functions/supportedLocales.js
 /src/site/content/en/patterns/**

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -49,3 +49,7 @@ if (process.env.ELEVENTY_ENV === 'prod') {
 }
 
 fs.writeFileSync('./firebase.json', JSON.stringify(firebaseJson, null, 2));
+fs.writeFileSync(
+  './functions/supportedLocales.js',
+  `export default ${JSON.stringify(supportedLocales)};`,
+);

--- a/firebase.incl.json
+++ b/firebase.incl.json
@@ -27,7 +27,13 @@
     "i18n": {
       "root": "/i18n"
     },
-    "redirects": []
+    "redirects": [],
+    "rewrites": [
+      {
+        "source": "/i18n/**",
+        "function": "i18n404"
+      }
+    ]
   },
   "emulators": {
     "hosting": {

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+supportedLocales.js

--- a/functions/https/i18n-404.js
+++ b/functions/https/i18n-404.js
@@ -1,4 +1,5 @@
 import * as functions from 'firebase-functions';
+// eslint-disable-next-line node/no-missing-import
 import supportedLocales from '../supportedLocales.js';
 
 export const i18n404 = functions.https.onRequest((request, response) => {

--- a/functions/https/i18n-404.js
+++ b/functions/https/i18n-404.js
@@ -1,0 +1,10 @@
+import * as functions from 'firebase-functions';
+
+export const i18n404 = functions.https.onRequest((request, response) => {
+  if (request.path === '/i18n/') {
+    response.redirect('/', 301);
+  } else {
+    const path = request.path.split('/');
+    response.redirect(`/${path.splice(3).join('/')}`, 301);
+  }
+});

--- a/functions/https/i18n-404.js
+++ b/functions/https/i18n-404.js
@@ -1,10 +1,14 @@
 import * as functions from 'firebase-functions';
+import supportedLocales from '../supportedLocales.js';
 
 export const i18n404 = functions.https.onRequest((request, response) => {
-  if (request.path === '/i18n/') {
-    response.redirect('/', 301);
-  } else {
-    const path = request.path.split('/');
+  const path = request.path.split('/');
+
+  // Redirect for locales
+  if (supportedLocales.includes(path[2])) {
     response.redirect(`/${path.splice(3).join('/')}`, 301);
+  } else {
+    // Redirect for everything else
+    response.redirect(`/${path.splice(2).join('/')}`, 301);
   }
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,5 +2,6 @@ import admin from 'firebase-admin';
 
 admin.initializeApp();
 
+export * from './https/i18n-404.js';
 export * from './pubsub/scheduled-firestore-export.js';
 export * from './pubsub/youtube.js';

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -8,6 +8,7 @@
 import {store} from './store';
 import {localStorage} from './utils/storage';
 import removeServiceWorkers from './utils/sw-remove';
+import './i18n';
 
 // This hides a legacy browser warning that can appear on the /measure page
 // See .unsupported-notice in _page-header.scss

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,0 +1,26 @@
+/**
+ * Detects if link should navigate to `i18n` path
+ * and then navigates there.
+ *
+ * @param {MouseEvent} e
+ */
+function i18nClickEvent(e) {
+  let target = /** @type {HTMLElement} */ (e.target);
+
+  if (target && target.tagName !== 'A') {
+    target = /** @type {HTMLElement} */ (target?.parentNode);
+  }
+
+  const href = target.getAttribute('href');
+
+  if (
+    window.location.pathname.startsWith('/i18n') &&
+    target.tagName === 'A' &&
+    !href.startsWith('#')
+  ) {
+    const urlRegex = window.location.pathname.match(/\/i18n\/([a-z]{2})\/*/);
+    target.setAttribute('href', `/i18n/${urlRegex[1]}${href}`);
+  }
+}
+
+document.addEventListener('click', i18nClickEvent);


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6669

Changes proposed in this pull request:

- If user navigates to `/SOME_LOCALE/:path` redirect them to `/i18n/SOME_LOCALE/:path`;
- If user goes to a `/i18n/SOME_LOCALE/:path` that doesn't exist, redirect them to `/:path`
- If user navigates to `/i18n/:path` redirect them to`/:path` 
- If user is on `/i18n/SOME_LOCALE/:path` and clicks link, navigate them to `/i18n/SOME_LOCALE/:href_of_link`

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
