### PR TITLE
Fix for the Aside component

### DIFF
--- a/src/site/_includes/components/Aside.js
+++ b/src/site/_includes/components/Aside.js
@@ -15,18 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
-const isDesignSystemContext = require('../../../lib/utils/is-design-system-context');
+
+const {html} = require('common-tags');
 const fs = require('fs');
+const md = require('markdown-it')();
 const path = require('path');
 
-/* NOTE: This component is in a transition period to support both new design system contexts
-and the existing system. Once the new design system has been *fully* rolled out, this component
-can be cleaned up with the following:
-
-1. The isDesignSystemContext conditional can be removed and code in that block should run as normal
-2. Everything from the '/// DELETE THIS WHEN ROLLOUT COMPLETE' comment *downwards* can be removed
-*/
+const {i18n, getLocaleFromPath} = require('../../_filters/i18n');
 
 /**
  * @this {EleventyPage}
@@ -34,148 +29,107 @@ can be cleaned up with the following:
 function Aside(content, type = 'note') {
   const locale = getLocaleFromPath(this.page && this.page.filePathStem);
 
-  /// UN-FENCE CODE IN THIS BLOCK WHEN ROLLOUT COMPLETE
-  if (isDesignSystemContext(this.page.filePathStem)) {
-    // CSS utility classes that vary per aside type
-    const utilities = {
-      main: '',
-      title: '',
-      icon: '',
-      body: '',
-    };
+  // CSS utility classes that vary per aside type
+  const utilities = {
+    main: '',
+    title: '',
+    icon: '',
+    body: '',
+  };
 
-    // These two get populated based on type
-    let title = '';
-    let icon = '';
+  // These two get populated based on type
+  let title = '';
+  let icon = '';
 
-    // If an icon is required, it grabs the SVG source with fs
-    // because in a shortcode, we have no access to includes etc
-    const getIcon = () => {
-      if (!icon.length) {
-        return '';
-      }
-
-      return fs.readFileSync(
-        path.join(__basedir, 'src', 'site', '_includes', 'icons', icon),
-        'utf8',
-      );
-    };
-
-    // Generate all the configurations per aside type
-    switch (type) {
-      case 'note':
-      default:
-        utilities.title = 'color-state-info-text';
-        utilities.main = 'bg-state-info-bg color-state-info-text';
-        break;
-
-      case 'caution':
-        utilities.title = 'color-state-bad-text';
-        utilities.main = 'bg-state-bad-bg color-state-bad-text';
-        icon = 'error.svg';
-        title = i18n(`i18n.common.${type}`, locale);
-        break;
-
-      case 'warning':
-        utilities.icon = 'color-state-warn-text';
-        utilities.main = 'bg-state-warn-bg color-state-warn-text';
-        icon = 'warning.svg';
-        title = i18n(`i18n.common.${type}`, locale);
-        break;
-
-      case 'success':
-        utilities.main = 'bg-state-good-bg color-state-good-text';
-        icon = 'done.svg';
-        title = i18n(`i18n.common.${type}`, locale);
-        break;
-
-      case 'objective':
-        utilities.main = 'bg-state-good-bg color-state-good-text';
-        icon = 'done.svg';
-        title = i18n(`i18n.common.${type}`, locale);
-        break;
-
-      case 'gotchas':
-        icon = 'lightbulb.svg';
-        title = i18n(`i18n.common.gotchas`, locale);
-        utilities.main = 'bg-tertiary-box-bg color-tertiary-box-text';
-        break;
-
-      case 'important':
-        icon = 'lightbulb.svg';
-        title = i18n(`i18n.common.important`, locale);
-        utilities.main = 'bg-tertiary-box-bg color-tertiary-box-text';
-        break;
-
-      case 'key-term':
-        icon = 'highlighter.svg';
-        title = i18n(`i18n.common.key_term`, locale);
-        utilities.main = 'color-secondary-box-text bg-secondary-box-bg';
-        break;
-
-      case 'codelab':
-        icon = 'code.svg';
-        title = i18n(`i18n.common.try_it`, locale);
-        utilities.main = 'bg-quaternary-box-bg color-quaternary-box-text';
-        break;
+  // If an icon is required, it grabs the SVG source with fs
+  // because in a shortcode, we have no access to includes etc
+  const getIcon = () => {
+    if (!icon.length) {
+      return '';
     }
 
-    return `<aside class="aside flow ${utilities.main}">
-${
-  title.length
-    ? `<p class="cluster ${utilities.title}">
-<span class="aside__icon box-block ${utilities.icon}">${getIcon()}</span>
-<strong>${title}</strong></p>`
-    : ''
-}
-<div class="${utilities.body} flow">
+    return fs.readFileSync(
+      path.join(__basedir, 'src', 'site', '_includes', 'icons', icon),
+      'utf8',
+    );
+  };
 
-${content}
-</div></aside>`;
-  }
-
-  /// DELETE THIS WHEN ROLLOUT COMPLETE
-  let prefix;
+  // Generate all the configurations per aside type
   switch (type) {
     case 'note':
-      prefix = '';
+    default:
+      utilities.title = 'color-state-info-text';
+      utilities.main = 'bg-state-info-bg color-state-info-text';
       break;
 
     case 'caution':
+      utilities.title = 'color-state-bad-text';
+      utilities.main = 'bg-state-bad-bg color-state-bad-text';
+      icon = 'error.svg';
+      title = i18n(`i18n.common.${type}`, locale);
+      break;
+
     case 'warning':
+      utilities.icon = 'color-state-warn-text';
+      utilities.main = 'bg-state-warn-bg color-state-warn-text';
+      icon = 'warning.svg';
+      title = i18n(`i18n.common.${type}`, locale);
+      break;
+
     case 'success':
+      utilities.main = 'bg-state-good-bg color-state-good-text';
+      icon = 'done.svg';
+      title = i18n(`i18n.common.${type}`, locale);
+      break;
+
     case 'objective':
-      prefix = `**${i18n(`i18n.common.${type}`, locale)}**:`;
-      break;
-
-    case 'codelab':
-      prefix = `**${i18n(`i18n.common.try_it`, locale)}**!`;
-      break;
-
-    case 'key-term':
-      prefix = `**${i18n(`i18n.common.key_term`, locale)}**:`;
+      utilities.main = 'bg-state-good-bg color-state-good-text';
+      icon = 'done.svg';
+      title = i18n(`i18n.common.${type}`, locale);
       break;
 
     case 'gotchas':
-      prefix = i18n(`i18n.common.gotchas`, locale);
-      // IMPORTANT: The weird whitespace control in both of the below returns
-      // is intentional. The newline after the opening div instructs the markdown
-      // parser to kick back in. But we have to be careful not to introduce any
-      // other newlines or it will insert an extra closing </p> and break the page.
-      // This is true for all shortcodes that accept markdown and return html.
+      icon = 'lightbulb.svg';
+      title = i18n(`i18n.common.gotchas`, locale);
+      utilities.main = 'bg-tertiary-box-bg color-tertiary-box-text';
+      break;
 
-      // The <strong> tag should appear outside of the <p> tag
-      // generated by markdown. This forces an intentional line break.
-      // prettier-ignore
-      return `<div class="w-aside w-aside--${type}"><strong>${prefix}!</strong>
+    case 'important':
+      icon = 'lightbulb.svg';
+      title = i18n(`i18n.common.important`, locale);
+      utilities.main = 'bg-tertiary-box-bg color-tertiary-box-text';
+      break;
 
-${content}</div>`;
+    case 'key-term':
+      icon = 'highlighter.svg';
+      title = i18n(`i18n.common.key_term`, locale);
+      utilities.main = 'color-secondary-box-text bg-secondary-box-bg';
+      break;
+
+    case 'codelab':
+      icon = 'code.svg';
+      title = i18n(`i18n.common.try_it`, locale);
+      utilities.main = 'bg-quaternary-box-bg color-quaternary-box-text';
+      break;
   }
 
-  // prettier-ignore
-  return `<div class="w-aside w-aside--${type}">
+  // Make sure that we don't insert multiple newlines when this component is
+  // used, as it can break the parent Markdown rendering.
+  // See https://github.com/GoogleChrome/web.dev/issues/7640
+  const renderedContent = md.renderInline(content);
+  const titleHTML = title.length
+    ? `<p class="cluster ${utilities.title}">` +
+      `<span class="aside__icon box-block ${
+        utilities.icon
+      }">${getIcon()}</span>` +
+      `<strong>${title}</strong></p>`
+    : '';
+  const asideHTML =
+    `<aside class="aside flow ${utilities.main}">` +
+    titleHTML +
+    `<div class="${utilities.body} flow">${renderedContent}</div></aside>`;
 
-${prefix} ${content}</div>`;
+  return html`${asideHTML}`;
 }
 
 module.exports = Aside;

--- a/src/site/content/en/blog/test-post/index.md
+++ b/src/site/content/en/blog/test-post/index.md
@@ -682,3 +682,17 @@ porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
 quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
 ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
 quam sem.
+
+### Test of Aside nested in an ordered list
+
+See the <a href="https://github.com/GoogleChrome/web.dev/issues/7640">underlying issue</a>.
+
+1. First item.
+   Another line.
+
+2. Second item.
+   {% Aside %}
+   This is an `<aside>`, including [Markdown](https://example.com/).
+   {% endAside %}
+
+3. Third item.


### PR DESCRIPTION
This PR does three things:

1. Fixes #7640, by ensuring that the string returned by the `{% Aside %}` component won't interact with the parent's Markdown parsing, e.g.  by including multiple newlines, which could cause a `</li>` tag to be potentially added to the middle of the returned string. The approach used here [mimics what's done](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_includes/components/Label.js) in the `{% Label %}` component.
2. Adds a test case to `/test-post/` to trigger this issue. I can confirm that the test results in incorrect HTML prior to this PR, and correct HTML with this PR.
3. Removes unused code that was leftover from before our design system migration.