### PR TITLE
Fix date of post "Rendering on the Web"

### DIFF
--- a/src/site/content/en/blog/rendering-on-the-web/index.md
+++ b/src/site/content/en/blog/rendering-on-the-web/index.md
@@ -4,8 +4,8 @@ subhead: Where should we implement logic and rendering in our applications? Shou
 authors:
   - developit
   - addyosmani
-date: 2019-08-27
-updated: 2019-02-06
+date: 2019-02-06
+updated: 2019-08-27
 description: |
   Where should we implement logic and rendering in our applications? Should we use Server Side Rendering? What about Rehydration? Let's find some answers!
 tags:


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fix reversed post date and update date of the post "Rendering on the Web"

A small note, I noticed the last update date is ["2019-11-26"](https://web.archive.org/web/20220404211354/https://developers.google.com/web/updates/2019/02/rendering-on-the-web#:~:text=Last%20updated-,2019%2D11%2D26,-UTC.) on the Wayback Machine, but I'm not sure if that's unrelated, so I didn't change it here.