### PR TITLE
Fix off-main-thread Spanish translation

### DIFF
--- a/src/site/content/es/blog/off-main-thread/index.md
+++ b/src/site/content/es/blog/off-main-thread/index.md
@@ -1,5 +1,5 @@
 ---
-title: Utilice trabajadores web para ejecutar JavaScript desde el hilo principal del navegador
+title: Utilice trabajadores web para ejecutar JavaScript fuera del hilo principal del navegador
 subhead: Una arquitectura fuera del hilo principal puede mejorar significativamente la confiabilidad y la experiencia del usuario de su aplicación.
 description: El hilo principal del navegador está increíblemente sobrecargado de trabajo. Utilizando trabajadores web para cambiar el código del hilo principal, puede mejorar significativamente la confiabilidad y la experiencia del usuario de su aplicación.
 authors:


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix `Use web workers to run JavaScript off the browser's main thread` Spanish translation, the current sentence means `Use web workers to run JavaScript FROM the browser's main thread`


`presubmit`
