### PR TITLE
Use 'en' codelabs on translated pages

### DIFF
--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -15,10 +15,10 @@
  */
 
 const {html} = require('common-tags');
+
+const {defaultLanguage} = require('../../../lib/utils/language');
 const {findByUrl} = require('../../_filters/find-by-url');
 const md = require('../../_filters/md');
-
-const DEFAULT_LANGUAGE_CODE = 'en';
 
 /**
  * Find matching collection items given a language code.
@@ -45,10 +45,10 @@ function CodelabsCallout(slugs, lang) {
   slugs = slugs instanceof Array ? slugs : [slugs];
 
   let codelabs = filterCodelabsByLang(slugs, lang);
-  // If there's no language-specific codelab, returning the English-language
-  // one is preferable.
+  // If there's no language-specific codelab, returning the default (English)
+  // language one is preferable.
   if (codelabs.length === 0) {
-    codelabs = filterCodelabsByLang(slugs, DEFAULT_LANGUAGE_CODE);
+    codelabs = filterCodelabsByLang(slugs, defaultLanguage);
   }
   // If there's still no codelabs found, return an empty string (not undefined).
   if (codelabs.length === 0) {

--- a/src/site/_includes/components/CodelabsCallout.js
+++ b/src/site/_includes/components/CodelabsCallout.js
@@ -18,6 +18,21 @@ const {html} = require('common-tags');
 const {findByUrl} = require('../../_filters/find-by-url');
 const md = require('../../_filters/md');
 
+const DEFAULT_LANGUAGE_CODE = 'en';
+
+/**
+ * Find matching collection items given a language code.
+ *
+ * @param {string[]} slugs
+ * @param {string} lang
+ * @returns {EleventyCollectionItem[]}
+ */
+function filterCodelabsByLang(slugs, lang) {
+  return slugs
+    .map((slug) => findByUrl(`/${lang}/${slug}/`))
+    .filter((item) => item); // filter out any undefined entries
+}
+
 /**
  * Generates codelab links HTML.
  *
@@ -29,12 +44,15 @@ function CodelabsCallout(slugs, lang) {
   // Coerce slugs to Array just in case someone pasted in a single slug string.
   slugs = slugs instanceof Array ? slugs : [slugs];
 
-  const codelabs = slugs
-    .map((slug) => findByUrl(`/${lang}/${slug}/`))
-    .filter((item) => item); // filter out any undefined entries
-
-  if (!codelabs.length) {
-    return;
+  let codelabs = filterCodelabsByLang(slugs, lang);
+  // If there's no language-specific codelab, returning the English-language
+  // one is preferable.
+  if (codelabs.length === 0) {
+    codelabs = filterCodelabsByLang(slugs, DEFAULT_LANGUAGE_CODE);
+  }
+  // If there's still no codelabs found, return an empty string (not undefined).
+  if (codelabs.length === 0) {
+    return '';
   }
 
   return `

--- a/test/unit/src/site/_includes/components/CodelabsCallout.js
+++ b/test/unit/src/site/_includes/components/CodelabsCallout.js
@@ -17,6 +17,8 @@
 
 const {expect} = require('chai');
 const cheerio = require('cheerio');
+
+const {defaultLanguage} = require('../../../../../../src/lib/utils/language');
 const {memoize} = require('../../../../../../src/site/_filters/find-by-url');
 const CodelabsCallout = require('../../../../../../src/site/_includes/components/CodelabsCallout');
 
@@ -42,12 +44,19 @@ describe('CodelabsCallout', function () {
       expect(li.length).to.equal(3);
     });
 
-    it('returns nothing if URLs not found', async function () {
+    it('returns an empty string if URLs not found', async function () {
       const html = CodelabsCallout(
         collectionAll.map((i) => i.url + '/pop'),
         'en',
       );
-      expect(html).to.equal(undefined);
+      expect(html).to.equal('');
+    });
+
+    it('returns the default-language codelab as a fallback', async function () {
+      const html = CodelabsCallout('foobar', 'zz');
+      const $ = cheerio.load(html);
+      expect($('a').attr('href')).to.equal(`/${defaultLanguage}/foobar/`);
+      expect($('span').text()).to.equal('foobar');
     });
   });
 


### PR DESCRIPTION
Fixes #7466

I'm working under the assumption that it's better to show English-language codelabs (and the accompanying English-language description) instead of showing nothing on a localized page where there's no language-specific codelab available.

If you disagree, then instead of falling back to checking for `en`, we can just return `''` if there's no language-specific codelab.

This ends up [looking like](https://deploy-preview-7470--web-dev-staging.netlify.app/i18n/ja/http-cache/):

<img width="855" alt="Screen Shot 2022-03-08 at 12 06 51 PM" src="https://user-images.githubusercontent.com/1749548/157288798-28bf3cab-a9b7-4a7f-b15b-95992122638e.png">