### PR TITLE
Remove references to jankfree.com

### DIFF
--- a/src/site/content/en/blog/speed-layers/index.md
+++ b/src/site/content/en/blog/speed-layers/index.md
@@ -221,5 +221,4 @@ That’s all for now. Stay tuned for a couple more articles on practical implica
 
 - [Scrolling Performance](http://www.html5rocks.com/en/tutorials/speed/scrolling/)
 - [Profiling Long Paint Times with DevTools' Continuous Painting Mode](http://updates.html5rocks.com/2013/02/Profiling-Long-Paint-Times-with-DevTools-Continuous-Painting-Mode)
-- [http://jankfree.com](http://jankfree.com)
 - [http://aerotwist.com/blog/on-translate3d-and-layer-creation-hacks/](http://aerotwist.com/blog/on-translate3d-and-layer-creation-hacks/)

--- a/src/site/content/en/blog/speed-rendering/index.md
+++ b/src/site/content/en/blog/speed-rendering/index.md
@@ -12,7 +12,7 @@ tags:
 
 You want your web app to feel responsive and smooth when doing animations, transitions, and other small UI effects. Making sure these effects are jank-free can mean the difference between a "native" feel or a clunky, unpolished one.
 
-This is the first in a series of articles covering rendering performance optimization in the browser. To kick things off, we'll cover why smooth animation is difficult and what needs to happen to achieve it, as well as a few easy best practices. Many of these ideas were originally presented in "Jank Busters," a talk Nat Duca and I gave at Google I/O talk ([video](https://www.youtube.com/watch?v=hAzhayTnhEI&amp;feature=plcp), [slides](http://www.jankfree.com/jank-busters-io/index.html#1)) this year.
+This is the first in a series of articles covering rendering performance optimization in the browser. To kick things off, we'll cover why smooth animation is difficult and what needs to happen to achieve it, as well as a few easy best practices. Many of these ideas were originally presented in "Jank Busters," a talk Nat Duca and I gave at Google I/O talk ([video](https://www.youtube.com/watch?v=hAzhayTnhEI&amp;feature=plcp)) this year.
 
 ## Introducing V-sync
 
@@ -153,11 +153,8 @@ short (<15ms).
 
 Lastly, vsync'd animation doesn't only apply to simple UI animations -- it applies to Canvas2D animation, WebGL animation, and even scrolling on static pages. In the next article in this series we'll dig into scrolling performance with these concepts in mind.
 
-For more on hunting down jank on the web, see [jankfree.com](http://www.jankfree.com/).
-
 Happy animating!
 
 ## References
 
-- [jankfree.com](http://www.jankfree.com/) for Jank Busters I/O talk, slides, and other info
 - [Using requestAnimationFrame for drag events](http://blog.digitalbackcountry.com/2012/05/using-requestanimationframe-to-optimize-dragging-events/)


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8722 

Changes proposed in this pull request:

- remove references to `jankfree.com` in https://web.dev/speed-rendering/ and in https://web.dev/speed-layers/

