### PR TITLE
Do Not Track short-circuit

### DIFF
--- a/src/site/content/en/vitals/index.md
+++ b/src/site/content/en/vitals/index.md
@@ -6,7 +6,7 @@ hero: image/admin/BHaoqqR73jDWe6FL2kfw.png
 authors:
   - philipwalton
 date: 2020-04-30
-updated: 2021-10-26
+updated: 2022-02-22
 tags:
   - metrics
   - performance
@@ -165,6 +165,8 @@ documentation for complete
 import {getCLS, getFID, getLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
+  if (navigator.doNotTrack === "1") return
+
   const body = JSON.stringify(metric);
   // Use `navigator.sendBeacon()` if available, falling back to `fetch()`.
   (navigator.sendBeacon && navigator.sendBeacon('/analytics', body)) ||


### PR DESCRIPTION
A quick one-liner can ensure user's consent and privacy is respected. While `sendBeacon` should respect `doNotTrack` setting, `fetch` has no such respect and it would be wasteful to `JSON.stringify` an object to no-op anyhow. Perhaps `Navigator.storeTrackingException` for [granting exceptions](https://www.w3.org/TR/tracking-dnt/#exception-granting) would be more robust, but the keep-it-simple approach should to respect privacy. DNT seems to still be the default for Brave and Firefox, which makes sense given their philosophies.
