### PR TITLE
Add TTFB guideline thresholds

### DIFF
--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -42,7 +42,7 @@ Reducing latency in connection setup time and on the backend will contribute to 
 
 ### What is a good TTFB score?
 
-Due to the wide variation of network and application backend stacks, an arbitrary number can't be placed on what consists of a "good" TTFB score. Because TTFB precedes [user-centric metrics](/user-centric-performance-metrics/) such as [First Contentful Paint (FCP)](/fcp/) and [Largest Contentful Paint (LCP)](/lcp/), it's recommended that your server responds to navigation requests quickly enough so that the **75th percentile** of users experience an [FCP within the "good" threshold](/fcp/#what-is-a-good-fcp-score). However, as a rough guide, most sites should strive to have Time To First Byte of **0.8 seconds** or less.
+Because TTFB precedes [user-centric metrics](/user-centric-performance-metrics/) such as [First Contentful Paint (FCP)](/fcp/) and [Largest Contentful Paint (LCP)](/lcp/), it's recommended that your server responds to navigation requests quickly enough so that the **75th percentile** of users experience an [FCP within the "good" threshold](/fcp/#what-is-a-good-fcp-score). As a rough guide, most sites should strive to have Time To First Byte of **0.8 seconds** or less.
 
 <figure>
   <picture>

--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -62,7 +62,7 @@ Due to the wide variation of network and application backend stacks, an arbitrar
 </figure>
 
 {% Aside %}
-  The above thresholds are guideline thresholds. Sites can still receive good Core Web Vitals with TTFB timings that exceed this depending on the network and application stack.
+  TTFB is not a [Core Web Vitals](/vitals) metric, so it's not absolutely necessary that sites meet the "good" TTFB threshold, provided that it doesn't impede their ability to score well on the metrics that matter.
 {% endAside %}
 
 ## How to measure TTFB

--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -3,8 +3,9 @@ layout: post
 title: Time to First Byte (TTFB)
 authors:
   - jlwagner
+  - barrypollard
 date: 2021-10-26
-updated: 2022-07-18
+updated: 2022-07-26
 description: |
   This post introduces the Time to First Byte (TTFB) metric and explains
   how to measure it.

--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -41,7 +41,28 @@ Reducing latency in connection setup time and on the backend will contribute to 
 
 ### What is a good TTFB score?
 
-Due to the wide variation of network and application backend stacks, an arbitrary number can't be placed on what consists of a "good" TTFB score. Because TTFB precedes [user-centric metrics](/user-centric-performance-metrics/) such as [First Contentful Paint (FCP)](/fcp/) and [Largest Contentful Paint (LCP)](/lcp/), it's recommended that your server responds to navigation requests quickly enough so that the **75th percentile** of users experience an [FCP within the "good" threshold](/fcp/#what-is-a-good-fcp-score).
+Due to the wide variation of network and application backend stacks, an arbitrary number can't be placed on what consists of a "good" TTFB score. Because TTFB precedes [user-centric metrics](/user-centric-performance-metrics/) such as [First Contentful Paint (FCP)](/fcp/) and [Largest Contentful Paint (LCP)](/lcp/), it's recommended that your server responds to navigation requests quickly enough so that the **75th percentile** of users experience an [FCP within the "good" threshold](/fcp/#what-is-a-good-fcp-score). However, as a rough guide, most sites should strive to have Time To First Byte of **0.8 seconds** or less.
+
+<figure>
+  <picture>
+    <source
+      srcset="{{ "image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/ILJ1xKjzVisqOPPyHYVA.svg" | imgix }}"
+      media="(min-width: 640px)"
+      width="800"
+      height="200">
+    {%
+      Img
+        src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/eNXaxPi9NdUVSTDRJFkV.svg",
+        alt="Good TTFB values are 0.8 seconds or less, poor values are greater than 1.8 seconds, and anything in between needs improvement",
+        width="640",
+        height="480"
+    %}
+  </picture>
+</figure>
+
+{% Aside %}
+  The above thresholds are guideline thresholds. Sites can still receive good Core Web Vitals with TTFB timings that exceed this depending on the network and application stack.
+{% endAside %}
 
 ## How to measure TTFB
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Adds TTFB guideline thresholds as [recently announced in the CrUX API addition of this metric](https://groups.google.com/a/chromium.org/g/chrome-ux-report-announce/c/v-h5gKkUEE0), as requested from the webperf community on Slack.

@philipwalton @malchata @rviscomi any thoughts on whether I've overdone it with the aside as well as the text at the top? It's a bit of repetition but trying to stress the reduced emphasis that should be placed on these thresholds.
