### PR TITLE
Fix TTFB gaphic on mobile

### DIFF
--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -53,7 +53,7 @@ Because TTFB precedes [user-centric metrics](/user-centric-performance-metrics/)
       height="200">
     {%
       Img
-        src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/eNXaxPi9NdUVSTDRJFkV.svg",
+        src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/EcKicxW5ErYYhf8RvpeO.svg",
         alt="Good TTFB values are 0.8 seconds or less, poor values are greater than 1.8 seconds, and anything in between needs improvement",
         width="640",
         height="480"


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes TTFB label on mobile view which is incorrectly labels Interaction to Next Paint

Prod:

<img width="272" alt="image" src="https://user-images.githubusercontent.com/10931297/193036787-0913c222-7e9d-4ca0-9cb3-8e41aaea8c8c.png">

This branch:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/10931297/193036835-79de7bbb-7ae0-426e-a5b5-ab6d6edf8b34.png">

