### PR TITLE
Sort language list to have Latin script languages appear first and alphabetically sorted, while maintaining relative ordering

### DIFF
--- a/src/lib/utils/language.js
+++ b/src/lib/utils/language.js
@@ -22,6 +22,20 @@ const languageNames = {
 };
 
 /**
+ * A map of script groups to their language codes.
+ * @const
+ */
+const scriptGroups = {
+  latin: ['cs', 'de', 'en', 'es', 'fr', 'it', 'no', 'pl', 'pt', 'sv'],
+  cyrillic: ['bg', 'ru'],
+  nonAlphabetic: ['ta', 'zh'],
+  arabic: 'fa',
+  devanagari: 'hi',
+  kanji: 'ja',
+  hangul: 'ko',
+};
+
+/**
  * A default language for the site.
  * @const
  */
@@ -47,4 +61,5 @@ module.exports = {
   defaultLanguage,
   isValidLanguage,
   supportedLanguages,
+  scriptGroups,
 };

--- a/src/lib/utils/language.js
+++ b/src/lib/utils/language.js
@@ -22,18 +22,23 @@ const languageNames = {
 };
 
 /**
- * A map of script groups to their language codes.
+ * When we display a list of translations available for a given page,
+ * use this ordering for the names of the languages.
+ * See https://github.com/GoogleChrome/web.dev/issues/7430
  * @const
  */
-const scriptGroups = {
-  latin: ['cs', 'de', 'en', 'es', 'fr', 'it', 'no', 'pl', 'pt', 'sv'],
-  cyrillic: ['bg', 'ru'],
-  nonAlphabetic: ['ta', 'zh'],
-  arabic: 'fa',
-  devanagari: 'hi',
-  kanji: 'ja',
-  hangul: 'ko',
-};
+const languageOrdering = [
+  'de',
+  'en',
+  'es',
+  'fr',
+  'pl',
+  'pt',
+  'ru',
+  'zh',
+  'ja',
+  'ko',
+];
 
 /**
  * A default language for the site.
@@ -57,9 +62,9 @@ function isValidLanguage(lang) {
 }
 
 module.exports = {
-  languageNames,
   defaultLanguage,
   isValidLanguage,
+  languageNames,
+  languageOrdering,
   supportedLanguages,
-  scriptGroups,
 };

--- a/src/site/_filters/urls.js
+++ b/src/site/_filters/urls.js
@@ -42,20 +42,34 @@ const getRelativePath = (url, pathPrefix) => path.relative(pathPrefix, url);
 /**
  * Find i18n equivalents of the current url and check if they exist.
  * @param {string} url Url of the original article.
- * @returns {Array} Array of language and url pairs.
+ * @returns {Array<Array<string, string>>} Array of language and url pairs.
  */
 const getTranslatedUrls = (url) => {
   url = getDefaultUrl(url);
   return (
     supportedLocales
-      .map((locale) => [locale, path.join('/', 'i18n', locale, url)])
+      .map((locale) => [locale, getLocaleSpecificUrl(locale, url)])
       // Filter out i18n urls that do not have an existing translated file.
-      .filter((langhref) => !!findByUrl(langhref[1]))
+      .filter((langHref) => !!findByUrl(langHref[1]))
   );
+};
+
+/**
+ * Generate a URL that includes the locale-specific prefix.
+ * @param {string} locale One of the support locale codes.
+ * @param {string} defaultUrl Default URL of the page.
+ * @returns {string} The locale-specific prefix followed by the default URL.
+ */
+const getLocaleSpecificUrl = (locale, defaultUrl) => {
+  if (!defaultUrl.startsWith('/')) {
+    defaultUrl = '/' + defaultUrl;
+  }
+  return `/i18n/${locale}${defaultUrl}`;
 };
 
 module.exports = {
   getDefaultUrl,
+  getLocaleSpecificUrl,
   getRelativePath,
   getTranslatedUrls,
 };

--- a/src/site/_includes/components/LanguageList.js
+++ b/src/site/_includes/components/LanguageList.js
@@ -16,27 +16,41 @@
 const path = require('path');
 const {getTranslatedUrls, getDefaultUrl} = require('../../_filters/urls');
 const {i18n} = require('../../_filters/i18n');
