### PR TITLE
aria-label text change starts with same text that's visually present - Fixes #8795

### DIFF
--- a/src/site/content/en/learn/accessibility/aria-html/index.md
+++ b/src/site/content/en/learn/accessibility/aria-html/index.md
@@ -293,7 +293,7 @@ Assigned the wrong role.
 
 {% Compare 'better' %}
 ```html
-<a aria-label="Some awesome article title">Read More</a>
+<a aria-label="Read more about some awesome article title">Read More</a>
 ```
 
 {% CompareCaption %}


### PR DESCRIPTION
My suggestion for aria-label that would work better than current, Fixes #8795

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8795

Changes proposed in this pull request:

- just a minor aria-label text change that would in my opinion work better for some users

