### PR TITLE
minor improvements to stale-while-revalidate blog

### DIFF
--- a/src/site/content/en/blog/stale-while-revalidate/index.md
+++ b/src/site/content/en/blog/stale-while-revalidate/index.md
@@ -51,7 +51,7 @@ fulfill a browser's request. From the perspective of `stale-while-revalidate`,
 there's nothing to do in this scenario.
 
 But if the cached response is stale, then another age-based check is performed:
-is the age of the cached response within the window of time covered by the
+is the age of the cached response within the additional time window provided by the
 `stale-while-revalidate` setting?
 
 If the age of a stale response falls into this window, then it will be used to


### PR DESCRIPTION
Before the change, there is one way to misunderstand the sentence, for example:
```
Cache-Control: max-age=100, stale-while-revalidate=200
```
can be understood as "if the cache age is **covered by** 200, then it can be served from cache. If the cache age is **not covered** by 200, e.g. if it's 250-second-old, then it cannot be served from cache". That's a wrong understanding because the cache is good for 300 seconds.

(Sorry I saw instruction of "don't forget to add the `$-presubmit` label" but I don't know what that means.)
