### PR TITLE
[File System Access API] Add behind a flag info

### DIFF
--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -12,7 +12,7 @@ description:
   user grants a web app access, this API allows them to read or save changes directly to files and
   folders on the user's device.
 date: 2019-08-20
-updated: 2022-06-02
+updated: 2022-06-24
 tags:
   - blog
   - capabilities
@@ -475,6 +475,10 @@ await directoryHandle.removeEntry('Abandoned Projects.txt');
 await directoryHandle.removeEntry('Old Stuff', { recursive: true });
 ```
 
+{% aside %}
+The `FileSystemDirectoryHandle.removeEntry()` method is currently still behind a flag. 
+{% endAside %}
+
 ### Deleting a file or folder directly
 
 If you have access to a file or directory handle, call `remove()` on a `FileSystemFileHandle` or
@@ -506,7 +510,7 @@ await file.move(directory, 'newer_name');
 ```
 
 {% Aside 'warning' %} Due to some open questions regarding cross-file-system moves, `move()` is unavailable for folders and moves outside of the
-[origin private file system](#accessing-the-origin-private-file-system).{% endAside %}
+[origin private file system](#accessing-the-origin-private-file-system) and still behind a flag.{% endAside %}
 
 ### Drag and drop integration
 

--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -475,10 +475,6 @@ await directoryHandle.removeEntry('Abandoned Projects.txt');
 await directoryHandle.removeEntry('Old Stuff', { recursive: true });
 ```
 
-{% aside %}
-The `FileSystemDirectoryHandle.removeEntry()` method is currently still behind a flag. 
-{% endAside %}
-
 ### Deleting a file or folder directly
 
 If you have access to a file or directory handle, call `remove()` on a `FileSystemFileHandle` or
@@ -490,6 +486,10 @@ await fileHandle.remove();
 // Delete a directory.
 await directoryHandle.remove();
 ```
+
+{% Aside %}
+The `FileSystemHandle.remove()` method is currently still behind a flag. 
+{% endAside %}
 
 ### Renaming and moving files and folders
 
@@ -509,8 +509,11 @@ await file.move(directory);
 await file.move(directory, 'newer_name');
 ```
 
-{% Aside 'warning' %} Due to some open questions regarding cross-file-system moves, `move()` is unavailable for folders and moves outside of the
-[origin private file system](#accessing-the-origin-private-file-system) and still behind a flag.{% endAside %}
+{% Aside %}
+The `FileSystemHandle.move()` method is shipped for files within the origin private file system (OPFS),
+behind a flag for files if the source or destination is outside of the OPFS,
+and not [yet](https://crbug.com/1250534) supported for directories.
+{% endAside %}
 
 ### Drag and drop integration
 

--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -488,7 +488,7 @@ await directoryHandle.remove();
 ```
 
 {% Aside %}
-The `FileSystemHandle.remove()` method is currently still behind a flag. 
+The `FileSystemHandle.remove()` method is currently behind a flag. 
 {% endAside %}
 
 ### Renaming and moving files and folders
@@ -510,9 +510,9 @@ await file.move(directory, 'newer_name');
 ```
 
 {% Aside %}
-The `FileSystemHandle.move()` method is shipped for files within the origin private file system (OPFS),
-behind a flag for files if the source or destination is outside of the OPFS,
-and not [yet](https://crbug.com/1250534) supported for directories.
+The `FileSystemHandle.move()` method has shipped for files within the origin private file system (OPFS),
+is behind a flag for files if the source or destination is outside of the OPFS,
+and is not [yet](https://crbug.com/1250534) supported for directories.
 {% endAside %}
 
 ### Drag and drop integration


### PR DESCRIPTION
Changes proposed in this pull request:

- Clarify `removeEntry()` and `move()` are still behind a flag.
