### PR TITLE
Corrects broken link to "Clean and maintain your site"

### DIFF
--- a/src/site/content/en/secure/assess-spam-damage/index.md
+++ b/src/site/content/en/secure/assess-spam-damage/index.md
@@ -13,7 +13,7 @@ This step is for sites hacked to host spam, often with the warning
 _"This site may be hacked"_ displayed in search results. It's one of the
 longest steps in the recovery process. In this step, you'll compile a list of
 the damaged files on your site. You'll use this list in a later step,
-[Clean and maintain your site](/secure/clean-site/).
+[Clean and maintain your site](/clean-and-maintain-your-site/).
 
 {% Aside %}
 If your site was affected by malware and is flagged with the warning


### PR DESCRIPTION
Changes proposed in this pull request:
 
The clean and maintain your site link at the end of the first paragraph is currently pointing to a 404, This PR fixes.
