### PR TITLE
Support url=... query parameter in /measure/

### DIFF
--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -159,7 +159,7 @@ class UrlChooser extends BaseElement {
 
     const currentURL = new URL(location.href);
     currentURL.searchParams.set('url', this._urlInput.value);
-    history.pushState({}, '', currentURL.href);
+    history.replaceState({}, '', currentURL.href);
   }
 
   onSwitchUrl() {

--- a/src/lib/components/UrlChooser/index.js
+++ b/src/lib/components/UrlChooser/index.js
@@ -30,6 +30,9 @@ class UrlChooser extends BaseElement {
   }
 
   render() {
+    const currentURL = new URL(location.href);
+    const urlSearchParam = currentURL.searchParams.get('url');
+
     return html`
       <div
         class="lh-report-header-enterurl ${this.disabled ? 'lh-running' : ''}"
@@ -50,6 +53,7 @@ class UrlChooser extends BaseElement {
             pattern="https?://.+"
             minlength="7"
             @keyup="${this.onUrlKeyup}"
+            value="${urlSearchParam}"
           />
           <button
             ?disabled=${this.disabled}
@@ -152,6 +156,10 @@ class UrlChooser extends BaseElement {
 
     const event = new CustomEvent('audit', {detail: this._urlInput.value});
     this.dispatchEvent(event);
+
+    const currentURL = new URL(location.href);
+    currentURL.searchParams.set('url', this._urlInput.value);
+    history.pushState({}, '', currentURL.href);
   }
 
   onSwitchUrl() {


### PR DESCRIPTION
Fixes #7957

This adds support for navigating to URLs like http://web.dev/measure/?url=https%3A%2F%2Fexample.com which will prefill the `value` of the `<input>` field used to determine the URL that's being measured.

It also updates the current page's URL to add in the corresponding `url=...` query parameter when a report is started.