### PR TITLE
add `allow="fullscreen"` attribute to the `:modal` demo

### DIFF
--- a/src/site/content/en/blog/is-it-modal/index.md
+++ b/src/site/content/en/blog/is-it-modal/index.md
@@ -107,7 +107,8 @@ header:modal span {
     user: 'web-dot-dev',
     id: 'YzLKQGx',
     height: 450,
-    tab: 'result'
+    tab: 'result',
+    allow: ['fullscreen']
   }
 %}
 


### PR DESCRIPTION
On https://web.dev/is-it-modal/ one of the embedded demos uses `requestFullscreen()` to open the page in fullscreen.

However, the shortcode doesn't have the `fullscreen` feature policy by default, so the demo doesn't work as expected. https://github.com/GoogleChrome/webdev-infra/blob/ac4056a326e0cb3f501fcb72c71de91a9b8ffd70/shortcodes/Codepen.js#L40-L48

This adds `fullscreen` directive to the iframe using shortcode property.

Fixes #8651

Changes proposed in this pull request:

-
-
-