-const {languageNames} = require('../../../lib/utils/language');
+const {languageNames, scriptGroups} = require('../../../lib/utils/language');
 
 module.exports = (url, lang) => {
-  const langhrefs = getTranslatedUrls(url)
-    .filter((langhref) => langhref[0] !== lang)
-    .map((langhref) => {
-      const href = langhref[1];
-      return `<a class="w-post-signpost__link"
-        translate="no"
-        lang="${langhref[0]}"
-        href="${href}">
-      ${languageNames[langhref[0]]}</a>`;
-    });
+  let langhrefs = getTranslatedUrls(url).filter(
+    (langhref) => langhref[0] !== lang,
+  );
 
   if (langhrefs.length) {
     const enHref = path.join('/', 'i18n', 'en', getDefaultUrl(url));
-    langhrefs.push(`<a class="w-post-signpost__link"
-        translate="no"
-        lang="en"
-        href="${enHref}">
-      ${languageNames['en']}</a>`);
+    langhrefs.push(['en', enHref]);
+    langhrefs = langhrefs
+      .sort((a, b) => {
+        if (
+          scriptGroups.latin.includes(a[0]) &&
+          !scriptGroups.latin.includes(b[0])
+        ) {
+          return -1;
+        }
+      })
+      .sort((a, b) => {
+        if (
+          scriptGroups.latin.includes(a[0]) &&
+          scriptGroups.latin.includes(b[0])
+        ) {
+          return a[0].localeCompare(b[0]);
+        }
+      })
+      .map((langhref) => {
+        const href = langhref[1];
+        return `<a class="w-post-signpost__link"
+          translate="no"
+          lang="${langhref[0]}"
+          href="${href}">
+        ${languageNames[langhref[0]]}</a>`;
+      });
   }
 
   const availableIn = i18n('i18n.post.available_in', lang);

--- a/src/site/_includes/components/LanguageList.js
+++ b/src/site/_includes/components/LanguageList.js
@@ -13,49 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const path = require('path');
-const {getTranslatedUrls, getDefaultUrl} = require('../../_filters/urls');
+
+const {
+  defaultLanguage,
+  languageNames,
+  languageOrdering,
+} = require('../../../lib/utils/language');
+const {
+  getDefaultUrl,
+  getLocaleSpecificUrl,
+  getTranslatedUrls,
+} = require('../../_filters/urls');
 const {i18n} = require('../../_filters/i18n');
-const {languageNames, scriptGroups} = require('../../../lib/utils/language');
 
 module.exports = (url, lang) => {
-  let langhrefs = getTranslatedUrls(url).filter(
-    (langhref) => langhref[0] !== lang,
+  const langHrefs = getTranslatedUrls(url).filter(
+    (langHref) => langHref[0] !== lang,
   );
 
-  if (langhrefs.length) {
-    const enHref = path.join('/', 'i18n', 'en', getDefaultUrl(url));
-    langhrefs.push(['en', enHref]);
-    langhrefs = langhrefs
-      .sort((a, b) => {
-        if (
-          scriptGroups.latin.includes(a[0]) &&
-          !scriptGroups.latin.includes(b[0])
-        ) {
-          return -1;
-        }
-      })
-      .sort((a, b) => {
-        if (
-          scriptGroups.latin.includes(a[0]) &&
-          scriptGroups.latin.includes(b[0])
-        ) {
-          return a[0].localeCompare(b[0]);
-        }
-      })
-      .map((langhref) => {
-        const href = langhref[1];
-        return `<a class="w-post-signpost__link"
-          translate="no"
-          lang="${langhref[0]}"
-          href="${href}">
-        ${languageNames[langhref[0]]}</a>`;
-      });
+  // Exit early if there are no translations.
+  if (langHrefs.length === 0) {
+    return '';
   }
 
+  // Ensure that the default (English) translation is added as well.
+  const defaultHref = getLocaleSpecificUrl(defaultLanguage, getDefaultUrl(url));
+  langHrefs.push([defaultLanguage, defaultHref]);
+
+  // Sort the list of languages with a specific ordering.
+  // C.f. https://github.com/GoogleChrome/web.dev/issues/7430
+  langHrefs.sort((a, b) => {
+    const indexOfA = languageOrdering.indexOf(a[0]);
+    const indexOfB = languageOrdering.indexOf(b[0]);
+    return indexOfA > indexOfB ? 1 : -1;
+  });
+
+  const languageLinks = langHrefs.map((langHref) => {
+    const href = langHref[1];
+    return `<a class="w-post-signpost__link"
+      translate="no"
+      lang="${langHref[0]}"
+      href="${href}">${languageNames[langHref[0]]}</a>`;
+  });
+
   const availableIn = i18n('i18n.post.available_in', lang);
-  return langhrefs.length
-    ? `<span class="w-post-signpost__title">${availableIn}:
-    ${langhrefs.join(', ')}</span>`
-    : '';
+  const listFormat = new Intl.ListFormat(lang);
+
+  return `<span class="w-post-signpost__title">
+    ${availableIn}:
+    ${listFormat.format(languageLinks)}
+  </span>`;
 };


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #7430 

Changes proposed in this pull request:

- Sort the `langhrefs` array with structure ['es', '/i18n/es/some-page', ...] by languages that are within the Latin script group.
- Sort the `langhrefs` array once more to ensure the latin script languages are sorted alphabetically.
- Non-latin script languages will keep their relative ordering
- Add `scriptGroups` object representing language script groups.

Page: https://web.dev/splash-screen/

**Before:**
Available in: [Español](https://web.dev/i18n/es/splash-screen/), [한국어](https://web.dev/i18n/ko/splash-screen/), [Português](https://web.dev/i18n/pt/splash-screen/), [中文](https://web.dev/i18n/zh/splash-screen/), [English](https://web.dev/i18n/en/splash-screen/)

**After:**
Available in: [English](http://localhost:8080/i18n/en/splash-screen/), [Español](http://localhost:8080/i18n/es/splash-screen/), [Português](http://localhost:8080/i18n/pt/splash-screen/), [한국어](http://localhost:8080/i18n/ko/splash-screen/), [中文](http://localhost:8080/i18n/zh/splash-screen/)


cc @jpmedley 