### PR TITLE
Adds `loading=lazy` to pattern iframe embeds

### DIFF
--- a/src/site/_includes/components/CodePattern.js
+++ b/src/site/_includes/components/CodePattern.js
@@ -58,7 +58,7 @@ module.exports = (patternId, height) => {
   return `<div class="code-pattern">
     <div class="code-pattern__content">
       <div class="code-pattern__demo" style="min-height: ${height}px">
-        <iframe src="${pattern.demo}" title="Demo" height="${height}"></iframe>
+        <iframe src="${pattern.demo}" title="Demo" height="${height}" loading="lazy"></iframe>
       </div>
       <div class="code-pattern__assets" style="height: ${height}px">
         <web-tabs>${assets}</web-tabs>


### PR DESCRIPTION
I'd noticed that the patterns page started to slow down and lag as more and more demo's are added. I added loading lazy to the pattern demo iframes and the issue is pacified. This PR contains that addition for y'all to review 👍🏻 