### PR TITLE
Use document, not window event listener for securitypolicyviolation

### DIFF
--- a/src/site/content/en/blog/trusted-types/index.md
+++ b/src/site/content/en/blog/trusted-types/index.md
@@ -121,7 +121,7 @@ You can deploy a report collector
 or use one of the commercial equivalents.
 You can also debug the violations in the browser:
 ```js
-window.addEventListener('securitypolicyviolation',
+document.addEventListener('securitypolicyviolation',
     console.error.bind(console));
 ```
 


### PR DESCRIPTION
Carrying this change over from https://github.com/GoogleChrome/web.dev/pull/6582, which we couldn't merge, as it seems important.

CC: @koto @agektmr 