### PR TITLE
Separate ScrollSpy into abstract class

### DIFF
--- a/src/lib/components/TocScrollSpy/index.js
+++ b/src/lib/components/TocScrollSpy/index.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the Licenspe.
+ */
+
+import {ScrollSpy} from '../ScrollSpy';
+
+/**
+ * Element that adds active classes to its children when the user scrolls to
+ * a heading this child points to.
+ * @extends {ScrollSpy}
+ * @final
+ */
+class TocScrollSpy extends ScrollSpy {
+  constructor() {
+    super();
+    this.selector = this.selector = 'h2[id], h3[id]';
+    this.tocActiveClass = 'w-scroll-spy__active';
+    this.tocVisibleClass = 'w-scroll-spy__visible';
+  }
+
+  scrollSpy(headings) {
+    const links = new Map(
+      [...this.querySelectorAll('a')].map((l) => [l.getAttribute('href'), l]),
+    );
+    for (const heading of headings) {
+      const href = `#${heading.target.getAttribute('id')}`;
+      const link = links.get(href);
+
+      if (link) {
+        if (heading.intersectionRatio > 0) {
+          link.classList.add(this.tocVisibleClass);
+          this.previouslyActiveHeading = heading.target.getAttribute('id');
+        } else {
+          link.classList.remove(this.tocVisibleClass);
+        }
+      }
+
+      const firstVisibleLink = this.querySelector(`.${this.tocVisibleClass}`);
+
+      links.forEach((link) => {
+        link.classList.remove(this.tocActiveClass, this.tocVisibleClass);
+      });
+
+      if (firstVisibleLink) {
+        firstVisibleLink.classList.add(this.tocActiveClass);
+      }
+
+      if (!firstVisibleLink && this.previouslyActiveHeading) {
+        const last = this.querySelector(
+          `a[href="#${this.previouslyActiveHeading}"]`,
+        );
+        last.classList.add(this.tocActiveClass);
+      }
+    }
+  }
+}
+
+customElements.define('toc-scroll-spy', TocScrollSpy);

--- a/src/site/_includes/partials/toc-side.njk
+++ b/src/site/_includes/partials/toc-side.njk
@@ -5,10 +5,10 @@
 {% if tocContents %}
   <nav class="course__toc toc over-scroll hidden-yes xl:hidden-no" data-type="side" aria-label="{{ tocTitle if tocTitle else 'i18n.toc.toc' | i18n(locale) }}">
     <div class="course-toc__heading font-google-sans weight-medium">{{ tocTitle if tocTitle else 'i18n.toc.toc' | i18n(locale) }}</div>
-    <web-scroll-spy>
+    <toc-scroll-spy>
       <div class="toc__wrapper flow-recursive">
         {{ tocContents | safe }}
       </div>
-    </web-scroll-spy>
+    </toc-scroll-spy>
   </nav>
 {% endif %}


### PR DESCRIPTION
The intention is to be able to observe arbitrary elements on the page, and be able to build widgets that react to the changes in scroll position of an article.