### PR TITLE
Log the exception when Algolia fails to run

### DIFF
--- a/run-algolia.js
+++ b/run-algolia.js
@@ -14,4 +14,6 @@
  * limitations under the License.
  */
 
-require('./algolia').index();
+require('./algolia')
+  .index()
+  .catch((e) => console.error(JSON.stringify(e, null, 2)));

--- a/run-algolia.js
+++ b/run-algolia.js
@@ -16,4 +16,8 @@
 
 require('./algolia')
   .index()
-  .catch((e) => console.error(JSON.stringify(e, null, 2)));
+  .catch((error) => {
+    console.error(JSON.stringify(error, null, 2));
+    // We want to explicitly exit with a non-0 code here, to indicate failure.
+    process.exit(1); // eslint-disable-line no-process-exit
+  });


### PR DESCRIPTION
This is useful for determining why `npm run algolia` fails. Without it, there's just a generic `The promise rejected with the reason "#<Object>".` logged.