### PR TITLE
Add analytics for user color scheme preference

### DIFF
--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -51,8 +51,9 @@ module.exports = {
       SIGNED_IN: 'dimension1',
       TRACKING_VERSION: 'dimension5',
       NAVIGATION_TYPE: 'dimension6',
+      COLOR_SCHEME_PREFERENCE: 'dimension7',
     },
-    version: 9,
+    version: 10,
   },
   firebase: {
     prod: {

--- a/src/site/_includes/partials/analytics.njk
+++ b/src/site/_includes/partials/analytics.njk
@@ -15,6 +15,7 @@ try {
 } catch (error) {
   ga('set', '{{ site.analytics.dimensions.NAVIGATION_TYPE }}', '(not set)');
 }
+ga('set', '{{ site.analytics.dimensions.COLOR_SCHEME_PREFERENCE }}', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 ga('send', 'pageview');
 {% endset %}
 <script>{{ analyticsScript | minifyJs | cspHash | safe }}</script>


### PR DESCRIPTION
This PR updates the analytics implementation to capture the user's color scheme preference (i.e. light vs. dark mode) as a custom dimension.

I originally wanted to include other user preferences here as well, but given that the site's analytics initialization code runs in the HTML templates, I didn't want to add too much bloat if we didn't have specific plans to use that information (please let me know if we do).
