### PR TITLE
Fix table markup in Defining CWV metrics article

### DIFF
--- a/src/site/content/en/blog/defining-core-web-vitals-thresholds/index.md
+++ b/src/site/content/en/blog/defining-core-web-vitals-thresholds/index.md
@@ -74,7 +74,8 @@ performance as either "good", "needs improvement", or "poor":
       <td>>0.25</td>
       <td>75</td>
     </tr>
-</table>
+  </table>
+</div>
 
 Additionally, to classify the overall performance of a page or site, we use the
 75th percentile value of all page views to that page or site. In other words, if


### PR DESCRIPTION
Minor fix to the [Defining the Core Web Vitals metrics thresholds](https://web.dev/defining-core-web-vitals-thresholds) article. The first `.table-wrapper` div is missing its closing tag causing the remaining article to not display properly - missing margins, making it difficult to read the article.

Checked the translations and it seems this is only an issue in the English version.

<details><summary>Before fix</summary>

![Screen Shot 2022-04-02 at 12 49 54 AM](https://user-images.githubusercontent.com/2221746/161352140-8fde1ca2-9197-4b00-b3ff-b5df2fcc0b8e.png)
</details>

<details><summary>After fix</summary>

![Screen Shot 2022-04-02 at 12 50 19 AM](https://user-images.githubusercontent.com/2221746/161352249-42bf54b7-c0dc-4b59-90ad-44a1e4414432.png)
</details>