### PR TITLE
Clarify LCP 'caution' aside regarding tabs loaded in background

### DIFF
--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -180,7 +180,7 @@ contentful element unless a larger element is rendered.
   `largest-contentful-paint` entry to be dispatched. However, due to popular UI
   patterns such as image carousels that often removed DOM elements, the metric
   was updated to more accurately reflect what users experience. See the
-  [CHANGELOG](https://chromium.googlesource.com/chromium/src/+/master/docs/speed/metrics_changelog/2020_11_lcp.md)
+  [CHANGELOG](https://chromium.googlesource.com/chromium/src/+/main/docs/speed/metrics_changelog/2020_11_lcp.md)
   for more details.
 {% endAside %}
 
@@ -334,7 +334,7 @@ getLCP(console.log);
 ```
 
 You can refer to [the source code for
-`getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/master/src/getLCP.ts)
+`getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts)
 for a complete example of how to measure LCP in JavaScript.
 
 {% Aside %}

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -191,12 +191,6 @@ what's visible to the user (which is especially true with scrolling).
 For analysis purposes, you should only report the most recently dispatched
 `PerformanceEntry` to your analytics service.
 
-{% Aside 'caution' %}
-  Since users can open pages in a background tab, it's possible that the largest
-  contentful paint will not happen until the user focuses the tab, which can be
-  much later than when they first loaded it.
-{% endAside %}
-
 #### Load time vs. render time
 
 For security reasons, the render timestamp of images is not exposed for

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -191,6 +191,16 @@ what's visible to the user (which is especially true with scrolling).
 For analysis purposes, you should only report the most recently dispatched
 `PerformanceEntry` to your analytics service.
 
+{% Aside 'caution' %}
+  Since users can open pages in a background tab, it's possible that
+  `largest-contentful-paint` entries will not be dispatched until the user
+  focuses the tab, which can be much later than when they first loaded it.
+
+  Google tools that measure LCP do not report this metric if the page was
+  loaded in the background, as it does not reflect the user-perceived load time.
+{% endAside %}
+
+
 #### Load time vs. render time
 
 For security reasons, the render timestamp of images is not exposed for


### PR DESCRIPTION
Hello! This change removes (what I believe to be) an outdated 'caution' aside on `/lcp` regarding tabs loaded in the background, as the web-vitals library [ignores paint metrics for tabs loaded in the background](https://github.com/GoogleChrome/web-vitals/commit/783a28ac8c77442a80038e94a1e1297e2084d7a2). This is reflected in the library's README.

The aside on `/lcp` was initially added in [August of 2019](95c072f480), and the web-vitals commit linked above landed in March of 2020, so I'm guessing the web.dev update probably just fell off the radar. 


