### PR TITLE
Fix typo in Building a dialog component post

### DIFF
--- a/src/site/content/en/blog/building-a-dialog-component/index.md
+++ b/src/site/content/en/blog/building-a-dialog-component/index.md
@@ -1057,8 +1057,8 @@ const dialogDeleteObserver = new MutationObserver((mutations, observer) => {
   mutations.forEach(mutation => {
     mutation.removedNodes.forEach(removedNode => {
       if (removedNode.nodeName === 'DIALOG') {
-        dialog.removeEventListener('click', lightDismiss)
-        dialog.removeEventListener('close', dialogClose)
+        removedNode.removeEventListener('click', lightDismiss)
+        removedNode.removeEventListener('close', dialogClose)
         removedNode.dispatchEvent(dialogRemovedEvent)
       }
     })
@@ -1134,8 +1134,8 @@ const dialogDeleteObserver = new MutationObserver((mutations, observer) => {
   mutations.forEach(mutation => {
     mutation.removedNodes.forEach(removedNode => {
       if (removedNode.nodeName === 'DIALOG') {
-        dialog.removeEventListener('click', lightDismiss)
-        dialog.removeEventListener('close', dialogClose)
+        removedNode.removeEventListener('click', lightDismiss)
+        removedNode.removeEventListener('close', dialogClose)
         removedNode.dispatchEvent(dialogRemovedEvent)
       }
     })


### PR DESCRIPTION
Changes proposed in this pull request:

- updates variable name inside dialog delete mutation observer callback `dialog` -> `removedNode`.
