### PR TITLE
Adjust avatar offset for bigger number of hosts

### DIFF
--- a/src/scss/pages/_spaces.scss
+++ b/src/scss/pages/_spaces.scss
@@ -99,6 +99,7 @@
   // Avatars
 
   .avatars {
+    overflow: hidden;
     padding-inline-end: 0;
     text-align: right;
     white-space: nowrap;
@@ -126,9 +127,21 @@
     }
   }
 
+  img.avatar {
+    --avatar-offset: -0.3;
+  }
+
+  // Set a bigger avatar offset if there are 5 or 6 hosts, so that they fit.
+  img.avatar:first-child:nth-last-child(5),
+  img.avatar:first-child:nth-last-child(5) ~ img.avatar,
+  img.avatar:first-child:nth-last-child(6),
+  img.avatar:first-child:nth-last-child(6) ~ img.avatar {
+    --avatar-offset: -0.5;
+  }
+
   img.avatar + img.avatar,
   .card .avatar + .avatar {
-    margin-left: calc(var(--avatar-size) * -0.5);
+    margin-left: calc(var(--avatar-size) * var(--avatar-offset));
   }
 
   // Hosts


### PR DESCRIPTION
Adjust the spacing of the avatars:
1. Shrink the avatars overlap tp 30% so that the hosts faces are better visible.
2. Expand the overlap to 50% for 5 or 6 hosts to prevent current overflow:

<img width="219" alt="Screenshot 2022-07-25 at 12 22 41" src="https://user-images.githubusercontent.com/1914261/180755582-1f2c4576-7de0-4c6f-a10a-3b692961202c.png">

