### PR TITLE
Remove the backslash from the landing page header.

### DIFF
--- a/src/site/_includes/item-page.njk
+++ b/src/site/_includes/item-page.njk
@@ -4,7 +4,7 @@ algolia_priority: 0.9
 eleventyComputed:
   noindex: "{{ paged.index > 0 }}"
 ---
-<div class="landing-page">\
+<div class="landing-page">
   {# Hero starts #}
   <header class="region bg-mid-bg">
     <div class="wrapper">


### PR DESCRIPTION
Changes proposed in this pull request:

- The page at https://web.dev/tags/case-study/ shows a misplaced \ at the top.
