### PR TITLE
Remove instruction to run presubmit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,3 @@ Changes proposed in this pull request:
 -
 -
 
-When you're ready to submit your PR, don't forget to add the `$-presubmit` label.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
