### PR TITLE
Fix code block wrapping for headers

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -395,7 +395,7 @@ h6 code,
   margin: 0;
   padding: 0;
   white-space: normal;
-  word-break: break-all;
+  overflow-wrap: break-word
 }
 
 p code,


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8632 

New wrapping:

<img width="766" alt="image" src="https://user-images.githubusercontent.com/10931297/190271082-f61a038d-e146-4ad2-9f39-ae0fd17da027.png">

Changes proposed in this pull request:

- Change from `word-break: break-all;` to `overflow-wrap: break-word`

