### PR TITLE
Remove fetchpriority from course cards

### DIFF
--- a/src/site/_includes/partials/course-cards-next.njk
+++ b/src/site/_includes/partials/course-cards-next.njk
@@ -22,7 +22,7 @@
                   {{ icon('mortarboard') }}
                 </div>
               </div>
-              <img fetchpriority="high" src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
+              <img src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
               <div class="card__content flow">
                 <p class="text-size-0">{{ course.meta.description | i18n(locale) }}</p>
               </div>


### PR DESCRIPTION
@philipwalton as discussed this removes `fetchpriority="high"` from learn cards.

- [Home page](https://web.dev/) - they are way down the page so shouldn't be high.
- [Learn page](https://web.dev/learn/) - They aren't LCP elements on desktop (only mobile) so only getting it right half the time.

Turns out didn't need `loading="auto"` as not using the `{% img %}` template so don't default to lazy loading.

