### PR TITLE
Treat subhead as markdown in post overview

### DIFF
--- a/src/site/_includes/macros/post-card.njk
+++ b/src/site/_includes/macros/post-card.njk
@@ -38,7 +38,7 @@
     <h2 class="card__heading text-size-3">
       <a href="{{ param.url }}">{{ param.title }}</a>
     </h2>
-    <p>{{ param.subhead }}</p>
+    <p>{{ param.subhead | md | safe }}</p>
   </div>
 
   {% if param.authors %}


### PR DESCRIPTION
In the post detail template `post-next.njk`, the subhead is treated as markdown. This PR implements that behavior in the blogpost card template as well, which is used in the blog overview.