### PR TITLE
Added links to relevant DevTools docs

### DIFF
--- a/src/site/content/en/blog/new-responsive/index.md
+++ b/src/site/content/en/blog/new-responsive/index.md
@@ -74,7 +74,7 @@ height="248" %}
 New user preference media features, give you the ability to style web
 experiences that align with the user's own specific preferences and needs. This
 means that preference media features allow you to adapt your user experiences to
-your user's experiences
+your user's experiences.
 
 These user preference media features include:
 
@@ -135,7 +135,7 @@ the new theme within the media query.
 autoplay=true, muted=true, playsinline=true, loop=true, controls=true %}
 
 To make it easier to test some of these preference queries out, you can use
-DevTools for emulation instead of opening up your system preferences each time.
+[DevTools for emulation](https://developer.chrome.com/docs/devtools/rendering/emulate-css/) instead of opening up your system preferences each time.
 
 {% Video src="video/HodOHWjMnbNw56hvNASHWSgZyAf2/ol6pVXJLT44wAkRADAcq.mp4",
 autoplay=true, muted=true, playsinline=true, loop=true, controls=true %}
@@ -182,7 +182,7 @@ Youtube play screen with a paused video at 100% screen brightness using dark
 theme for the app UI vs a light theme.
 
 You should always provide a dark theme experience for your users whenever
-possible
+possible.
 
 ## Responsive to the container
 
@@ -315,6 +315,9 @@ These demos are now available to play with behind a flag in Chrome Canary. Go to
 `about://flags` in Canary and turn on the `#enable-container-queries` flag.
 This will enable support for `@container`, `inline-size` and `block-size` values
 for the `contain` property, and the LayoutNG Grid implementation.
+
+The flag also enables the corresponding Chrome DevTools features.
+Learn how to [inspect and debug container queries in DevTools](https://developer.chrome.com/docs/devtools/css/container-queries/).
 
 ### Scoped styles
 

--- a/src/site/content/en/learn/css/flexbox/index.md
+++ b/src/site/content/en/learn/css/flexbox/index.md
@@ -634,3 +634,4 @@ If you need to align something it's a great way to do it.
 - [Everything You Need To Know About Alignment In Flexbox](https://www.smashingmagazine.com/2018/08/flexbox-alignment/)
 - [How Big Is That Flexible Box?](https://www.smashingmagazine.com/2018/09/flexbox-sizing-flexible-box/)
 - [Use Cases For Flexbox](https://www.smashingmagazine.com/2018/10/flexbox-use-cases/)
+- [Inspect and debug CSS Flexbox layouts in Chrome DevTools](https://developer.chrome.com/docs/devtools/css/flexbox/)

--- a/src/site/content/en/learn/css/grid/index.md
+++ b/src/site/content/en/learn/css/grid/index.md
@@ -177,7 +177,7 @@ they will immediately lay out on this grid. You can see this in action in the de
   id: 'NWdbrzr'
 } %}
 
-The Chrome Grid dev tools can help you to understand the various parts of the grid.
+The [grid overlay in Chrome DevTools ](https://developer.chrome.com/docs/devtools/css/grid/) can help you understand the various parts of the grid.
 
 Open the [demo](https://codepen.io/web-dot-dev/full/NWdbrzr) in Chrome.
 Inspect the element with the grey background, which has an ID of `container`.
@@ -492,7 +492,7 @@ To place your item set the start and end lines of the grid area that it should b
 }
 ```
 
-Chrome DevTools can give you a visual guide to the lines in order to check where your item is placed.
+[Chrome DevTools](https://developer.chrome.com/docs/devtools/css/grid/) can give you a visual guide to the lines in order to check where your item is placed.
 
 The line numbering follows the writing mode and direction of the component.
 In the next demo change the writing mode or direction
@@ -818,4 +818,5 @@ To find out more, take a look at the following resources.
 - [MDN CSS Grid Layout](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout)
 - [A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)
 - [Creating a Grid Container](https://www.smashingmagazine.com/2020/01/understanding-css-grid-container/)
+- [Inspect CSS grid in Chrome DevTools](https://developer.chrome.com/docs/devtools/css/grid/)
 - [A comprehensive collection of grid learning material](https://gridbyexample.com/)

--- a/src/site/content/en/learn/css/grid/index.md
+++ b/src/site/content/en/learn/css/grid/index.md
@@ -177,7 +177,7 @@ they will immediately lay out on this grid. You can see this in action in the de
   id: 'NWdbrzr'
 } %}
 
-The [grid overlay in Chrome DevTools ](https://developer.chrome.com/docs/devtools/css/grid/) can help you understand the various parts of the grid.
+The [grid overlay in Chrome DevTools](https://developer.chrome.com/docs/devtools/css/grid/) can help you understand the various parts of the grid.
 
 Open the [demo](https://codepen.io/web-dot-dev/full/NWdbrzr) in Chrome.
 Inspect the element with the grey background, which has an ID of `container`.

--- a/src/site/content/en/learn/design/micro-layouts/index.md
+++ b/src/site/content/en/learn/design/micro-layouts/index.md
@@ -67,7 +67,7 @@ h1::after {
  </figcaption>
 </figure>
 
-
+Learn how to [inspect grid layouts](https://developer.chrome.com/docs/devtools/css/grid/) in Chrome DevTools.
 
 ## Flexbox
 
@@ -108,6 +108,8 @@ But the image never gets larger than 200 pixels.
  </figcaption>
 </figure>
 
+Learn how to [inspect flexbox layouts](https://developer.chrome.com/docs/devtools/css/flexbox/) in Chrome DevTools.
+
 ## Container queries
 
 Flexbox allows you to design from the content out. 
@@ -130,6 +132,7 @@ Container queries are a new experimental technology that isn't widely available 
 To test the code below, and see the example working, enable container queries in Chrome. 
 
 Go to `chrome://flags/`, search for **Container Queries**, and enable the `#enable-container-queries` flag.
+With the flag enabled, you can [inspect and debug container queries](https://developer.chrome.com/docs/devtools/css/container-queries/) in Chrome DevTools.
 {% endAside %}
 
 To start, define which elements will act as containers.


### PR DESCRIPTION
Linking grid, flexbox, user adaptive emulation, and container queries content to relevant DevTools docs.

Fixes [GoogleChrome/developer.chrome.com/#3271](https://github.com/GoogleChrome/developer.chrome.com/issues/3271), fixes [GoogleChrome/developer.chrome.com/#3264](https://github.com/GoogleChrome/developer.chrome.com/issues/3264), fixes [GoogleChrome/developer.chrome.com/#3263](https://github.com/GoogleChrome/developer.chrome.com/issues/3263), fixes [GoogleChrome/developer.chrome.com/#3202](https://github.com/GoogleChrome/developer.chrome.com/issues/3202).