### PR TITLE
Fix incorrect list nesting on /learn/pwa/ pages

### DIFF
--- a/src/site/content/en/learn/pwa/installation-prompt/index.md
+++ b/src/site/content/en/learn/pwa/installation-prompt/index.md
@@ -137,13 +137,14 @@ Try it yourself with the [Make it installable](/codelab-make-installable/) codel
 ## Libraries
 
 Check out these libraries for help with rendering a custom install prompt:
+
 - [PWA Builder <pwa-install>](https://github.com/pwa-builder/pwa-install)
 - [PWA Installer Prompt for React](https://github.com/shnaveen25/react-pwa-installer-prompt)
 - [React PWA Install](https://www.npmjs.com/package/react-pwa-install)
 - [Vue PWA Install](https://github.com/Bartozzz/vue-pwa-install)
 - [Add to Home Screen](https://github.com/docluv/add-to-homescreen)
 
-##  Resources
+## Resources
 
 - [Patterns for Promoting PWA installation](/promote-install/)
 - [How to provide your own in-app install experience](/customize-install/)

--- a/src/site/content/en/learn/pwa/installation/index.md
+++ b/src/site/content/en/learn/pwa/installation/index.md
@@ -194,7 +194,7 @@ If you want to learn more about how to publish a PWA to app catalogs and stores,
 Some app catalogs and stores have technical or business requirements that before your PWA is accepted for publication. Check each store's requirements before starting.
 {% endAside %}
 
-##  Resources
+## Resources
 
 - [What does it take to be installable](/install-criteria/)
 - [WebAPKs on Android](https://developers.google.com/web/fundamentals/integration/webapks)


### PR DESCRIPTION
Fixes #7955 by cleaning up a few implicit list-y things that Markdown creates.