### PR TITLE
Change order of Learn PWA modules.

### DIFF
--- a/src/site/_data/courses/pwa/toc.yml
+++ b/src/site/_data/courses/pwa/toc.yml
@@ -15,11 +15,11 @@
 - url: /learn/pwa/update
 - url: /learn/pwa/enhancements
 - url: /learn/pwa/detection
-- url: /learn/pwa/capabilities
 - url: /learn/pwa/os-integration
 - url: /learn/pwa/windows
 - url: /learn/pwa/experimental
 - url: /learn/pwa/tools-and-debug
 - url: /learn/pwa/architecture
 - url: /learn/pwa/complexity
+- url: /learn/pwa/capabilities
 - url: /learn/pwa/conclusion


### PR DESCRIPTION
This moves the list of capabilities to the end so that we can later replace it with something more robust at a higher level without disrupting the numbering of the parts.

@rachelandrew I marked this p0 because it blocks PRs or remaining parts in Learn PWA