### PR TITLE
Building a dialog component: Swap out overflow-y: scroll with auto

### DIFF
--- a/src/site/content/en/blog/building-a-dialog-component/index.md
+++ b/src/site/content/en/blog/building-a-dialog-component/index.md
@@ -665,7 +665,7 @@ will be custom presentation styles:
 
 ```css
 dialog > form > article {
-  overflow-y: scroll; 
+  overflow-y: auto; 
   max-block-size: 100%; /* safari */
   overscroll-behavior-y: contain;
   display: grid;


### PR DESCRIPTION
Changes proposed in this pull request:

- The author mentions using `overflow: auto` so the scrollbar only shows up when needed, but in the code example `overflow-y: scroll` is used. 
