### PR TITLE
Update @mdn/browser-compat-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@google-cloud/cloudbuild": "^2.6.0",
         "@google-cloud/error-reporting": "^2.0.3",
         "@google-cloud/secret-manager": "^3.10.0",
-        "@mdn/browser-compat-data": "^5.1.3",
+        "@mdn/browser-compat-data": "^5.1.5",
         "@minify-html/js": "^0.8.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -1626,9 +1626,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.3.tgz",
-      "integrity": "sha512-5RqTIOtj/8m2yfiAT7fRtVwqDzpHkliozS86puqlceAFFuUQpYn17nIXTZ7hPVyhQ8wacCW42crCBdwscNBjFw=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.5.tgz",
+      "integrity": "sha512-B86Pr/KsXRl/AG68KySjBWjrS3JlzhA0otCHnkDAfnePEveOTa6j//6pWp9RZvDcsAL1DJTvADcTkt2xX7xjDw=="
     },
     "node_modules/@minify-html/js": {
       "version": "0.8.0",
@@ -30248,9 +30248,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "@mdn/browser-compat-data": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.3.tgz",
-      "integrity": "sha512-5RqTIOtj/8m2yfiAT7fRtVwqDzpHkliozS86puqlceAFFuUQpYn17nIXTZ7hPVyhQ8wacCW42crCBdwscNBjFw=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.1.5.tgz",
+      "integrity": "sha512-B86Pr/KsXRl/AG68KySjBWjrS3JlzhA0otCHnkDAfnePEveOTa6j//6pWp9RZvDcsAL1DJTvADcTkt2xX7xjDw=="
     },
     "@minify-html/js": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@google-cloud/cloudbuild": "^2.6.0",
     "@google-cloud/error-reporting": "^2.0.3",
     "@google-cloud/secret-manager": "^3.10.0",
-    "@mdn/browser-compat-data": "^5.1.3",
+    "@mdn/browser-compat-data": "^5.1.5",
     "@minify-html/js": "^0.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",


### PR DESCRIPTION
This updates`@mdn/browser-compat-data` to version 5.1.5. That release includes updated data needed for https://github.com/GoogleChrome/web.dev/pull/8375