### PR TITLE
Remove misleading guidance on maskable icons

### DIFF
--- a/src/site/content/en/lighthouse-pwa/maskable-icon-audit/index.md
+++ b/src/site/content/en/lighthouse-pwa/maskable-icon-audit/index.md
@@ -39,8 +39,8 @@ In order to pass the audit:
 ## How to add maskable icon support to your PWA
 
 1. Use [Maskable.app Editor][editor] to convert an existing icon to a maskable icon.
-1. Add the `purpose` property to one of the `icons` objects in your [web app manifest][manifest].
-   Set the value of `purpose` to `maskable` or `any maskable`. See [Values][values].
+1. Add the maskable icon in different sizes to the `icons` array in your [web app manifest][manifest].
+   Set the value of `purpose` to `maskable`. See [Values][values].
 
    ```json/8
    {
@@ -48,10 +48,16 @@ In order to pass the audit:
      "icons": [
        …
        {
-         "src": "path/to/maskable_icon.png",
-         "sizes": "196x196",
+         "src": "path/to/maskable_icon_192.png",
+         "sizes": "192x192",
          "type": "image/png",
-         "purpose": "any maskable"
+         "purpose": "maskable"
+       },
+       {
+         "src": "path/to/maskable_icon_512.png",
+         "sizes": "512x512",
+         "type": "image/png",
+         "purpose": "maskable"
        }
      ]
      …


### PR DESCRIPTION
When lighthouse detects that you do not have any maskable icons, it sends you to this article, which makes it seem like you can fix it by taking the existing icons that you already have in your web app manifest, and simply adding `purpose: any maskable` to them.

I will quote [one of your other articles](https://web.dev/maskable-icon/#how-do-i-adopt-maskable-icons) on why this is a problem:

> While you _can_ specify multiple space-separated purposes such as `any maskable`, in practice you _shouldn't_. Using `maskable` icons as `any` icons is suboptimal as the icon is going to be used as-is, resulting in excess padding, making the core icon content smaller. Ideally, icons for the `any` purpose should have transparent regions and no extra padding, like your site's favicons, since the browser isn't going to add that for them.

But Lighthouse is not aware of this issue, it will no longer warn about missing `maskable` icons, and the developer might not be aware that they now have completely malformed app icons.

Also, the code example only shows a single `maskable` image being added at size `196`. To quote [one more of your own articles](https://web.dev/add-manifest/#icons):

> For Chromium, you must provide at least a 192x192 pixel icon, and a 512x512 pixel icon. If only those two icon sizes are provided, Chrome automatically scales the icons to fit the device.


Changes proposed in this pull request:
- Make it more obvious that the developer needs to generate and add novel icons to the manifest to solve this problem correctly.
- Change the code example to follow best practices for image sizes.
