### PR TITLE
Clarify code for checking if the navigation menu is currently open

### DIFF
--- a/src/site/content/en/blog/website-navigation/index.md
+++ b/src/site/content/en/blog/website-navigation/index.md
@@ -370,12 +370,9 @@ const button = burgerClone.querySelector('button');
 
 // Toggle aria-expanded attribute
 button.addEventListener('click', e => {
-  // Get the aria-expanded attribute and check if the value is "false"
-  // If it's "false", isOpen is true
-  // If it's "true", isOpen is false
-  const isOpen = button.getAttribute('aria-expanded') === "false"
-  // Change the aria-expanded value accordingly
-  button.setAttribute('aria-expanded', isOpen);
+  // aria-expanded="true" signals that the menu is currently open
+  const isOpen = button.getAttribute('aria-expanded') === "true"
+  button.setAttribute('aria-expanded', !isOpen);
 });
 
 // Hide list on keydown Escape


### PR DESCRIPTION
I was reading the latest article on [building the main navigation for a website](https://web.dev/website-navigation/) and found this bit of code confusing the way it was written since it suggests that `isOpen` is true when `aria-expanded="false"` (but `aria-expanded="false"` means the menu `isClosed`). Imo, it makes more sense to check `isOpen` directly but negate the condition when updating the `aria-expanded` attribute.

(Note: I'm not sure how to update the associated CodePens, or if that's even necessary since the code is functionally the same.)