### PR TITLE
Update the BrowserCompat component to filter against stable browsers

### DIFF
--- a/src/site/_includes/components/BrowserCompat.js
+++ b/src/site/_includes/components/BrowserCompat.js
@@ -30,7 +30,7 @@ const compatVersion = (support, release) => {
   } else if (
     !support.version_removed &&
     typeof support.version_added === 'string' &&
-    release.status === 'current'
+    (release.status === 'current' || release.status === 'retired')
   ) {
     return support.version_added;
   } else {
@@ -49,7 +49,7 @@ const compatProperty = (support, release) => {
   } else if (
     !support.version_removed &&
     support.version_added &&
-    release.status === 'current'
+    (release.status === 'current' || release.status === 'retired')
   ) {
     return 'yes';
   } else {
@@ -69,7 +69,7 @@ const compatAria = (support, release, locale) => {
   } else if (
     !support.version_removed &&
     support.version_added &&
-    release.status === 'current'
+    (release.status === 'current' || release.status === 'retired')
   ) {
     return i18n('i18n.browser_compat.supported', locale);
   } else {

--- a/src/site/_includes/components/BrowserCompat.js
+++ b/src/site/_includes/components/BrowserCompat.js
@@ -15,19 +15,22 @@
  */
 const bcd = require('../../_utils/browserCompat');
 const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
+const defaultBcd = require('@mdn/browser-compat-data');
 
 const browsers = ['chrome', 'firefox', 'edge', 'safari'];
 
 /**
  * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
+ * @param {import('@mdn/browser-compat-data/types').ReleaseStatement} release
  * @returns {string}
  */
-const compatVersion = (support) => {
+const compatVersion = (support, release) => {
   if (!support.version_removed && support.version_added === 'preview') {
     return '\uD83D\uDC41'; // 👁 eye
   } else if (
     !support.version_removed &&
-    typeof support.version_added === 'string'
+    typeof support.version_added === 'string' &&
+    release.status === 'current'
   ) {
     return support.version_added;
   } else {
@@ -37,12 +40,17 @@ const compatVersion = (support) => {
 
 /**
  * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
+ * @param {import('@mdn/browser-compat-data/types').ReleaseStatement} release
  * @returns {string}
  */
-const compatProperty = (support) => {
+const compatProperty = (support, release) => {
   if (!support.version_removed && support.version_added === 'preview') {
     return 'preview';
-  } else if (!support.version_removed && support.version_added) {
+  } else if (
+    !support.version_removed &&
+    support.version_added &&
+    release.status === 'current'
+  ) {
     return 'yes';
   } else {
     return 'no';
@@ -51,13 +59,18 @@ const compatProperty = (support) => {
 
 /**
  * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
+ * @param {import('@mdn/browser-compat-data/types').ReleaseStatement} release
  * @param {string} locale
  * @returns {string}
  */
-const compatAria = (support, locale) => {
+const compatAria = (support, release, locale) => {
   if (!support.version_removed && support.version_added === 'preview') {
     return i18n('i18n.browser_compat.preview', locale);
-  } else if (!support.version_removed && support.version_added) {
+  } else if (
+    !support.version_removed &&
+    support.version_added &&
+    release.status === 'current'
+  ) {
     return i18n('i18n.browser_compat.supported', locale);
   } else {
     return i18n('i18n.browser_compat.not_supported', locale);
@@ -72,6 +85,8 @@ function BrowserCompat(feature) {
   const locale = getLocaleFromPath(this.page && this.page.filePathStem);
   const data = bcd();
   let compatIcons = [];
+  /** @type {import('@mdn/browser-compat-data/types').ReleaseStatement} */
+  let release;
 
   if (data[feature] && data[feature].support) {
     compatIcons = browsers.map((browser) => {
@@ -82,19 +97,23 @@ function BrowserCompat(feature) {
 
       const isSupported = support.version_added && !support.version_removed;
 
+      if (isSupported && typeof support.version_added === 'string') {
+        release = defaultBcd.browsers[browser].releases[support.version_added];
+      }
+
       const ariaLabel = [
         browser,
         isSupported ? ` ${support.version_added}, ` : ', ',
-        compatAria(support, locale),
+        compatAria(support, release, locale),
       ].join('');
 
       return `<span class="browser-compat__icon" data-browser="${browser}">
           <span class="visually-hidden">${ariaLabel}</span>
       </span>
       <span class="browser-compat__version"
-        data-compat="${compatProperty(support)}"
+        data-compat="${compatProperty(support, release)}"
       >
-        ${compatVersion(support)}
+        ${compatVersion(support, release)}
       </span>
       `;
     });


### PR DESCRIPTION
Fixes #7447 

Changes proposed in this pull request:

- Introduce a `ReleaseStatement` to lookup `status` info for a given browser release version within compatAria, compatVersion, compatProperty functions.
- Perform a `status` check to determine if the browser release is "current" or not when deciding whether to display the version number or "x" in the compat* functions.

Notes:
The BrowserCompat.js component before my proposed changes was mainly relying on [`SimpleSupportStatement`](https://github.com/mdn/browser-compat-data/blob/312dabab943fe43f7caf7466224d844fa8c4aace/types.d.ts#L134) which provided `version_added`, `version_removed` etc. But this statement type did not include the fields we needed to check the browser version status, as this information was stored in [`ReleaseStatement`](https://github.com/mdn/browser-compat-data/blob/312dabab943fe43f7caf7466224d844fa8c4aace/types.d.ts#L72).

Since we needed to get ahold of a `ReleaseStatement` along with the `SimpleSupportStatement`, I added a bit of logic to do a lookup for a given browser release version provided a `support` object to get the `version_added`, and then check if that release version has a "current" status (not beta). This seems to do the trick for filtering only stable browser release versions, but there is definitely room for improvement for more sturdy filtering based on the possible [`status`](https://github.com/mdn/browser-compat-data/blob/312dabab943fe43f7caf7466224d844fa8c4aace/types.d.ts#L95-L116) values in `ReleaseStatement` object. 

For example, the [scrollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter#browser_compatibility) property displays a browser release version "94" which corresponds to a "[retired](https://github.com/mdn/browser-compat-data/blob/312dabab943fe43f7caf7466224d844fa8c4aace/types.d.ts#L99)" `status` meaning the release is no longer supported, but Chrome 94 does support `scrollbar-gutter` according to [caniuse/scrollbar-gutter](https://caniuse.com/?search=scrollbar-gutter), so this case was something I wanted to mention.
