### PR TITLE
Add note about CSP and unsafe-inline

### DIFF
--- a/src/site/content/en/fast/defer-non-critical-css/index.md
+++ b/src/site/content/en/fast/defer-non-critical-css/index.md
@@ -126,6 +126,9 @@ production scenario, it's a good practice to use functions like
 [loadCSS](https://github.com/filamentgroup/loadCSS/blob/master/README.md), that
 can encapsulate this behavior and work well across browsers.
 {% endAside %}
+{% Aside 'important' %}
+If your site has a [Content Security Policy](/csp/) you will not be able to use this technique without enabling `unsafe-inline` for `script-src`.
+{% endAside %}
 
 The [resulting page](https://defer-css-optimized.glitch.me/) looks exactly like the previous version, even when most styles load asynchronously. Here's how the inlined styles and asynchronous request to the CSS file look like in the HTML file:
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- Clarify that the `onload` technique is not compatible with CSP
