### PR TITLE
Adds the link to the CrUX documentation to the responsiveness metric feedback page.

### DIFF
--- a/src/site/content/en/blog/responsiveness/index.md
+++ b/src/site/content/en/blog/responsiveness/index.md
@@ -14,7 +14,7 @@ tags:
 ---
 
 {% Aside 'important' %}
-We have chosen option 2 of [high quantile approximation](/responsiveness/#high-quantile-approximation) as the candidate for the new responsiveness metric, with [maximum event duration](/responsiveness/#measure-interaction-latency) as the definition for interaction latency. This metric will be available as `experimental.responsiveness` starting in the February 2022 CrUX BigQuery dataset, released on March 8, 2022.
+We have chosen option 2 of [high quantile approximation](/responsiveness/#high-quantile-approximation) as the candidate for the new responsiveness metric, with [maximum event duration](/responsiveness/#measure-interaction-latency) as the definition for interaction latency. This metric will be available as `experimental.responsiveness` starting in the February 2022 [CrUX BigQuery dataset](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started), released on March 8, 2022.
 {% endAside %}
 
 Earlier this year, the Chrome Speed Metrics Team shared [some of the

--- a/src/site/content/en/blog/responsiveness/index.md
+++ b/src/site/content/en/blog/responsiveness/index.md
@@ -14,7 +14,7 @@ tags:
 ---
 
 {% Aside 'important' %}
-We have chosen option 2 of [high quantile approximation](/responsiveness/#high-quantile-approximation) as the candidate for the new responsiveness metric, with [maximum event duration](/responsiveness/#measure-interaction-latency) as the definition for interaction latency. This metric will be available as `experimental.responsiveness` starting in the February 2022 [CrUX BigQuery dataset](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started), released on March 8, 2022.
+We have chosen option 2 of [high quantile approximation](/responsiveness/#high-quantile-approximation) as the candidate for the new responsiveness metric, with [maximum event duration](/responsiveness/#measure-interaction-latency) as the definition for interaction latency. This metric will be available as `experimental.responsiveness` starting in the February 2022 [CrUX BigQuery](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started) dataset, released on March 8, 2022.
 {% endAside %}
 
 Earlier this year, the Chrome Speed Metrics Team shared [some of the


### PR DESCRIPTION
As the title suggests, this is a small update to add a link to the CrUX landing page in the aside at the top of the responsiveness metric call for feedback.

cc: @philipwalton 