### PR TITLE
Only feature English-language case studies on homepage

### DIFF
--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -114,33 +114,36 @@ pageScripts:
       <div class="homepage__case-studies switcher gap-top-size-2">
       {% set cardCount = 0 %}
       {% for item in collections['case-study'] | reverse %}
-        {% if cardCount <= 1 %}
-          {% if item.data.hero %}
-            {% if not item.data.alt %}
-              {% set alt = '' %}
-            {% else %}
-              {% set alt = item.data.alt %}
+        {# See https://github.com/GoogleChrome/web.dev/issues/8121 #}
+        {% if item.data.lang === 'en' %}
+          {% if cardCount <= 1 %}
+            {% if item.data.hero %}
+              {% if not item.data.alt %}
+                {% set alt = '' %}
+              {% else %}
+                {% set alt = item.data.alt %}
+              {% endif %}
+              <article class="card">
+                <a href="{{ item.url }}" aria-hidden="true">
+                  {% Img src=item.data.thumbnail or item.data.hero, alt=item.data.alt, width="570", height="330", class="card__hero" %}
+                </a>
+                <div class="card__content flow">
+                  <h3 class="card__heading text-size-3">
+                    <a href="{{ item.url }}">{{ item.data.title }}</a>
+                  </h3>
+                  <p>{{ item.data.description }}</p>
+                </div>
+                <div class="card__tags cluster gap-top-size-1" aria-label="tags for this case study">
+                  {% for tagKey in item.data.tags or [] %}
+                    {% if tagKey in collections.tags %}
+                      {% set tag = collections.tags[tagKey] %}
+                      <a class="pill" href="{{ tag.url }}">{{ tag.overrideTitle or tag.title | i18n(locale) }}</a>
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </article>
+              {% set cardCount = cardCount + 1 %}
             {% endif %}
-            <article class="card">
-              <a href="{{ item.url }}" aria-hidden="true">
-                {% Img src=item.data.thumbnail or item.data.hero, alt=item.data.alt, width="570", height="330", class="card__hero" %}
-              </a>
-              <div class="card__content flow">
-                <h3 class="card__heading text-size-3">
-                  <a href="{{ item.url }}">{{ item.data.title }}</a>
-                </h3>
-                <p>{{ item.data.description }}</p>
-              </div>
-              <div class="card__tags cluster gap-top-size-1" aria-label="tags for this case study">
-                {% for tagKey in item.data.tags or [] %}
-                  {% if tagKey in collections.tags %}
-                    {% set tag = collections.tags[tagKey] %}
-                    <a class="pill" href="{{ tag.url }}">{{ tag.overrideTitle or tag.title | i18n(locale) }}</a>
-                  {% endif %}
-                {% endfor %}
-              </div>
-            </article>
-            {% set cardCount = cardCount + 1 %}
           {% endif %}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Fixes #8121 by only considering case studies with the language code of `en` for inclusion on the homepage.