### PR TITLE
Add Browser Compat data to metrics where available

### DIFF
--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -329,6 +329,7 @@ available in the following tools:
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Measure CLS in JavaScript

--- a/src/site/content/en/metrics/cls/index.md
+++ b/src/site/content/en/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-08-17
+updated: 2022-10-19
 description: |
   This post introduces the Cumulative Layout Shift (CLS) metric and explains
   how to measure it.
@@ -332,6 +332,8 @@ available in the following tools:
 - [WebPageTest](https://webpagetest.org/)
 
 ### Measure CLS in JavaScript
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 To measure CLS in JavaScript, you can use the [Layout Instability
 API](https://github.com/WICG/layout-instability). The following example shows

--- a/src/site/content/en/metrics/fcp/index.md
+++ b/src/site/content/en/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: |
   This post introduces the First Contentful Paint (FCP) metric and explains
   how to measure it
@@ -87,6 +87,8 @@ available in the following tools:
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### Measure FCP in JavaScript
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 To measure FCP in JavaScript, you can use the [Paint Timing
 API](https://w3c.github.io/paint-timing/). The following example shows how to

--- a/src/site/content/en/metrics/fid/index.md
+++ b/src/site/content/en/metrics/fid/index.md
@@ -260,6 +260,8 @@ user to interact with your page. You can measure FID with the following tools.
 
 ### Measure FID in JavaScript
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 To measure FID in JavaScript, you can use the [Event Timing
 API](https://wicg.github.io/event-timing). The following example shows how to
 create a

--- a/src/site/content/en/metrics/inp/index.md
+++ b/src/site/content/en/metrics/inp/index.md
@@ -178,6 +178,8 @@ The best way to measure your website's INP is by gathering metrics from actual u
 
 ### Measure INP In JavaScript
 
+{% BrowserCompat 'api.PerformanceEventTiming.interactionId' %}
+
 Writing your own [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) to measure INP can be difficult. To measure INP in JavaScript, it's advised that you use the [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals), which exports an `onINP` function to do this work for you. You can then get a page's INP by passing a function to the `onINP` method:
 
 ```js

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -286,6 +286,7 @@ available in the following tools:
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Measure LCP in JavaScript

--- a/src/site/content/en/metrics/lcp/index.md
+++ b/src/site/content/en/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-08-17
+updated: 2022-10-19
 description: |
   This post introduces the Largest Contentful Paint (LCP) metric and explains
   how to measure it
@@ -289,6 +289,8 @@ available in the following tools:
 - [WebPageTest](https://webpagetest.org/)
 
 ### Measure LCP in JavaScript
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 To measure LCP in JavaScript, you can use the [Largest Contentful Paint
 API](https://wicg.github.io/largest-contentful-paint/). The following example

--- a/src/site/content/en/metrics/ttfb/index.md
+++ b/src/site/content/en/metrics/ttfb/index.md
@@ -5,7 +5,7 @@ authors:
   - jlwagner
   - tunetheweb
 date: 2021-10-26
-updated: 2022-07-26
+updated: 2022-10-19
 description: |
   This post introduces the Time to First Byte (TTFB) metric and explains
   how to measure it.
@@ -80,6 +80,8 @@ TTFB can be measured in [the lab](/user-centric-performance-metrics/#in-the-lab)
 - [WebPageTest](https://www.webpagetest.org/)
 
 ### Measure TTFB in JavaScript
+
+{% BrowserCompat 'api.PerformanceResourceTiming.responseStart' %}
 
 You can measure the TTFB of [navigation requests](https://developer.mozilla.org/docs/Web/API/Request/mode) in the browser with the [Navigation Timing API](https://developer.mozilla.org/docs/Web/API/Navigation_timing_API). The following example shows how to create a [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) that listens for a `navigation` entry and logs it to the console:
 

--- a/src/site/content/es/metrics/cls/index.md
+++ b/src/site/content/es/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-19
 description: |
   Esta publicación presenta la métrica Cumulative Layout Shift (CLS) y explica cómo medirlo.
 tags:
@@ -176,9 +176,12 @@ CLS se puede medir [en el laboratorio](/user-centric-performance-metrics/#in-the
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Medir CLS en JavaScript
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 Para medir CLS en JavaScript, puede utilizar la [API de inestabilidad de diseño](https://github.com/WICG/layout-instability) . El siguiente ejemplo muestra cómo crear un [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que atiende las entradas inesperadas de `layout-shift`, las agrupa en sesiones y registra el valor máximo de la sesión cada vez que cambia.
 

--- a/src/site/content/es/metrics/fcp/index.md
+++ b/src/site/content/es/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: En esta publicación se presenta la métrica First Contentful Paint (FCP) y se explica como medirla
 tags:
   - performance
@@ -50,6 +50,8 @@ FCP se puede medir [en el laboratorio](/user-centric-performance-metrics/#in-the
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### Medir FCP en JavaScript
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 Para medir FCP en JavaScript, puede utilizar la [API de Paint Timing](https://w3c.github.io/paint-timing/). En el siguiente ejemplo se muestra cómo crear un [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que capta una entrada de `paint` con el nombre `first-contentful-paint` y la registra en la consola.
 

--- a/src/site/content/es/metrics/fid/index.md
+++ b/src/site/content/es/metrics/fid/index.md
@@ -127,6 +127,8 @@ FID es una métrica que solo se puede medir [en el campo](/user-centric-performa
 
 ### Cómo medir FID en JavaScript
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 Para medir FID en JavaScript, puede utilizar la [API para cronometrar eventos](https://wicg.github.io/event-timing). En el siguiente ejemplo se muestra cómo crear un [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que capte las entradas [`first-input`](https://wicg.github.io/event-timing/#sec-performance-event-timing) y las registre en la consola:
 
 ```js

--- a/src/site/content/es/metrics/lcp/index.md
+++ b/src/site/content/es/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-19
 description: Esta publicación presenta la métrica de Largest Contentful Paint (LCP) y explica como medirla
 tags:
   - performance
@@ -129,9 +129,12 @@ LCP se puede medir [en el laboratorio](/user-centric-performance-metrics/#in-the
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Cómo medir LCP en JavaScript
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 Para medir LCP en JavaScript, puede utilizar la [API de Largest Contentful Paint](https://wicg.github.io/largest-contentful-paint/). En el siguiente ejemplo se muestra cómo crear un [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que capte las entradas de `largest-contentful-paint` y las registre en la consola.
 

--- a/src/site/content/ja/metrics/cls/index.md
+++ b/src/site/content/ja/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-19
 description: この投稿では、Cumulative Layout Shift (累積レイアウト シフト数、CLS) という指標について紹介し、その測定方法に関する説明を行います。
 tags:
   - performance
@@ -170,9 +170,12 @@ CLS は[ラボ環境](/user-centric-performance-metrics/#in-the-lab)または[�
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### JavaScript を使用して CLS を測定する
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 JavaScript を使用した CLS の測定には、[Layout Instability API](https://github.com/WICG/layout-instability) を使用することができます。以下の例では、予期しない `layout-shift` エントリをリッスンしてセッションごとに分類し、変更が発生するたびにセッションの最大値をログとして記録する [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) の作成方法を示しています。
 

--- a/src/site/content/ja/metrics/fcp/index.md
+++ b/src/site/content/ja/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: この投稿では、First Contentful Paint (視覚コンテンツの初期表示時間、FCP) という指標について紹介し、その測定方法に関する説明を行います。
 tags:
   - performance
@@ -50,6 +50,8 @@ FCP は[ラボ環境](/user-centric-performance-metrics/#in-the-lab)または[�
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### JavaScript を使用して FCP を測定する
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 JavaScript を使用した FCP の測定には、[Paint Timing API](https://w3c.github.io/paint-timing/) を使用することができます。以下の例では、`first-contentful-paint` という名前の `paint` エントリをリッスンし、コンソールにログを記録する [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) の作成方法を示しています。
 

--- a/src/site/content/ja/metrics/fid/index.md
+++ b/src/site/content/ja/metrics/fid/index.md
@@ -127,6 +127,8 @@ FID の測定には実際のユーザーによるページの操作が必要と�
 
 ### JavaScript を使用して FID を測定する
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 JavaScript を使用した FID の測定には、[Event Timing API](https://wicg.github.io/event-timing) を使用することができます。以下の例では、[`first-input`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) エントリをリッスンしてコンソールにログを記録する [`PerformanceObserver`](https://wicg.github.io/event-timing/#sec-performance-event-timing) の作成方法を示しています。
 
 ```js

--- a/src/site/content/ja/metrics/lcp/index.md
+++ b/src/site/content/ja/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-19
 description: この投稿では、Largest Contentful Paint (LCP) という指標について紹介し、その測定方法に関する説明を行います。
 tags:
   - performance
@@ -129,9 +129,12 @@ LCP は[ラボ環境](/user-centric-performance-metrics/#in-the-lab)または[�
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### JavaScript を使用して LCP を測定する
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 JavaScript を使用した LCP の測定には、[Largest Contentful Paint API](https://wicg.github.io/largest-contentful-paint/) を使用することができます。以下の例では、`largest-contentful-paint` エントリをリッスンしてコンソールにログを記録する [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) の作成方法を示しています。
 

--- a/src/site/content/ko/metrics/cls/index.md
+++ b/src/site/content/ko/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-13
 description: 이 게시물에서는 누적 레이아웃 이동(CLS) 메트릭을 소개하고 이를 측정하는 방법을 설명합니다.
 tags:
   - performance
@@ -170,9 +170,12 @@ CLS는 [실험실](/user-centric-performance-metrics/#in-the-lab)이나 [현장]
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### JavaScript에서 CLS 측정
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 JavaScript에서 CLS를 측정하려면 [Layout Instability API를](https://github.com/WICG/layout-instability) 사용할 수 있습니다. 다음 예시에서는 예기치 않은 `layout-shift` 항목을 수신 대기하고, 세션으로 그룹화하고, 변경될 때마다 최대 세션 값을 기록하는 [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) 를 생성하는 방법을 보여줍니다.
 

--- a/src/site/content/ko/metrics/fcp/index.md
+++ b/src/site/content/ko/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint(최초 콘텐츠풀 페인트, FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-13
 description: 이 게시물에서는 최초 콘텐츠풀 페인트(FCP) 메트릭을 소개하고 이를 측정하는 방법을 설명합니다.
 tags:
   - performance
@@ -50,6 +50,8 @@ FCP는 [실험실](/user-centric-performance-metrics/#in-the-lab)이나 [현장]
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### JavaScript에서 FCP 측정
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 JavaScript에서 FCP를 측정하려면 [Paint Timing API를](https://w3c.github.io/paint-timing/) 사용할 수 있습니다. 다음 예시에서는 이름이 `first-contentful-paint`인 `paint` 항목을 수신 대기하고 콘솔에 기록하는 [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)를 작성하는 방법을 확인하실 수 있습니다.
 

--- a/src/site/content/ko/metrics/fid/index.md
+++ b/src/site/content/ko/metrics/fid/index.md
@@ -127,6 +127,8 @@ FID는 실제 사용자가 페이지와 상호 작용해야 하므로 [사이트
 
 ### JavaScript에서 FID 측정
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 JavaScript에서 FID를 측정하려면 [Event Timing API](https://wicg.github.io/event-timing)를 사용할 수 있습니다. 다음 예시에서는 [`PerformanceObserver`](https://wicg.github.io/event-timing/#sec-performance-event-timing)를 작성해 [`first-input`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) 항목을 수신 대기하고 콘솔에 기록하는 방법을 확인하실 수 있습니다.
 
 ```js

--- a/src/site/content/ko/metrics/lcp/index.md
+++ b/src/site/content/ko/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint(최대 콘텐츠풀 페인트, LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-13
 description: 이 게시물에서는 최대 콘텐츠풀 페인트(LCP) 메트릭을 소개하고 이를 측정하는 방법을 설명합니다.
 tags:
   - performance
@@ -129,9 +129,12 @@ LCP는 [실험실](/user-centric-performance-metrics/#in-the-lab)이나 [현장]
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### JavaScript에서 LCP 측정
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 JavaScript에서 LCP를 측정하려면 [Largest Contentful Paint API](https://wicg.github.io/largest-contentful-paint/)를 사용할 수 있습니다. 다음 예시에서는 `largest-contentful-paint` 항목을 수신 대기하고 콘솔에 기록하는 [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)를 작성하는 방법을 확인하실 수 있습니다.
 

--- a/src/site/content/pt/metrics/cls/index.md
+++ b/src/site/content/pt/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-19
 description: Este artigo apresenta a métrica Cumulative Layout Shift (CLS) e explica como medi-la.
 tags:
   - performance
@@ -170,9 +170,12 @@ A CLS pode ser medida [em laboratório](/user-centric-performance-metrics/#in-th
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Medição da CLS em JavaScript
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 Para medir a CLS em JavaScript, você pode usar a [API Layout Instability](https://github.com/WICG/layout-instability). O exemplo a seguir mostra como criar um [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que escuta as entradas `layout-shift`, as agrupa em sessões registra o valor máximo da sessão sempre que ela mudar.
 

--- a/src/site/content/pt/metrics/fcp/index.md
+++ b/src/site/content/pt/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: Este artigo apresenta a métrica First Contentful Paint (FCP) e explica como medi-la
 tags:
   - performance
@@ -50,6 +50,8 @@ A FCP pode ser medida [em laboratório](/user-centric-performance-metrics/#in-th
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### Medição da FCP em JavaScript
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 Para medir a FCP em JavaScript, você pode usar a [API Paint Timing](https://w3c.github.io/paint-timing/). O exemplo a seguir mostra como criar um [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que escuta uma entrada `paint` com o nome `first-contentful-paint` e a registra no console.
 

--- a/src/site/content/pt/metrics/fid/index.md
+++ b/src/site/content/pt/metrics/fid/index.md
@@ -127,6 +127,8 @@ A FID é uma métrica que só pode ser medida [em campo](/user-centric-performan
 
 ### Medição da FID em JavaScript
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 Para medir a FID em JavaScript, você pode usar a [API Event Timing](https://wicg.github.io/event-timing). O exemplo a seguir mostra como criar um [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que escuta as entradas [`first-input`](https://wicg.github.io/event-timing/#sec-performance-event-timing) e as registra no console:
 
 ```js

--- a/src/site/content/pt/metrics/lcp/index.md
+++ b/src/site/content/pt/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-19
 description: Este artigo apresenta a métrica Largest Contentful Paint (LCP) e explica como medi-la
 tags:
   - performance
@@ -129,9 +129,12 @@ A LCP pode ser medida [em laboratório](/user-centric-performance-metrics/#in-th
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Medição da LCP em JavaScript
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 Para medir o LCP em JavaScript, você pode usar a [API Largest Contentful Paint](https://wicg.github.io/largest-contentful-paint/). O exemplo a seguir mostra como criar um [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) que escuta as `largest-contentful-paint` e as registra no console.
 

--- a/src/site/content/ru/metrics/cls/index.md
+++ b/src/site/content/ru/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-19
 description: В этой статье описывается метрика CLS (Совокупное смещение макета) и объясняются принципы ее измерения
 tags:
   - performance
@@ -170,9 +170,12 @@ CLS можно измерить в [лабораторных](/user-centric-perf
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Измерение CLS в JavaScript
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 Чтобы измерить CLS с помощью JavaScript, можно воспользоваться [Layout Instability API (API нестабильности макета)](https://github.com/WICG/layout-instability). В следующем примере показано, как создать [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) который прослушивает неожиданные записи смещений макета `layout-shift`, группирует их в сеансы и регистрирует максимальное значение сеанса при каждом его изменении.
 

--- a/src/site/content/ru/metrics/fcp/index.md
+++ b/src/site/content/ru/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: Первая отрисовка контента (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: В этой статье описывается метрика FCP (Первая отрисовка контента) и объясняются принципы ее измерения
 tags:
   - performance
@@ -50,6 +50,8 @@ FCP можно измерить в [лабораторных](/user-centric-perf
 - [PageSpeed Insights](https://pagespeed.web.dev/)
 
 ### Измерение FCP в JavaScript
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 Чтобы измерить FCP в JavaScript, можно воспользоваться [Paint Timing API](https://w3c.github.io/paint-timing/). В следующем примере показано, как создать [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver), который прослушивает записи `paint` с именем `first-contentful-paint` и регистрирует их в консоли.
 

--- a/src/site/content/ru/metrics/fid/index.md
+++ b/src/site/content/ru/metrics/fid/index.md
@@ -127,6 +127,8 @@ FIDэто показатель, который измеряет скорость
 
 ### Измерение FID в JavaScript
 
+{% BrowserCompat 'api.PerformanceEventTiming' %}
+
 Чтобы измерить FID с помощью JavaScript, можно воспользоваться [Event Timing API](https://wicg.github.io/event-timing). В следующем примере показано, как создать [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver), который прослушивает записи [`first-input`](https://wicg.github.io/event-timing/#sec-performance-event-timing) и регистрирует их в консоли:
 
 ```js

--- a/src/site/content/ru/metrics/lcp/index.md
+++ b/src/site/content/ru/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Скорость загрузки основного контента (LC
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-19
 description: В этой статье описывается метрика LCP (Скорость загрузки основного контента) и объясняются принципы ее измерения
 tags:
   - performance
@@ -129,9 +129,12 @@ LCP можно измерить в [лабораторных](/user-centric-perf
 
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
 - [WebPageTest](https://webpagetest.org/)
 
 ### Измерение LCP в JavaScript
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 Чтобы измерить LCP с помощью JavaScript, можно воспользоваться [Largest Contentful Paint API](https://wicg.github.io/largest-contentful-paint/). В следующем примере показано, как создать [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver), который прослушивает записи `largest-contentful-paint` и регистрирует их в консоли.
 

--- a/src/site/content/zh/metrics/cls/index.md
+++ b/src/site/content/zh/metrics/cls/index.md
@@ -5,7 +5,7 @@ authors:
   - philipwalton
   - mihajlija
 date: 2019-06-11
-updated: 2022-07-18
+updated: 2022-10-19
 description: 本篇文章介绍了累积布局偏移 (CLS) 指标并说明了该指标的测量方式。
 tags:
   - performance
@@ -181,9 +181,12 @@ CLS 可以进行[实验室](/user-centric-performance-metrics/#in-the-lab)测量
 
 - [Chrome 开发者工具](https://developer.chrome.com/docs/devtools/)
 - [灯塔](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights 网页速度测量工具](https://pagespeed.web.dev/)
 - [WebPageTest 网页性能测试工具](https://webpagetest.org/)
 
 ### 在 JavaScript 中测量 CLS
+
+{% BrowserCompat 'api.LayoutShift' %}
 
 要在 JavaScript 中测量 CLS，您可以使用[布局不稳定性 API](https://github.com/WICG/layout-instability)。以下示例说明了如何创建一个[`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)来侦听意外`layout-shift`条目、将条目按会话分组、记录最大会话值，并在最大会话值发生改变时更新记录。
 

--- a/src/site/content/zh/metrics/fcp/index.md
+++ b/src/site/content/zh/metrics/fcp/index.md
@@ -4,7 +4,7 @@ title: First Contentful Paint 首次内容绘制 (FCP)
 authors:
   - philipwalton
 date: 2019-11-07
-updated: 2022-07-18
+updated: 2022-10-19
 description: 本篇文章介绍了首次内容绘制 (FCP) 指标并说明了该指标的测量方式
 tags:
   - performance
@@ -50,6 +50,8 @@ FCP 可以进行[实验室](/user-centric-performance-metrics/#in-the-lab)测量
 - [PageSpeed Insights 网页速度测量工具](https://pagespeed.web.dev/)
 
 ### 在 JavaScript 中测量 FCP
+
+{% BrowserCompat 'api.PerformancePaintTiming' %}
 
 要在 JavaScript 中测量 FCP，您可以使用[绘制计时 API](https://w3c.github.io/paint-timing/)。以下示例说明了如何创建一个[`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)来侦听名称为`first-contentful-paint`的`paint`条目并记录在控制台中。
 

--- a/src/site/content/zh/metrics/lcp/index.md
+++ b/src/site/content/zh/metrics/lcp/index.md
@@ -4,7 +4,7 @@ title: Largest Contentful Paint 最大内容绘制 (LCP)
 authors:
   - philipwalton
 date: 2019-08-08
-updated: 2022-07-18
+updated: 2022-10-19
 description: 本篇文章介绍了最大内容绘制 (LCP) 指标并说明了该指标的测量方式
 tags:
   - performance
@@ -129,9 +129,12 @@ LCP 可以进行[实验室](/user-centric-performance-metrics/#in-the-lab)测量
 
 - [Chrome 开发者工具](https://developer.chrome.com/docs/devtools/)
 - [灯塔](https://developer.chrome.com/docs/lighthouse/overview/)
+- [PageSpeed Insights 网页速度测量工具](https://pagespeed.web.dev/)
 - [WebPageTest 网页性能测试工具](https://webpagetest.org/)
 
 ### 在 JavaScript 中测量 LCP
+
+{% BrowserCompat 'api.LargestContentfulPaint' %}
 
 要在 JavaScript 中测量 LCP，您可以使用[最大内容绘制 API](https://wicg.github.io/largest-contentful-paint/) 。以下示例说明了如何创建一个[`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)来侦听`largest-contentful-paint`条目并记录在控制台中。
 

--- a/src/site/content/zh/metrics/ttfb/index.md
+++ b/src/site/content/zh/metrics/ttfb/index.md
@@ -4,7 +4,7 @@ title: Time to First Byte 第一字节时间 (TTFB)
 authors:
   - jlwagner
 date: 2021-10-26
-updated: 2022-03-30
+updated: 2022-10-19
 description: |
   本篇文章介绍了第一字节时间 (TTFB) 指标并说明了该指标的测量方式
 tags:
@@ -78,6 +78,8 @@ TTFB 可以在[实验场景](/user-centric-performance-metrics/#in-the-lab)或[�
 - [WebPageTest](https://www.webpagetest.org/)
 
 ### 在 JavaScript 中测量 TTFB
+
+{% BrowserCompat 'api.PerformanceResourceTiming.responseStart' %}
 
 可以在具备[Navigation Timing API](https://developer.mozilla.org/docs/Web/API/Navigation_timing_API)功能的浏览器中测量 TTFB。下面的这个示例展示了如何创建 [`PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) 并监听 `navigation` ，最终把日志输出到控制台：
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds Browser Compat Data to the metric pages where available to show browser support
- Add PSI link I noticed was missing from some of the Lab Tools sections.

@philipwalton would be good to get your eyes on this to make sure I've pick the best APIs. Decided to put under the "Measure XXX in JavaScript" section.

