### PR TITLE
Fetch streaming requests: Update article for Chrome 105

### DIFF
--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -290,7 +290,7 @@ Safari _does_ support streams in request objects, but _doesn't_ allow them to be
 used with `fetch`, so the `duplex` option is tested, which Safari doesn't
 currently support.
 
-### Writable streams
+## Using with writable streams
 
 Sometimes it's easier to work with streams when you have a `WritableStream`. You
 can do this using an 'identity' stream, which is a readable/writable pair that

--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -29,7 +29,7 @@ You could use this to:
   wait until the user presses 'send' before sending the data they entered.
 - Gradually send data generated on the client, such as audio, video, or input
   data.
-- Recreate web sockets over HTTP/2.
+- Recreate web sockets over HTTP/2 or HTTP/3.
 
 But since this is a low-level web platform feature, don't be limited by _my_
 ideas. Maybe you can think of a much more exciting use-case for request
@@ -200,9 +200,9 @@ preflight.
 
 Streaming `no-cors` requests are not allowed.
 
-### HTTP/2 only
+### Doesn't work on HTTP/1.x
 
-The fetch will be rejected if the connection isn't HTTP/2.
+The fetch will be rejected if the connection is HTTP/1.x.
 
 This is because, according to HTTP/1.1 rules, request and response bodies either
 need to send a `Content-Length` header, so the other side knows how much data
@@ -214,7 +214,7 @@ Chunked encoding is pretty common when it comes to HTTP/1.1 _responses_, but
 very rare when it comes to _requests_, so it's too much of a compatibility risk.
 
 {% Aside %}
