### PR TITLE
Fix typo in code splitting code sample

### DIFF
--- a/src/site/content/en/fast/reduce-javascript-payloads-with-code-splitting/index.md
+++ b/src/site/content/en/fast/reduce-javascript-payloads-with-code-splitting/index.md
@@ -63,7 +63,7 @@ form.addEventListener("submit", e => {
   e.preventDefault();
   import('library.moduleA')
     .then(module => module.default) // using the default export
-    .then(someFunction())
+    .then(() => someFunction())
     .catch(handleError());
 });
 


### PR DESCRIPTION
Minor content fix for correctness. The previous code example ran `someFunction` immediately instead of inside the promise callback.
