### PR TITLE
Adds full viewport image guidance for LCP.

### DIFF
--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -100,7 +100,7 @@ considered for Largest Contentful Paint are:
   elements containing text nodes or other inline-level text elements children.
 
 {% Aside 'important' %}
-Starting in Chrome 88, [images that occupy the entire viewport are no longer considered LCP candidates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/speed/metrics_changelog/2020_11_lcp.md).
+Images that occupy the entire viewport are not considered LCP candidates.
 {% endAside %}
 
 Note, restricting the elements to this limited set was intentional in order to

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-08-09
 description: |
   This post introduces the Largest Contentful Paint (LCP) metric and explains
   how to measure it

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -99,6 +99,10 @@ considered for Largest Contentful Paint are:
 * [Block-level](https://developer.mozilla.org/docs/Web/HTML/Block-level_elements)
   elements containing text nodes or other inline-level text elements children.
 
+{% Aside 'important' %}
+Starting in Chrome 88, [images that occupy the entire viewport are no longer considered LCP candidates](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/speed/metrics_changelog/2020_11_lcp.md).
+{% endAside %}
+
 Note, restricting the elements to this limited set was intentional in order to
 keep things simple in the beginning. Additional elements (e.g. `<svg>`,
 `<video>`) may be added in the future as more research is conducted.


### PR DESCRIPTION
Changes proposed in this pull request:

- Updates the LCP candidate information by specifying that full-viewport images are no longer considered for LCP [since Chrome 88](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/speed/metrics_changelog/2020_11_lcp.md).