### PR TITLE
Fixing cut-off description

### DIFF
--- a/src/site/content/en/blog/web-components/index.md
+++ b/src/site/content/en/blog/web-components/index.md
@@ -1,9 +1,9 @@
 ---
 title: Building components
-subhead: Components are the building blocks of modern web applications. What best practices should you foll
+subhead: Components are the building blocks of modern web applications. What best practices should you follow when building your own components so they can stand the test of time?
 date: 2017-08-14
 updated: 2018-09-20
-description: Components are the building blocks of modern web applications. What best practices should you foll
+description: Components are the building blocks of modern web applications. What best practices should you follow when building your own components so they can stand the test of time?
 tags:
   - blog
 ---


### PR DESCRIPTION
Completed entire description field, instead of cutting it off at 'foll'
<img width="1237" alt="Screen Shot 2022-04-29 at 6 28 27 PM" src="https://user-images.githubusercontent.com/20875599/166076681-cc62c892-4bc0-4e50-ba7f-ec799217ef6e.png">

Seen in Safari & Chrome
Check it out for yourself: https://web.dev/web-components/