### PR TITLE
Update to package-lock.json for @mdn/browser-compat-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@google-cloud/cloudbuild": "^2.6.0",
         "@google-cloud/error-reporting": "^2.0.3",
         "@google-cloud/secret-manager": "^3.10.0",
-        "@mdn/browser-compat-data": "^4.1.10",
+        "@mdn/browser-compat-data": "^4.1.14",
         "@minify-html/js": "^0.8.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -1606,9 +1606,9 @@
       "integrity": "sha512-ni+E5jbVVrN7D7xfB7qzXjMq5rhSh20dILHfQl02GrySpdT+9KZp1acs8bZtBgmIqhOBkjk8+fTX30nq1UraGg=="
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.10.tgz",
-      "integrity": "sha512-z3UzXqOjrgUnKENwdhFZmU7oeEWTOjUmWGQtXTOEbTR1FdwSBF6RCU6RPkv10ryP00y5ybCUm++4t5B8Wc3tPg=="
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.14.tgz",
+      "integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw=="
     },
     "node_modules/@minify-html/js": {
       "version": "0.8.0",
@@ -27004,6 +27004,7 @@
       "version": "3.13.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
       "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
+      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -30169,9 +30170,9 @@
       "integrity": "sha512-ni+E5jbVVrN7D7xfB7qzXjMq5rhSh20dILHfQl02GrySpdT+9KZp1acs8bZtBgmIqhOBkjk8+fTX30nq1UraGg=="
     },
     "@mdn/browser-compat-data": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.10.tgz",
-      "integrity": "sha512-z3UzXqOjrgUnKENwdhFZmU7oeEWTOjUmWGQtXTOEbTR1FdwSBF6RCU6RPkv10ryP00y5ybCUm++4t5B8Wc3tPg=="
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.14.tgz",
+      "integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw=="
     },
     "@minify-html/js": {
       "version": "0.8.0",
@@ -50315,7 +50316,8 @@
     "uglify-js": {
       "version": "3.13.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
-      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg=="
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
+      "optional": true
     },
     "uhyphen": {
       "version": "0.1.0",


### PR DESCRIPTION
This resolves an issue we're having with our production deployment following https://github.com/GoogleChrome/web.dev/pull/7614, in which `npm ci` is failing with the following error:

```
Step #0 - "Install dependencies": npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
Step #0 - "Install dependencies": npm ERR! 
Step #0 - "Install dependencies": npm ERR! Invalid: lock file's @mdn/browser-compat-data@4.1.10 does not satisfy @mdn/browser-compat-data@4.1.14
```