### PR TITLE
Slugify slash

### DIFF
--- a/src/site/_filters/slugify.js
+++ b/src/site/_filters/slugify.js
@@ -31,7 +31,7 @@ module.exports = (str) => {
 
   return slugify(str, {
     replacement: '-',
-    remove: /[$*_+~.()'"!\/\-:@?]+/g,
+    remove: /[$*_+~.()'"!/\-:@?]+/g,
     lower: true,
   });
 };

--- a/src/site/_filters/slugify.js
+++ b/src/site/_filters/slugify.js
@@ -31,7 +31,7 @@ module.exports = (str) => {
 
   return slugify(str, {
     replacement: '-',
-    remove: /[$*_+~.()'"!\-:@?]+/g,
+    remove: /[$*_+~.()'"!\/\-:@?]+/g,
     lower: true,
   });
 };

--- a/src/site/_plugins/markdown.js
+++ b/src/site/_plugins/markdown.js
@@ -36,7 +36,7 @@ const markdown = md({
     permalinkClass: 'w-headline-link',
     permalinkSymbol: '#',
     // @ts-ignore
-    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!\/\-:@?]+/g}),
+    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!/\-:@?]+/g}),
   })
   // Disable indented code blocks.
   // We only support fenced code blocks.

--- a/src/site/_plugins/markdown.js
+++ b/src/site/_plugins/markdown.js
@@ -36,7 +36,7 @@ const markdown = md({
     permalinkClass: 'w-headline-link',
     permalinkSymbol: '#',
     // @ts-ignore
-    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!\-:@?]+/g}),
+    slugify: (s) => slugify(s, {lower: true, remove: /[$*_+~.()'"!\/\-:@?]+/g}),
   })
   // Disable indented code blocks.
   // We only support fenced code blocks.


### PR DESCRIPTION
Another addition to #8263 and #8549 (the gift that keeps on giving!) that I discovered is needed after writing an article with HTTP/2 in a heading.

Changes proposed in this pull request:

- Removes `/` from slugs

