### PR TITLE
Semantic HTML code snippet typo fix

### DIFF
--- a/src/site/content/en/learn/html/semantic-html/index.md
+++ b/src/site/content/en/learn/html/semantic-html/index.md
@@ -150,7 +150,7 @@ Go back to the screenshot of the AOM for the non-semantic code block. You'll not
 
 ```html
 <div role="banner">
-    <span role=header aria-level="1">Three words</span>
+    <span role="heading" aria-level="1">Three words</span>
     <div role="navigation">
       <a>one word</a>
       <a>one word</a>


### PR DESCRIPTION
changes `role=header` to `role="heading"`

closes #8789
