### PR TITLE
Strip question marks from slugs

### DIFF
--- a/src/site/_filters/slugify.js
+++ b/src/site/_filters/slugify.js
@@ -31,7 +31,7 @@ module.exports = (str) => {
 
   return slugify(str, {
     replacement: '-',
-    remove: /[$*_+~.()'"!\-:@]+/g,
+    remove: /[$*_+~.()'"!\-:@?]+/g,
     lower: true,
   });
 };

--- a/src/site/_plugins/markdown.js
+++ b/src/site/_plugins/markdown.js
@@ -36,7 +36,7 @@ const markdown = md({
     permalinkClass: 'w-headline-link',
     permalinkSymbol: '#',
     // @ts-ignore
-    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!\-:@]+/g}),
+    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!\-:@?]+/g}),
   })
   // Disable indented code blocks.
   // We only support fenced code blocks.


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Follow on from #8263 - looks like I missed question marks from filter breaking some links

Changes proposed in this pull request:

- Add question marks to slugs filter so https://web.dev/cls/#what-is-a-good-cls-score works again, rather than requiring [https://web.dev/cls/#what-is-a-good-cls-score?](https://web.dev/cls/#what-is-a-good-cls-score?) which also doesn't play nice with GitHub markdown auto conversion (I had to linkify it properly myself) - another reason to fix this!
