### PR TITLE
Fixed: loop dropping out at first non file entry

### DIFF
--- a/src/site/content/en/blog/file-system-access/index.md
+++ b/src/site/content/en/blog/file-system-access/index.md
@@ -428,7 +428,7 @@ butDir.addEventListener('click', async () => {
   const promises = [];
   for await (const entry of dirHandle.values()) {
     if (entry.kind !== 'file') {
-      break;
+      continue;
     }
     promises.push(entry.getFile().then((file) => `${file.name} (${file.size})`));
   }


### PR DESCRIPTION
Fixes an issue in the file system access blog post that results in the exiting the loop of entries early.

https://web.dev/file-system-access/#opening-a-directory-and-enumerating-its-contents
