### PR TITLE
BrowserCompat UI for deprecated and flagged features

### DIFF
--- a/src/scss/blocks/_browser-compat.scss
+++ b/src/scss/blocks/_browser-compat.scss
@@ -69,6 +69,16 @@
     color: get-utility-value('color', 'state-warn-text');
   }
 
+  &[data-compat='flag'] {
+    background: get-utility-value('bg', 'state-warn-bg');
+    color: get-utility-value('color', 'state-warn-text');
+  }
+
+  &[data-compat='deprecated'] {
+    background: get-utility-value('bg', 'state-bad-bg');
+    color: get-utility-value('color', 'state-bad-text');
+  }
+
   &[data-compat='no'] {
     background: get-utility-value('bg', 'state-bad-bg');
     color: get-utility-value('color', 'state-bad-text');

--- a/src/site/_data/i18n/browser_compat.yml
+++ b/src/site/_data/i18n/browser_compat.yml
@@ -42,3 +42,9 @@ preview:
   pt: Visualizar
   ru: Предварительный просмотр
   zh: 预览
+
+flag:
+  en: Behind a flag
+
+deprecated:
+  en: Deprecated

--- a/src/site/_includes/components/BrowserCompat.js
+++ b/src/site/_includes/components/BrowserCompat.js
@@ -20,54 +20,51 @@ const browsers = ['chrome', 'firefox', 'edge', 'safari'];
 
 /**
  * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
- * @returns {string}
+ * @param {import('@mdn/browser-compat-data/types').StatusBlock} status
+ * @returns {{aria: string, compatProperty: string, icon: string}}}
  */
-const compatVersion = (support) => {
+function getInfoFromSupportStatement(support, status, locale) {
+  if (status && status.deprecated) {
+    return {
+      aria: i18n('i18n.browser_compat.deprecated', locale),
+      compatProperty: 'deprecated',
+      icon: '🗑',
+    };
+  }
+
   if (!support.version_removed) {
     if (support.version_added === 'preview') {
-      return '👁';
+      return {
+        aria: i18n('i18n.browser_compat.preview', locale),
+        compatProperty: 'preview',
+        icon: '👁',
+      };
     }
 
     if (support.flags?.length > 0) {
-      return '⚐';
+      return {
+        aria: i18n('i18n.browser_compat.flag', locale),
+        compatProperty: 'flag',
+        icon: '⚑',
+      };
     }
 
     if (typeof support.version_added === 'string') {
-      return support.version_added;
+      return {
+        aria: i18n('i18n.browser_compat.supported', locale),
+        compatProperty: 'yes',
+        icon: support.version_added,
+      };
     }
   }
 
-  return '×';
-};
+  return {
+    aria: i18n('i18n.browser_compat.not_supported', locale),
+    compatProperty: 'no',
+    icon: '×',
+  };
+}
 
-/**
- * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
- * @returns {string}
- */
-const compatProperty = (support) => {
-  if (!support.version_removed && support.version_added === 'preview') {
-    return 'preview';
-  } else if (!support.version_removed && support.version_added) {
-    return 'yes';
-  } else {
-    return 'no';
-  }
-};
-
-/**
- * @param {import('@mdn/browser-compat-data/types').SimpleSupportStatement} support
- * @param {string} locale
- * @returns {string}
- */
-const compatAria = (support, locale) => {
-  if (!support.version_removed && support.version_added === 'preview') {
-    return i18n('i18n.browser_compat.preview', locale);
-  } else if (!support.version_removed && support.version_added) {
-    return i18n('i18n.browser_compat.supported', locale);
-  } else {
-    return i18n('i18n.browser_compat.not_supported', locale);
-  }
-};
 /**
  * A shortcode for embedding caniuse.com browser compatibility table.
  * @this {EleventyPage}
@@ -85,21 +82,27 @@ function BrowserCompat(feature) {
         ? data[feature].support[browser][0]
         : data[feature].support[browser];
 
+      const supportInfo = getInfoFromSupportStatement(
+        support,
+        data[feature].status,
+        locale,
+      );
+
       const isSupported = support.version_added && !support.version_removed;
 
       const ariaLabel = [
         browser,
         isSupported ? ` ${support.version_added}, ` : ', ',
-        compatAria(support, locale),
+        supportInfo.aria,
       ].join('');
 
       return `<span class="browser-compat__icon" data-browser="${browser}">
           <span class="visually-hidden">${ariaLabel}</span>
       </span>
       <span class="browser-compat__version"
-        data-compat="${compatProperty(support)}"
+        data-compat="${supportInfo.compatProperty}"
       >
-        ${compatVersion(support)}
+        ${supportInfo.icon}
       </span>
       `;
     });

--- a/src/site/_includes/components/BrowserCompat.js
+++ b/src/site/_includes/components/BrowserCompat.js
@@ -23,16 +23,21 @@ const browsers = ['chrome', 'firefox', 'edge', 'safari'];
  * @returns {string}
  */
 const compatVersion = (support) => {
-  if (!support.version_removed && support.version_added === 'preview') {
-    return '\uD83D\uDC41'; // 👁 eye
-  } else if (
-    !support.version_removed &&
-    typeof support.version_added === 'string'
-  ) {
-    return support.version_added;
-  } else {
-    return '\u00D7'; // × small x
+  if (!support.version_removed) {
+    if (support.version_added === 'preview') {
+      return '👁';
+    }
+
+    if (support.flags?.length > 0) {
+      return '⚐';
+    }
+
+    if (typeof support.version_added === 'string') {
+      return support.version_added;
+    }
   }
+
+  return '×';
 };
 
 /**

--- a/src/site/content/en/handbook/web-dev-components/index.md
+++ b/src/site/content/en/handbook/web-dev-components/index.md
@@ -274,14 +274,23 @@ With the `BrowserCompat` shortcode, you can embed an
 widget in your post. You have to pass in the dot-separated feature ID,
 as used on [BCD Schema](https://github.com/mdn/browser-compat-data), e.g. for
 [Web/API/BackgroundFetchEvent](https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent)
-the ID is `api.BackgroundFetchEvent`:
-
+the ID is `api.BackgroundFetchEvent`.
 
 ```text
 {% raw %}{% BrowserCompat 'api.BackgroundFetchEvent' %}{% endraw %}
 ```
 
 {% BrowserCompat 'api.BackgroundFetchEvent' %}
+
+The widget will use 🗑 symbols to represent features that are deprecated:
+
+{% BrowserCompat 'api.Document.execCommand' %}
+
+The following JavaScript snippet, run from the DevTools console, will display the correct ID for a given MDN page that's currently open:
+
+```js
+window.alert(document.querySelector(".bc-github-link")?.href.match(/title=(.+?)\+/)[1] ?? "No browser compat widget found on the page.")
+```
 
 ## Buttons
 


### PR DESCRIPTION
Fixes #7936 and fixes #7798

This adds logic to the existing `BrowserCompat` shortcode to do two things:

- If a feature is currently marked as being available behind a flag, show a flag icon, not a version number for the browser:
<img width="592" alt="Screen Shot 2022-06-17 at 2 38 22 PM" src="https://user-images.githubusercontent.com/1749548/174384545-19349590-4665-40f3-ac67-c5fcbf905f15.png">

- If a feature is deprecated, show the trash icon, not a version number for the browser:
<img width="582" alt="Screen Shot 2022-06-17 at 2 42 01 PM" src="https://user-images.githubusercontent.com/1749548/174385123-07d411db-551e-4c8a-be43-1a6262abf6de.png">