### PR TITLE
'defer-non-critical-css' with broken image in ko

### DIFF
--- a/src/site/content/ko/fast/defer-non-critical-css/index.md
+++ b/src/site/content/ko/fast/defer-non-critical-css/index.md
@@ -66,43 +66,15 @@ CSS 파일은 [렌더링 차단 리소스](https://developers.google.com/web/too
 
 ```html
 <style type="text/css">
-  .accordion-btn {
-    background-color: #add8e6;
-    color: #444;
-    cursor: pointer;
-    padding: 18px;
-    width: 100%;
-    border: none;
-    text-align: left;
-    outline: none;
-    font-size: 15px;
-    transition: 0.4s;
-  }
-  .container {
-    padding: 0 18px;
-    display: none;
-    background-color: white;
-    overflow: hidden;
-  }
-  h1 {
-    word-spacing: 5px;
-    color: blue;
-    font-weight: bold;
-    text-align: center;
-  }
+  .accordion-btn {background-color: #ADD8E6;color: #444;cursor: pointer;padding: 18px;width: 100%;border: none;text-align: left;outline: none;font-size: 15px;transition: 0.4s;}.container {padding: 0 18px;display: none;background-color: white;overflow: hidden;}h1 {word-spacing: 5px;color: blue;font-weight: bold;text-align: center;}
 </style>
 ```
 
 - 그다음, 다음과 같은 패턴을 적용하여 나머지 클래스를 비동기적으로 로드합니다.
 
 ```html
-<link
-  rel="preload"
-  href="styles.css"
-  as="style"
-  onload="this.onload=null;this.rel='stylesheet'"
-/>
-<noscript><link rel="stylesheet" href="styles.css" /></noscript>
+<link rel="preload" href="styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="styles.css"></noscript>
 ```
 
 이것은 CSS를 로드하는 일반적인 방법이 아닙니다. 작동 방식은 다음과 같습니다.

--- a/src/site/content/ko/fast/defer-non-critical-css/index.md
+++ b/src/site/content/ko/fast/defer-non-critical-css/index.md
@@ -30,7 +30,7 @@ CSS 파일은 [렌더링 차단 리소스](https://developers.google.com/web/too
 
 보고서는 값이 "1s"인 **First Contentful Paint** 메트릭과 **style.css** 파일을 가리키는 **렌더 차단 리소스 제거** 기회를 보여줍니다.
 
-<figure>% Img src="image/admin/eZtuQ2IwL3Mtnmz09bmp.png", alt="'1s'의 FCP를 표시하는 최적화되지 않은 페이지의 Lighthouse 보고서 및  '기회'" 아래 '차단 리소스 제거', width="800", height="640" %}</figure>
+<figure>{% Img src="image/admin/eZtuQ2IwL3Mtnmz09bmp.png", alt="'1s'의 FCP를 표시하는 최적화되지 않은 페이지의 Lighthouse 보고서 및  '기회'" 아래 '차단 리소스 제거', width="800", height="640" %}</figure>
 
 {% Aside %} 이 데모 사이트에 사용하는 CSS는 매우 작습니다.  더 큰 CSS 파일(프로덕션 시나리오에서 흔히 볼 수 있음)을 요청하는 경우 그리고 Lighthouse가 **폴드 상에 있는** 콘텐츠를  렌더링하는 동안 사용되지 않은 2048바이트 이상의 CSS 규칙이 페이지에 있음을 감지하면 **미사용 CSS 제거**라는 제안도 받게 됩니다. {% endAside %}
 

--- a/src/site/content/ko/fast/defer-non-critical-css/index.md
+++ b/src/site/content/ko/fast/defer-non-critical-css/index.md
@@ -66,7 +66,7 @@ CSS 파일은 [렌더링 차단 리소스](https://developers.google.com/web/too
 
 ```html
 <style type="text/css">
-  .accordion-btn {background-color: #ADD8E6;color: #444;cursor: pointer;padding: 18px;width: 100%;border: none;text-align: left;outline: none;font-size: 15px;transition: 0.4s;}.container {padding: 0 18px;display: none;background-color: white;overflow: hidden;}h1 {word-spacing: 5px;color: blue;font-weight: bold;text-align: center;}
+.accordion-btn {background-color: #ADD8E6;color: #444;cursor: pointer;padding: 18px;width: 100%;border: none;text-align: left;outline: none;font-size: 15px;transition: 0.4s;}.container {padding: 0 18px;display: none;background-color: white;overflow: hidden;}h1 {word-spacing: 5px;color: blue;font-weight: bold;text-align: center;}
 </style>
 ```
 

--- a/src/site/content/ko/fast/defer-non-critical-css/index.md
+++ b/src/site/content/ko/fast/defer-non-critical-css/index.md
@@ -30,9 +30,9 @@ CSS 파일은 [렌더링 차단 리소스](https://developers.google.com/web/too
 
 보고서는 값이 "1s"인 **First Contentful Paint** 메트릭과 **style.css** 파일을 가리키는 **렌더 차단 리소스 제거** 기회를 보여줍니다.
 
-<figure>{% Img src="image/admin/eZtuQ2IwL3Mtnmz09bmp.png", alt="'1s'의 FCP를 표시하는 최적화되지 않은 페이지의 Lighthouse 보고서 및  '기회'" 아래 '차단 리소스 제거', width="800", height="640" %}</figure>
+<figure>{% Img src="image/admin/eZtuQ2IwL3Mtnmz09bmp.png", alt="'1초'의 FCP 및 'Opportunities' 아래에 'Eliminate blocking resources'가 표시되는 최적화되지 않은 페이지에 대한 Lighthouse 보고서, ", width="800", height="640" %}</figure>
 
-{% Aside %} 이 데모 사이트에 사용하는 CSS는 매우 작습니다.  더 큰 CSS 파일(프로덕션 시나리오에서 흔히 볼 수 있음)을 요청하는 경우 그리고 Lighthouse가 **폴드 상에 있는** 콘텐츠를  렌더링하는 동안 사용되지 않은 2048바이트 이상의 CSS 규칙이 페이지에 있음을 감지하면 **미사용 CSS 제거**라는 제안도 받게 됩니다. {% endAside %}
+{% Aside %} 이 데모 사이트에 사용하는 CSS는 매우 작습니다. 더 큰 CSS 파일(프로덕션 시나리오에서 흔히 볼 수 있음)을 요청하는 경우 그리고 Lighthouse가 **폴드 상에 있는** 콘텐츠를 렌더링하는 동안 사용되지 않은 2048바이트 이상의 CSS 규칙이 페이지에 있음을 감지하면 **미사용 CSS 제거**라는 제안도 받게 됩니다. {% endAside %}
 
 이 CSS가 렌더링을 차단하는 방법을 시각화하려면:
 
@@ -66,15 +66,43 @@ CSS 파일은 [렌더링 차단 리소스](https://developers.google.com/web/too
 
 ```html
 <style type="text/css">
-.accordion-btn {background-color: #ADD8E6;color: #444;cursor: pointer;padding: 18px;width: 100%;border: none;text-align: left;outline: none;font-size: 15px;transition: 0.4s;}.container {padding: 0 18px;display: none;background-color: white;overflow: hidden;}h1 {word-spacing: 5px;color: blue;font-weight: bold;text-align: center;}
+  .accordion-btn {
+    background-color: #add8e6;
+    color: #444;
+    cursor: pointer;
+    padding: 18px;
+    width: 100%;
+    border: none;
+    text-align: left;
+    outline: none;
+    font-size: 15px;
+    transition: 0.4s;
+  }
+  .container {
+    padding: 0 18px;
+    display: none;
+    background-color: white;
+    overflow: hidden;
+  }
+  h1 {
+    word-spacing: 5px;
+    color: blue;
+    font-weight: bold;
+    text-align: center;
+  }
 </style>
 ```
 
 - 그다음, 다음과 같은 패턴을 적용하여 나머지 클래스를 비동기적으로 로드합니다.
 
 ```html
-<link rel="preload" href="styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="styles.css"></noscript>
+<link
+  rel="preload"
+  href="styles.css"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+/>
+<noscript><link rel="stylesheet" href="styles.css" /></noscript>
 ```
 
 이것은 CSS를 로드하는 일반적인 방법이 아닙니다. 작동 방식은 다음과 같습니다.


### PR DESCRIPTION
Changes proposed in this pull request:

- [defer-non-critical-css](https://web.dev/i18n/ko/defer-non-critical-css/#%EC%B8%A1%EC%A0%95) page has broken image because `{` was missing in front of img tag (only ko)
  - <img width="753" alt="image" src="https://user-images.githubusercontent.com/33471826/195772913-0ac4aeed-3a95-4a45-8e84-f02efe3319a8.png">
- fix alt text