### PR TITLE
Do not use block syntax in `{% aside %}` in `prefers-reduced-motion` article

### DIFF
--- a/src/site/content/en/blog/prefers-reduced-motion/index.md
+++ b/src/site/content/en/blog/prefers-reduced-motion/index.md
@@ -150,12 +150,7 @@ have opted out of animations, or users on browsers that don't understand the med
 {% Aside %}
 If you have a lot of animation-related CSS, you can spare your opted-out users from
 downloading it by outsourcing all animation-related CSS into a separate stylesheet that you only
-load conditionally via the `media` attribute on the `link` element&nbsp;😎:
-
-```html
-<link rel="stylesheet" href="animations.css"
-      media="(prefers-reduced-motion: no-preference)">
-```
+load conditionally via the `media` attribute on the `link` element&nbsp;😎: `<link rel="stylesheet" href="animations.css" media="(prefers-reduced-motion: no-preference)">`
 {% endAside %}
 
 To illustrate how to work with `prefers-reduced-motion` with JavaScript, let's imagine I have

--- a/src/site/content/es/blog/prefers-reduced-motion/index.md
+++ b/src/site/content/es/blog/prefers-reduced-motion/index.md
@@ -88,13 +88,8 @@ Para ilustrar ambos, digamos que tengo un botón de registro importante en el qu
 }
 ```
 
-{% Aside %} Si tiene una gran cantidad de CSS relacionado con la animación, puede evitar que los usuarios que optaron por no recibir animaciones lo descarguen mediante la transferencia de todo el CSS relacionado con la animación a una hoja de estilo separada que solo carga condicionalmente a través del atributo `media` en el elemento del `link` 😎:
-
-```html
-<link rel="stylesheet" href="animations.css"
-      media="(prefers-reduced-motion: no-preference)">
-```
-
+{% Aside %}
+Si tiene una gran cantidad de CSS relacionado con la animación, puede evitar que los usuarios que optaron por no recibir animaciones lo descarguen mediante la transferencia de todo el CSS relacionado con la animación a una hoja de estilo separada que solo carga condicionalmente a través del atributo `media` en el elemento del `link` 😎: `<link rel="stylesheet" href="animations.css" media="(prefers-reduced-motion: no-preference)">`
 {% endAside %}
 
 Para ilustrar cómo trabajar con `prefers-reduced-motion` con JavaScript, imaginemos que he definido una animación compleja con la [API de animaciones web](https://developer.mozilla.org/docs/Web/API/Web_Animations_API) (Web Animations API). Si bien el navegador activará dinámicamente las reglas de CSS cuando cambie la preferencia del usuario, para las animaciones de JavaScript tengo que captar los cambios por mi cuenta y luego detener manualmente las animaciones potencialmente en ejecución (o reiniciarlas si el usuario me lo permite):

--- a/src/site/content/ko/blog/prefers-reduced-motion/index.md
+++ b/src/site/content/ko/blog/prefers-reduced-motion/index.md
@@ -93,13 +93,7 @@ feedback:
 ```
 
 {% Aside %}
-`link` 요소 `media` 속성을 통해서만 조건부로 로드하는 별도의 스타일시트에 모든 애니메이션 관련 CSS를 아웃소싱하여 선택 해제된 사용자가 다운로드하지 않도록 할 수 있습니다. 😎
-
-```html
-<link rel="stylesheet" href="animations.css"
-      media="(prefers-reduced-motion: no-preference)">
-```
-
+`link` 요소 `media` 속성을 통해서만 조건부로 로드하는 별도의 스타일시트에 모든 애니메이션 관련 CSS를 아웃소싱하여 선택 해제된 사용자가 다운로드하지 않도록 할 수 있습니다. 😎 `<link rel="stylesheet" href="animations.css" media="(prefers-reduced-motion: no-preference)">`
 {% endAside %}
 
 `prefers-reduced-motion`으로 작업하는 방법을 설명하기 위해 [Web Animations API](https://developer.mozilla.org/docs/Web/API/Web_Animations_API)로 복잡한 애니메이션을 정의했다고 가정해 보겠습니다. CSS 규칙은 사용자 기본 설정이 변경될 때 브라우저에 의해 동적으로 트리거되지만 JavaScript 애니메이션의 경우 변경 사항을 직접 수신한 다음 잠재적으로 실행 중인 애니메이션을 수동으로 중지해야 합니다(또는 사용자가 허용하는 경우 다시 시작해야 함).

--- a/src/site/content/pt/blog/prefers-reduced-motion/index.md
+++ b/src/site/content/pt/blog/prefers-reduced-motion/index.md
@@ -92,13 +92,8 @@ Para ilustrar ambos, digamos que eu tenha um botão de inscrição importante no
 }
 ```
 
-{% Aside %} Se você tem muito CSS relacionado à animação, pode evitar que os usuários que optaram por não façam o download terceirizando todo o CSS relacionado à animação em uma folha de estilo separada que você carrega apenas condicionalmente por `media` atributo de mídia no elemento de `link`:
-
-```html
-<link rel="stylesheet" href="animations.css"
-      media="(prefers-reduced-motion: no-preference)">
-```
-
+{% Aside %}
+Se você tem muito CSS relacionado à animação, pode evitar que os usuários que optaram por não façam o download terceirizando todo o CSS relacionado à animação em uma folha de estilo separada que você carrega apenas condicionalmente por `media` atributo de mídia no elemento de `link`: `<link rel="stylesheet" href="animations.css" media="(prefers-reduced-motion: no-preference)">`
 {% endAside %}
 
 Para ilustrar como trabalhar com `prefers-reduced-motion` com JavaScript, vamos imaginar que eu tenha definido uma animação complexa com a [API Web Animations](https://developer.mozilla.org/docs/Web/API/Web_Animations_API). Embora as regras CSS sejam acionadas dinamicamente pelo navegador quando a preferência do usuário muda, para animações JavaScript eu mesmo tenho que escutar as mudanças e, em seguida, parar manualmente minhas animações em potencial (ou reiniciá-las se o usuário permitir):


### PR DESCRIPTION
Resolves #8569. This removes the language hints for the code blocks as they are not supported with `{% aside %}`.