### PR TITLE
Add location of LH client to /measure/ results

### DIFF
--- a/src/lib/components/LighthouseViewer/index.js
+++ b/src/lib/components/LighthouseViewer/index.js
@@ -38,10 +38,15 @@ class LighthouseViewer extends BaseStateElement {
           />
         </svg>`
       : '';
+    // Hardcode "central United States" based on the current region for
+    // https://lighthouse-dot-webdotdevsite.appspot.com/. If the AppEngine
+    // instance ever moves, we'll need to update this.
+    // See https://github.com/GoogleChrome/web.dev/issues/4321
     return html`
       <div class="text-size-0">
         <span ?hidden="${this.metaHidden}">
-          <span>Audited on:</span> <span>${this.auditedOn}</span>
+          Audited on ${this.auditedOn} using a client in the central
+          United States.
           <a
             title="View latest Lighthouse report"
             href="#"


### PR DESCRIPTION
Fixes #4321 

This just hardcodes the "central United States" as the location, because the underlying infrastructure isn't multi-region, and I'm doubtful that we'll change it anytime soon.

Happy to tweak the exact wording. It looks like:

<img width="1025" alt="Screen Shot 2022-03-15 at 1 59 12 PM" src="https://user-images.githubusercontent.com/1749548/158442401-321ee90a-e0b4-4538-823e-70bc1f6b6d8f.png">