### PR TITLE
Fix long words in code blocks in titles

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -395,6 +395,7 @@ h6 code,
   margin: 0;
   padding: 0;
   white-space: normal;
+  word-break: break-all;
 }
 
 /// Sub and sup


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Avoiding long words from overlapping the sidebar on desktop.
    - Added `word-break: break-all;` in code blocks inside titles.

I've tested it with [this article](https://web.dev/monitor-total-page-memory-usage/). You can see the before and after here:

Before 🤸🏼
![image](https://user-images.githubusercontent.com/6775220/153543129-46e4a50d-ab85-44dd-af07-a49af7a4f3be.png)

After ✅
![image](https://user-images.githubusercontent.com/6775220/153543239-3f949992-7287-4595-b1a7-a4833ff8544a.png)

- I chose `break-all` instead of `break-word` because this way the long word starts at the same line. Where with `break-word`, it would start on the next line:

🤔
![image](https://user-images.githubusercontent.com/6775220/153543444-6611dce6-84d6-4653-a68d-11ab8a87c941.png)


When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
