### PR TITLE
Fixed broken link referencing to Render-tree Construction page

### DIFF
--- a/src/site/content/en/blog/critical-rendering-path-render-blocking-css/index.md
+++ b/src/site/content/en/blog/critical-rendering-path-render-blocking-css/index.md
@@ -13,7 +13,7 @@ browser won't render any processed content until the CSSOM is
 constructed. Make sure to keep your CSS lean, deliver it as quickly as
 possible, and use media types and queries to unblock rendering.
 
-In the [render tree construction](render-tree-construction) we saw that the critical rendering path requires both the DOM and the CSSOM to construct the render tree. This creates an important performance implication: **both HTML and CSS are render blocking resources.** The HTML is obvious, since without the DOM we would not have anything to render, but the CSS requirement may be less obvious. What would happen if we try to render a typical page without blocking rendering on CSS?
+In the [render tree construction](/critical-rendering-path-render-tree-construction/) we saw that the critical rendering path requires both the DOM and the CSSOM to construct the render tree. This creates an important performance implication: **both HTML and CSS are render blocking resources.** The HTML is obvious, since without the DOM we would not have anything to render, but the CSS requirement may be less obvious. What would happen if we try to render a typical page without blocking rendering on CSS?
 
 ### TL;DR {: .hide-from-toc }
 


### PR DESCRIPTION
Current link on the page https://web.dev/critical-rendering-path-render-blocking-css/ 
leads to https://web.dev/critical-rendering-path-render-blocking-css/render-tree-construction, 
which is semantically incorrect as well as incorrect (maybe stale) link.



Changes proposed in this pull request:

- Just fixing a broken link referencing to an article on Render-tree Construction


