### PR TITLE
Use checkmark icon in BrowserCompat when version_added is true

### DIFF
--- a/src/site/_includes/components/BrowserCompat.js
+++ b/src/site/_includes/components/BrowserCompat.js
@@ -56,6 +56,15 @@ function getInfoFromSupportStatement(support, status, locale) {
         icon: support.version_added,
       };
     }
+
+    // See https://github.com/GoogleChrome/web.dev/issues/8333
+    if (support.version_added === true) {
+      return {
+        aria: i18n('i18n.browser_compat.supported', locale),
+        compatProperty: 'yes',
+        icon: '✅',
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
Fixes #8333 by using a ✅ icon when there's a feature whose `version_added` field is set to `true` (as opposed to being set to an actual version number).

CC: @jpmedley 