### PR TITLE
Correct hidden lazy-loading information

### DIFF
--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -8,7 +8,7 @@ authors:
   - mathiasbynens
   - tunetheweb
 date: 2019-08-06
-updated: 2022-07-12
+updated: 2022-10-14
 hero: image/admin/F6VE4QkpCsomiJilTFNG.png
 alt: Phone outline with loading image and assets
 description: |

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -235,7 +235,7 @@ It is safer to avoid putting `loading=lazy` on above-the-fold images, as Chrome 
 ### How does the `loading` attribute work with images that are in the viewport but not immediately visible (for example: behind a carousel, or hidden by CSS for certain screen sizes)?
 
 Using `loading="lazy"` _may_ prevent them being loaded when they are not visible but within the [calculated
--distance](#distance-from-viewport-thresholds). For example, Chrome, Safari and Firefox do not load images using `display: none;` styling—either on the image or on a parent element. However, other techniques to hide images—such as using `opacity:0` styling will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
+-distance](#distance-from-viewport-thresholds). For example, Chrome, Safari and Firefox do not load images using `display: none;` styling—either on the image element or on a parent element. However, other techniques to hide images—such as using `opacity:0` styling—will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
 
 ### What if I'm already using a third-party library or a script to lazy-load images?
 

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -235,7 +235,7 @@ It is safer to avoid putting `loading=lazy` on above-the-fold images, as Chrome 
 ### How does the `loading` attribute work with images that are in the viewport but not immediately visible (for example: behind a carousel, or hidden by CSS for certain screen sizes)?
 
 Using `loading="lazy"` _may_ prevent them being loaded when they are not visible but within the [calculated
--distance](#distance-from-viewport-thresholds). For example, Chrome and Safari do not load images using `display: none;` styling—though Firefox does. However, other techniques to hide images—such as using `opacity:0` styling will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
+-distance](#distance-from-viewport-thresholds). For example, Chrome, Safari and Firefox do not load images using `display: none;` styling—either on the image or on a parent element. However, other techniques to hide images—such as using `opacity:0` styling will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
 
 ### What if I'm already using a third-party library or a script to lazy-load images?
 

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -8,7 +8,7 @@ authors:
   - mathiasbynens
   - tunetheweb
 date: 2019-08-06
-updated: 2022-10-14
+updated: 2022-10-18
 hero: image/admin/F6VE4QkpCsomiJilTFNG.png
 alt: Phone outline with loading image and assets
 description: |

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -234,9 +234,8 @@ It is safer to avoid putting `loading=lazy` on above-the-fold images, as Chrome 
 
 ### How does the `loading` attribute work with images that are in the viewport but not immediately visible (for example: behind a carousel, or hidden by CSS for certain screen sizes)?
 
-Only images that are below the device viewport by the [calculated
-distance](#distance-from-viewport-thresholds) load lazily. All images above the viewport, regardless of
-whether they're immediately visible, load normally.
+Using `loading="lazy"` _may_ prevent them being loaded when they are not visible but within the [calculated
+-distance](#distance-from-viewport-thresholds). For example, Chrome and Safari do not load images using `display: none;` styling—though Firefox does. However, other techniques to hide images—such as using `opacity:0` styling will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
 
 ### What if I'm already using a third-party library or a script to lazy-load images?
 


### PR DESCRIPTION
It appears [this information is incorrect](https://web.dev/browser-level-image-lazy-loading/#how-does-the-loading-attribute-work-with-images-that-are-in-the-viewport-but-not-immediately-visible-for-example-behind-a-carousel,-or-hidden-by-css-for-certain-screen-sizes)

Demo: https://resource-loading-examples.glitch.me/lazy-loading.html

Changes proposed in this pull request:

- Correct lazy loading guidance to note hidden images may not be loaded when hidden by CSS.

