### PR TITLE
Adds INP mentions to relevant docs.

### DIFF
--- a/src/site/_data/paths/metrics.json
+++ b/src/site/_data/paths/metrics.json
@@ -20,7 +20,8 @@
         "fid",
         "tti",
         "tbt",
-        "cls"
+        "cls",
+        "inp"
       ]
     },
     {

--- a/src/site/content/en/blog/better-responsiveness-metric/index.md
+++ b/src/site/content/en/blog/better-responsiveness-metric/index.md
@@ -8,6 +8,7 @@ authors:
   - anniesullie
   - hbsong
 date: 2021-06-21
+updated: 2022-05-11
 hero: image/kns0INkO77RkiEStzHWYrugyWj32/TwRpOuLV9Z5GEZkGmAXi.jpeg
 alt: Hand about to press a key in a keyboard
 tags:
@@ -15,6 +16,10 @@ tags:
   - performance
   - web-vitals
 ---
+
+{% Aside 'important' %}
+This article was written during a period of time in which a new responsiveness metric was being developed to measure end-to-end latency on web pages. That new metric has been released, and is named [Interaction to Next Paint (INP)](/inp/).
+{% endAside %}
 
 On the Chrome Speed Metrics team, we're working on deepening our understanding of how quickly web
 pages respond to user input. We'd like to share some ideas for improving responsiveness metrics and

--- a/src/site/content/en/blog/optimizing-content-efficiency-javascript-startup-optimization/index.md
+++ b/src/site/content/en/blog/optimizing-content-efficiency-javascript-startup-optimization/index.md
@@ -6,7 +6,7 @@ authors:
 description: >
   Keep your network transmission and parse/compile cost for JavaScript low to ensure pages get interactive quickly.
 date: 2017-11-30
-updated: 2018-07-02
+updated: 2022-05-11
 ---
 
 As we build sites more heavily reliant on JavaScript, we sometimes pay for what
@@ -99,7 +99,7 @@ DevTools](/web/tools/chrome-devtools/), parse and compile are part of the yellow
 
 The Bottom-Up and Call Tree tabs show you exact Parse/compile timings:
 
-<figure> 
+<figure>
   {% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/idCp6NvAEITLFHkQgJUq.png", alt="ALT_TEXT_HERE", width="800", height="228" %}
  <figcaption> Chrome
 DevTools Performance panel > Bottom-Up. With V8’s Runtime Call Stats enabled, we
@@ -227,7 +227,7 @@ JavaScript can impact page performance in other ways:
   href="/web/fundamentals/performance/rendering/optimize-javascript-execution#use_requestanimationframe_for_visual_changes">requestAnimationFrame()</a></code>
   or <code><a
   href="/web/updates/2015/08/using-requestidlecallback">requestIdleCallback()</a></code>
-  for scheduling) can minimize responsiveness issues.
+  for scheduling) can minimize responsiveness issues which can help improve [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/).
 
 ## Patterns for reducing JavaScript delivery cost
 

--- a/src/site/content/en/blog/responsiveness/index.md
+++ b/src/site/content/en/blog/responsiveness/index.md
@@ -5,6 +5,7 @@ description: An update on our plans for measuring responsiveness on the web.
 authors:
   - hbsong
 date: 2021-11-03
+updated: 2022-05-11
 hero: image/eqprBhZUGfb8WYnumQ9ljAxRrA72/GNWyQZ5l1uy1b7s5ursN.jpeg
 alt: Water droplet rippling outward
 tags:
@@ -14,7 +15,7 @@ tags:
 ---
 
 {% Aside 'important' %}
