### PR TITLE
change skip link z-index

### DIFF
--- a/src/scss/blocks/_skip-link.scss
+++ b/src/scss/blocks/_skip-link.scss
@@ -2,7 +2,7 @@
 /// It exists so when a user hits tab on load, they can quickly
 /// skip to the main content of the site—avoiding navigation etc
 .skip-link {
-  z-index: 10;
+  z-index: 11;
   width: max-content;
   inset: $global-gutter-narrow auto auto $global-gutter;
   position: absolute;


### PR DESCRIPTION
.course web-header has a z-index of 10, and so does the skip link. As the skip link is first in the source code order, it shows up behind the header on narrow screens. This fixes that.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

