### PR TITLE
Make web-navigation-drawer inert when search UI is open

### DIFF
--- a/src/lib/components/NavigationDrawer/index.js
+++ b/src/lib/components/NavigationDrawer/index.js
@@ -86,8 +86,11 @@ export class NavigationDrawer extends BaseStateElement {
     this.addEventListener('click', closeNavigationDrawer);
   }
 
-  onStateChanged({isNavigationDrawerOpen, currentUrl}) {
+  onStateChanged({isSearchExpanded, isNavigationDrawerOpen, currentUrl}) {
     this.open = isNavigationDrawerOpen;
+
+    // See https://github.com/GoogleChrome/web.dev/issues/8131
+    this.inert = isSearchExpanded;
 
     if (currentUrl) {
       // Ensure that the "active" attribute is applied to any matching header

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -305,11 +305,6 @@ class Search extends BaseStateElement {
     this.updateComplete.then(() => {
       this.inputEl.focus();
     });
-
-    // See https://github.com/GoogleChrome/web.dev/issues/8131
-    /** @type {HTMLElement|object} */
-    const navDrawer = document.querySelector('web-navigation-drawer') || {};
-    navDrawer.inert = true;
   }
 
   /**
@@ -317,11 +312,6 @@ class Search extends BaseStateElement {
    */
   onCloseSearch() {
     this.expanded = false;
-
-    // See https://github.com/GoogleChrome/web.dev/issues/8131
-    /** @type {HTMLElement|object} */
-    const navDrawer = document.querySelector('web-navigation-drawer') || {};
-    navDrawer.inert = false;
   }
 
   /**

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -295,7 +295,6 @@ class Search extends BaseStateElement {
 
   /**
    * Expand the search box.
-   * Only used on mobile viewports where we hide the search box behind an icon.
    */
   onOpenSearch() {
     this.expanded = true;
@@ -306,14 +305,23 @@ class Search extends BaseStateElement {
     this.updateComplete.then(() => {
       this.inputEl.focus();
     });
+
+    // See https://github.com/GoogleChrome/web.dev/issues/8131
+    /** @type {HTMLElement|object} */
+    const navDrawer = document.querySelector('web-navigation-drawer') || {};
+    navDrawer.inert = true;
   }
 
   /**
    * Collapse the search box.
-   * Only used on mobile viewports.
    */
   onCloseSearch() {
     this.expanded = false;
+
+    // See https://github.com/GoogleChrome/web.dev/issues/8131
+    /** @type {HTMLElement|object} */
+    const navDrawer = document.querySelector('web-navigation-drawer') || {};
+    navDrawer.inert = false;
   }
 
   /**


### PR DESCRIPTION
Fixes #8131

It would be great to get your take on this approach, @devnook, as I feel like I'm addressing these in an ad hoc fashion, and don't really understand how, e.g., the whole actions/state model for controlling how elements on the page behave when specific actions are being performed.

That being said, I'm basically re-adding the same logic around setting `inert` that was removed #8105, except:

- only when the search UI interface is open **and**
- only on the `<web-navigation-drawer>` element, not `<web-header>` (since the search element is a child of `<web-header>`)