### PR TITLE
Update markdown-it-attrs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "luxon": "^1.12.1",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^5.0.2",
-        "markdown-it-attrs": "^3.0.0",
+        "markdown-it-attrs": "^4.1.4",
         "markdown-it-deflist": "^2.1.0",
         "moment": "^2.24.0",
         "node-fetch": "^2.6.7",
@@ -15645,14 +15645,14 @@
       }
     },
     "node_modules/markdown-it-attrs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-3.0.3.tgz",
-      "integrity": "sha512-cLnICU2t61skNCr4Wih/sdza+UbQcqJGZwvqAypnbWA284nzDm+Gpc90iaRk/JjsIy4emag5v3s0rXFhFBWhCA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.4.tgz",
+      "integrity": "sha512-53Zfv8PTb6rlVFDlD106xcZHKBSsRZKJ2IW/rTxEJBEVbVaoxaNsmRkG0HXfbHl2SK8kaxZ2QKqdthWy/QBwmA==",
       "engines": {
         "node": ">=6"
       },
       "peerDependencies": {
-        "markdown-it": ">= 9.0.0 < 12.0.0"
+        "markdown-it": ">= 9.0.0"
       }
     },
     "node_modules/markdown-it-deflist": {
@@ -41440,9 +41440,9 @@
       "requires": {}
     },
     "markdown-it-attrs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-3.0.3.tgz",
-      "integrity": "sha512-cLnICU2t61skNCr4Wih/sdza+UbQcqJGZwvqAypnbWA284nzDm+Gpc90iaRk/JjsIy4emag5v3s0rXFhFBWhCA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.4.tgz",
+      "integrity": "sha512-53Zfv8PTb6rlVFDlD106xcZHKBSsRZKJ2IW/rTxEJBEVbVaoxaNsmRkG0HXfbHl2SK8kaxZ2QKqdthWy/QBwmA==",
       "requires": {}
     },
     "markdown-it-deflist": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "luxon": "^1.12.1",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^5.0.2",
-    "markdown-it-attrs": "^3.0.0",
+    "markdown-it-attrs": "^4.1.4",
     "markdown-it-deflist": "^2.1.0",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
This matches the change made in https://github.com/GoogleChrome/developer.chrome.com/pull/2892, and makes newer versions of `npm` happy.