### PR TITLE
Extend WebGPU Origin Trial

### DIFF
--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -87,7 +87,7 @@ To experiment with WebGPU locally, without an origin trial token, enable the
 ### Enabling support during the origin trial phase
 
 Starting in Chrome&nbsp;94, WebGPU is available as an origin trial in Chrome. The
-origin trial is expected to end in Chrome&nbsp;104 (Sep 21, 2022).
+origin trial is expected to end in Chrome&nbsp;105 (Sep 21, 2022).
 
 {% include 'content/origin-trials.njk' %}
 

--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-updated: 2022-03-10
+updated: 2022-03-21
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 description: |
@@ -87,7 +87,7 @@ To experiment with WebGPU locally, without an origin trial token, enable the
 ### Enabling support during the origin trial phase
 
 Starting in Chrome&nbsp;94, WebGPU is available as an origin trial in Chrome. The
-origin trial is expected to end in Chrome&nbsp;101 (May 18, 2022).
+origin trial is expected to end in Chrome&nbsp;104 (Aug 31, 2022).
 
 {% include 'content/origin-trials.njk' %}
 

--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -87,7 +87,7 @@ To experiment with WebGPU locally, without an origin trial token, enable the
 ### Enabling support during the origin trial phase
 
 Starting in Chrome&nbsp;94, WebGPU is available as an origin trial in Chrome. The
-origin trial is expected to end in Chrome&nbsp;104 (Aug 31, 2022).
+origin trial is expected to end in Chrome&nbsp;104 (Sep 21, 2022).
 
 {% include 'content/origin-trials.njk' %}
 

--- a/src/site/content/en/blog/gpu/index.md
+++ b/src/site/content/en/blog/gpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-updated: 2022-03-21
+updated: 2022-03-23
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 thumbnail: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/SN6GIsxmcINXJZKszOTr.jpeg
 description: |


### PR DESCRIPTION
A request to extend WebGPU origin trial has been made:  https://groups.google.com/a/chromium.org/g/blink-dev/c/GD0shbDnFuM

I will merge this PR when/if the request gets approved.

FYI @kangz