### PR TITLE
Break words in `p code` elements

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -398,6 +398,10 @@ h6 code,
   word-break: break-all;
 }
 
+p code {
+  word-break: break-all;
+}
+
 /// Sub and sup
 sub,
 sup {


### PR DESCRIPTION
Long strings (like URLs) wrapped in `code` elements used in paragraphs can cause overflow issues. This PR allows them to break. Fixes #8262.

**Before**
<img width="320" alt="image" src="https://user-images.githubusercontent.com/12857772/185599835-5698279f-9a2d-41c7-afcd-fc18129b071b.png">

**After**
<img width="321" alt="image" src="https://user-images.githubusercontent.com/12857772/185599917-e675a697-6dc9-48ae-b4da-b420710f8d34.png">
