### PR TITLE
Increase Memory for Percy to prevent CI failures

### DIFF
--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -15,6 +15,7 @@ on:
       - '**.scss'
   pull_request:
     paths:
+      - '.github/workflows/percy-workflow.yml'
       - 'src/**.js'
       - 'shared/**.js'
       - '!src/site/_data/countries.js'

--- a/.github/workflows/percy-workflow.yml
+++ b/.github/workflows/percy-workflow.yml
@@ -36,5 +36,6 @@ jobs:
 
       - name: Percy
         env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
         run: npm run percy


### PR DESCRIPTION
See if this fixes Percy since it started failing 

Changes proposed in this pull request:

- Increase memory size for node for Percy CI.

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
