### PR TITLE
Remove distinction between relative/absolute sizing

### DIFF
--- a/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
+++ b/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
@@ -66,7 +66,10 @@ displayed at.
 
 ### The "Better" approach
 
-For images with both absolute and relative sizing, use [srcset](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset) and [sizes](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes) attributes to serve different images to different display densities. (Read the guide on Responsive Images [here](/serve-responsive-images).)
+For images with both absolute and relative sizing, use [`srcset`](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset)
+and [`sizes`](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes)
+attributes to serve different images to different display densities.
+Read the [guide on responsive images](/serve-responsive-images).
 
 "Display density" refers to the fact that different displays have different
 densities of pixels. All other things being equal, a high pixel density

--- a/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
+++ b/src/site/content/en/fast/serve-images-with-correct-dimensions/index.md
@@ -66,8 +66,7 @@ displayed at.
 
 ### The "Better" approach
 
-For images with sizing based on…
-- **Absolute units:** Use [srcset](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset) and [sizes](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes) attributes to serve different images to different display densities. (Read the guide on Responsive Images [here](/serve-responsive-images).)
+For images with both absolute and relative sizing, use [srcset](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset) and [sizes](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes) attributes to serve different images to different display densities. (Read the guide on Responsive Images [here](/serve-responsive-images).)
 
 "Display density" refers to the fact that different displays have different
 densities of pixels. All other things being equal, a high pixel density
@@ -85,9 +84,6 @@ does not.
 Responsive image techniques make this possible by allowing you to list
 multiple image versions and for the device to choose the image that works
 best for it.
-
-- **Relative units:** Use responsive images to serve different images to display sizes. (Read
-the guide [here](/serve-responsive-images).)
 
 An image that works across all devices will be unnecessarily large for
 smaller devices. Responsive image techniques, specifically [srcset](https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset")


### PR DESCRIPTION
The distinction between relative/absolute sizing in this section seems redundant as the solution seems the same (as is the link for each one, which goes to the same article on responsive images). Makes for confusing reading and I can't see any disadvantage to consolidating these sections into one.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
