### PR TITLE
Document new web-vitals attribution features

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -389,9 +389,11 @@ redirects:
   - source: /speed-scrolling/
     destination: /intersectionobserver/
 
-  # Redirects /learn-web-vitals/ to /learn-core-web-vitals/ for consistency in terminology
+  # Redirects for outdated usage of "Web Vitals"
   - source: /learn-web-vitals/
     destination: /learn-core-web-vitals/
+  - source: /debug-web-vitals-in-the-field/
+    destination: /debug-performance-in-the-field/
 
    # Redirects for Lighthouse accessibility audits, now deferring to axe docs.
   - source: /accesskeys/

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -97,7 +97,7 @@ function sendToGoogleAnalytics({name, delta, id, attribution, navigationType}) {
     // Use a non-interaction event to avoid affecting bounce rate.
     nonInteraction: true,
 
-    // See: https://web.dev/debug-web-vitals-in-the-field/
+    // See: https://web.dev/debug-performance-in-the-field/
     [dimensions.WEB_VITALS_DEBUG]: webVitalInfo,
     [dimensions.NAVIGATION_TYPE]: navigationType,
   });

--- a/src/site/_data/paths/learn-core-web-vitals.json
+++ b/src/site/_data/paths/learn-core-web-vitals.json
@@ -35,7 +35,7 @@
             "pathItems": [
                 "lab-and-field-data-differences",
                 "debug-layout-shifts",
-                "debug-web-vitals-in-the-field"
+                "debug-performance-in-the-field"
             ]
         },
         {

--- a/src/site/_data/paths/learn-core-web-vitals.json
+++ b/src/site/_data/paths/learn-core-web-vitals.json
@@ -34,6 +34,7 @@
             "title": "i18n.paths.learn_core_web_vitals.topics.debug_core_web_vitals",
             "pathItems": [
                 "lab-and-field-data-differences",
+                "crux-and-rum-differences",
                 "debug-layout-shifts",
                 "debug-performance-in-the-field"
             ]

--- a/src/site/content/en/blog/debug-performance-in-the-field/index.md
+++ b/src/site/content/en/blog/debug-performance-in-the-field/index.md
@@ -298,8 +298,8 @@ For example, if the vast majority of your user's first interactions are with a
 particular element, consider inlining the JavaScript code needed for that
 element in the HTML, and lazy loading the rest.
 
-To get the element associated with the first input event, you can reference the
-`first-input` entry's `target` property:
+To get the interaction type and element associated with the first input event,
+you can reference the `first-input` entry's `target` and `name` properties:
 
 ```js
 new PerformanceObserver((list) => {

--- a/src/site/content/en/blog/vitals-ga4/index.md
+++ b/src/site/content/en/blog/vitals-ga4/index.md
@@ -281,7 +281,7 @@ why?
 Knowing _what_ your scores are is not helpful if you're not able to take action
 and fix the problems.
 
-[Debug Web Vitals in the field](/debug-web-vitals-in-the-field/) explains how
+[Debug performance in the field](/debug-performance-in-the-field/) explains how
 you can send additional debug information with your analytics data. If you
 follow the instructions detailed in that post, you should see that debug
 information appear in BigQuery as well.
@@ -360,8 +360,8 @@ WHERE metric_name = 'CLS'
 WHERE metric_name = 'LCP'
 ```
 
-Again, you can refer to [Debug Web Vitals in the
-field](/debug-web-vitals-in-the-field/) for instructions on how to collect and
+Again, you can refer to [Debug performance in the
+field](/debug-performance-in-the-field/) for instructions on how to collect and
 send debug information for each of the Core Web Vitals metrics.
 
 ## Visualize

--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -232,8 +232,8 @@ allow you to both debug individual issues that occur throughout the page
 lifecycle as well as aggregate by original page URL in order to match how Google
 tools measure and report on the metrics.
 
-For more details and best practices on this topic, see: [Debug Web Vitals in the
-field](/debug-web-vitals-in-the-field/).
+For more details and best practices on this topic, see: [Debug performance in the
+field](/debug-performance-in-the-field/).
 
 ### What is Google doing to ensure MPAs do not have an unfair advantage compared to SPAs?
 

--- a/src/site/content/en/blog/vitals-tools/index.md
+++ b/src/site/content/en/blog/vitals-tools/index.md
@@ -275,7 +275,7 @@ When debugging performance issues related to LCP, TBT, and FID, and general load
 
 #### Debug Core Web Vitals in the field
 
-Lab tools can't always identify the cause of all Core Web Vitals issues affecting your users. This is one reason why it's so important to collect your own field data, as it takes factors into account that lab data cannot. Additionally, [learning how to debug Core Web Vitals in the field](/debug-web-vitals-in-the-field/) can help you make sense of changes in your website's Core Web Vitals in the field.
+Lab tools can't always identify the cause of all Core Web Vitals issues affecting your users. This is one reason why it's so important to collect your own field data, as it takes factors into account that lab data cannot. Additionally, [learning how to debug Core Web Vitals in the field](/debug-performance-in-the-field/) can help you make sense of changes in your website's Core Web Vitals in the field.
 
 ### Step 3: Monitor with continuous integration tools
 

--- a/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
+++ b/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
@@ -34,7 +34,7 @@ However, for a deeper dive in investigating _why_ data is showing the numbers it
 
 ### Deeper analysis to investigate issues
 
-CrUX can often be used to point out if you have a problem on your site, but not necessarily exactly where on your site the issue lies nor why. RUM solutions—whether home-grown through [the likes of the web-vitals library](/debug-web-vitals-in-the-field/) or some of the many commercial products—can help bridge that gap.
+CrUX can often be used to point out if you have a problem on your site, but not necessarily exactly where on your site the issue lies nor why. RUM solutions—whether home-grown through [the likes of the web-vitals library](/debug-performance-in-the-field/) or some of the many commercial products—can help bridge that gap.
 
 Using a RUM solution gives you access to much more fine-grained data for all your pages, and on all browsers. It also allows you to slice and dice this data in ways CrUX does not, enabling you to drill down and investigate problem areas of the site. Are they affected by a particular segment of users? Or users who take certain actions? Exactly when did the problem start? These are questions that are much easier to answer with the additional data that a RUM tool can provide.
 

--- a/src/site/content/en/learn-core-web-vitals/lab-and-field-data-differences/index.md
+++ b/src/site/content/en/learn-core-web-vitals/lab-and-field-data-differences/index.md
@@ -383,7 +383,7 @@ experience for your users.
 
 ## Further reading
 
-* [Debug Web Vitals in the Field](/debug-web-vitals-in-the-field/)
+* [Debug performance in the Field](/debug-performance-in-the-field/)
 * [A performance-focused workflow based on Google
   tools](/vitals-tools-workflow/)
 


### PR DESCRIPTION
This PR updates the [Debug Web Vitals in the field]() post to reference the new [attribution build](https://github.com/GoogleChrome/web-vitals#attribution-build) in `web-vitals` v3 and adds debug guidance for INP.

However, since the post now includes INP, to avoid any confusion (consistent with other recent changes we've made) this PR also updates the title and URL of the post from "Debug Web Vitals..." to "Debug performance...".

Note: to make it easier to review the diff I've kept the original file location (if I rename the file and make changes, GitHub does not render the diff properly, so it's impossible to review). Once these changes have been approved I'll update the file location and merge.


