### PR TITLE
Fixes patterns landing page table of contents copy to match blog posts

### DIFF
--- a/src/site/_includes/pattern-set.njk
+++ b/src/site/_includes/pattern-set.njk
@@ -13,7 +13,7 @@ pageScripts:
 {% from 'macros/code-pattern.njk' import codePattern with context %}
 
 
-{% set tocTitle = "Layout Patterns" %}
+{% set tocTitle = "On this page" %}
 
 {% if page.url %}
   {% set patternSetId = page.url | getRelativePath('/patterns/') %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Patterns page now says "On this page" instead of "Layout patterns"

It's confusing going to a patterns page that isnt about layout and seeing the ToC titled "Layout patterns" when really it's the same component as a blog post has which reads "On this page". This normalizes the text and disambiguates pattern detail pages table of contents.

side note / feature request:
if the pattern page has no sub categories, this ToC component shouldn't be present on the page because it's pointless to show "Table of contents > All". thoughts? 
