### PR TITLE
Remove single letter at the end

### DIFF
--- a/src/site/content/en/blog/avoid-large-complex-layouts-and-layout-thrashing/index.md
+++ b/src/site/content/en/blog/avoid-large-complex-layouts-and-layout-thrashing/index.md
@@ -174,4 +174,3 @@ function resizeAllParagraphsToMatchBlockWidth() {
 ```
 
 If you want to guarantee safety you should check out [FastDOM](https://github.com/wilsonpage/fastdom), which automatically batches your reads and writes for you, and should prevent you from triggering forced synchronous layouts or layout thrashing accidentally.
-å


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes a single letter at the end of the document which seems to be a typo.

