### PR TITLE
Adds core web vitals guidance to the remove unused code guide.

### DIFF
--- a/src/site/content/en/fast/remove-unused-code/index.md
+++ b/src/site/content/en/fast/remove-unused-code/index.md
@@ -25,9 +25,11 @@ download and use over _half a million_ public packages. But we often include
 libraries we're not fully utilizing. To fix this issue, **analyze your bundle**
 to detect unused code. Then remove **unused** and **unnecessary** libraries.
 
-By removing unused code, you can improve your website's [Core Web Vitals](/vitals/). [Largest Contentful Paint](/lcp/), for example, can be affected by unused code by increased bandwidth contention caused by large assets for [LCP candidates](/lcp/#what-elements-are-considered). LCP can also be affected if large JavaScript assets that render markup solely on the client [contain references to LCP candidates](/preload-scanner/#rendering-markup-with-client-side-javascript) by [delaying when these resources can load](/optimize-lcp/#1-eliminate-resource-load-delay).
+## Impact on Core Web Vitals
 
-Other metrics such as [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/) can also be affected by unused code during startup, because even unused JavaScript must be downloaded, parsed, compiled, and then executed. The unused code can introduce unnecessary delays in resource load time and main thread activity that contribute to poor page responsiveness.
+By removing unused code, you can improve your website's [Core Web Vitals](/vitals/). [Largest Contentful Paint](/lcp/), for example, can be affected by unused code by increased bandwidth contention caused by larger than necessary assets. LCP can also be affected if large JavaScript assets that render markup solely on the client [contain references to LCP candidates](/preload-scanner/#rendering-markup-with-client-side-javascript) by [delaying when these resources can load](/optimize-lcp/#1-eliminate-resource-load-delay).
+
+Other metrics such as [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/) can also be affected by unused code, because even unused JavaScript must be downloaded, parsed, compiled, and then executed. The unused code can introduce unnecessary delays in resource load time, memory usage, and main thread activity that contribute to poor page responsiveness.
 
 This guide will help you get a handle on your project's unused code by showing you how to analyze your project's codebase, and offer strategies for pruning unused code from the JavaScript assets you ship to your users in production.
 

--- a/src/site/content/en/fast/remove-unused-code/index.md
+++ b/src/site/content/en/fast/remove-unused-code/index.md
@@ -7,6 +7,7 @@ subhead: |
 authors:
   - houssein
 date: 2018-11-05
+updated: 2022-08-29
 description: |
   Registries like npm have transformed the JavaScript world for the better by
   allowing anyone to easily download and use over half a million public
@@ -23,6 +24,12 @@ transformed the JavaScript world for the better by allowing anyone to easily
 download and use over _half a million_ public packages. But we often include
 libraries we're not fully utilizing. To fix this issue, **analyze your bundle**
 to detect unused code. Then remove **unused** and **unnecessary** libraries.
+
+By removing unused code, you can improve your website's [Core Web Vitals](/vitals/). [Largest Contentful Paint](/lcp/), for example, can be affected by unused code by increased bandwidth contention caused by large assets for [LCP candidates](/lcp/#what-elements-are-considered). LCP can also be affected if large JavaScript assets that render markup solely on the client [contain references to LCP candidates](/preload-scanner/#rendering-markup-with-client-side-javascript) by [delaying when these resources can load](/optimize-lcp/#1-eliminate-resource-load-delay).
+
+Other metrics such as [First Input Delay (FID)](/fid/) and [Interaction to Next Paint (INP)](/inp/) can also be affected by unused code during startup, because even unused JavaScript must be downloaded, parsed, compiled, and then executed. The unused code can introduce unnecessary delays in resource load time and main thread activity that contribute to poor page responsiveness.
+
+This guide will help you get a handle on your project's unused code by showing you how to analyze your project's codebase, and offer strategies for pruning unused code from the JavaScript assets you ship to your users in production.
 
 ## Analyze your bundle
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Updates the [remove unused code post](https://web.dev/remove-unused-code/) intro with a note about how unused code can affect certain Core Web Vitals and other metrics.