### PR TITLE
Correcting /customelements title to describe the article correctly

### DIFF
--- a/src/site/content/en/blog/customelements/index.md
+++ b/src/site/content/en/blog/customelements/index.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting started with Web Audio API
+title: Working with Custom Elements
 authors:
   - smus
 date: 2011-10-14


### PR DESCRIPTION
Previously entitled "Getting started with Web Audio API", which is a different article at web.dev/webaudio-intro

Fixes #8240 
