### PR TITLE
Fix formatting in "Unblocking clipboard access"

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -130,7 +130,7 @@ try {
 ### The copy event
 
 In the case where a user initiates a clipboard copy
-and does _not_ call `preventDefault(), the
+and does _not_ call `preventDefault()`, the
 [`copy` event](https://developer.mozilla.org/docs/Web/API/Document/copy_event)
 includes a `clipboardData` property with the items already in the right format.
 If you want to implement your own logic, you need to call `preventDefault()` to


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

The ["Unblocking clipboard access"](https://web.dev/async-clipboard/) article is missing a backtick in the ["The copy event"](https://web.dev/async-clipboard/#the-copy-event) section. This corrupts the formatting of the remaining text in the paragraph.

Changes proposed in this pull request:

- Add missing backtick after `preventDefault()`
