### PR TITLE
Fix typo in Next.js Script article

### DIFF
--- a/src/site/content/en/blog/script-component/index.md
+++ b/src/site/content/en/blog/script-component/index.md
@@ -15,15 +15,15 @@ tags:
   - blog
 ---
 
-Around [45%](https://almanac.httparchive.org/en/2021/third-parties#fig-3) of requests from websites served on mobile and desktop are third-party requests of which [33% are scripts](https://almanac.httparchive.org/en/2021/third-parties#fig-9). The size, latency, and loading of third-party scripts can significantly affect a site's performance. The Next.js Script component comes with baked-in best practices and defaults to help developers introduce third-party scripts in their applications while addressing potential performance issues out of the box. 
+Around [45%](https://almanac.httparchive.org/en/2021/third-parties#fig-3) of requests from websites served on mobile and desktop are third-party requests of which [33% are scripts](https://almanac.httparchive.org/en/2021/third-parties#fig-9). The size, latency, and loading of third-party scripts can significantly affect a site's performance. The Next.js Script component comes with baked-in best practices and defaults to help developers introduce third-party scripts in their applications while addressing potential performance issues out of the box.
 
 ## Third-party scripts and their impact on performance
 
-[Third-party scripts](/third-party-javascript/) allow web developers to leverage existing solutions to implement common features and reduce development time. But the creators of these scripts typically do not have any incentive to consider the performance impact on the consuming website. These scripts are also a blackbox to developers who use them. 
+[Third-party scripts](/third-party-javascript/) allow web developers to leverage existing solutions to implement common features and reduce development time. But the creators of these scripts typically do not have any incentive to consider the performance impact on the consuming website. These scripts are also a blackbox to developers who use them.
 
-Scripts account for a significant number of [third-party bytes](https://almanac.httparchive.org/en/2021/third-parties#fig-11) downloaded by websites across different categories of third-party requests. By default, the browser prioritizes scripts based on where they are in the document which may delay the discovery or execution of scripts critical to user experience. 
+Scripts account for a significant number of [third-party bytes](https://almanac.httparchive.org/en/2021/third-parties#fig-11) downloaded by websites across different categories of third-party requests. By default, the browser prioritizes scripts based on where they are in the document which may delay the discovery or execution of scripts critical to user experience.
 
-Third-party libraries required for layout should be loaded early to render the page. Third-parties that are not required for initial render should be deferred so that they do not block other processing on the main thread. [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) has two audits to flag render-blocking or main thread blocking scripts. 
+Third-party libraries required for layout should be loaded early to render the page. Third-parties that are not required for initial render should be deferred so that they do not block other processing on the main thread. [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) has two audits to flag render-blocking or main thread blocking scripts.
 
 <figure>
   {% Img src="image/IypihH3o5cSpEMVp5i08dp69otp2/nzgIO68cBW9y5xCsW0g6.png", alt="Lighthouse audits for Eliminate render-blocking resources and Minimize third-party usage", width="800", height="301" %}
@@ -34,15 +34,15 @@ It's important to consider the resource loading sequence of your page so that cr
 While there are [best practices](/fast/#optimize-your-third-party-resources) to reduce the impact of third parties, not everyone may be aware of how to implement them for every third-party they use. This can be complicated because:
 
 * On average, websites use [21 to 23 different third parties](https://almanac.httparchive.org/en/2021/third-parties#fig-4)&mdash;including scripts&mdash;on mobile and desktop. Usage and recommendations may differ for each.
-* Implementing many third-parties can differ based on whether a particular framework or UI library is used. 
+* Implementing many third-parties can differ based on whether a particular framework or UI library is used.
 * Newer third-party libraries are introduced frequently.
 * Varying business requirements related to the same third-party makes it difficult for developers to standardize its use.
 
 ## Aurora’s focus on third-party scripts
 
-Part of Aurora's [collaboration](/introducing-aurora/#aurora:-a-collaboration-between-chrome-and-open-source-web-frameworks-and-tools) with open source web frameworks and tools is to provide strong defaults and opinionated tooling to help developers improve aspects of the user experience such as performance, accessibility, security, and mobile readiness. In 2021, we were focused on helping framework stacks improve user experience and their [Core Web Vitals](/vitals/) metrics. 
+Part of Aurora's [collaboration](/introducing-aurora/#aurora:-a-collaboration-between-chrome-and-open-source-web-frameworks-and-tools) with open source web frameworks and tools is to provide strong defaults and opinionated tooling to help developers improve aspects of the user experience such as performance, accessibility, security, and mobile readiness. In 2021, we were focused on helping framework stacks improve user experience and their [Core Web Vitals](/vitals/) metrics.
 
-One of the most significant steps towards achieving our goal to improve framework performance involved researching the ideal loading sequence of third-party scripts in Next.js. Frameworks such as Next.js are uniquely positioned to provide useful defaults and features that help developers efficiently load resources, including third-parties. We studied extensive [HTTP Archive](https://httparchive.org/) and Lighthouse [data](https://docs.google.com/spreadsheets/d/1Td-4qFjuBzxp8af_if5iBC0Lkqm_OROb7_2OcbxrU_g/edit?resourcekey=0-ZCfve5cngWxF0-sv5pLRzg#gid=1628564987) to find which third-parties [block rendering](/render-blocking-resources/) the most across different frameworks. 
+One of the most significant steps towards achieving our goal to improve framework performance involved researching the ideal loading sequence of third-party scripts in Next.js. Frameworks such as Next.js are uniquely positioned to provide useful defaults and features that help developers efficiently load resources, including third-parties. We studied extensive [HTTP Archive](https://httparchive.org/) and Lighthouse [data](https://docs.google.com/spreadsheets/d/1Td-4qFjuBzxp8af_if5iBC0Lkqm_OROb7_2OcbxrU_g/edit?resourcekey=0-ZCfve5cngWxF0-sv5pLRzg#gid=1628564987) to find which third-parties [block rendering](/render-blocking-resources/) the most across different frameworks.
 
 To address the issue of main-thread blocking third-party scripts used in an application, we built the [Script component](https://nextjs.org/docs/basic-features/script). The component encapsulates sequencing features to provide developers with better controls for third-party script loading.
 
@@ -54,7 +54,7 @@ The [available guidance](/efficiently-load-third-party-javascript/) to reduce th
 
     ```html
        <script src="https://example.com/script1.js" defer></script>
-       <script src="https://example.com/script2.js" async></script> 
+       <script src="https://example.com/script2.js" async></script>
     ```
 
 2. [Establish early connections to required origins](/preconnect-and-dns-prefetch/) using preconnect and dns-prefetch. This allows critical scripts to start downloading earlier.
@@ -72,7 +72,7 @@ The [available guidance](/efficiently-load-third-party-javascript/) to reduce th
 
 ## The Next.js Script component
 
-The [Next.js Script component](https://nextjs.org/docs/basic-features/script) implements the above methods for sequencing scripts and provides a template for developers to define their loading strategy. Once the suitable strategy is specified, it will load optimally without blocking other critical resources. 
+The [Next.js Script component](https://nextjs.org/docs/basic-features/script) implements the above methods for sequencing scripts and provides a template for developers to define their loading strategy. Once the suitable strategy is specified, it will load optimally without blocking other critical resources.
 
 The Script component builds on the HTML &lt;script&gt; tag and provides an option to set the loading priority for third-party scripts using the strategy attribute.
 
@@ -92,11 +92,11 @@ The strategy attribute can take three values.
 
 1. **`beforeInteractive`**: This option may be used for critical scripts that should execute before the page becomes interactive. Next.js ensures that such scripts are injected into the initial HTML on the server and executed before other self-bundled JavaScript. Consent management, bot detection scripts, or helper libraries required to render critical content are good candidates for this strategy.
 
-2. **`afterInteractive`**: This is the default strategy applied and is equivalent to loading a script with the defer attribute. It should be used for scripts that the browser can run after the page is interactive&mdash;for example, analytics scripts. Next.js injects these scripts on the client-side, and they run after the page is hydrated. Thus, unless otherwise specified, all third-party scripts defined using the Script component are deferred by Next.js, thereby providing a strong default.  
+2. **`afterInteractive`**: This is the default strategy applied and is equivalent to loading a script with the defer attribute. It should be used for scripts that the browser can run after the page is interactive&mdash;for example, analytics scripts. Next.js injects these scripts on the client-side, and they run after the page is hydrated. Thus, unless otherwise specified, all third-party scripts defined using the Script component are deferred by Next.js, thereby providing a strong default.
 
 3. **`lazyOnload`**: This option may be used to lazy-load low-priority scripts when the browser is idle. The functionality provided by such scripts is not required immediately after the page becomes interactive&mdash;for example, chat or social media plug-ins.
 
-Developers can tell Next.js how their application uses a script by specifying the strategy. This allows the framework to apply optimizations and best practices to load the script while ensuring the best loading sequence. 
+Developers can tell Next.js how their application uses a script by specifying the strategy. This allows the framework to apply optimizations and best practices to load the script while ensuring the best loading sequence.
 
 {% Aside 'caution' %}
 Since the default strategy used is `afterInteractive`, developers must remember to set the strategy to `beforeInteractive` for scripts necessary for rendering the page.
@@ -110,7 +110,7 @@ We used the templates for the Next.js [commerce app](https://nextjs.org/commerce
 
 ### Third-party scripts in a Next.js commerce app
 
-Third-party scripts were added to the commerce app template for the demo as given below. 
+Third-party scripts were added to the commerce app template for the demo as given below.
 
 <div class="table-wrapper scrollbar">
 <table>
@@ -143,7 +143,7 @@ The following comparison shows the visual progress for both versions of the [Nex
 
 ### Third-party scripts in a Next.js blog
 
-Third-party scripts were added to the demo blog app as given below. 
+Third-party scripts were added to the demo blog app as given below.
 
 <div>
 <table>
@@ -180,11 +180,11 @@ Third-party scripts were added to the demo blog app as given below.
   {% Img src="image/IypihH3o5cSpEMVp5i08dp69otp2/BAWQVlyBX1UUJOMyrBJm.gif", alt="Video showing the loading progress for the index page with and without the Script component. There is a 0.5 seconds improvement in FCP with the Script component.", width="800", height="306" %}
 </figure>
 
-As seen in the video, [First Contentful Paint (FCP)](/fcp/) occurs at 0.4 seconds on the page without the Script component and 0.9 seconds with the Script component. 
+As seen in the video, [First Contentful Paint (FCP)](/fcp/) occurs at 0.9 seconds on the page without the Script component and 0.4 seconds with the Script component.
 
 ## What’s next for the Script component
 
-While the strategy options for `afterInteractive` and `lazyOnload` provide significant control over render-blocking scripts, we are also exploring other options that would increase the utility of the Script component. 
+While the strategy options for `afterInteractive` and `lazyOnload` provide significant control over render-blocking scripts, we are also exploring other options that would increase the utility of the Script component.
 
 ### Using web workers
 
@@ -194,9 +194,9 @@ With the current implementation of the Next.js script component, we recommend de
 
 ### Minimizing CLS
 
-Third-party embeds like advertisements, video, or social media feed embeds can cause layout shifts when lazy-loaded. This affects the user experience and the [Cumulative Layout Shift (CLS)](/cls/) metric for the page. CLS can be minimized by specifying the size of the container where the embed will load. 
+Third-party embeds like advertisements, video, or social media feed embeds can cause layout shifts when lazy-loaded. This affects the user experience and the [Cumulative Layout Shift (CLS)](/cls/) metric for the page. CLS can be minimized by specifying the size of the container where the embed will load.
 
-The Script component may be used to load embeds that can cause layout shifts. We are considering augmenting it to provide configuration options that will help reduce the CLS. This could be made available within the Script component itself or as a companion component.    
+The Script component may be used to load embeds that can cause layout shifts. We are considering augmenting it to provide configuration options that will help reduce the CLS. This could be made available within the Script component itself or as a companion component.
 
 ### Wrapper components
 
@@ -211,4 +211,4 @@ Third-party scripts are usually created to include specific features in the cons
 
 ## Acknowledgments
 
-Thank you to [Kara Erickson](/authors/karaerickson/), [Janicklas Ralph](https://github.com/janicklas-ralph), [Katie Hempenius](/authors/katiehempenius/), [Philip Walton](/authors/philipwalton/), [Jeremy Wagner](/authors/jlwagner/), and [Addy Osmani](/authors/addyosmani/) for their feedback on this post.  
+Thank you to [Kara Erickson](/authors/karaerickson/), [Janicklas Ralph](https://github.com/janicklas-ralph), [Katie Hempenius](/authors/katiehempenius/), [Philip Walton](/authors/philipwalton/), [Jeremy Wagner](/authors/jlwagner/), and [Addy Osmani](/authors/addyosmani/) for their feedback on this post.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Noticed a small typo here https://web.dev/script-component/#third-party-scripts-in-a-next.js-blog:~:text=As%20seen%20in%20the%20video%2C%20First%20Contentful%20Paint%20(FCP)%20occurs%20at%200.4%20seconds%20on%20the%20page%20without%20the%20Script%20component%20and%200.9%20seconds%20with%20the%20Script%20component.

Changes proposed in this pull request:

- Fixes text to show the Script component improves performance instead of regressing it 😁

Unless I'm misunderstanding this?

