### PR TITLE
Make web-copy-code position relative

### DIFF
--- a/src/scss/web-components/_web-copy-code.scss
+++ b/src/scss/web-components/_web-copy-code.scss
@@ -1,4 +1,5 @@
 web-copy-code {
+  position: relative;
   display: block;
 
   &:active,


### PR DESCRIPTION
Fixes #8507. This adds `position: relative` to the `web-copy-code` button as currently the UI element is positioned absolutely and by this jumps to the next relative element which is the wrapping `article` element. 