### PR TITLE
Use authors data for Spaces hosts

### DIFF
--- a/src/site/_includes/spaces.njk
+++ b/src/site/_includes/spaces.njk
@@ -6,7 +6,16 @@ layout: default-next
   <div class="card__header">
     <div class="avatars">
     {% for host in space.data.hosts %}
-      <img class="avatar" src="{{ host.image }}" alt="alt" decoding="async" height="40" loading="lazy" width="40">
+      {% set alt = "Profile image for " + collections.authors[host].title | i18n(locale) %}
+      {% Img
+        src=collections.authors[host].image,
+        class="avatar",
+        width="96",
+        height="96",
+        alt=alt,
+        decoding="async",
+        loading="lazy"
+      %}
     {% endfor %}
     </div>
   </div>
@@ -17,8 +26,10 @@ layout: default-next
     <ul class="hosts">
       {% for host in space.data.hosts %}
         <li>
-            {{ host.name }}
-          {% if host.primary %} <span class="pill" data-inactive>{{ 'i18n.spaces.host' | i18n(locale) }}</span> {% endif %}
+            {{ collections.authors[host].title | i18n(locale) }}
+            {% if space.data.primary_host == host %}
+              <span class="pill" data-inactive>{{ 'i18n.spaces.host' | i18n(locale) }}</span>
+            {% endif %}
         </li>
       {% endfor %}
     </ul>
@@ -39,7 +50,6 @@ layout: default-next
 {% endmacro %}
 
 <div class="landing-page spaces">
-
   <header>
     <div class="hero wrapper pad-inline-size-3">
       <div class="hero__columns switcher">
@@ -108,7 +118,16 @@ layout: default-next
         <td class="pad-block-size-1 pad-inline-size-1">
           <div class="avatars">
             {% for host in space.data.hosts %}
-              <img class="avatar" src="{{ host.image }}" alt="alt" decoding="async" height="40" loading="lazy" width="40">
+              {% set alt = "Profile image for " + collections.authors[host].title | i18n(locale) %}
+              {% Img
+                src=collections.authors[host].image,
+                class="avatar",
+                width="96",
+                height="96",
+                alt=alt,
+                decoding="async",
+                loading="lazy"
+              %}
             {% endfor %}
           </div>
           <p class="gap-top-size-1 eyebrow sm-only">
@@ -121,17 +140,26 @@ layout: default-next
           </h2>
           <p>
             {% for host in space.data.hosts %}
-              <span class="host">{{ host.name }} {% if host.primary %} <span class="pill" data-inactive>{{ 'i18n.spaces.host' | i18n(locale) }}</span> {% endif %}</span>
+              <span class="host">
+                {{ collections.authors[host].title | i18n(locale) }}
+                {% if space.data.primary_host == host %}
+                  <span class="pill" data-inactive>{{ 'i18n.spaces.host' | i18n(locale) }}</span>
+                {% endif %}
+              </span>
             {% endfor %}
-          <details class="ellipsis">
-            <summary><span class="ellipsis__full">{{ space.data.description }}</span><span class="ellipsis__more">{{ 'i18n.spaces.see_more' | i18n(locale) }}</span></summary>
-          </details>
-          <p><audio src="{{ space.data.audio }}" class="audio-player__element" controls=""></audio></p>
+            <details class="ellipsis">
+              <summary>
+                <span class="ellipsis__full">{{ space.data.description }}</span>
+                <span class="ellipsis__more">{{ 'i18n.spaces.see_more' | i18n(locale) }}</span>
+              </summary>
+            </details>
+            <p>
+              <audio src="{{ space.data.audio }}" class="audio-player__element" controls=""></audio>
+            </p>
+          </p>
         </td>
       </tr>
     {% endfor %}
-    </table>
-</div>
-
+  </table>
 </div>
 

--- a/src/site/content/en/spaces/_example_ended/index.md
+++ b/src/site/content/en/spaces/_example_ended/index.md
@@ -5,9 +5,9 @@ hosts:
   - jeffposnick
   - una
 primary_host:
-  - jeffposnick
+  - una
 twitter_link: http://twitter.com
-event_date: 2023-02-21
+event_date: 2021-02-21
 audio: https://traffic.libsyn.com/secure/thecsspodcast/TCP_CSS_Podcast__Episode_003_v2.0_FINAL.mp3?dest-id=1891556
 tags: twitter-space
 permalink: false


### PR DESCRIPTION
This addresses some feedback from @una ahead of the Spaces landing page launch.

All metadata is now pulled in from our standard `authors.yaml` source, instead of using Twitter metadata.

Each `space.hosts` entry in the YAML metadata for a Space can now just be set to a `authors.yaml` id. Additionally, an optional `primary_host` property can be set to an `authors.yaml` id, in order to trigger the "HOST" display tag.

I'm not sure if this follows 100% of the best practices, but hopefully it's enough to get us launched. There might be some cleanup of the templating that's needed post-launch.

Here are screenshots from the locally staged version:

<img width="656" alt="Screen Shot 2022-07-18 at 11 34 11 AM" src="https://user-images.githubusercontent.com/1749548/179547966-98a8f8c1-03ad-4a17-8ec4-7ee3f225c1de.png">

<img width="1190" alt="Screen Shot 2022-07-18 at 11 34 16 AM" src="https://user-images.githubusercontent.com/1749548/179547979-64df81b4-8bf6-497b-8379-e77015bf4884.png">

