### PR TITLE
Use a header to register the Priority Hints origin trial

### DIFF
--- a/firebase.incl.json
+++ b/firebase.incl.json
@@ -20,6 +20,10 @@
           {
             "key": "Cache-Control",
             "value": "max-age=0"
+          },
+          {
+            "key": "Origin-Trial",
+            "value": "AroL15qduRNqNxaVOrRCcy3Lg2qmVISGidsHrfTRIwaZgUoJqZfqGYBAcqTKWf+6SgVWVbHV/OWkQCUy/ut0PwAAAABReyJvcmlnaW4iOiJodHRwczovL3dlYi5kZXY6NDQzIiwiZmVhdHVyZSI6IlByaW9yaXR5SGludHNBUEkiLCJleHBpcnkiOjE2NDc5OTM1OTl9"
           }
         ]
       }

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -52,7 +52,7 @@ module.exports = {
       TRACKING_VERSION: 'dimension5',
       NAVIGATION_TYPE: 'dimension6',
     },
-    version: 8,
+    version: 9,
   },
   firebase: {
     prod: {

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -23,9 +23,6 @@
 <link rel="preload" as="font" crossorigin href="/fonts/google-sans/bold/latin.woff2">
 <link rel="preconnect" href="https://{{site.imgixDomain}}">
 
-<!-- Priority Hints origin trial (registered by: philipwalton, M96-M99) -->
-<meta http-equiv="origin-trial" content="AroL15qduRNqNxaVOrRCcy3Lg2qmVISGidsHrfTRIwaZgUoJqZfqGYBAcqTKWf+6SgVWVbHV/OWkQCUy/ut0PwAAAABReyJvcmlnaW4iOiJodHRwczovL3dlYi5kZXY6NDQzIiwiZmVhdHVyZSI6IlByaW9yaXR5SGludHNBUEkiLCJleHBpcnkiOjE2NDc5OTM1OTl9">
-
 <meta name="theme-color" content="#fff"/>
 
 {% if noindex or draft -%}


### PR DESCRIPTION
Due to the issue discovered in #7326, this PR moves the origin trial registration for priority hints from a `<meta>` tag to an HTTP header. It also bumps the analytics version so we can filter out traffic in reports where this wasn't working properly.