### PR TITLE
Fix invalid/broken container query syntax

### DIFF
--- a/src/site/content/en/patterns/layout/container-query-card/index.md
+++ b/src/site/content/en/patterns/layout/container-query-card/index.md
@@ -23,7 +23,9 @@ To create the container, first set containment on the parent:
 ```css
 /* Set containment on parent */
 .container {
-  container: inline-size;
+  container-name: myContainer;
+  container-type: inline-size;
+  /* You can also use the shorthand property `container: myContainer / inline-size`.
 }
 ```
 


### PR DESCRIPTION
The shorthand `container` property requires the `container-name` to be specified. As it's missing in the container query it uses `inline-size` as the name of the container and the default value of `normal` for the `container-type`.

The article could be slightly expanded to point out that the `@container` rule can also take the name of a container.

The same fix is required in the linked codepen at the bottom https://codepen.io/una/pen/xxLPwBX