### PR TITLE
Tweaks the language and fixes misspellings in the preload scanner article.

### DIFF
--- a/src/site/content/en/blog/preload-scanner/index.md
+++ b/src/site/content/en/blog/preload-scanner/index.md
@@ -5,7 +5,7 @@ subhead: |
 authors:
   - jlwagner
 date: 2022-05-13
-updated: 2022-10-11
+updated: 2022-10-12
 hero: image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/ZYfhboCPqPWawQ5LzWKO.jpg
 thumbnail: image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/irM6kTXZoP0MmXGtHOSa.jpg
 alt: A close-up photograph of a screen with various bits of HTML markup shown in a text editor.


### PR DESCRIPTION
Changes proposed in this pull request:

- Since launching the section in the preload scanner article about inlining, I noticed some tweaks I could make to the copy to make it flow a bit better, plus a couple of misspellings. _Mea culpa._