### PR TITLE
Fix code overflow issue on INP article

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -398,7 +398,8 @@ h6 code,
   word-break: break-all;
 }
 
-p code {
+p code,
+li code {
   word-break: break-all;
 }
 

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -400,7 +400,7 @@ h6 code,
 
 p code,
 li code {
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 /// Sub and sup

--- a/src/site/content/en/metrics/inp/index.md
+++ b/src/site/content/en/metrics/inp/index.md
@@ -162,8 +162,8 @@ The best way to measure your website's INP is by gathering metrics from actual u
 
 - [PageSpeed Insights](https://pagespeed.web.dev).
 - [Chrome User Experience Report (CrUX)](https://developer.chrome.com/docs/crux/).
-  - Via BigQuery in the CrUX dataset's <code style="overflow-wrap: break-word">experimental.interaction_to_next_paint</code> table.
-  - CrUX API via <code style="overflow-wrap: break-word">experimental_interaction_to_next_paint</code>.
+  - Via BigQuery in the CrUX dataset's `experimental.interaction_to_next_paint` table.
+  - CrUX API via `experimental_interaction_to_next_paint`.
   - CrUX Dashboard.
 - [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals).
 

--- a/src/site/content/en/metrics/inp/index.md
+++ b/src/site/content/en/metrics/inp/index.md
@@ -162,8 +162,8 @@ The best way to measure your website's INP is by gathering metrics from actual u
 
 - [PageSpeed Insights](https://pagespeed.web.dev).
 - [Chrome User Experience Report (CrUX)](https://developer.chrome.com/docs/crux/).
-  - Via BigQuery in the CrUX dataset's `experimental.interaction_to_next_paint` table.
-  - CrUX API via `experimental_interaction_to_next_paint`.
+  - Via BigQuery in the CrUX dataset's <code style="overflow-wrap: break-word">experimental.interaction_to_next_paint</code> table.
+  - CrUX API via <code style="overflow-wrap: break-word">experimental_interaction_to_next_paint</code>.
   - CrUX Dashboard.
 - [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals).
 


### PR DESCRIPTION
The [INP article](https://web.dev/inp/) overflows on mobile (I'm on an iPhone but think it's the same on Android based on desktop emulation).

Changes proposed in this pull request:

- Add a CSS to allow the long code to wrap in `li code` similar to `p code` added in #8565 by @matthiasrohmer 


Note: I changed it from `word-break: break-all;` to `overflow-wrap: break-word;` to only break the word if it needs to.
