### PR TITLE
Fix social image

### DIFF
--- a/src/site/content/en/blog/css-individual-transform-properties/index.md
+++ b/src/site/content/en/blog/css-individual-transform-properties/index.md
@@ -8,7 +8,7 @@ authors:
   - dbaron
 description: >
   Learn how you can use the individual translate, rotate, and scale CSS properties to approach transforms in an intuitive way.
-thumbnail: image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/IzfmyutXOJG8DQLTxka7.svg
+thumbnail: image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/4KSYYba8wDbfZsycAV23.svg
 hero: image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/AtVvxkLmxdp0Mso8Mnnc.svg
 date: 2022-08-02
 tags:


### PR DESCRIPTION
The Image service does not seem to handle `rgb(r g b a)` in SVGs when converting to another format. The boxes become black. This behavior is exposes in the `css-individual-transform-properties` post:

![image](https://user-images.githubusercontent.com/213073/182392123-8a3dd176-5fa4-490c-9af8-4af597565a4d.png)

This PR updates the image to a version that uses `rgba(r,g,b,a,)`, which is supported.

For reference, my findings:

- ❌ RGB(R G B / A): https://web-dev.imgix.net/image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/IzfmyutXOJG8DQLTxka7.svg?w=1200
- ✅ HEX: https://web-dev.imgix.net/image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/NO3X4blU7sVayJx7EX25.svg?w=1200
- ✅ RGB(R G B): https://web-dev.imgix.net/image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/OiZitY9ly3Gc3dsw3fGj.svg?w=1200
- ✅ RGBA(R,G,B,A): https://web-dev.imgix.net/image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/4KSYYba8wDbfZsycAV23.svg?w=1200
