### PR TITLE
Adds a missing alt for hero img

### DIFF
--- a/src/site/content/en/blog/farfetch/index.md
+++ b/src/site/content/en/blog/farfetch/index.md
@@ -6,6 +6,7 @@ subhead: |
 description: |
   How luxury retailer Farfetch's investment in improving Core Web Vitals led to better business outcomes.
 hero: image/OcYv93SYnIg1kfTihK6xqRDebvB2/h3mza3j8moM7N9lGGg15.png
+alt: An image of a phone displaying a Farfetch web page.
 authors:
   - ruisantos
   - manuelgarcia


### PR DESCRIPTION
https://github.com/GoogleChrome/web.dev/pull/8384 includes a post that breaks our build, due to a missing `alt` for the hero image. This PR adds the `alt` text.

(#8385 tracks getting the presubmit checks to run unconditionally, which I think is a good idea at this point.)