### PR TITLE
Allow HTML in Aside components

### DIFF
--- a/src/site/_includes/components/Aside.js
+++ b/src/site/_includes/components/Aside.js
@@ -18,7 +18,9 @@
 
 const {html} = require('common-tags');
 const fs = require('fs');
-const md = require('markdown-it')();
+// We need html: true since folks embed HTML inside of {% Aside %}.
+// See https://markdown-it.github.io/markdown-it/#MarkdownIt.new
+const md = require('markdown-it')({html: true});
 const path = require('path');
 
 const {i18n, getLocaleFromPath} = require('../../_filters/i18n');


### PR DESCRIPTION
Fixes #7710

Following #7648, the logic for parsing the content inside an `{% Aside %}` changed. Markdown is parsed, but there's an extra level of escaping done by default that would prevent HTML inside of `{% Aside %}` from being rendered.

It seems like it's common enough for folks to use HTML inside of `{% Aside %}` (@rachelandrew fixed a similar issue in #7680), so I think we need to enable it here rather than trying to clean up each instance.