### PR TITLE
There are two values for attribute “loading”, not three

### DIFF
--- a/src/site/content/en/blog/iframe-lazy-loading/index.md
+++ b/src/site/content/en/blog/iframe-lazy-loading/index.md
@@ -69,7 +69,7 @@ Delay](/fid/) (FID) improvements at the 95th percentile.
 ### How does built-in lazy-loading for iframes work?
 
 The `loading` attribute allows a browser to defer loading offscreen iframes and
-images until users scroll near them. `loading` supports three values:
+images until users scroll near them. `loading` supports two values:
 
 *   `lazy`: is a good candidate for lazy-loading.
 *   `eager`: is not a good candidate for lazy-loading. Load right away.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

The document said there was three possible values for the attribute “loading”, when only two `exist`

