### PR TITLE
Info about image CDN and dimensions in handbook

### DIFF
--- a/src/site/content/en/handbook/markup-media/index.md
+++ b/src/site/content/en/handbook/markup-media/index.md
@@ -16,6 +16,10 @@ description: |
 - Content images should be no wider than 1600px.
 - Author images should be a 384px square.
 
+When using the images CDN, treat those dimensions as the minimums and overall
+aspect ratio for the source image you upload. The CDN will take care of
+downsizing source images that are larger than the recommended dimensions.
+
 ### Using the images CDN
 
 All images on web.dev are required to use our image CDN so we can optimize


### PR DESCRIPTION
This updated recommendation for image dimensions in the handbook matches what I've observed the best practice to be when uploading images to the CDN.

The current wording was a source of confusions for @malchata in https://github.com/GoogleChrome/developer.chrome.com/pull/2611#discussion_r852238823

@devnook, it would be great if you could confirm that this update describes what is in fact the best practice.