### PR TITLE
Allow custom aspect ratio on <video>

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -703,6 +703,11 @@ video,
   aspect-ratio: 16/9;
 }
 
+video {
+  height: auto;
+  aspect-ratio: var(--vid-width) / var(--vid-height);
+}
+
 /// COMPOSITIONS
 @import 'compositions/auto-grid';
 @import 'compositions/breakout';

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -700,12 +700,8 @@ web-copy-code {
 video,
 .youtube {
   position: relative;
-  aspect-ratio: 16/9;
-}
-
-video {
   height: auto;
-  aspect-ratio: var(--vid-width) / var(--vid-height);
+  aspect-ratio: var(--vid-width, 16) / var(--vid-height, 9);
 }
 
 /// COMPOSITIONS


### PR DESCRIPTION
This is part of https://github.com/GoogleChrome/webdev-infra/issues/28, to allow custom aspect ratios on video elements and reduce CLS.