### PR TITLE
Improve regex in markdown hack

### DIFF
--- a/src/site/_includes/components/CodePattern.js
+++ b/src/site/_includes/components/CodePattern.js
@@ -55,7 +55,7 @@ module.exports = (patternId, height) => {
         asset.content,
         Prism.languages[type],
         type,
-      ).replace(/\n(\s*)\n/g, '\n<span></span>$1\n');
+      ).replace(/^(\s*?)$/gm, '<span></span>$1');
 
       return `<web-tab title="${asset.type}" data-label="${asset.type}">
           <pre><code class="language-${asset.type}">${content}</code></pre>


### PR DESCRIPTION
The previous regex didn't correctly handle more than two newlines in a row. This now matches each blank line separately.