### PR TITLE
Updating OT limitations

### DIFF
--- a/src/site/content/en/blog/speculative-prerendering/index.md
+++ b/src/site/content/en/blog/speculative-prerendering/index.md
@@ -293,7 +293,7 @@ selectors](https://drafts.csswg.org/selectors/).
 An initial implementation for prerendering that covers some of the previously
 discussed features is available as a
 [Chrome origin trial](https://developer.chrome.com/origintrials/#/view_trial/1325184190353768449)
-which will run from Chrome 94 to 98. Following are the
+which will run from Chrome 94 to 100 (Android only). Following are the
 [key features](https://github.com/mfalken/alternate-loading-modes/blob/chrome-origin-trial/same-origin-explainer.md)
 included in this trial.
 


### PR DESCRIPTION
- Suggestion to make the OT limitation explicitly written for prerender2 that it is **only for Android**
- Suggestion to update the writing of the OT period to be available until M100 (source: https://developer.chrome.com/origintrials/#/view_trial/1325184190353768449)

Fixes #7506 

cc/ @addyosmani 