### PR TITLE
fix link on "how to check if your site is hacked"

### DIFF
--- a/src/site/content/en/secure/fixing-the-japanese-keyword-hack/index.md
+++ b/src/site/content/en/secure/fixing-the-japanese-keyword-hack/index.md
@@ -11,7 +11,7 @@ tags:
 
 {% Aside %}
 Unsure whether or not your site is hacked? Start by reading our
-[how to check if your site is hacked](/secure/how-do-I-know-if-my-site-was-hacked/) guide.
+[how to check if your site is hacked](/how-do-i-know-if-my-site-was-hacked/) guide.
 {% endAside %}
 
 This guide is created specifically for a type of hack that creates


### PR DESCRIPTION
The current URL `/secure/how-do-I-know-if-my-site-was-hacked/` 301 redirects to `/how-do-I-know-if-my-site-was-hacked/` which 404's due to the uppercase I
