### PR TITLE
fix stale-while-revalidate example in Learn/PWA

### DIFF
--- a/src/site/content/en/learn/pwa/serving/index.md
+++ b/src/site/content/en/learn/pwa/serving/index.md
@@ -183,6 +183,7 @@ self.addEventListener("fetch", event => {
            caches.open("pwa-assets").then(cache => {
                cache.put(event.request, response.clone());
            });
+           return response;
          });
          // prioritize cached response over network
          return cachedResponse || networkFetch;


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Fixes the example code for the stale-while-revalidate caching pattern [example code](https://web.dev/learn/pwa/serving/#stale-while-revalidate) in the Learn PWA section. Makes sure the network response is used (otherwise, `networkFetch` would be a promise resolving to `undefined`).
