### PR TITLE
fix(codelabs): Code blocks not matching article and non-formatted code blocks

### DIFF
--- a/src/site/content/en/fast/codelab-text-compression-brotli/index.md
+++ b/src/site/content/en/fast/codelab-text-compression-brotli/index.md
@@ -136,14 +136,14 @@ var shrinkRay = require('shrink-ray');
 
 And add it as a middleware before `express.static` is mounted:
 
-```js/6
+```js/4
 //...
 var app = express();
 
-app.use(express.static('public'));
-
 // compress all requests
 app.use(shrinkRay());
+
+app.use(express.static('public'));
 ```
 
 Now reload the app, and take a look at the bundle size in the Network panel:

--- a/src/site/content/en/fast/codelab-text-compression-brotli/index.md
+++ b/src/site/content/en/fast/codelab-text-compression-brotli/index.md
@@ -209,18 +209,18 @@ var BrotliPlugin = require('brotli-webpack-plugin');
 
 And include it within the plugins array:
 
-<pre>
+```js/4-7
 module.exports = {
   // ...
   plugins: [
     // ...
-    <strong>new BrotliPlugin({
+    new BrotliPlugin({
       asset: '[file].br',
       test: /\.(js)$/
-    })</strong>
+    })
   ]
 },
-</pre>
+```
 
 The following arguments are used in the plugin array:
 +  `asset`: The target asset name.
@@ -256,20 +256,20 @@ Next, tell the server to send these brotli-compressed files whenever their
 original JS versions are being requested. This can be done by defining a new
 route in `server.js` before the files are served with `express.static`.
 
-<pre>
+```js/4-9
 var express = require('express');
 
 var app = express();
 
-<strong>app.get('*.js', (req, res, next) => {
+app.get('*.js', (req, res, next) => {
   req.url = req.url + '.br';
   res.set('Content-Encoding', 'br');
   res.set('Content-Type', 'application/javascript; charset=UTF-8');
   next();
-});</strong>
+});
 
 app.use(express.static('public'));
-</pre>
+```
 
 `app.get` is used to tell the server how to respond to a `GET` request for a
 specific endpoint. A callback function is then used to define how to handle this


### PR DESCRIPTION
Fixes #7635

Changes proposed in this pull request:

- [Move shrink-ray middleware above express.static](https://github.com/GoogleChrome/web.dev/commit/ec1814219781ec35299f7e8b29b92636b66d91e0)
- [Add missing codeblocks](https://github.com/GoogleChrome/web.dev/commit/70bf2821719e05bdf2280d19b3cc26f45df70170)

### Screenshots

<details><summary>Before the fix</summary>

![Screen Shot 2022-04-02 at 3 39 16 PM](https://user-images.githubusercontent.com/2221746/161386273-97ae950f-fb57-49e6-bfae-4a2e81f82367.png)
![Screen Shot 2022-04-02 at 3 39 26 PM](https://user-images.githubusercontent.com/2221746/161386276-3b006fc3-b9da-4219-85bc-3b1dc3822093.png)
![Screen Shot 2022-04-02 at 3 39 47 PM](https://user-images.githubusercontent.com/2221746/161386275-d737d659-5420-45e5-af39-ccfb9f28037d.png)
</details>

<details><summary>After the fix</summary>

![Screen Shot 2022-04-02 at 4 29 53 PM](https://user-images.githubusercontent.com/2221746/161388049-60dbdbaa-259b-42f1-989b-05fc5bbbb994.png)
![Screen Shot 2022-04-02 at 4 30 11 PM](https://user-images.githubusercontent.com/2221746/161388048-1df9de35-a715-4f51-963a-af04b142fca7.png)
![Screen Shot 2022-04-02 at 4 30 20 PM](https://user-images.githubusercontent.com/2221746/161388047-d25205d5-3645-4168-83d9-fc8019c9f4cb.png)
</details>