### PR TITLE
Fix: changed the color from $PRIMARY_TEXT_COLOR  to var(--color-mid-text) to enhance the contrast in the Dark theme

### DIFF
--- a/src/lib/components/ResponseThinkAndCheck/_styles.scss
+++ b/src/lib/components/ResponseThinkAndCheck/_styles.scss
@@ -4,7 +4,7 @@
   @include w-body-text();
   background: rgba($SUCCESS_COLOR, .08);
   border-radius: $GLOBAL_RADIUS;
-  color: $PRIMARY_TEXT_COLOR;
+  color: var(--color-mid-text);
   display: block;
   line-height: 1.778 !important; // Override w-body-text mixin
   padding: 1.125rem;


### PR DESCRIPTION
Fixes #7424

Changed from `color: $PRIMARY_TEXT_COLOR;` to `color: var(--color-mid-text);`

- enhanced the contrast ratio from `1.06` to `10.14`.
- it's working well in both Dark and Light themes.
