### PR TITLE
Remove experimental items from Manifest article

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -331,34 +331,6 @@ truncates longer descriptions
 right in your browser."
 ```
 
-#### `screenshots` {: #screenshots }
-
-The `screenshots` property is used with the description to show an installation
-prompt that contains more than just an application name and an installation
-button. It is an array of image objects representing your app in common usage
-scenarios. Each object must include the `src`, a `sizes` property, and the
-`type` of image. The `screenshots` property may contain no more than eight image
-objects.
-
-<figure>
-  {% Img src="image/xizoeLGxYNf3VLUHc5BsIoiE1Af1/SpStAtUk8Zp5iwi9yqKP.jpg", 
-alt="Richer Android installation prompt", width="342", height="722" %}
-  <figcaption>Richer Android installation prompt.</figcaption>
-</figure>
-
-In Chrome, the image must respond to certain criteria:
-
-* Width and height must be at least 320px and at most 3840px.
-* The maximum dimension can't be more than 2.3 times as long as the minimum
-  dimension.
-* All screenshots must have the same aspect ratio.
-* Only JPEG and PNG image formats are supported.
-
-{% Aside 'gotchas' %}
-The `description` and `screenshots` properties are currently used only in Chrome
-for Android when a user wants to install your app.
-{% endAside %}
-
 ## Add the web app manifest to your pages {: #link-manifest }
 
 After creating the manifest, add a `<link>` tag to all the pages of your

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -320,13 +320,31 @@ is a dictionary that contains at least a `name` and a `url`.
 
 #### `description` {: #description }
 
-The `description` property describes the purpose of your app.
+The `description` property describes the purpose of your app. Descriptions are
+optional; however, only seven lines of text are allowed. That works out to
+roughly 324 characters. After that an ellipse appears and 
+truncates longer descriptions 
+([for example](https://glitch.com/edit/#!/richerinstall-longer-description)). 
+
+ ```json
+"description": "Compress and compare images with different codecs 
+right in your browser."
+```
 
 #### `screenshots` {: #screenshots }
 
-The `screenshots` property is an array of image objects representing your app
-in common usage scenarios. Each object must include the `src`, a `sizes`
-property, and the `type` of image.
+The `screenshots` property is used with the description to show an installation
+prompt that contains more than just an application name and an installation
+button. It is an array of image objects representing your app in common usage
+scenarios. Each object must include the `src`, a `sizes` property, and the
+`type` of image. The `screenshots` property may contain no more than eight image
+objects.
+
+<figure>
+  {% Img src="image/xizoeLGxYNf3VLUHc5BsIoiE1Af1/SpStAtUk8Zp5iwi9yqKP.jpg", 
+alt="Richer Android installation prompt", width="342", height="722" %}
+  <figcaption>Richer Android installation prompt.</figcaption>
+</figure>
 
 In Chrome, the image must respond to certain criteria:
 

--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -80,18 +80,6 @@ A typical manifest looks something like this:
     }
   ],
   "description": "Weather forecast information",
-  "screenshots": [
-    {
-      "src": "/images/screenshot1.png",
-      "type": "image/png",
-      "sizes": "540x720"
-    },
-    {
-      "src": "/images/screenshot2.jpg",
-      "type": "image/jpg",
-      "sizes": "540x720"
-    }
-  ]
 }
 ```
 
@@ -320,16 +308,7 @@ is a dictionary that contains at least a `name` and a `url`.
 
 #### `description` {: #description }
 
-The `description` property describes the purpose of your app. Descriptions are
-optional; however, only seven lines of text are allowed. That works out to
-roughly 324 characters. After that an ellipse appears and 
-truncates longer descriptions 
-([for example](https://glitch.com/edit/#!/richerinstall-longer-description)). 
-
- ```json
-"description": "Compress and compare images with different codecs 
-right in your browser."
-```
+The `description` property describes the purpose of your app. 
 
 ## Add the web app manifest to your pages {: #link-manifest }
 


### PR DESCRIPTION
The article contained information that is still experimental and is behind a flag in Chrome. I'm working on an update to an article that covers the removed items. 