### PR TITLE
Close the <h3> on the /learn/ page properly

### DIFF
--- a/src/site/_includes/learn-page.njk
+++ b/src/site/_includes/learn-page.njk
@@ -65,7 +65,7 @@ pageScripts:
                 </div>
                 <img src="{{ path.cover | imgix }}" alt="{{ path.title | i18n(locale) }}" />
                 <div class="card__content flow">
-                  <h3 class="card__heading text-size-2">{{ path.title | i18n(locale) }}</h2>
+                  <h3 class="card__heading text-size-2">{{ path.title | i18n(locale) }}</h3>
                   <p class="text-size-0">{{ path.description | i18n(locale) }}</p>
                 </div>
               </a>


### PR DESCRIPTION
This was the root cause of the issue in #7523, as the HTML minifier we switched to was not as forgiving about mis-matched tags as the previous one we were using.