### PR TITLE
Adds missing authors data

### DIFF
--- a/src/site/_data/authorsData.json
+++ b/src/site/_data/authorsData.json
@@ -618,7 +618,7 @@
     "image": "image/admin/KxIs73yjsWwzEPHQaHEA.jpg"
   },
   "nabeelalshamma": {
-    "image" : "image/8WbTDNrhLsU0El80frMBGE4eMCD3/gZlM5s1kj09oCG5h2buz.jpeg",
+    "image": "image/8WbTDNrhLsU0El80frMBGE4eMCD3/gZlM5s1kj09oCG5h2buz.jpeg",
     "github": "alshamma",
     "linkedin": "https://www.linkedin.com/in/alshamma/"
   },
@@ -1093,7 +1093,7 @@
     "country": "DE",
     "image": "image/ZDZVuXt6QqfXtxkpXcPGfnygYjd2/OZvyDgCkUQAIA87UJV7A.jpg"
   },
-  "leenasohoni":{
+  "leenasohoni": {
     "country": "Singapore",
     "twitter": "leena_sohoni",
     "image": "image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/VXCjCzLEGWApTkZkNZkR.JPG"
@@ -1163,11 +1163,11 @@
     "image": "image/MtjnObpuceYe3ijODN3a79WrxLU2/sWOfAs4f2WyQMMF9xt1A.jpg"
   },
   "alexandrawhite": {
-     "country": "US",
-     "github": "heyawhite",
-     "twitter": "heyawhite",
-     "image": "image/VbsHyyQopiec0718rMq2kTE1hke2/tKKMrgVB852NNd1UMRzN.png"
-   },
+    "country": "US",
+    "github": "heyawhite",
+    "twitter": "heyawhite",
+    "image": "image/VbsHyyQopiec0718rMq2kTE1hke2/tKKMrgVB852NNd1UMRzN.png"
+  },
   "svenmay": {
     "country": "DE",
     "github": "Svenmay",
@@ -1259,5 +1259,10 @@
   "kbalasub": {
     "country": "US",
     "github": "kbalasub"
+  },
+  "patrickhlauke": {
+    "github": "patrickhlauke",
+    "country": "UK",
+    "homepage": "https://www.splintered.co.uk/"
   }
 }

--- a/src/site/_data/i18n/authors.yml
+++ b/src/site/_data/i18n/authors.yml
@@ -3753,3 +3753,9 @@ kbalasub:
     en: Kalyanaraman Balasubramaniam Krishnan
   description:
     en: Kalyan is a Sr. Computer Scientist at Adobe
+
+patrickhlauke:
+  title:
+    en: Patrick H. Lauke
+  description:
+    en: Patrick is a Web Evangelist


### PR DESCRIPTION
#7503 introduced `patrickhlauke` as an author, but there was no corresponding metadata, which broke our build.

I copied info from @patrickhlauke's GitHub profile to bootstrap things and unbreak us; Patrick, feel free to tweak that info in a follow-up PR if you would prefer to be represented differently.

(We will follow-up separately about improving the processes that allowed this breakage to occur.)