### PR TITLE
Respect raw permalink property for algolia index

### DIFF
--- a/src/site/_filters/algolia-indexable.js
+++ b/src/site/_filters/algolia-indexable.js
@@ -27,6 +27,7 @@ function algoliaIndexable(posts) {
     (post) =>
       post.url &&
       post.data.title &&
+      !(post.template.frontMatter.data.permalink === false) &&
       !(post.data.noindex === true || post.data.noindex === 'true'),
   );
 }

--- a/src/site/content/en/spaces/2022-09-16-subgrid/index.md
+++ b/src/site/content/en/spaces/2022-09-16-subgrid/index.md
@@ -10,4 +10,5 @@ event_date: 2022-09-16
 event_time: 9AM PT / 12PM ET / 5PM GMT
 cal_link: "https://twitter.com/i/spaces/1OwGWwjkRmnGQ"
 tags: twitter-space
+permalink: false
 ---


### PR DESCRIPTION
Fixes #8872. Happy for suggestions to fix this more elegant.

The problem is that Spaces announcements which are only used to render as list items on the spaces pages are also indexed in search, while actually not having pages on their own.

As 11ty mangles the permalink property looking it up on the unprocessed frontmatter is the only option. `permalink` is undefined for both `post` and `post.data` in case of the spaces pages.