### PR TITLE
change timeline to performance, fix image mismatch

### DIFF
--- a/src/site/content/en/blog/critical-rendering-path-constructing-the-object-model/index.md
+++ b/src/site/content/en/blog/critical-rendering-path-constructing-the-object-model/index.md
@@ -19,7 +19,7 @@ CSS to the browser as quickly as possible.
 - HTML markup is transformed into a Document Object Model (DOM); CSS markup is
   transformed into a CSS Object Model (CSSOM).
 - DOM and CSSOM are independent data structures.
-- Chrome DevTools Timeline allows us to capture and inspect the construction
+- Chrome DevTools Performance panel allows us to capture and inspect the construction
   and processing costs of DOM and CSSOM.
 
 ## Document Object Model (DOM)
@@ -73,14 +73,14 @@ above: convert bytes to characters, identify tokens, convert tokens to nodes,
 and build the DOM tree. This entire process can take some time, especially if
 we have a large amount of HTML to process.
 
-{% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/nAI6iO8vsAf03EUs4nWZ.png", alt="Tracing DOM construction in DevTools", width="766", height="180" %}
+{% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/RHpJTxB4gBYuhzILaB7Y.png", alt="Tracing DOM construction in DevTools", width="766", height="180" %}
 
 {% Aside %}
 We're assuming that you have basic familiarity with Chrome DevTools - that
 is, you know how to capture a network waterfall or record a timeline. If you
 need a quick refresher, check out the
-[Chrome DevTools documentation](/web/tools/chrome-devtools/); if you're new to
-DevTools, check out [DevTools for Beginners](/web/tools/chrome-devtools/beginners/html)
+[Chrome DevTools documentation](https://developer.chrome.com/docs/devtools/overview/); if you're new to
+DevTools, check out [DevTools for Beginners](https://developer.chrome.com/docs/devtools/open/)
 in our DevTools documentation.
 {% endAside %}
 
@@ -162,7 +162,7 @@ timeline doesn’t show a separate "Parse CSS" entry, and instead captures
 parsing and CSSOM tree construction, plus the recursive calculation of
 computed styles under this one event.
 
-{% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/RHpJTxB4gBYuhzILaB7Y.png", alt="Tracing CSSOM construction in DevTools", width="766", height="180" %}
+{% Img src="image/C47gYyWYVMMhDmtYSLOWazuyePF2/nAI6iO8vsAf03EUs4nWZ.png", alt="Tracing CSSOM construction in DevTools", width="766", height="180" %}
 
 Our trivial stylesheet takes ~0.6ms to process and affects eight elements on
 the page&mdash;not much, but once again, not free. However, where did the


### PR DESCRIPTION
Changes proposed in this pull request:

- Changed Chrome DevTools Timeline to Chrome DevTools Performance panel
- Fix Chrome Devtools broken links returning 404
- Fix DOM and CSSOM construction images mismatch

