### PR TITLE
Update @mdn/browser-compat-data to v5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@google-cloud/cloudbuild": "^2.6.0",
         "@google-cloud/error-reporting": "^2.0.3",
         "@google-cloud/secret-manager": "^3.10.0",
-        "@mdn/browser-compat-data": "^4.1.18",
+        "@mdn/browser-compat-data": "^5.1.3",
         "@minify-html/js": "^0.8.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -1626,9 +1626,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
-      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.3.tgz",
+      "integrity": "sha512-5RqTIOtj/8m2yfiAT7fRtVwqDzpHkliozS86puqlceAFFuUQpYn17nIXTZ7hPVyhQ8wacCW42crCBdwscNBjFw=="
     },
     "node_modules/@minify-html/js": {
       "version": "0.8.0",
@@ -30248,9 +30248,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "@mdn/browser-compat-data": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
-      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.3.tgz",
+      "integrity": "sha512-5RqTIOtj/8m2yfiAT7fRtVwqDzpHkliozS86puqlceAFFuUQpYn17nIXTZ7hPVyhQ8wacCW42crCBdwscNBjFw=="
     },
     "@minify-html/js": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@google-cloud/cloudbuild": "^2.6.0",
     "@google-cloud/error-reporting": "^2.0.3",
     "@google-cloud/secret-manager": "^3.10.0",
-    "@mdn/browser-compat-data": "^4.1.18",
+    "@mdn/browser-compat-data": "^5.1.3",
     "@minify-html/js": "^0.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",


### PR DESCRIPTION
As discussed with @rachelandrew, this is a major semver bump but from what I can tell, the breaking changes are related to TypeScript definitions that we are not dependent on. Things look okay when tested locally.

Still, we're breaking this up into a separate PR to accompany #8251 to keep it simpler if we need to roll things back.