-We have chosen option 2 of [high quantile approximation](/responsiveness/#high-quantile-approximation) as the candidate for the new responsiveness metric, with [maximum event duration](/responsiveness/#measure-interaction-latency) as the definition for interaction latency. This metric will be available as `experimental.responsiveness` starting in the February 2022 [CrUX BigQuery](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started) dataset, released on March 8, 2022.
+This article was written during a period of time in which a new responsiveness metric was being developed to measure end-to-end latency on web pages. That new metric has been released, and is named [Interaction to Next Paint (INP)](/inp/).
 {% endAside %}
 
 Earlier this year, the Chrome Speed Metrics Team shared [some of the

--- a/src/site/content/en/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/en/blog/vitals-field-measurement-best-practices/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
 description: How to measure Web Vitals with your current analytics tool
 date: 2020-05-27
-updated: 2021-11-30
+updated: 2022-05-11
 hero: image/admin/WNrgCVjmp8Gyc8EbZ9Jv.png
 alt: How to measure Web Vitals with your current analytics tool
 tags:
@@ -264,7 +264,7 @@ Analytics code often runs in response to user input, but if your analytics code
 is conducting a lot of DOM measurements or using other processor-intensive APIs
 the analytics code itself can cause poor input responsiveness. In addition, if
 the JavaScript file containing your analytics code is large, executing that file
-can block the main thread and negatively affect FID.
+can block the main thread and negatively affect [First Input Delay (FID)](/fid/) or [Interaction to Next Paint (INP)](/inp/).
 
 ### Use non-blocking APIs
 

--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -6,6 +6,7 @@ authors:
   - philipwalton
   - yoavweiss
 date: 2021-09-14
+updated: 2022-05-11
 hero: image/eqprBhZUGfb8WYnumQ9ljAxRrA72/FITOGeO0PDyPrBveixB7.jpeg
 alt: "Exterior view of the Walt Disney Concert Hall"
 tags:
@@ -184,8 +185,7 @@ in-page navigation experience is excellent.
 In the future we plan to develop metrics that encourage great, post-load
 experiences, and we believe this is the best path to incentivize high-quality
 SPAs in a way that doesn't compromise the initial load experience. We have
-already published our plans to develop [a new responsiveness
-metric](/better-responsiveness-metric/), and we're actively working on other
+already delivered a new metric named [Interaction to Next Paint (INP)](/inp/) that measures interaction latency throughout the entire page lifecycle, and we're actively working on other
 post-load metrics as well, including metrics that measure SPA route transitions
 ([see below](#design-new-apis-that-enable-better-spa-measurement)).
 

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -4,7 +4,7 @@ title: First Input Delay (FID)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2020-06-19
+updated: 2022-05-11
 description: |
   This post introduces the First Input Delay (FID) metric and explains
   how to measure it
@@ -184,6 +184,10 @@ recommend measuring the first input delay for a few reasons:
   the same solutions for fixing slow input delays after page load. By separating
   out these metrics we'll be able to provide more specific performance
   guidelines to web developers.
+
+{% Aside %}
+While FID is one of the Core Web Vitals, we have recognized the importance of measuring interaction latency throughout the entire page lifecycle. This has lead to ongoing work that resulting in the [Interaction to Next Paint (INP)](/inp/) metric, which is a more holistic measurement of overall page responsiveness, not just load responsiveness.
+{% endAside %}
 
 ### What counts as a first input?
 

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -4,7 +4,7 @@ title: First Input Delay (FID)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-05-11
+updated: 2020-06-19
 description: |
   This post introduces the First Input Delay (FID) metric and explains
   how to measure it
@@ -184,10 +184,6 @@ recommend measuring the first input delay for a few reasons:
   the same solutions for fixing slow input delays after page load. By separating
   out these metrics we'll be able to provide more specific performance
   guidelines to web developers.
-
-{% Aside %}
-While FID is one of the Core Web Vitals, we have recognized the importance of measuring interaction latency throughout the entire page lifecycle. This has lead to ongoing work that resulting in the [Interaction to Next Paint (INP)](/inp/) metric, which is a more holistic measurement of overall page responsiveness, not just load responsiveness.
-{% endAside %}
 
 ### What counts as a first input?
 

--- a/src/site/content/en/metrics/tbt/index.md
+++ b/src/site/content/en/metrics/tbt/index.md
@@ -4,7 +4,7 @@ title: Total Blocking Time (TBT)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2020-06-15
+updated: 2022-05-11
 description: |
   This post introduces the Total Blocking Time (TBT) metric and explains
   how to measure it
@@ -128,7 +128,7 @@ TBT](/lighthouse-total-blocking-time) for usage details.
   While it is possible to measure TBT in the field, it's not recommended as user
   interaction can affect your page's TBT in ways that lead to lots of variance
   in your reports. To understand a page's interactivity in the field, you should
-  measure [First Input Delay (FID)](/fid/).
+  measure [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/).
 {% endAside %}
 
 ## What is a good TBT score?

--- a/src/site/content/en/metrics/tti/index.md
+++ b/src/site/content/en/metrics/tti/index.md
@@ -4,7 +4,7 @@ title: Time to Interactive (TTI)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2020-06-15
+updated: 2022-05-11
 description: |
   This post introduces the Time to Interactive (TTI) metric and explains
   how to measure it
@@ -82,7 +82,7 @@ TTI](/tti/) for usage details.
   While it's possible to measure TTI in the field, it's not recommended, as user
   interaction can affect your page's TTI in ways that lead to lots of variance
   in your reports. To understand a page's interactivity in the field, you should
-  measure [First Input Delay (FID)](/fid/).
+  measure [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/).
 {% endAside %}
 
 ## What is a good TTI score?

--- a/src/site/content/en/metrics/user-centric-performance-metrics/index.md
+++ b/src/site/content/en/metrics/user-centric-performance-metrics/index.md
@@ -4,6 +4,7 @@ title: User-centric performance metrics
 authors:
   - philipwalton
 date: 2019-11-08
+updated: 2022-05-11
 description: |
   User-centric performance metrics are a critical tool in understanding and
   improving the experience of your site in a way that benefits real
@@ -137,28 +138,36 @@ page.
 
 ## Important metrics to measure
 
-- **[First contentful paint (FCP)](/fcp/):** measures the time from when the
+- **[First Contentful Paint (FCP)](/fcp/):** measures the time from when the
   page starts loading to when any part of the page's content is rendered on the
   screen. _([lab](#in-the-lab), [field](#in-the-field))_
-- **[Largest contentful paint (LCP)](/lcp/):** measures the time from when the
+- **[Largest Contentful Paint (LCP)](/lcp/):** measures the time from when the
   page starts loading to when the largest text block or image element is
   rendered on the screen. _([lab](#in-the-lab), [field](#in-the-field))_
-- **[First input delay (FID)](/fid/):** measures the time from when a user first
+- **[First Input Delay (FID)](/fid/):** measures the time from when a user first
   interacts with your site (i.e. when they click a link, tap a button, or use a
   custom, JavaScript-powered control) to the time when the browser is actually
   able to respond to that interaction. _([field](#in-the-field))_
+- **[Interaction to Next Paint (INP)](/inp/)**: measures the latency of every
+  tap, click, or keyboard interaction made with the page, and&mdash;based on the
+  number of interactions&mdash;selects the worst interaction latency of the page
+  (or close to the highest) as a single, representative value to describe a
+  page's overall responsiveness. _([lab](#in-the-lab), [field](#in-the-field))_
 - **[Time to Interactive (TTI)](/tti/):** measures the time from when the page
   starts loading to when it's visually rendered, its initial scripts (if any)
   have loaded, and it's capable of reliably responding to user input quickly.
   _([lab](#in-the-lab))_
-- **[Total blocking time (TBT)](/tbt/):** measures the total amount of time
+- **[Total Blocking Time (TBT)](/tbt/):** measures the total amount of time
   between FCP and TTI where the main thread was blocked for long enough to
   prevent input responsiveness. _([lab](#in-the-lab))_
-- **[Cumulative layout shift (CLS)](/cls/):** measures the cumulative score of
+- **[Cumulative Layout Shift (CLS)](/cls/):** measures the cumulative score of
   all unexpected layout shifts that occur between when the page starts loading
   and when its [lifecycle
   state](https://developer.chrome.com/blog/page-lifecycle-api/)
   changes to hidden. _([lab](#in-the-lab), [field](#in-the-field))_
+- **[Time to First Byte (TTFB)](/ttfb/)**: measures the time it takes for the
+  network to respond to a user request with the first byte of a resource.
+  _([lab](#in-the-lab), [field](#in-the-field))_
 
 While this list includes metrics measuring many of the various aspects of
 performance relevant to users, it does not include everything (e.g. runtime


### PR DESCRIPTION
Since the new [INP metric](https://web.dev/inp/) has landed, the current docs should be updated to reflect the inclusion of that metric as a web vital. This pull request updates and tweaks language in necessary docs to mention INP where needed. This PR does _not_ update any articles about runtime/page responsiveness that were framed around a certain time period (e.g., https://web.dev/vitals-tools-2020/).