-This isn't an issue for HTTP/2, as HTTP/2 data is always 'chunked', although it
+This isn't an issue for HTTP/2 or 3, as data is always 'chunked', although it
 calls the chunks
 [frames](https://developers.google.com/web/fundamentals/performance/http2#streams_messages_and_frames).
 {% endAside %}

--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -7,8 +7,8 @@ description: >
   Chrome now supports upload streaming as of version 95, which means
   you can start a request before you have the whole body available.
 date: 2020-07-22
-updated: 2021-09-22
-hero: image/admin/9U7u4C7WCGbrdHm3181W.jpg
+updated: 2022-07-12
+hero: image/CZmpGM8Eo1dFe0KNhEO9SGO8Ok23/Szy6o6TSfz3BEXJO3670.jpg
 alt: A canoe pointed up stream.
 tags:
   - blog
@@ -19,18 +19,21 @@ feedback:
   - api
 ---
 
-From Chrome 95, you can start a request before you have the whole body available by using the streams API.
+From Chrome 105, you can start a request before you have the whole body
+available by using the streams API.
 
 You could use this to:
 
 - Warm up the server. In other words, you could start the request once the user
   focuses a text input field, and get all of the headers out of the way, then
   wait until the user presses 'send' before sending the data they entered.
-- Gradually send data generated on the client, such as audio, video, or input data.
-- Recreate web sockets over HTTP.
+- Gradually send data generated on the client, such as audio, video, or input
+  data.
+- Recreate web sockets over HTTP/2.
 
-But since this is a low-level web platform feature, don't be limited by _my_ ideas.
-Maybe you can think of a much more exciting use-case for request streaming.
+But since this is a low-level web platform feature, don't be limited by _my_
+ideas. Maybe you can think of a much more exciting use-case for request
+streaming.
 
 ## Demo {: #demo }
 
@@ -58,7 +61,7 @@ const response = await fetch(url);
 const reader = response.body.getReader();
 
 while (true) {
-  const { value, done } = await reader.read();
+  const {value, done} = await reader.read();
   if (done) break;
   console.log('Received', value);
 }
@@ -78,9 +81,7 @@ it](https://caniuse.com/#feat=mdn-api_textdecoderstream):
 
 ```js
 const response = await fetch(url);
-const reader = response.body
-  .pipeThrough(new TextDecoderStream())
-  .getReader();
+const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
 ```
 
 `TextDecoderStream` is a transform stream that grabs all those `Uint8Array`
@@ -105,7 +106,8 @@ await fetch(url, {
 ```
 
 Previously, you needed the whole body ready to go before you could start the
-request, but now in Chrome 95 you can provide your own `ReadableStream` of data:
+request, but now in Chrome 105, you can provide your own `ReadableStream` of
+data:
 
 ```js
 function wait(milliseconds) {
@@ -130,8 +132,9 @@ const stream = new ReadableStream({
 
 fetch(url, {
   method: 'POST',
-  headers: { 'Content-Type': 'text/plain' },
+  headers: {'Content-Type': 'text/plain'},
   body: stream,
+  duplex: 'half',
 });
 ```
 
@@ -141,81 +144,40 @@ with a one second pause between each word.
 Each chunk of a request body needs to be a `Uint8Array` of bytes, so I'm using
 `pipeThrough(new TextEncoderStream())` to do the conversion for me.
 
-### Writable streams
-
-Sometimes it's easier to work with streams when you have a `WritableStream`. You can do this using an 'identity' stream, which is a readable/writable pair that takes anything that's passed to its writable end, and sends it to the readable end. You can create one of these by creating a `TransformStream` without any arguments:
-
-```js
-const { readable, writable } = new TransformStream();
-
-const responsePromise = fetch(url, {
-  method: 'POST',
-  body: readable,
-});
-```
-
-Now, anything you send to the writable stream will be part of the request. This
-lets you compose streams together. For instance, here's a silly example where
-data is fetched from one URL, compressed, and sent to another URL:
-
-```js
-// Get from url1:
-const response = await fetch(url1);
-const { readable, writable } = new TransformStream();
-
-// Compress the data from url1:
-response.body
-  .pipeThrough(new CompressionStream('gzip'))
-  .pipeTo(writable);
-
-// Post to url2:
-await fetch(url2, {
-  method: 'POST',
-  body: readable,
-});
-```
-
-The above example uses [compression
-streams](https://chromestatus.com/feature/5855937971617792) to compress
-arbitrary data using gzip.
-
-### Feature detection
-
-```js
-const supportsRequestStreamsP = (async () => {
-  const supportsStreamsInRequestObjects = !new Request('', {
-    body: new ReadableStream(),
-    method: 'POST',
-  }).headers.has('Content-Type');
-
-  if (!supportsStreamsInRequestObjects) return false;
-
-  return fetch('data:a/a;charset=utf-8,', {
-    method: 'POST',
-    body: new ReadableStream(),
-  }).then(() => true, () => false);
-})();
-
-// Note: supportsRequestStreamsP is a promise.
-if (await supportsRequestStreamsP) {
-  // …
-} else {
-  // …
-}
-```
-
-If you're curious, here's how the feature detection works:
-
-If the browser doesn't support a particular `body` type, it calls `toString()` on the object and uses the result as the body. So, if the browser doesn't support request streams, the request body becomes the string `"[object ReadableStream]"`. When a string is used as a body, it conveniently sets the `Content-Type` header to `text/plain;charset=UTF-8`. So, if that header is set, then we know the browser _doesn't_ support streams in request objects, and we can exit early.
-
-Unfortunately, Safari _does_ support streams in request objects, but _doesn't_ allow them to be used with `fetch`.
-
-To test that, we try `fetch` with a stream body. The test would be flakey and slow if it depended on the network, but thankfully a quirk in the spec allows for `POST` requests to be made to `data:` URLs. This is fast and works without a connection. Safari will reject this call because it doesn't support the stream body.
-
 ## Restrictions
 
 Streaming requests are a new power for the web, so they come with a few
 restrictions:
+
+### Half duplex?
+
+To allow streams to be used in a request, the `duplex` request option needs to
+be set to `'half'`.
+
+A little-known feature of HTTP (although, whether this is standard behavior
+depends on who you ask) is that you can start receiving the response while
+you're still sending the request. However, it's so little-known, that it isn't
+well supported by servers, and isn't supported by any browser.
+
+In browsers, the response never becomes available until the request body has
+been fully sent, even if the server sends a response sooner. This is true for
+all browser fetching.
+
+This default pattern is known as 'half duplex'. However, some implementations,
+such as [`fetch` in Deno](https://doc.deno.land/deno/stable/~/fetch), defaulted
+to 'full duplex' for streaming fetches, meaning the response can become
+available before the request is complete.
+
+So, to work around this compatibility issue, in browsers, `duplex: 'half'` needs
+to be specified on requests that have a stream body.
+
+In future, `duplex: 'full'` may be supported in browsers for streaming requests,
+and other kinds of fetches.
+
+In the meantime, the next best thing to duplex communication is to make one
+fetch with a streaming request, then make another fetch to receive the streaming
+response. The server will need some way to associate these two requests, like an
+ID in the URL. That's how the [demo](#demo) works.
 
 ### Restricted redirects
 
@@ -230,80 +192,45 @@ followed.
 303 redirects are allowed, since they explicitly change the method to `GET` and
 discard the request body.
 
-### HTTP/2 only by default
+### Requires CORS and triggers a preflight
 
-By default, the fetch will be rejected if the connection isn't HTTP/2. If you
-want to use streaming requests over HTTP/1.1, you need to opt in:
+Streaming requests have a body, but don't have a `Content-Length` header. That's
+a new kind of request, so CORS is required, and these requests always trigger a
+preflight.
 
-```js/3-3
-await fetch(url, {
-  method: 'POST',
-  body: stream,
-  allowHTTP1ForStreamingUpload: true,
-});
-```
+Streaming `no-cors` requests are not allowed.
 
-{% Aside 'caution' %}
-`allowHTTP1ForStreamingUpload` is non-standard and will only be used as part of
-Chrome's experimental implementation.
-{% endAside %}
+### HTTP/2 only
 
-According to HTTP/1.1 rules, request and response bodies either need to send a
-`Content-Length` header, so the other side knows how much data it'll receive, or
-change the format of the message to use [chunked
+The fetch will be rejected if the connection isn't HTTP/2.
+
+This is because, according to HTTP/1.1 rules, request and response bodies either
+need to send a `Content-Length` header, so the other side knows how much data
+it'll receive, or change the format of the message to use [chunked
 encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding). With chunked
 encoding, the body is split into parts, each with their own content length.
 
 Chunked encoding is pretty common when it comes to HTTP/1.1 _responses_, but
-very rare when it comes to _requests_. Because of this, Chrome is a little worried
-about compatibility, so it's opt-in for now.
+very rare when it comes to _requests_, so it's too much of a compatibility risk.
 
 {% Aside %}
 This isn't an issue for HTTP/2, as HTTP/2 data is always 'chunked', although it
 calls the chunks
 [frames](https://developers.google.com/web/fundamentals/performance/http2#streams_messages_and_frames).
-Chunked encoding wasn't introduced until HTTP/1.1, so requests with streaming
-bodies will always fail on HTTP/1 connections.
 {% endAside %}
-
-Depending on how this trial goes, the spec will either restrict streaming
-responses to HTTP/2, or always allow it for both HTTP/1.1 and HTTP/2.
-
-### No duplex communication
-
-A little-known feature of HTTP (although, whether this is standard behaviour
-depends on who you ask) is that you can start receiving the response while
-you're still sending the request. However, it's so little-known, that it isn't
-well supported by servers, and, well, browsers.
-
-In Chrome's current implementation, you won't get the response until the body
-has been fully sent. In the following example `responsePromise` won't resolve
-until the readable stream has been closed. Anything the server sends before that
-point will be buffered.
-
-```js
-const responsePromise = fetch(url, {
-  method: 'POST',
-  body: readableStream,
-});
-```
-
-The next best thing to duplex communication is to make one fetch with a
-streaming request, then make another fetch to receive the streaming response.
-The server will need some way to associate these two requests, like an ID in the
-URL. That's how the [demo](#demo) works.
 
 ## Potential issues
 
-Yeah, so… this is a new feature, and one that's underused on the internet today.
-Here are some issues to look out for:
+This is a new feature, and one that's underused on the internet today. Here are
+some issues to look out for:
 
 ### Incompatibility on the server side
 
 Some app servers don't support streaming requests, and instead wait for the full
 request to be received before letting you see any of it, which kinda defeats the
 point. Instead, use an app server that supports streaming, like
-[NodeJS](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_class_http_incomingmessage).
+[NodeJS](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_class_http_incomingmessage)
+or [Deno](https://deno.land/).
 
 But, you're not out of the woods yet! The application server, such as NodeJS,
 usually sits behind another server, often called a "front-end server", which may
@@ -311,38 +238,97 @@ in turn sit behind a CDN. If any of those decide to buffer the request before
 giving it to the next server in the chain, you lose the benefit of request
 streaming.
 
-Also, if you're using HTTP/1.1, one of the servers may not be prepared for
-chunked encoding, and may fail with an error. But hey, at least you can test
-that and try to change servers if needed.
-
-_…long sigh…_
-
 ### Incompatibility outside of your control
 
-If you're using HTTPS you don't need to worry about proxies between you and the
-user, but the user may be running a proxy on their machine. Some internet
-protection software does this to allow it to monitor everything that goes
-between the browser and network.
-
-There may be cases where this software buffers request bodies, or in the case of
-HTTP/1.1, doesn't expect chunked encoding, and breaks in some exciting way.
-
-Right now, it's not clear how often this will happen, if at all.
+Since this feature only works over HTTPS, you don't need to worry about proxies
+between you and the user, but the user may be running a proxy on their machine.
+Some internet protection software does this to allow it to monitor everything
+that goes between the browser and network, and there may be cases where this
+software buffers request bodies.
 
 If you want to protect against this, you can create a 'feature test' similar to
 the [demo above](#demo), where you try to stream some data without closing the
 stream. If the server receives the data, it can respond via a different fetch.
 Once this happens, you know the client supports streaming requests end-to-end.
 
-## Feedback welcome
+### Feature detection
 
-Feedback from the community is crucial to the design of new APIs, so please try
-it out and tell us what you think! If you encounter any bugs, please [report
-them](https://bugs.chromium.org/p/chromium/issues/list), but if you have general
-feedback, please send it to the [blink-network-dev Google
-Group](https://groups.google.com/a/chromium.org/forum/#!forum/blink-network-dev).
+```js
+const supportsRequestStreams = (() => {
+  let duplexAccessed = false;
 
-Photo by [Laura
-Lefurgey-Smith](https://unsplash.com/@lauralefurgeysmith?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText)
-on
-[Unsplash](https://unsplash.com/s/photos/canoe-stream?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText)
+  const hasContentType = new Request('', {
+    body: new ReadableStream(),
+    method: 'POST',
+    get duplex() {
+      duplexAccessed = true;
+      return 'half';
+    },
+  }).headers.has('Content-Type');
+
+  return duplexAccessed && !hasContentType;
+})();
+
+if (supportsRequestStreams) {
+  // …
+} else {
+  // …
+}
+```
+
+If you're curious, here's how the feature detection works:
+
+If the browser doesn't support a particular `body` type, it calls `toString()`
+on the object and uses the result as the body. So, if the browser doesn't
+support request streams, the request body becomes the string
+`"[object ReadableStream]"`. When a string is used as a body, it conveniently
+sets the `Content-Type` header to `text/plain;charset=UTF-8`. So, if that header
+is set, then we know the browser _doesn't_ support streams in request objects,
+and we can exit early.
+
+Safari _does_ support streams in request objects, but _doesn't_ allow them to be
+used with `fetch`, so the `duplex` option is tested, which Safari doesn't
+currently support.
+
+### Writable streams
+
+Sometimes it's easier to work with streams when you have a `WritableStream`. You
+can do this using an 'identity' stream, which is a readable/writable pair that
+takes anything that's passed to its writable end, and sends it to the readable
+end. You can create one of these by creating a `TransformStream` without any
+arguments:
+
+```js
+const {readable, writable} = new TransformStream();
+
+const responsePromise = fetch(url, {
+  method: 'POST',
+  body: readable,
+});
+```
+
+Now, anything you send to the writable stream will be part of the request. This
+lets you compose streams together. For instance, here's a silly example where
+data is fetched from one URL, compressed, and sent to another URL:
+
+```js
+// Get from url1:
+const response = await fetch(url1);
+const {readable, writable} = new TransformStream();
+
+// Compress the data from url1:
+response.body.pipeThrough(new CompressionStream('gzip')).pipeTo(writable);
+
+// Post to url2:
+await fetch(url2, {
+  method: 'POST',
+  body: readable,
+});
+```
+
+The above example uses [compression
+streams](https://chromestatus.com/feature/5855937971617792) to compress
+arbitrary data using gzip.
+
+Photo by [Alexandru Trandafir](https://unsplash.com/@trandafir93) on
+[Unsplash](https://unsplash.com/photos/XsZwoxL_HNM)

--- a/src/site/content/en/blog/fetch-upload-streaming/index.md
+++ b/src/site/content/en/blog/fetch-upload-streaming/index.md
@@ -251,7 +251,7 @@ the [demo above](#demo), where you try to stream some data without closing the
 stream. If the server receives the data, it can respond via a different fetch.
 Once this happens, you know the client supports streaming requests end-to-end.
 
-### Feature detection
+## Feature detection
 
 ```js
 const supportsRequestStreams = (() => {


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8288

Preview: https://deploy-preview-8317--web-dev-staging.netlify.app/fetch-upload-streaming/

Changes proposed in this pull request:

- Clarifies that feature is launching in Chrome 105
- Removes origin trial details, and other references to experimentation
- Updates API references and feature detect
- Reordering article a bit, as some of the restrictions became more important
- Updated details on duplexing, since it's a new option
- Removed references to the HTTP/1 opt-in, as it's no longer a thing
- Changed the hero image because it was low contrast and it annoyed me

