### PR TITLE
Fix small text threshold explanation

### DIFF
--- a/src/site/content/en/lighthouse-seo/font-size/index.md
+++ b/src/site/content/en/lighthouse-seo/font-size/index.md
@@ -22,7 +22,7 @@ with font sizes that are too small to read easily on mobile:
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ky2VDt8ZtedleWFLn1Gt.png", alt="Lighthouse audit showing page has illegible font sizes", width="800", height="225" %}
 </figure>
 
-Lighthouse flags pages on which 60% or more of the text has a font size smaller
+Lighthouse flags pages on which 40% or more of the text has a font size smaller
 than 12&nbsp;px. When a page fails the audit, Lighthouse lists the results in a
 table with four columns:
 


### PR DESCRIPTION
In the image above the changed paragraph it says:

> Strive to have >60% of page text >= 12px

I think that is the same as what the text ends up saying after the this commit (?) "Lighthouse flags pages on which 40% or more of the text has a font size smaller
than 12&nbsp;px."

Maybe it would be better to change the explanation to explain this the other way around like "Unless your page have 60% or more text with text size bigger than 12px"?

I think I'm leaning towards it being more intuitive the way that the text ended up in this commit though :)

/ Trond froding
PS: Thanks a lot for all amazing content on web.dev!
