### PR TITLE
docs(style-focus): button focus macos firefox

### DIFF
--- a/src/site/content/en/accessible/style-focus/index.md
+++ b/src/site/content/en/accessible/style-focus/index.md
@@ -56,8 +56,8 @@ button:focus {
 
 If you click on the `<button>` with a mouse in Chrome on macOS you should see
 its custom focus style. However, you will not see the custom focus style if you
-click on the `<button>` in Firefox or Safari on macOS. This is because in
-Firefox and Safari the element does not receive focus when you click on it.
+click on the `<button>` in Safari on macOS. This is because in
+Safari the element does not receive focus when you click on it.
 
 {% Glitch {
   id: 'focus-style2',

--- a/src/site/content/en/accessible/style-focus/index.md
+++ b/src/site/content/en/accessible/style-focus/index.md
@@ -85,12 +85,6 @@ beneficial to the user. In particular, if the most recent user interaction
 was via the keyboard and the key press did not include a meta, `ALT` / `OPTION`,
 or `CONTROL` key, then `:focus-visible` will match.
 
-{% Aside %}
-`:focus-visible` is currently only supported in Chrome behind a flag,
-but there is a [lightweight polyfill](https://github.com/WICG/focus-visible)
-that can be added to your app to make it work.
-{% endAside %}
-
 The button in the example below will _selectively_ show a focus indicator. If
 you use a mouse to click on it, the results are different than if you first use
 a keyboard to tab to it.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:
* updated info about button focus in Firefox on macOS
* rm block about `:focus-visible` is experimental

1. Seems like focus works correctly in `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 Firefox/102.0`
2. It have nice browsers support by https://caniuse.com/?search=focus-visible info
