### PR TITLE
Fix `@media min-width` example

### DIFF
--- a/src/site/content/en/blog/state-of-css-2022/index.md
+++ b/src/site/content/en/blog/state-of-css-2022/index.md
@@ -1438,7 +1438,7 @@ articulate over and under conditions. It may look like this:
 After media query ranges, the same media query could look like this:
 
 ```css
-@media (320px >= width) {
+@media (width >= 320px) {
   …
 }
 ```


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal `before`
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fixes an example in [new media query width syntax](https://web.dev/state-of-css-2022/#was-in-min-width-or-max-width).

I think the example is wrong, can you check if I'm right?
