### PR TITLE
Do not add an id to h1 in posts

### DIFF
--- a/src/site/_includes/partials/post-next.njk
+++ b/src/site/_includes/partials/post-next.njk
@@ -76,7 +76,7 @@
           </nav>
         {% endif %}
 
-        <h1 id="{{ safeTitle | slugify }}">{{ safeTitle }}</h1>
+        <h1>{{ safeTitle }}</h1>
         {% if subhead | length %}
           <p class="color-mid-text flow-space-base">
             {{ subhead | md | safe }}


### PR DESCRIPTION
Resolves #8574. This PR stops adding the slugified title as an id to the `h1` of our posts. As the headline is not linkable from the UI (other headlines show a # you can use to copy a deep link) this should not affect anyone.