### PR TITLE
ServiceWorkerRegistration.active and friends return null

### DIFF
--- a/src/site/content/en/reliable/service-worker-lifecycle/index.md
+++ b/src/site/content/en/reliable/service-worker-lifecycle/index.md
@@ -342,9 +342,9 @@ So, to enable as many patterns as we can, the whole update cycle is observable:
 
 ```js
 navigator.serviceWorker.register('/sw.js').then(reg => {
-  reg.installing; // the installing worker, or undefined
-  reg.waiting; // the waiting worker, or undefined
-  reg.active; // the active worker, or undefined
+  reg.installing; // the installing worker, or null
+  reg.waiting; // the waiting worker, or null
+  reg.active; // the active worker, or null
 
   reg.addEventListener('updatefound', () => {
     // A wild service worker has appeared in reg.installing!


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

The `installing`, `waiting` and `active` getters on a ServiceWorkerRegistration return `null` now. I reckon this is outdated.

- [`ServiceWorkerRegistration.active` on mdn](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/active)
- [ServiceWorkerRegistration interface spec](https://w3c.github.io/ServiceWorker/#serviceworkerregistration-interface)

![image](https://user-images.githubusercontent.com/2737650/193612188-7fbcc6cd-11f5-416d-b4b5-2eab00d7ee90.png)

