### PR TITLE
Use commas for viewport properties per spec

### DIFF
--- a/src/site/content/en/learn/html/document-structure/index.md
+++ b/src/site/content/en/learn/html/document-structure/index.md
@@ -88,7 +88,7 @@ The other meta tag that should be considered essential is the [viewport](/learn/
 The preceding code means "make the site responsive, starting by making the width of the content the width of the screen". In addition to `width`, you can set zoom and scalability, but they both default to accessible values. If you want to be explicit, include:
 
 ```html  
-<meta name="viewport" content="width=device-width;initial-scale:1;user-scalable=1;">  
+<meta name="viewport" content="width=device-width, initial-scale:1, user-scalable=1">  
 ```
 
 Viewport is part of the [Lighthouse accessibility audit](/meta-viewport/); your site will pass if it is scalable and has no maximum size set.  


### PR DESCRIPTION
Changes proposed in this pull request:

- Replaces semicolons with commas for viewport properties
- Formats properties for better readability

Per spec’s [recommendation](https://drafts.csswg.org/css-viewport/#parsing-algorithm):

> Authors should be using comma in order to ensure content works as expected in all UAs

MDN also [doesn’t mention](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) semicolons as a potential divider.