### PR TITLE
Add flags to the ffmpeg command for creating GIFs

### DIFF
--- a/src/site/content/en/fast/replace-gifs-with-videos/index.md
+++ b/src/site/content/en/fast/replace-gifs-with-videos/index.md
@@ -47,7 +47,7 @@ To use FFmpeg to convert the GIF, `my-animation.gif` to an MP4 video, run the
 following command in your console:
 
 ```bash
-ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
+ffmpeg -i my-animation.gif -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p -color_primaries bt709 -color_trc iec61966_2_1 -colorspace smpte170m my-animation.mp4
 ```
 
 This tells FFmpeg to take `my-animation.gif` as the **input**, signified by the
@@ -58,7 +58,7 @@ by 240px. If the input GIF has odd dimensions you can include a crop filter to
 avoid FFmpeg throwing a 'height/width not divisible by 2' error:
 
 ```bash
-ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p my-animation.mp4
+ffmpeg -i my-animation.gif -vf "crop=trunc(iw/2)*2:trunc(ih/2)*2" -b:v 0 -crf 25 -f mp4 -vcodec libx264 -pix_fmt yuv420p -color_primaries bt709 -color_trc iec61966_2_1 -colorspace smpte170m my-animation.mp4
 ```
 
 ## Create WebM videos


### PR DESCRIPTION
This adds flags to the ffmpeg command for creating an MP4 from a GIF that tag the output in the sYCC color space, which fixes the "washed out" colors and color shifts often reported when doing this conversion. Without the flags, browsers tend to interpret the colorspace incorrectly.

Note this currently does not affect Firefox, but does improve display in Chrome and Safari.

