### PR TITLE
Learn a11y: Fix typo in first paragraph

### DIFF
--- a/src/site/content/en/learn/accessibility/index.md
+++ b/src/site/content/en/learn/accessibility/index.md
@@ -10,7 +10,7 @@ tags:
 
 ## Welcome to Learn Accessibility!
 
-Digital accessibility, commonly abbreviated a11y, is about designing and building websites and web apps so that disabled people can interact with in a meaningful and equivalent way.
+Digital accessibility, commonly abbreviated a11y, is about designing and building websites and web apps that disabled people can interact with in a meaningful and equivalent way.
 
 This course is created for beginner and advanced web developers.
 You can go through the series from start to finish

--- a/src/site/content/en/learn/accessibility/index.md
+++ b/src/site/content/en/learn/accessibility/index.md
@@ -10,7 +10,9 @@ tags:
 
 ## Welcome to Learn Accessibility!
 
-Digital accessibility, commonly abbreviated a11y, is about designing and building websites and web apps that disabled people can interact with in a meaningful and equivalent way.
+Digital accessibility, commonly abbreviated a11y, is about designing and
+building websites and web apps that disabled people can interact with in
+a meaningful and equivalent way.
 
 This course is created for beginner and advanced web developers.
 You can go through the series from start to finish


### PR DESCRIPTION
https://web.dev/learn/accessibility/

> Digital accessibility, commonly abbreviated a11y, is about designing and building websites and web apps so that disabled people can interact with in a meaningful and equivalent way.

“so” was apparently part of an abandoned turn of phrase, but was kept there.