### PR TITLE
Fix web.dev article link

### DIFF
--- a/src/site/content/en/blog/yahoo-japan-identity-case-study/index.md
+++ b/src/site/content/en/blog/yahoo-japan-identity-case-study/index.md
@@ -406,7 +406,7 @@ authentication.
 FIDO has a higher success rate than SMS authentication, and faster average and
 median authentication times. As for passwords, some groups have short
 authentication times, and we suspect that this is due to the browser's
-[`autocomplete="current-password"`](/sign-in-form-best-practices /#current-password).
+[`autocomplete="current-password"`](/sign-in-form-best-practices/#current-password).
 
 <figure class="screenshot">
 {% Img


### PR DESCRIPTION
Fixed link to `/sign-in-form-best-practices/#current-password` in article https://web.dev/yahoo-japan-identity-case-study/

Fixes #SOME_ISSUE_NUMBER??? (Do I need to create an issue first?)

**Changes proposed in this pull request:**

- Removes the space from the Markdown so the link is properly formed.

