### PR TITLE
Read CSS only once in purge-css transform instead of for every page

### DIFF
--- a/src/site/_transforms/purify-css.js
+++ b/src/site/_transforms/purify-css.js
@@ -24,7 +24,9 @@ const stagingUrls =
   require('../../../tools/lhci/lighthouserc').ci.collect.url.map((url) =>
     path.join('dist', new URL(url).pathname, 'index.html'),
   );
-const pathToCss = 'dist/css/main.css';
+const mainCss = fs.readFileSync('dist/css/main.css', {
+  encoding: 'utf-8',
+});
 const isProd = process.env.ELEVENTY_ENV === 'prod';
 const isStaging = process.env.ELEVENTY_ENV === 'staging';
 
@@ -40,10 +42,6 @@ const purifyCss = async (content, outputPath) => {
       !/data-style-override/.test(content)) ||
     (isStaging && stagingUrls.includes(outputPath))
   ) {
-    const before = fs.readFileSync(pathToCss, {
-      encoding: 'utf-8',
-    });
-
     const purged = await new PurgeCSS().purge({
       // Here we take the actual text of the current page and give it to
       // PurgeCss to grep and look for any strings that match the regex listed
@@ -63,7 +61,7 @@ const purifyCss = async (content, outputPath) => {
       ],
       css: [
         {
-          raw: before,
+          raw: mainCss,
         },
       ],
       defaultExtractor: (content) => {


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/8844. The CSS should already be available when 11ty starts so it can be read from the filesystem as soon as the module is available and then be reused, as only the purge result changes per page, but the input stays the same.

Improves build time quite a bit, hence squeezed it in. Test run for /en/ only, ELEVENTY_ENV=prod:

Before: Copied 31 files / Wrote 2315 files in 189.66 seconds (81.9ms each, v1.0.1)
After: Copied 31 files / Wrote 2315 files in 159.26 seconds (68.8ms each, v1.0.1)
