### PR TITLE
Some small Accessibility tweaks to score 100 in Lighthouse

### DIFF
--- a/src/site/_includes/partials/post-next.njk
+++ b/src/site/_includes/partials/post-next.njk
@@ -118,14 +118,14 @@
         {% StackOverflow stack_overflow_tag %}
       {% endif %}
 
-      <div class="cluster gutter-base flow-space-size-2" aria-label="tags">
+      <nav class="cluster gutter-base flow-space-size-2" aria-label="tags">
         {% for tagKey in tags or [] %}
           {% if tagKey in collections.tags %}
             {% set tag = collections.tags[tagKey] %}
             <a class="pill" href="{{tag.url}}">{{tag.overrideTitle or tag.title | i18n(locale)}}</a>
           {% endif %}
         {% endfor %}
-      </div>
+      </nav>
 
       <div class="text-size-0 color-mid-text">
         <span>

--- a/src/site/_includes/partials/post-next.njk
+++ b/src/site/_includes/partials/post-next.njk
@@ -118,7 +118,7 @@
         {% StackOverflow stack_overflow_tag %}
       {% endif %}
 
-      <div class="cluster gutter-base flow-space-size-2" role="list" aria-label="tags">
+      <div class="cluster gutter-base flow-space-size-2" aria-label="tags">
         {% for tagKey in tags or [] %}
           {% if tagKey in collections.tags %}
             {% set tag = collections.tags[tagKey] %}

--- a/src/site/_includes/partials/site-header.njk
+++ b/src/site/_includes/partials/site-header.njk
@@ -2,7 +2,7 @@
 
 <web-header role="banner" class="site-header">
   <div class="cluster gutter-base">
-    <button class="icon-button tooltip color-core-text md:hidden-yes" data-open-drawer-button data-alignment="right">
+    <button class="icon-button tooltip color-core-text md:hidden-yes" data-open-drawer-button data-alignment="right" aria-labelled="Open menu">
       {% include "icons/menu.svg" %}
       <span class="tooltip__content">Open menu</span>
     </button>

--- a/src/site/_includes/partials/site-header.njk
+++ b/src/site/_includes/partials/site-header.njk
@@ -2,9 +2,9 @@
 
 <web-header role="banner" class="site-header">
   <div class="cluster gutter-base">
-    <button class="icon-button tooltip color-core-text md:hidden-yes" data-open-drawer-button data-alignment="right" aria-labelled="Open menu">
+    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right">
       {% include "icons/menu.svg" %}
-      <span class="tooltip__content">Open menu</span>
+      <span class="tooltip__content" id="menu-button-toolip">Open menu</span>
     </button>
     <a href="/" class="site-header__brand brand">
       {{ svg('../../images/lockup.svg', {label: 'web.dev'}) }}


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8320 

Changes proposed in this pull request:

- Our Hamburger menu button on mobile doesn't have an accessible name - added an aria-labelledby to point to tool tip (which is hidden by default), similar to other code.
- Our Article tags are in a `role="list"` but there are no list items within that list (as it's a `div` instead of `ul`, and there are no `li` items). I changed it to a `<nav>` instead (which has an implicit `navigation` role as changing the `div` to `ul` causes an indentation (requiring CSS changes), it would require wrapping the links in `<li>`s (possibly requiring further CSS changes), and other "lists" like language links do are not in `role="lists"` anyway. Plus `<nav>` is actually more accurate.
