### PR TITLE
Adding note about `start` attribute

### DIFF
--- a/src/site/content/en/blog/creative-list-styling/index.md
+++ b/src/site/content/en/blog/creative-list-styling/index.md
@@ -239,6 +239,8 @@ li::before {
 }  
 ```
 
+This will be sufficient in Firefox, but in Chrome and Safari the markers will count down from zero to -10. We can fix that by adding the `start` attribute to the list.
+
 {% Codepen {
   user: 'web-dot-dev',
   id: 'QWmBrGp',


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Addresses #8697. (Codepen demos will also need to be updated.)

Changes proposed in this pull request:

- Add line detailing use of `start` attribute in order for list markers to count down correctly across all browsers when using `::before`.

