### PR TITLE
Prevent prism generating blank lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "nunjucks": "^3.2.3",
         "postcss": "^8.2.10",
         "prettier": "^2.3.2",
-        "prismjs": "^1.25.0",
+        "prismjs": "^1.28.0",
         "purgecss": "^4.0.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.64.0",
@@ -20210,9 +20210,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "engines": {
         "node": ">=6"
       }
@@ -44927,9 +44927,9 @@
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "nunjucks": "^3.2.3",
     "postcss": "^8.2.10",
     "prettier": "^2.3.2",
-    "prismjs": "^1.25.0",
+    "prismjs": "^1.28.0",
     "purgecss": "^4.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.64.0",

--- a/src/site/_includes/components/CodePattern.js
+++ b/src/site/_includes/components/CodePattern.js
@@ -40,11 +40,23 @@ module.exports = (patternId, height) => {
     .map((asset) => {
       const type = prismTypes.includes(asset.type) ? asset.type : 'text';
       assetLines.push(asset.content.split('\n').length);
+
+      // Jake says:
+      // Because Prism outputs preformatted code, it will often contain blank
+      // lines, eg if the source contains blank lines. Unfortunately the
+      // markdown parser sees that as "the HTML has ended, process as markdown".
+      // This results in lots of malformed HTML that may appear fine in dev,
+      // but may appear differently once the minifier has chewed through it.
+      // To avoid this, 'blank lines' (which in markdown-speak can include
+      // whitespace) are replaced with an empty span, followed by any
+      // whitespace. The span is not an empty line in markdown-speak, so it
+      // continues to defer to HTML source.
       const content = Prism.highlight(
         asset.content,
         Prism.languages[type],
         type,
-      );
+      ).replace(/\n(\s*)\n/g, '\n<span></span>$1\n');
+
       return `<web-tab title="${asset.type}" data-label="${asset.type}">
           <pre><code class="language-${asset.type}">${content}</code></pre>
         </web-tab>`;

--- a/src/site/content/en/patterns/components/split-buttons/assets/body.html
+++ b/src/site/content/en/patterns/components/split-buttons/assets/body.html
@@ -26,6 +26,7 @@
     </ul>
   </span>
 </div>
+
 <div class="gui-split-button">
   <button>Send</button>
   <span class="gui-popup-button" aria-haspopup="true" aria-expanded="false" title="Open for more actions">
@@ -54,6 +55,7 @@
     </ul>
   </span>
 </div>
+
 <div class="gui-split-button">
   <button>Squash</button>
   <span class="gui-popup-button" aria-haspopup="true" aria-expanded="false" title="Open for more actions">

--- a/src/site/content/en/patterns/components/split-buttons/assets/body.html
+++ b/src/site/content/en/patterns/components/split-buttons/assets/body.html
@@ -26,7 +26,6 @@
     </ul>
   </span>
 </div>
-
 <div class="gui-split-button">
   <button>Send</button>
   <span class="gui-popup-button" aria-haspopup="true" aria-expanded="false" title="Open for more actions">
@@ -55,7 +54,6 @@
     </ul>
   </span>
 </div>
-
 <div class="gui-split-button">
   <button>Squash</button>
   <span class="gui-popup-button" aria-haspopup="true" aria-expanded="false" title="Open for more actions">


### PR DESCRIPTION
Because Prism outputs preformatted code, it will often contain blank lines, eg if the source contains blank lines. Unfortunately the markdown parser sees that as "the HTML has ended, process as markdown".

This results in lots of malformed HTML that may appear fine in dev, but may appear differently once the minifier has chewed through it. On the live site, this resulted in articles that appeared to abruptly end (although in truth the HTML was just reparented somewhere it wasn't visible).

To avoid this, 'blank lines' (which in markdown-speak can include whitespace) are replaced with an empty span, followed by any whitespace.

The span is not an empty line in markdown-speak, so it continues to defer to HTML source.

A more robust solution would be to insert this kind of markup _after_ markdown parsing.