### PR TITLE
Add tag for "Aurora project" blog posts

### DIFF
--- a/src/site/_data/i18n/tags.yml
+++ b/src/site/_data/i18n/tags.yml
@@ -124,6 +124,12 @@ augmented-reality:
     ru: Последние новости и статьи о дополненной реальности.
     zh: 我们关于增强现实的最新资讯、动态和故事。
 
+aurora-project:
+  title:
+    en: Aurora Project
+  description:
+    en: Our latest news, updates, and stories about the Chrome Aurora project.
+
 canvas:
   title:
     en: Canvas

--- a/src/site/content/en/blog/aurora-resource-inlining/index.md
+++ b/src/site/content/en/blog/aurora-resource-inlining/index.md
@@ -8,6 +8,7 @@ hero: image/S838B7UEsdXmwrD8q5gvNlWTHHP2/yXASsFeUg39y0K7aFJIY.jpg
 alt: A labyrinth.
 description: Learn about the latest optimizations implemented in JavaScript frameworks in collaboration with project Aurora.
 tags:
+  - aurora-project
   - blog
   # - angular
   - web-vitals

--- a/src/site/content/en/blog/conformance/index.md
+++ b/src/site/content/en/blog/conformance/index.md
@@ -10,8 +10,8 @@ alt: Yellow and black warnings wall
 
 description: This article describes Conformance, a methodology used in frameworks within Google, and how we plan on open-sourcing it to the JavaScript framework ecosystem
 tags:
+  - aurora-project
   - blog
-  # - aurora
 ---
 
 In our [introductory blog post](/aurora), we covered how we've learned a lot while

--- a/src/site/content/en/blog/image-component/index.md
+++ b/src/site/content/en/blog/image-component/index.md
@@ -13,6 +13,7 @@ description: |
 hero: image/IypihH3o5cSpEMVp5i08dp69otp2/Orid6fbbep03o45XkRis.jpeg
 alt: Assembling the pieces of a puzzle
 tags:
+  - aurora-project
   - blog
 ---
 

--- a/src/site/content/en/blog/introducing-aurora/index.md
+++ b/src/site/content/en/blog/introducing-aurora/index.md
@@ -11,6 +11,7 @@ alt: Night sky
 
 description: This article introduces Aurora, a Chrome initiative to collaborate closely with open-source frameworks
 tags:
+  - aurora-project
   - blog # blog is a required tag for the article to show up in the blog.
   # - aurora
 ---

--- a/src/site/content/en/blog/script-component/index.md
+++ b/src/site/content/en/blog/script-component/index.md
@@ -11,6 +11,7 @@ description: |
 hero: image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/I71rvvFlEORPhGILHsZX.jpg
 alt: A child arranging Jenga blocks.
 tags:
+  - aurora-project
   - blog
 ---
 


### PR DESCRIPTION
There currently isn't a way to easily find content about the
Aurora project. The Insights Team suggested adding a tag to
web.dev to make our content more discoverable / searchable.
