### PR TITLE
Type `pointer` cursor for the entire toggle switch

### DIFF
--- a/src/scss/blocks/_toggle-switch.scss
+++ b/src/scss/blocks/_toggle-switch.scss
@@ -10,6 +10,7 @@ $toggle-switch-decor-ratio: 0.8;
   position: relative;
   width: max-content;
   gap: 1em;
+  cursor: pointer;
 }
 
 .toggle-switch__input {


### PR DESCRIPTION
Changes proposed in this pull request:

- Make sure the entire toggle switch has a type `pointer` cursor, currently only the `input` has it, which looks bad.

<img width="375" alt="Screen Shot 2022-02-10 at 12 29 35" src="https://user-images.githubusercontent.com/145676/153400308-1214b5a4-5222-4611-8997-0b71583c35c4.png">
