### PR TITLE
fix(assessment): allow overflow on mobile, fixes #7262

### DIFF
--- a/src/lib/components/Assessment/_styles.scss
+++ b/src/lib/components/Assessment/_styles.scss
@@ -89,6 +89,7 @@ web-assessment[animatable] {
   display: flex;
   left: 0;
   margin: 0;
+  overflow: auto;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7262

Changes proposed in this pull request:

- set overflow to auto when web-assessment is open
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.

https://threadit.app/thread/to9fc3kmn1kb36rd6aap/message/vi5rb2u9183l10pvsdagt9dq?utm_medium=referral-link
