### PR TITLE
Update webdev-infra to enable fetchpriority use

### DIFF
--- a/firebase.incl.json
+++ b/firebase.incl.json
@@ -20,10 +20,6 @@
           {
             "key": "Cache-Control",
             "value": "max-age=0"
-          },
-          {
-            "key": "Origin-Trial",
-            "value": "AroL15qduRNqNxaVOrRCcy3Lg2qmVISGidsHrfTRIwaZgUoJqZfqGYBAcqTKWf+6SgVWVbHV/OWkQCUy/ut0PwAAAABReyJvcmlnaW4iOiJodHRwczovL3dlYi5kZXY6NDQzIiwiZmVhdHVyZSI6IlByaW9yaXR5SGludHNBUEkiLCJleHBpcnkiOjE2NDc5OTM1OTl9"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "truncate-utf8-bytes": "^1.0.2",
         "unistore": "^3.4.1",
         "web-vitals": "^2.1.4",
-        "webdev-infra": "^1.0.31",
+        "webdev-infra": "^1.0.32",
         "wicg-inert": "^3.0.1",
         "yaml-front-matter": "^4.0.0"
       },
@@ -28342,9 +28342,9 @@
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.31.tgz",
-      "integrity": "sha512-Z+8Z4UB8SjJJDX2FRdmNBuGlQ1ezcm37s1kCgwI2IczryGDqgP1Soxa5idPOfFwbOPh/wyh2hO3EQTlgzAkxZg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
+      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
@@ -28356,7 +28356,7 @@
         "striptags": "^3.1.1"
       },
       "engines": {
-        "node": "14.x"
+        "node": ">=14"
       }
     },
     "node_modules/webidl-conversions": {
@@ -51505,9 +51505,9 @@
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "webdev-infra": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.31.tgz",
-      "integrity": "sha512-Z+8Z4UB8SjJJDX2FRdmNBuGlQ1ezcm37s1kCgwI2IczryGDqgP1Soxa5idPOfFwbOPh/wyh2hO3EQTlgzAkxZg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
+      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
       "requires": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "truncate-utf8-bytes": "^1.0.2",
     "unistore": "^3.4.1",
     "web-vitals": "^2.1.4",
-    "webdev-infra": "^1.0.31",
+    "webdev-infra": "^1.0.32",
     "wicg-inert": "^3.0.1",
     "yaml-front-matter": "^4.0.0"
   },

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -53,7 +53,7 @@ module.exports = {
       NAVIGATION_TYPE: 'dimension6',
       COLOR_SCHEME_PREFERENCE: 'dimension7',
     },
-    version: 10,
+    version: 11,
   },
   firebase: {
     prod: {


### PR DESCRIPTION
This PR continues the work done in https://github.com/GoogleChrome/web.dev/pull/8517 and updates the [webdev-infra](https://github.com/GoogleChrome/webdev-infra) package, so `fetchpriority` works with the image shortcode.