### PR TITLE
Update bfcache article with section on measuring cache ratio hit

### DIFF
--- a/src/site/_data/authorsData.json
+++ b/src/site/_data/authorsData.json
@@ -586,6 +586,13 @@
     "github": "philipwalton",
     "image": "image/admin/ovBM8MF9rYDxVVHUVlcG.jpg"
   },
+  "tunetheweb": {
+    "country": "Ireland",
+    "homepage": "https://www.tunetheweb.com",
+    "twitter": "tunetheweb",
+    "github": "tunetheweb",
+    "image": "image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/FzCdsVVLfgdqxfgs6BDc.jpeg"
+  },
   "ekharvey": {
     "twitter": "HarveyLizzi",
     "github": "ekharvey",

--- a/src/site/_data/i18n/authors.yml
+++ b/src/site/_data/i18n/authors.yml
@@ -63,7 +63,7 @@ joemarini:
     en: Joe Marini
   description:
     en: Chrome Developer Advocate at Google
-    
+
 loreenalee:
   title:
     en: Loreena Lee
@@ -129,7 +129,7 @@ gskinnerdotcom:
     en: Sean Middleditch
   description:
     en: Agency
-    
+
 seanmiddleditch:
   title:
     en: Sean Middleditch
@@ -1161,6 +1161,25 @@ philipwalton:
     pt: Engenheiro na empresa Google trabalhando na plataforma web
     ru: Инженер в компании Google, участвующий в разработке веб-платформы
     zh: 研究网络平台的 Google 工程师
+
+tunetheweb:
+  title:
+    en: Barry Pollard
+    es: Barry Pollard
+    ja: Barry Pollard
+    ko: Barry Pollard
+    pt: Barry Pollard
+    ru: Barry Pollard
+    zh: Barry Pollard
+  description:
+    en: Web Performance Developer Advocate for Google
+    es: Rendimiento web aesarrollador partidario para Google
+    ja: Google を対象とした Developer Advocate
+    ko: Google의 개발자 애드버킷
+    pt: Developer Advocate para o Google
+    ru: Developer Advocate по вопросам Google
+    zh: 负责 Google 的开发技术推广工程师
+
 
 ekharvey:
   title:

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -533,10 +533,10 @@ the bfcache, including:
 - when the user duplicates a tab
 - when the user closes a tab and uncloses it
 
-So, website owners are not aiming for 100% bfcache hit ratio on all
-`back_forward` navigations, but measuring their ratio can be useful to identify
-pages where the page itself is preventing bfcache usage for a high proportion
-of navigations.
+So, website owners should not be expecting a 100% bfcache hit ratio for all
+`back_forward` navigations. However, measuring their ratio can be useful to
+identify pages where the page itself is preventing bfcache usage for a high
+proportion of back and forward navigations.
 
 The Chrome team is working on a
 (`NotRestoredReason API`)[https://github.com/rubberyuzu/bfcache-not-retored-reason/blob/main/NotRestoredReason.md]

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -87,7 +87,7 @@ Chrome usage data shows that 1 in 10 navigations on desktop and 1 in 5 on mobile
 are either back or forward. With bfcache enabled, browsers could eliminate the
 data transfer and time spent loading for billions of web pages every single day!
 
-### How the "cache" works {: #how-the-cache-works }
+### How the "cache" works
 
 The "cache" used by bfcache is different from the [HTTP cache](/http-cache/)
 (which is also useful in speeding up repeat navigations). The bfcache is a

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -501,7 +501,7 @@ window.addEventListener('pageshow', (event) => {
 ### Measuring your bfcache hit ratio
 
 As well as measuring pageview measurements for bfcache page navigations, you
-may wish to also track whether the bfcached was used to help identify pages
+may wish to also track whether the bfcache was used to help identify pages
 that are not utilising the bfcache. For example:
 
 ```js
@@ -520,7 +520,8 @@ window.addEventListener('pageshow', (event) => {
     gtag('event', 'bfcache', {
       'event_category': 'page_load_details',
       'event_label': window.location.pathname,
-      'value': event.persisted });
+      'value': event.persisted
+    });
   }
 });
 ```

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -6,6 +6,7 @@ description: |
   Learn how to optimize your pages for instant loads when using the browser's back and forward buttons.
 authors:
   - philipwalton
+  - tunetheweb
 date: 2020-11-10
 updated: 2022-07-01
 hero: image/admin/Qoeb8x3a11BdGgRzYJbY.png

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -500,34 +500,24 @@ window.addEventListener('pageshow', (event) => {
 
 ### Measuring your bfcache hit ratio
 
-As well as pageview measurements for bfcache page navigations, you may also
-wish to track whether the bfcache was used, to help identify pages that are not
-utilizing the bfcache. For example:
+You may also wish to track whether the bfcache was used, to help identify pages
+that are not utilizing the bfcache. For example, with an event:
 
 ```js
-// Send a pageview when the page is first loaded.
-gtag('event', 'page_view');
-
 window.addEventListener('pageshow', (event) => {
-
-  // Send another pageview if the page is restored from bfcache.
-  if (event.persisted) {
-    gtag('event', 'page_view');
-  }
-
-  // For bfcache restores (note navigation type may be the original)
-  // or other Back/Forward navigations, track whether bfcache was used:
-  if (event.persisted || performance.getEntriesByType('navigation')[0].type == "back_forward") {
-    gtag('event', 'bfcache', {
-      'event_category': 'page_load_details',
-      'value': event.persisted
+  // You can measure bfcache hit rate by tracking all bfcache restores and
+  // other back/forward navigations via a seperate event.
+  const navigationType = performance.getEntriesByType('navigation')[0].type;
+  if (event.persisted || navigationType == 'back_forward' ) {
+    gtag('event', 'back_forward_navigation', {
+      'isBFCache': event.persisted,
     });
   }
 });
 ```
 
 It is important to realize that there are a number of scenarios, outside
-of the site owners control, when a `back_forward` navigation will not use
+of the site owners control, when a Back/Forward navigation will not use
 the bfcache, including:
 - when the user quits the browser and starts it again
 - when the user duplicates a tab

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -515,7 +515,7 @@ window.addEventListener('pageshow', (event) => {
     gtag('event', 'page_view');
   }
 
-  // For Back/Forward navigations, send track bfcache usage.
+  // For Back/Forward navigations, send another event to track bfcache usage.
   if (performance.getEntriesByType('navigation')[0].type == "back_forward") {
     gtag('event', 'bfcache', {
       'event_category': 'page_load_details',
@@ -526,7 +526,7 @@ window.addEventListener('pageshow', (event) => {
 });
 ```
 
-It is important to reali`e that there are a number of scenarios, outside
+It is important to realize that there are a number of scenarios, outside
 of the site owners control, when a `back_forward` navigation will not use
 the bfcache, including:
 - when the user quits the browser and starts it again

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -500,9 +500,9 @@ window.addEventListener('pageshow', (event) => {
 
 ### Measuring your bfcache hit ratio
 
-As well as measuring pageview measurements for bfcache page navigations, you
-may wish to also track whether the bfcache was used to help identify pages
-that are not utilising the bfcache. For example:
+As well as pageview measurements for bfcache page navigations, you may also
+wish to track whether the bfcache was used, to help identify pages that are not
+utilizing the bfcache. For example:
 
 ```js
 // Send a pageview when the page is first loaded.
@@ -526,7 +526,7 @@ window.addEventListener('pageshow', (event) => {
 });
 ```
 
-It is important to realise that there are a number of scenarios, outside
+It is important to reali`e that there are a number of scenarios, outside
 of the site owners control, when a `back_forward` navigation will not use
 the bfcache, including:
 - when the user quits the browser and starts it again

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -515,8 +515,9 @@ window.addEventListener('pageshow', (event) => {
     gtag('event', 'page_view');
   }
 
-  // For Back/Forward navigations, send another event to track bfcache usage.
-  if (performance.getEntriesByType('navigation')[0].type == "back_forward") {
+  // For bfcache restores (note navigation type may be the original)
+  // or other Back/Forward navigations, track whether bfcache was used:
+  if (event.persisted || performance.getEntriesByType('navigation')[0].type == "back_forward") {
     gtag('event', 'bfcache', {
       'event_category': 'page_load_details',
       'value': event.persisted

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -519,7 +519,6 @@ window.addEventListener('pageshow', (event) => {
   if (performance.getEntriesByType('navigation')[0].type == "back_forward") {
     gtag('event', 'bfcache', {
       'event_category': 'page_load_details',
-      'event_label': window.location.pathname,
       'value': event.persisted
     });
   }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Adds a section on measuring bfcache hit ratio

Also includes some other misc changes
- Removed unnecessary `=== true` code section as follow on from #4272
- Adds case study from Smashing Magazine (full disclosure - I wrote this one).

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
