### PR TITLE
webrtc: dont use "stuns:" which is not implemented in any browser

### DIFF
--- a/src/site/content/en/blog/webrtc-basics/index.md
+++ b/src/site/content/en/blog/webrtc-basics/index.md
@@ -209,7 +209,7 @@ For example, imagine Alice wants to communicate with Bob. Here's a code sample f
 // handles JSON.stringify/parse
 const signaling = new SignalingChannel();
 const constraints = {audio: true, video: true};
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 const pc = new RTCPeerConnection(configuration);
 
 // Send any ice candidates to the other peer.

--- a/src/site/content/en/blog/webrtc-infrastructure/index.md
+++ b/src/site/content/en/blog/webrtc-infrastructure/index.md
@@ -115,7 +115,7 @@ The following code snippet is a [W3C code example](https://w3c.github.io/webrtc-
 // handles JSON.stringify/parse
 const signaling = new SignalingChannel();
 const constraints = {audio: true, video: true};
-const configuration = {iceServers: [{urls: 'stuns:stun.example.org'}]};
+const configuration = {iceServers: [{urls: 'stun:stun.example.org'}]};
 const pc = new RTCPeerConnection(configuration);
 
 // Send any ice candidates to the other peer.


### PR DESCRIPTION
and throws an exception in chrome:
```
Uncaught DOMException: Failed to construct 'RTCPeerConnection': 'stuns' is not one of
the supported URL schemes 'stun', 'turn' or 'turns'.
```