### PR TITLE
Add missing `self` in the Service worker two-way-communication guide

### DIFF
--- a/src/site/content/en/reliable/two-way-communication-guide/index.md
+++ b/src/site/content/en/reliable/two-way-communication-guide/index.md
@@ -62,7 +62,7 @@ service worker:
 ```javascript
 const SW_VERSION = '1.0.0';
 
-addEventListener('message', (event) => {
+self.addEventListener('message', (event) => {
   if (event.data.type === 'GET_VERSION') {
     event.ports[0].postMessage(SW_VERSION);
   }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- Fixes #SOME_ISSUE_NUMBER -->

Changes proposed in this pull request:

- Added `self` in sample code in service worker
