### PR TITLE
Adding new to the web platform tag

### DIFF
--- a/src/site/_data/i18n/tags.yml
+++ b/src/site/_data/i18n/tags.yml
@@ -850,6 +850,12 @@ network:
     ru: Последние новости и статьи о работе с сетью.
     zh: 我们关于网络的最新资讯、动态和故事。
 
+new-to-the-web:
+  title:
+    en: New to the web platform
+  description:
+    en: A series of posts to keep you updated with what's landing in web browsers each month.
+
 node:
   title:
     en: Node

--- a/src/site/content/en/blog/web-platform-01-2022/index.md
+++ b/src/site/content/en/blog/web-platform-01-2022/index.md
@@ -12,6 +12,7 @@ authors:
   - rachelandrew
 tags:
   - blog
+  - new-to-the-web
 ---
 
 ## Stable browser releases

--- a/src/site/content/en/blog/web-platform-02-2022/index.md
+++ b/src/site/content/en/blog/web-platform-02-2022/index.md
@@ -12,6 +12,7 @@ authors:
   - rachelandrew
 tags:
   - blog
+  - new-to-the-web
 ---
 
 ## Stable browser releases


### PR DESCRIPTION
Fixes #7344 

Adds a tag for the new to the web platform series, this fixes the issue requesting this but I also want to be able to link to the series from a talk.
