### PR TITLE
Switch courses carousel for a grid on /learn

### DIFF
--- a/src/site/_includes/learn-page.njk
+++ b/src/site/_includes/learn-page.njk
@@ -50,6 +50,7 @@ pageScripts:
           </div>
         {% endif %}
       {% endfor %}
+      </div>
     </div>
   </div>
   {# Courses end #}

--- a/src/site/_includes/learn-page.njk
+++ b/src/site/_includes/learn-page.njk
@@ -22,12 +22,34 @@ pageScripts:
   {# Hero ends #}
 
   {# Courses start #}
-  <div class="wrapper">
-    <h2 id="{{ 'i18n.learn.courses' | i18n(locale) | slug }}" class="text-size-3">{{ 'i18n.learn.courses' | i18n(locale) }}</h2>
-  </div>
   <div class="bg-mid-bg region gap-top-size-1">
     <div class="wrapper">
-      {% include "partials/course-cards-next.njk" %}
+      <h2 id="{{ 'i18n.learn.courses' | i18n(locale) | slug }}" class="text-size-3">{{ 'i18n.learn.courses' | i18n(locale) }}</h2>
+      <div class="auto-grid gap-top-size-2">
+      {# Convert the courses object into an array of objects. #}
+      {% set coursesArr = helpers.values(courses) %}
+      {# Sort courses by descending date order (most recent comes first) #}
+      {% for course in coursesArr|sort(true, false, 'meta.date') %}
+        {% if course.meta and not course.meta.draft %}
+          <div>
+            <a href="{{ course.meta.url }}" class="card" data-style="branded">
+              <h3 class="visually-hidden">{{ course.meta.title }}</h3>
+              <div class="card__header repel">
+                <p class="color-mid-text">Course</p>
+                <div class="counter t-bg-core-primary t-color-shades-light-bright">
+                  {% set pages = collections.all | navigation(course.toc) %}
+                  <span class="counter__content" aria-label="{{ pages.list.length }} {{ 'i18n.learn.resources' | i18n(locale) }}">{{ pages.list.length }}</span>
+                  {{ icon('mortarboard') }}
+                </div>
+              </div>
+              <img importance="high" src="{{ course.meta.card }}" alt="{{ course.meta.title }} branding" />
+              <div class="card__content flow">
+                <p class="text-size-0">{{ course.meta.description | i18n(locale) }}</p>
+              </div>
+            </a>
+          </div>
+        {% endif %}
+      {% endfor %}
     </div>
   </div>
   {# Courses end #}


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8713

Changes proposed in this pull request:

- Swap the `<web-carousel>` for a CSS grid like the collections on /learn


<img width="1181" alt="Screen Shot 2022-10-04 at 10 32 14 PM" src="https://user-images.githubusercontent.com/48612525/193994652-e16ce758-f512-4b90-a906-7dcca931432a.png">

