### PR TITLE
Fix description of checks for "bypass" Lighthouse audit based on Axe

### DIFF
--- a/src/site/content/en/lighthouse-accessibility/bypass/index.md
+++ b/src/site/content/en/lighthouse-accessibility/bypass/index.md
@@ -27,7 +27,7 @@ Lighthouse flags pages that don't provide a way to skip repetitive content:
 </figure>
 
 Lighthouse checks that the page contains at least one of the following:
-- A `<header>` element
+- A [heading element](/headings-and-landmarks/#use-headings-to-outline-the-page)
 - A [skip link](/headings-and-landmarks#bypass-repetitive-content-with-skip-links)
 - A [landmark](/headings-and-landmarks/#use-landmarks-to-aid-navigation)
 


### PR DESCRIPTION
This audit is based on Axe’s [bypass](https://dequeuniversity.com/rules/axe/3.3/bypass) rule, which checks headings, not header elements. The error might stem from Axe’s check for this being called [header-present](https://github.com/dequelabs/axe-core/blob/develop/lib/checks/navigation/header-present.json), but it does check h1…h6 elements, not `<header>`.

I looked for similar copy elsewhere and this seems to be the only place with the issue.