### PR TITLE
Mention alternatives to Thumbor

### DIFF
--- a/src/site/content/en/fast/image-cdns/index.md
+++ b/src/site/content/en/fast/image-cdns/index.md
@@ -77,7 +77,9 @@ Image CDNs can be broken down into two categories: self-managed and third-party-
 
 Self-managed CDNs can be a good choice for sites with engineering staff who are comfortable maintaining their own infrastructure.
 
-[Thumbor](https://github.com/thumbor/thumbor) is the only self-managed image CDN available today. While it is open-source and free to use, it generally has fewer features than most commercial CDNs, and its documentation is somewhat limited. [Wikipedia](https://wikitech.wikimedia.org/wiki/Thumbor), [Square](https://medium.com/square-corner-blog/dynamic-images-with-thumbor-a430a1cfcd87), and [99designs](https://99designs.com/tech-blog/blog/2013/07/01/thumbnailing-with-thumbor/) are three sites that use Thumbor. See the [How to install the Thumbor image CDN](/install-thumbor) post for instructions on setting it up.
+- [Thumbor](https://github.com/thumbor/thumbor) is the most popular self-managed image CDN. While it is open-source and free to use, it generally has fewer features than most commercial CDNs, and its documentation is somewhat limited. [Wikipedia](https://wikitech.wikimedia.org/wiki/Thumbor), [Square](https://medium.com/square-corner-blog/dynamic-images-with-thumbor-a430a1cfcd87), and [99designs](https://99designs.com/tech-blog/blog/2013/07/01/thumbnailing-with-thumbor/) are three sites that use Thumbor. See the [How to install the Thumbor image CDN](/install-thumbor) post for instructions on setting it up.
+- [Imaginary](https://github.com/h2non/imaginary)
+- [Imagor](https://github.com/cshum/imagor)
 
 ### Third-party image CDNs
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

The document specifies that _"[Thumbor](https://github.com/thumbor/thumbor) is the only self-managed image CDN available today."_

https://github.com/GoogleChrome/web.dev/blob/8ee8b7fcf6f37fab3f6a0fe345f720a6bc8f2629/src/site/content/en/fast/image-cdns/index.md?plain=1#L80

Looks like there are a few other alternatives out there, so saying it's the only one available today is false.

P.S. 
1. I am not affiliated with any of these projects, just stumbled upon them while doing my own research
2. I am not suggesting to accept my edit "as is", just wanted to bring the attention to the fact there are other projects out there, this PR needs revising :-)