### PR TITLE
Update web-vitals code per v3 changes

### DIFF
--- a/src/site/content/en/blog/lcp-lazy-loading/index.md
+++ b/src/site/content/en/blog/lcp-lazy-loading/index.md
@@ -399,12 +399,13 @@ follow along with progress on that audit. Until then, one thing developers could
 instances of LCP elements being lazy-loaded is to add more detailed logging to their field data.
 
 ```js
-webVitals.getLCP(lcp => {
-  const latestEntry = lcp.entries[lcp.entries.length - 1];
+new PerformanceObserver((list) => {
+  const latestEntry = list.getEntries().at(-1);
+
   if (latestEntry?.element?.getAttribute('loading') == 'lazy') {
     console.warn('Warning: LCP element was lazy loaded', latestEntry);
   }
-});
+}).observe({type: 'largest-contentful-paint', buffered: true});
 ```
 
 The JavaScript snippet above will evaluate the most recent LCP element and log a warning if it was

--- a/src/site/content/en/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/en/blog/vitals-field-measurement-best-practices/index.md
@@ -67,7 +67,7 @@ The following code sample shows how easy it can be to track these metrics in
 code and send them to an analytics service.
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -76,9 +76,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## Avoid averages

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -432,15 +432,15 @@ Rather than memorizing and grappling with all of these cases yourself, developer
 measure CLS, which accounts for everything mentioned above:
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // Measure and log CLS in all situations
 // where it needs to be reported.
-getCLS(console.log);
+onCLS(console.log);
 ```
 
 You can refer to [the source code for
-`getCLS)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts)
+`onCLS)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts)
 for a complete example of how to measure CLS in JavaScript.
 
 {% Aside %}

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -137,14 +137,14 @@ Rather than memorizing all these subtle differences, developers can use the
 measure FCP, which handles these differences for you (where possible):
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // Measure and log FCP as soon as it's available.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
 You can refer to [the source code for
-`getFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts)
+`onFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts)
 for a complete example of how to measure FCP in JavaScript.
 
 {% Aside %}

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -314,14 +314,14 @@ Rather than memorizing all these subtle differences, developers can use the
 measure FID, which handles these differences for you (where possible):
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // Measure and log FID as soon as it's available.
-getFID(console.log);
+onFID(console.log);
 ```
 
 You can refer to [the source code for
-`getFID)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts)
+`onFID)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts)
 for a complete example of how to measure FID in JavaScript.
 
 {% Aside %}

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -345,14 +345,14 @@ Rather than memorizing all these subtle differences, developers can use the
 measure LCP, which handles these differences for you (where possible):
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // Measure and log LCP as soon as it's available.
-getLCP(console.log);
+onLCP(console.log);
 ```
 
 You can refer to [the source code for
-`getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts)
+`onLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts)
 for a complete example of how to measure LCP in JavaScript.
 
 {% Aside %}

--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -101,10 +101,10 @@ Not all browsers support `PerformanceObserver` or its `buffered` flag. To get th
 The [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals) can also measure TTFB in the browser with less complexity:
 
 ```javascript
-import {getTTFB} from 'web-vitals';
+import {onTTFB} from 'web-vitals';
 
 // Measure and log TTFB as soon as it's available.
-getTTFB(console.log);
+onTTFB(console.log);
 ```
 
 ### Measuring resource requests

--- a/src/site/content/en/vitals/index.md
+++ b/src/site/content/en/vitals/index.md
@@ -166,7 +166,7 @@ documentation for complete
 [API](https://github.com/GoogleChrome/web-vitals#api) details):
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -175,9 +175,9 @@ function sendToAnalytics(metric) {
     fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 Once you've configured your site to use the


### PR DESCRIPTION
This PR updates all references to `getXXX()` function names from `web-vitals` v2 to `onXXX()` names per `web-vitals` v3 changes. It also updates documentation links since those have been moved and the links were broken.