### PR TITLE
Add double quotes to rel=preconnect occurrences

### DIFF
--- a/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
+++ b/src/site/content/en/lighthouse-performance/uses-rel-preconnect/index.md
@@ -10,7 +10,7 @@ web_lighthouse:
 ---
 
 The Opportunities section of your Lighthouse report lists all key requests
-that aren't yet prioritizing fetch requests with `<link rel=preconnect>`:
+that aren't yet prioritizing fetch requests with `<link rel="preconnect">`:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/K5TLz5LOyRjffxJ6J9zl.png", alt="A screenshot of the Lighthouse Preconnect to required origins audit", width="800", height="226" %}
@@ -18,7 +18,7 @@ that aren't yet prioritizing fetch requests with `<link rel=preconnect>`:
 
 ## Browser compatibility
 
-`<link rel=preconnect>` is supported on most browsers. See
+`<link rel="preconnect">` is supported on most browsers. See
 [Browser compatibility](https://developer.mozilla.org/docs/Web/HTML/Link_types/preconnect#Browser_compatibility).
 
 ## Improve page load speed with preconnect


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7445 

Changes proposed in this pull request:

- Add double quotes to all occurrences of `<link rel=preconnect>`

<!-- When you're ready to submit your PR, don't forget to add the `$-presubmit` label. -->
