### PR TITLE
Fix part, which do not match the current spec

### DIFF
--- a/src/site/content/en/blog/webtransport/index.md
+++ b/src/site/content/en/blog/webtransport/index.md
@@ -200,7 +200,7 @@ await writer.abort();
 
 #### ReceiveStream
 
-A <code>[ReceiveStream](https://wicg.github.io/web-transport/#receivestream)</code> is initiated by the server. Obtaining a <code>ReceiveStream</code> is a two-step process for a web client. First, it calls the <code>receiveStreams()</code> method of a `WebTransport` instance, which returns a <code>ReadableStream</code>. Each chunk of that <code>ReadableStream</code>, is, in turn, a <code>ReceiveStream</code> that can be used to read <code>Uint8Array</code> instances sent by the server.
+A <code>[ReceiveStream](https://wicg.github.io/web-transport/#receivestream)</code> is initiated by the server. Obtaining a <code>ReceiveStream</code> is a two-step process for a web client. First, it calls the <code>incomingUnidirectionalStreams</code> attribute of a `WebTransport` instance, which returns a <code>ReadableStream</code>. Each chunk of that <code>ReadableStream</code>, is, in turn, a <code>ReceiveStream</code> that can be used to read <code>Uint8Array</code> instances sent by the server.
 
 ```js
 async function readFrom(receiveStream) {
@@ -215,7 +215,7 @@ async function readFrom(receiveStream) {
   }
 }
 
-const rs = transport.receiveStreams();
+const rs = transport.incomingUnidirectionalStreams;
 const reader = rs.getReader();
 while (true) {
   const {done, value} = await reader.read();
@@ -252,10 +252,10 @@ const stream = await transport.createBidirectionalStream();
 // stream.writable is a WritableStream
 ```
 
-You can listen for a `BidirectionalStream` created by the server with the `receiveBidirectionalStreams()` method of a `WebTransport` instance, which returns a `ReadableStream`. Each chunk of that `ReadableStream`, is, in turn, a `BidirectionalStream`.
+You can listen for a `BidirectionalStream` created by the server with the `incomingBidirectionalStreams` attribute of a `WebTransport` instance, which returns a `ReadableStream`. Each chunk of that `ReadableStream`, is, in turn, a `BidirectionalStream`.
 
 ```js
-const rs = transport.receiveBidrectionalStreams();
+const rs = transport.incomingBidirectionalStreams;
 const reader = rs.getReader();
 while (true) {
   const {done, value} = await reader.read();


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes wrong documentation

Changes proposed in this pull request:

Refer to the incomingBidirectionalStreams and its unidirectional counterpart instead of the older method, that is not present in current specs and implementation.

