### PR TITLE
Add https://webserial.io

### DIFF
--- a/src/site/content/en/blog/serial/index.md
+++ b/src/site/content/en/blog/serial/index.md
@@ -612,6 +612,7 @@ and let us know where and how you're using it.
 ## Demos {: #demos }
 
 * [Serial Terminal](https://googlechromelabs.github.io/serial-terminal/)
+* [WebSerial](https://webserial.io/)
 * [Espruino Web IDE](https://www.espruino.com/ide/)
 
 ## Acknowledgements


### PR DESCRIPTION
Changes proposed in this pull request:

- Add https://webserial.io to the list of WebSerial Demos
