### PR TITLE
Remove missing images from CSS Animations guide

### DIFF
--- a/src/site/content/en/animations/animations-guide/index.md
+++ b/src/site/content/en/animations/animations-guide/index.md
@@ -268,26 +268,6 @@ can help you to understand where the browser is spending time.
 If you see entries for [**Recalculate Style**](https://developer.mozilla.org/docs/Tools/Performance/Scenarios/Animating_CSS_properties)
 then the browser is having to begin at the start of the [rendering waterfall](https://developer.mozilla.org/docs/Tools/Performance/Scenarios/Animating_CSS_properties).
 
-<figure>
-  <img
-       src="waterfall-before.jpg"
-       alt="The Waterfall panel shows many entries for Recalculate Style.">
-  <figcaption>
-    The <a href="https://animation-with-top-left.glitch.me/">animation-with-top-left</a>
-    example causes style recalculation.
-  </figcaption>
-</figure>
-
-<figure>
-  <img
-       src="waterfall-after.jpg"
-       alt="The Waterfall panel shows no entries for Recalculate Style.">
-  <figcaption>
-    The <a href="https://animation-with-transform.glitch.me/">animation-with-transform</a>
-    example does not cause style recalculation.
-  </figcaption>
-</figure>
-
 ### Check if an animation is dropping frames {: #fps }
 
 1. Open the [**Rendering** tab][rendering] of Chrome DevTools.


### PR DESCRIPTION
Fixes #5946

It's not clear that the original images were ever checked in to GitHub—I can't find it in old commits—and reproducing the images with the current Firefox's DevTools is not feasible, as the interface has changed since the article was originally written.

I'm in favor of just removing the broken images, as the text itself, including the link to the authoritative MDN documentation, should be sufficiently useful.