### PR TITLE
add link to /accessibile from /lighthouse-accessibility

### DIFF
--- a/src/site/_data/i18n/paths/lighthouse_accessibility.yml
+++ b/src/site/_data/i18n/paths/lighthouse_accessibility.yml
@@ -26,6 +26,9 @@ overview:
   zh: 这些检查能够突出可以改进您的 Web 应用无障碍功能的机会。只有一部分无障碍功能问题可以被自动检测到，所以我们也鼓励您进行人工测试。
 
 topics:
+  a11y_overview:
+    en: Accessibility Overview
+
   audit_scoring:
     en: Audit scoring
     es: Puntuación de la auditoría

--- a/src/site/_data/paths/lighthouse-accessibility.json
+++ b/src/site/_data/paths/lighthouse-accessibility.json
@@ -6,6 +6,12 @@
   "overview": "i18n.paths.lighthouse_accessibility.overview",
   "topics": [
     {
+      "title": "i18n.paths.lighthouse_accessibility.topics.a11y_overview",
+      "pathItems": [
+        "accessible"
+      ]
+    },
+    {
       "title": "i18n.paths.lighthouse_accessibility.topics.audit_scoring",
       "pathItems": [
         "accessibility-scoring"


### PR DESCRIPTION
Lighthouse report will be changing the link here:
![image](https://user-images.githubusercontent.com/4071474/152891518-5d09502b-3943-4e39-92dc-34cefa1e2887.png)

from https://developers.google.com/web/fundamentals/accessibility to https://web.dev/lighthouse-accessibility/

Adding link to /accessible to give developers a starting point on a11y. Hopefully all the content under that group of pages is equivalent to the old link (I did not verify. I would have liked to linked to it aswell in /lighthouse-accesibility, but I could not work eleventy).