### PR TITLE
Fix missing link and word

### DIFF
--- a/src/site/content/en/blog/critical-rendering-path-constructing-the-object-model/index.md
+++ b/src/site/content/en/blog/critical-rendering-path-constructing-the-object-model/index.md
@@ -168,7 +168,7 @@ Our trivial stylesheet takes ~0.6ms to process and affects eight elements on
 the page&mdash;not much, but once again, not free. However, where did the
 eight elements come from? The CSSOM and DOM are independent data structures!
 Turns out, the browser is hiding an important step. Next, lets talk about the
-[render tree](/web/fundamentals/performance/critical-rendering-path/render-tree-construction)
+[render tree](/critical-rendering-path-render-tree-construction)
 that links the DOM and CSSOM together.
 
 ## Feedback {: #feedback }

--- a/src/site/content/en/blog/critical-rendering-path-render-tree-construction/index.md
+++ b/src/site/content/en/blog/critical-rendering-path-render-tree-construction/index.md
@@ -45,7 +45,7 @@ To construct the render tree, the browser roughly does the following:
 As a brief aside, note that `visibility: hidden` is different from `display: none`. The former makes the element invisible, but the element still occupies space in the layout (that is, it's rendered as an empty box), whereas the latter (`display: none`) removes the element entirely from the render tree such that the element is invisible and is not part of the layout.
 {% endAside %}
 
-The final output is a render that contains both the content and style information of all the visible content on the screen. **With the render tree in place, we can proceed to the "layout" stage.**
+The final output is a render tree that contains both the content and style information of all the visible content on the screen. **With the render tree in place, we can proceed to the "layout" stage.**
 
 Up to this point we've calculated which nodes should be visible and their computed styles, but we have not calculated their exact position and size within the [viewport](/web/fundamentals/design-and-ux/responsive/#set-the-viewport) of the device---that's the "layout" stage, also known as "reflow."
 


### PR DESCRIPTION
1. The blog [Constructing the Object Model](https://web.dev/critical-rendering-path-constructing-the-object-model/) contains a broken link __render tree__. I think that link should point to this blog [Render-tree Construction, Layout, and Paint](https://web.dev/critical-rendering-path-render-tree-construction/). ![image](https://user-images.githubusercontent.com/56380096/190978299-1d4e7c33-a5f9-4bf9-80d5-79dd920fe502.png)
2. The first sentence should be "The final output is a render **tree** that contains..."
   > The final output is a render that contains both the content and style information of all the visible content on the screen. With the render tree in place, we can proceed to the "layout" stage.
  



