### PR TITLE
Remove HTTP/2 Server Push recommendations

### DIFF
--- a/src/site/content/en/blog/optimizing-content-efficiency-loading-third-party-javascript/index.md
+++ b/src/site/content/en/blog/optimizing-content-efficiency-loading-third-party-javascript/index.md
@@ -467,9 +467,8 @@ a site.
 
 Self-hosting third-party scripts may be an option if you would like more control
 over a script’s loading story. For example, if you wanted to reduce DNS or
-round-trip times, improve HTTP caching headers or take advantage of advanced
-techniques like HTTP/2 server push. Self-hosting may be a viable consideration
-if a script is considered critical.
+round-trip times, or improve HTTP caching headers. Self-hosting may be a viable
+consideration if a script is considered critical.
 
 Self-hosting can come with a number of big caveats:
 

--- a/src/site/content/en/blog/optimizing-content-efficiency-loading-third-party-javascript/index.md
+++ b/src/site/content/en/blog/optimizing-content-efficiency-loading-third-party-javascript/index.md
@@ -7,7 +7,7 @@ authors:
 description: >
   Third-party scripts provide a wide range of useful functionality, making the web more dynamic. Learn how to optimize the loading of third-party scripts to reduce their impact on performance.
 date: 2018-02-28
-updated: 2018-10-31
+updated: 2022-08-18
 ---
 
 You've optimized all of your code, but your site still loads too slowly. Who's

--- a/src/site/content/en/blog/performance-http2/index.md
+++ b/src/site/content/en/blog/performance-http2/index.md
@@ -38,7 +38,7 @@ process, and hides all the complexity from our applications within the new
 framing layer. As a result, all existing applications can be delivered without
 modification.
 
-## Why not HTTP/1.2?\_
+## Why not HTTP/1.2?
 
 To achieve the performance goals set by the HTTP Working Group, HTTP/2
 introduces a new binary framing layer that is not backward compatible with

--- a/src/site/content/en/blog/rendering-on-the-web/index.md
+++ b/src/site/content/en/blog/rendering-on-the-web/index.md
@@ -178,8 +178,8 @@ client rather than the server._
 Client-side rendering can be difficult to get and keep fast for mobile. It can
 approach the performance of pure server-rendering if doing minimal work, keeping
 a [tight JavaScript budget] and delivering value in as few [RTTs] as possible.
-Critical scripts and data can be delivered sooner using [HTTP/2 Server Push] or
-`<link rel=preload>`, which gets the parser working for you sooner. Patterns
+Critical scripts and data can be delivered sooner using `<link rel=preload>`,
+which gets the parser working for you sooner. Patterns
 like [PRPL] are worth evaluating in order to ensure initial and subsequent
 navigations feel instant.
 

--- a/src/site/content/en/blog/rendering-on-the-web/index.md
+++ b/src/site/content/en/blog/rendering-on-the-web/index.md
@@ -5,7 +5,7 @@ authors:
   - developit
   - addyosmani
 date: 2019-02-06
-updated: 2019-08-27
+updated: 2022-08-18
 description: |
   Where should we implement logic and rendering in our applications? Should we use Server Side Rendering? What about Rehydration? Let's find some answers!
 tags:

--- a/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
+++ b/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
@@ -16,7 +16,7 @@ tags:
 PRPL is an acronym that describes a pattern used to make web pages load and
 become interactive, faster:
 
-+  **Push** (or **preload**) the most important resources.
++  **Preload** the most important resources.
 +  **Render** the initial route as soon as possible.
 +  **Pre-cache** remaining assets.
 +  **Lazy load** other routes and non-critical assets.
@@ -142,7 +142,7 @@ It's important to remember that not all of the techniques need to be
 applied together. Any efforts made with any of the following will provide
 noticeable performance improvements.
 
-+  **Push** (or **preload**) critical resources.
++  **Preload** critical resources.
 +  **Render** the initial route as soon as possible.
 +  **Pre-cache** remaining assets.
 +  **Lazy load** other routes and non-critical assets.

--- a/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
+++ b/src/site/content/en/fast/apply-instant-loading-with-prpl/index.md
@@ -9,6 +9,7 @@ description: |
   fit together but still can be used independently to achieve performance
   results.
 date: 2018-11-05
+updated: 2022-08-18
 tags:
   - performance
 ---

--- a/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
+++ b/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
@@ -5,6 +5,7 @@ subhead: Avoid the common pitfalls of using third-party scripts to improve load 
 authors:
   - mihajlija
 date: 2019-08-14
+updated: 2022-08-18
 description: |
   Learn how to avoid the common pitfalls of using third-party scripts to improve load times and user experience.
 hero: image/admin/udp7L9LSo5mfI3F0tvNY.jpg
@@ -146,7 +147,7 @@ When you use files from third-party servers, you rarely have control over cachin
 Self-hosting third-party scripts is an option that gives you more control over a script's loading process. By self-hosting you can:
 
 * Reduce DNS lookup and round-trip times.
-* Improve [HTTP caching](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) headers.
+* Improve [HTTP caching](https://web.dev/http-cache/) headers.
 * Take advantage of [HTTP/2](/performance-http2/), or the newer HTTP/3.
 
 For example, Casper managed to [shave 1.7 seconds](https://medium.com/caspertechteam/we-shaved-1-7-seconds-off-casper-com-by-self-hosting-optimizely-2704bcbff8ec) off load time by self-hosting an A/B testing script.

--- a/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
+++ b/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
@@ -147,7 +147,7 @@ When you use files from third-party servers, you rarely have control over cachin
 Self-hosting third-party scripts is an option that gives you more control over a script's loading process. By self-hosting you can:
 
 * Reduce DNS lookup and round-trip times.
-* Improve [HTTP caching](https://web.dev/http-cache/) headers.
+* Improve [HTTP caching](/http-cache/) headers.
 * Take advantage of [HTTP/2](/performance-http2/), or the newer HTTP/3.
 
 For example, Casper managed to [shave 1.7 seconds](https://medium.com/caspertechteam/we-shaved-1-7-seconds-off-casper-com-by-self-hosting-optimizely-2704bcbff8ec) off load time by self-hosting an A/B testing script.

--- a/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
+++ b/src/site/content/en/fast/efficiently-load-third-party-javascript/index.md
@@ -147,7 +147,7 @@ Self-hosting third-party scripts is an option that gives you more control over a
 
 * Reduce DNS lookup and round-trip times.
 * Improve [HTTP caching](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) headers.
-* Take advantage of [HTTP/2 server push](/performance-http2/).
+* Take advantage of [HTTP/2](/performance-http2/), or the newer HTTP/3.
 
 For example, Casper managed to [shave 1.7 seconds](https://medium.com/caspertechteam/we-shaved-1-7-seconds-off-casper-com-by-self-hosting-optimizely-2704bcbff8ec) off load time by self-hosting an A/B testing script.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Minor tweaks where we push HTTP/2 push (pardon the pun), but shouldn't since it's going away.

