### PR TITLE
Do not make web-navigation-drawer inert. Fixes #8462

### DIFF
--- a/src/lib/components/NavigationDrawer/index.js
+++ b/src/lib/components/NavigationDrawer/index.js
@@ -86,11 +86,8 @@ export class NavigationDrawer extends BaseStateElement {
     this.addEventListener('click', closeNavigationDrawer);
   }
 
-  onStateChanged({isSearchExpanded, isNavigationDrawerOpen, currentUrl}) {
+  onStateChanged({isNavigationDrawerOpen, currentUrl}) {
     this.open = isNavigationDrawerOpen;
-
-    // See https://github.com/GoogleChrome/web.dev/issues/8131
-    this.inert = isSearchExpanded;
 
     if (currentUrl) {
       // Ensure that the "active" attribute is applied to any matching header

--- a/src/scss/blocks/_site-header.scss
+++ b/src/scss/blocks/_site-header.scss
@@ -138,6 +138,7 @@
 
   .site-header[class*='expanded'] web-navigation-drawer {
     opacity: 0;
+    pointer-events: none !important;
   }
 
   .site-header__nav {


### PR DESCRIPTION
This PR takes a different approach to solving #8134, thereby fixing the unpleasant side-effect as described in #8462. 

Because the whole `web-navigation-drawer` was made `inert` in #8134, the search box –which is a child of `web-navigation-drawer` on some pages– would no longer work.

Instead of making the entire `web-navigation-drawer` `inert`, this PR sets its `pointer-events` to `none`. This solves #8134 and fixes #8462 as well.