### PR TITLE
Treat missing type attribute as type=text in CSS

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -503,6 +503,8 @@ details summary + * {
 
 /// Form fields
 
+// See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
+input:not([type]),
 input[type='text'],
 input[type='email'],
 input[type='password'],
@@ -526,6 +528,8 @@ textarea {
   @include apply-utility('leading', 'short');
 }
 
+// See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
+input:not([type]),
 input[type='text'],
 input[type='email'],
 input[type='password'],

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -503,6 +503,8 @@ details summary + * {
 
 /// Form fields
 
+// Style inputs without a type attribute the same as type="text", since they
+// are semantically equivalent.
 // See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
 input:not([type]),
 input[type='text'],
@@ -528,6 +530,8 @@ textarea {
   @include apply-utility('leading', 'short');
 }
 
+// Style inputs without a type attribute the same as type="text", since they
+// are semantically equivalent.
 // See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
 input:not([type]),
 input[type='text'],

--- a/src/scss/web-components/_web-subscribe.scss
+++ b/src/scss/web-components/_web-subscribe.scss
@@ -13,6 +13,8 @@ web-subscribe {
     margin-inline: auto;
   }
 
+  // See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
+  input:not([type]),
   input[type='text'],
   input[type='email'],
   input[type='password'],

--- a/src/styles/generic/_input.scss
+++ b/src/styles/generic/_input.scss
@@ -1,5 +1,7 @@
 @import '../settings/colors';
 
+// See https://github.com/GoogleChrome/web.dev/issues/7638#issuecomment-1087607518
+input:not([type]),
 input[type='email'],
 input[type='password'],
 input[type='text'] {


### PR DESCRIPTION
Fixes #7638

Our current HTML minifier removes the `type="text"` attribute from `<input>` elements, since that's the implicit value. (I don't see any [option](https://docs.rs/minify-html/latest/minify_html/struct.Cfg.html) to disable this removal.)

Our current CSS uses the presence of `type="text"` to style certain form fields, including the newsletter signup field. When those fields are unstyled, they can look jarring, especially in Dark Mode.

This PR attempts to address this by finding all the places we have explicit styling for `input[type='text']`, and adds `input:not([type])` as an additional selector to apply the same styling.

I could have also removed the `type="text"` attributes from the original HTML (since they're going to be removed during minification anyway), to keep the development and production HTML similar, but I didn't in this PR. Let me know if you think I should.

It would be good to hear from @hankchizljaw to see if I'm missing something when it comes to these styles, since I believe they worked them originally.