### PR TITLE
Update importance="high" to fetchpriority="high"

### DIFF
--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -14,7 +14,7 @@ pageScripts:
         <div>
           <span aria-hidden="true" class="hero__eyebrow">{{ intro.eyebrow }}</span>
           <div class="hero__content flow">
-            <img importance="high" src="{{ intro.image }}" alt="" aria-hidden="true" class="hero__decor" width="{{ intro.imageWidth }}" height="{{ intro.imageHeight }}" />
+            <img fetchpriority="high" src="{{ intro.image }}" alt="" aria-hidden="true" class="hero__decor" width="{{ intro.imageWidth }}" height="{{ intro.imageHeight }}" />
             <h1 class="hero__title">{{ intro.title }}</h1>
             {{ intro.summary | md | safe }}
             <a class="button" data-type="primary" href="{{ intro.buttonUrl }}">{{ intro.buttonText }}</a>
@@ -24,7 +24,7 @@ pageScripts:
           <a class="feature-card" href="{{ featureCard.url }}" data-theme="{{ featureCard.theme }}" data-treatment="illustration">
             <span class="feature-card__eyebrow">{{ featureCard.eyebrow }}</span>
             <h3 class="{{ 'visually-hidden' if featureCard.hiddenTitle else 'feature-card__title' }}" style="width: 230px;">{{ featureCard.title }}</h3>
-            <img importance="high" class="feature-card__background" alt="" aria-hidden="true" src="{{ featureCard.background }}" />
+            <img fetchpriority="high" class="feature-card__background" alt="" aria-hidden="true" src="{{ featureCard.background }}" />
           </a>
           {% include "partials/picked-case-study.njk" %}
         </div>
@@ -50,7 +50,7 @@ pageScripts:
             </div>
           </div>
           <div>
-            <img importance="high" src="{{ promoPanel.image }}" alt="" aria-hidden="true" class="hero__decor" width="{{ promoPanel.imageWidth }}" height="{{ promoPanel.imageHeight }}" />
+            <img fetchpriority="high" src="{{ promoPanel.image }}" alt="" aria-hidden="true" class="hero__decor" width="{{ promoPanel.imageWidth }}" height="{{ promoPanel.imageHeight }}" />
           </div>
         </div>
       </div>

--- a/src/site/_includes/partials/course-cards-next.njk
+++ b/src/site/_includes/partials/course-cards-next.njk
@@ -22,7 +22,7 @@
                   {{ icon('mortarboard') }}
                 </div>
               </div>
-              <img importance="high" src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
+              <img fetchpriority="high" src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
               <div class="card__content flow">
                 <p class="text-size-0">{{ course.meta.description | i18n(locale) }}</p>
               </div>

--- a/src/site/_includes/path.njk
+++ b/src/site/_includes/path.njk
@@ -21,7 +21,7 @@ eleventyComputed:
       {% if path.cover %}
         <div class="all-center">
           {% Img
-            importance="high",
+            fetchpriority="high",
             height=220,
             width=330,
             src=path.cover,

--- a/src/site/content/en/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/en/react/route-prefetching-in-nextjs/index.md
@@ -6,6 +6,7 @@ authors:
 subhead: |
   How Next.js speeds up navigations with route prefetching and how to customize it.
 date: 2019-11-08
+updated: 2022-08-12
 feedback:
   - api
 ---
@@ -89,7 +90,7 @@ Console warnings. [Priority
 hints](/priority-hints/) will
 soon become available in Chrome, which will allow Next.js to indicate lower
 priority for resources that are not needed immediately with `<link rel="preload"
-importance="low">`. {% endAside %}
+fetchpriority="low">`. {% endAside %}
 
 ## Avoid unnecessary prefetching
 

--- a/src/site/content/es/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/es/react/route-prefetching-in-nextjs/index.md
@@ -5,6 +5,7 @@ authors:
   - mihajlija
 subhead: Cómo acelera Next.js la navegación con la precarga de rutas y cómo personalizarla.
 date: 2019-11-08
+updated: 2022-08-12
 feedback:
   - api
 ---
@@ -55,7 +56,7 @@ Next.js solo *lee* JavaScript; no lo ejecuta. De esa manera, no descargará ning
 
 {% Aside 'caution' %} Los ejemplos de fallas se ejecutan en modo de producción porque la precarga depende de las condiciones de navegación y está habilitada solo en compilaciones de producción optimizadas. Para cambiar al modo de desarrollo, verifique el archivo `README.md` en los ejemplos de Glitch. {% endAside %}
 
-{% Aside %} Debido a que `<link rel="preload">` solicita recursos con prioridad alta, el navegador espera que se utilicen de inmediato, lo que activa las advertencias de la consola. Las [sugerencias de prioridad](/priority-hints/) pronto estarán disponibles en Chrome, lo que permitirá que Next.js indique una prioridad más baja para los recursos que no se necesitan de inmediato con `<link rel="preload" importance="low">`. {% endAside %}
+{% Aside %} Debido a que `<link rel="preload">` solicita recursos con prioridad alta, el navegador espera que se utilicen de inmediato, lo que activa las advertencias de la consola. Las [sugerencias de prioridad](/priority-hints/) pronto estarán disponibles en Chrome, lo que permitirá que Next.js indique una prioridad más baja para los recursos que no se necesitan de inmediato con `<link rel="preload" fetchpriority="low">`. {% endAside %}
 
 ## Evite la precarga innecesaria
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes the sites use of `importance="high"` to `fetchpriority="high"` for banner images and the like, since this was renamed and Chrome no longer supports `importance`
- Update one doc (and it's translation) for similar reasons.

