### PR TITLE
Fix Displaying a Notification Page's Unclosed Code Block

### DIFF
--- a/src/site/content/en/blog/push-notifications-display-a-notification/index.md
+++ b/src/site/content/en/blog/push-notifications-display-a-notification/index.md
@@ -3,7 +3,7 @@ title: Displaying a Notification
 authors:
   - mattgaunt
 date: 2016-06-30
-updated: 2019-06-08
+updated: 2022-05-31
 ---
 
 I've split up notification options into two sections, one that deals with the visual aspects
@@ -240,6 +240,7 @@ if (maxVisibleActions < 4) {
   options.body =
     `This notification can display up to ` + `${maxVisibleActions} actions.`;
 }
+```
 
 registration.showNotification(title, options);
 At the time of writing only Chrome and Opera for Android support actions.

--- a/src/site/content/en/blog/push-notifications-display-a-notification/index.md
+++ b/src/site/content/en/blog/push-notifications-display-a-notification/index.md
@@ -240,9 +240,10 @@ if (maxVisibleActions < 4) {
   options.body =
     `This notification can display up to ` + `${maxVisibleActions} actions.`;
 }
-```
 
 registration.showNotification(title, options);
+```
+
 At the time of writing only Chrome and Opera for Android support actions.
 
 {% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/GI8sj9krxVtxWVeHGuvs.png", alt="Notification with actions on Chrome for Android.", width="800", height="296" %}


### PR DESCRIPTION
A code block in the  [Displaying a Notification](https://web.dev/push-notifications-display-a-notification/) article was missing the closing back-ticks which was breaking the formatting for three sections (Actions, Directions, and Vibrate). This restores the documentation for these sections

Changes proposed in this pull request:

- Add closing back-ticks to the "Actions" codeblock example

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
