### PR TITLE
Fix unprintable characters in URL

### DIFF
--- a/src/site/content/en/learn/design/theming/index.md
+++ b/src/site/content/en/learn/design/theming/index.md
@@ -176,7 +176,7 @@ button {
  tab: 'css,result'
 } %}
 
-See [building a color scheme](​​/building-a-color-scheme/) for more advanced examples of theming with custom properties.
+See [building a color scheme](/building-a-color-scheme/) for more advanced examples of theming with custom properties.
 
 ## Images
 


### PR DESCRIPTION
Fixes #7509

There are some non-printable characters in the old URL, which ends up escaped as `%E2%80%8B%E2%80%8B` when applied to the `<a>` tag.