### PR TITLE
Don't set inert on web-header when nav drawer opens

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -115,13 +115,10 @@ const disablePage = () => {
   /** @type {HTMLElement|object} */
   const main = document.querySelector('main') || {};
   /** @type {HTMLElement|object} */
-  const header = document.querySelector('web-header') || {};
-  /** @type {HTMLElement|object} */
   const footer = document.querySelector('.w-footer') || {};
 
   document.body.classList.add('overflow-hidden');
   main.inert = true;
-  header.inert = true;
   footer.inert = true;
 };
 
@@ -132,13 +129,10 @@ const enablePage = () => {
   /** @type {HTMLElement|object} */
   const main = document.querySelector('main') || {};
   /** @type {HTMLElement|object} */
-  const header = document.querySelector('web-header') || {};
-  /** @type {HTMLElement|object} */
   const footer = document.querySelector('.w-footer') || {};
 
   document.body.classList.remove('overflow-hidden');
   main.inert = false;
-  header.inert = false;
   footer.inert = false;
 };
 


### PR DESCRIPTION
Fixes #7749

This seems to behave reasonably, as far as I can tell, in Safari and Chrome (which now natively support `inert`) as well as in Firefox (where the `wicg-inert` polyfill will still get used).

My guess is that there's a difference between native `inert` and the polyfill with regards to the children of a parent element that has `inert` set on it—but that's just a guess. In any case, removing `inert` from the parent `web-header` when the navigation drawer is open looks like it makes the navigation drawer interactive again.