### PR TITLE
use extension

### DIFF
--- a/src/site/content/en/blog/commonjs-larger-bundles/index.md
+++ b/src/site/content/en/blog/commonjs-larger-bundles/index.md
@@ -47,7 +47,7 @@ Later on, another module can import and use some or all of these functions:
 
 ```javascript
 // index.js
-const { add } = require('./utils');
+const { add } = require('./utils.js');
 console.log(add(1, 2));
 ```
 
@@ -103,7 +103,7 @@ export const max = arr => maxBy(arr);
 And `index.js` would import from `utils.js` using ECMAScript module syntax:
 
 ```javascript
-import { add } from './utils';
+import { add } from './utils.js';
 
 console.log(add(1, 2));
 ```
@@ -135,7 +135,7 @@ export const subtract = (a, b) => a - b;
 
 ```javascript
 // index.js
-import { add } from './utils';
+import { add } from './utils.js';
 const subtract = (a, b) => a - b;
 
 console.log(add(1, 2));


### PR DESCRIPTION
you talk about esm but you aren't truly using esm, b/c esm is strict about the path
this only works cuz you are using a bundler...

also extensionless file lookups makes a lot of unnecessary stats lookup on the HDD
made a benchmark on a module that included 5000 empty dummy files with and without `.js` extension and the result was that it took like like 0.5 - 1.5s longer to find all those small modules.
