### PR TITLE
Update Optimize CLS article

### DIFF
--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -389,7 +389,7 @@ To learn more about what CSS properties trigger layout, see [CSS Triggers](https
 
 The back/forward cache, or bfcache keeps pages in browsers memory for a short period so if you return to them, then they will be restored exactly as you left them. This means the fully loaded page is instantly available—without any shifts which may be normally seen during load to to any of the reason above. When this was rolled out to Chrome, we saw [noticeable improvements in CLS](https://twitter.com/anniesullie/status/1491399685961293828?s=20&t=Qj_nzSRZD0_c-HaAnfr98Q).
 
-However, some sites are inelgible for the bfcache. Ensuring your site is eligible is a sure fire way to keep CLS scores down. Read [the bfcache article](/bfcache/) for more details on how to test and identify any issues preventing bfcache usage.
+Some sites are ineligible for the bfcache due to a variety of reasons. Ensuring your site is eligible is a sure fire way to keep CLS scores down. Read [the bfcache article](/bfcache/) for more details on how to test and identify any issues preventing bfcache usage.
 
 ### Developer Tools
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -131,7 +131,7 @@ img[Attributes Style] {
 
 Safari behaves similarly by using a `HTML Attributes` style source. Firefox does not currently display this calculated `aspect-ratio` at all in it's Inspector panel, but does use it for layout.
 
-The `auto` part of the above code, is important and causes the `640 / 360` to be overriden with the image dimensions once the image is downloaded. If the image dimensions are different this will still cause some layout shift after the impage loads, but this ensures the image aspect-ratio is still used ultimately when it becomes available—as it was in the past—in case the HTML is incorrect. Plus, the shift is likely to be a lot smaller than the 0x0 default image size when dimentions are not provided!
+The `auto` part of the above code is important as it causes the `640 / 360` to be overriden with the image dimensions once the image is downloaded. If the image dimensions are different this will still cause some layout shift after the image loads, but this ensures the image aspect ratio is still used ultimately when it becomes available—as it was in the past—in case the HTML is incorrect. Plus, the shift is likely to be a lot smaller than the 0x0 default image size when dimensions are not provided!
 
 Tip: If you're having a hard time understanding aspect ratio, a handy [calculator](https://aspectratiocalculator.com/16-9.html) is available to help.
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -49,9 +49,7 @@ The most common causes of a poor CLS are:
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/8wKRITUkK3Zrp5jvQ1Xw.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Images without width and height specified.
     </figcaption>
@@ -63,9 +61,7 @@ The most common causes of a poor CLS are:
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/wm4VqJtKvove6qjiIjic.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Images with width and height specified.
     </figcaption>
@@ -221,9 +217,7 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rW77UoJQBHHehihkw2Rd.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Ads without sufficient space reserved.
     </figcaption>
@@ -235,9 +229,7 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rW77UoJQBHHehihkw2Rd.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Ads with sufficient space reserved.
     </figcaption>
@@ -257,7 +249,7 @@ Statically style slot DOM elements with the same sizes passed to your tag librar
 This can be as simple as adding a `min-height` styling to reserve space or, for responsive ad sizings using the new [`aspect-ratio`](/aspect-ratio/) CSS property in a similar manner to the way browsers automatically use this for images with dimensions provided.
 
 <figure>
-  {% Img src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/ThcGvVp0RiiABpmnWz7u.svg", alt="Three mobile devices with jjst text content in the first device, this is shifted down in the second device, and reserving space with a placehodler as shown in the third device prevents the shift", width="295", height="150" %}
+  {% Img src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/ThcGvVp0RiiABpmnWz7u.svg", alt="Three mobile devices with jjst text content in the first device, this is shifted down in the second device, and reserving space with a placehodler as shown in the third device prevents the shift", width="1180", height="600" %}
   <figcaption>
     Reserving space for ads can prevent layout shifts
   </figcaption>
@@ -287,9 +279,7 @@ These embeds often aren't aware in advance just how large an embed will be (for 
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/w0TM1JilKPQktQgb94un.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Embed without space reserved.
     </figcaption>
@@ -301,9 +291,7 @@ These embeds often aren't aware in advance just how large an embed will be (for 
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/gtYqKkoEse47ErJPqVjg.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Embed with space reserved.
     </figcaption>
@@ -341,9 +329,7 @@ You've probably experienced layout shifts due to UI that pops-in at the top or b
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PF9ulVHDQOvoWendb6ea.jpg",
       controls=true,
       loop=true,
-      muted=true,
-      width=2482,
-      height=1396 %}
+      muted=true %}
    <figcaption>
       Dynamic content without space reserved.
     </figcaption>

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -3,8 +3,9 @@ title: Optimize Cumulative Layout Shift
 subhead: Learn how to avoid sudden layout shifts to improve user-experience
 authors:
   - addyosmani
+  - tunetheweb
 date: 2020-05-05
-updated: 2021-08-17
+updated: 2022-10-24
 hero: image/admin/74TRx6aETydsBGa2IZ7R.png
 description: |
   Cumulative Layout Shift (CLS) is a metric that quantifies how often users experience sudden shifts in page content. In this guide, we'll cover optimizing common causes of CLS such as images and iframes without dimensions or dynamic content.
@@ -38,7 +39,7 @@ The most common causes of a poor CLS are:
 - Web Fonts causing FOIT/FOUT
 - Actions waiting for a network response before updating DOM
 
-## Images without dimensions 🌆
+## Images without dimensions
 
 **Summary:** Always include `width` and `height` size attributes on your images and video elements. Alternatively, reserve the required space with [CSS aspect ratio boxes](https://css-tricks.com/aspect-ratio-boxes/). This approach ensures that the browser can allocate the correct amount of space in the document while the image is loading.
 
@@ -112,19 +113,23 @@ Modern browsers now set the default aspect ratio of images based on an image's w
 <img src="puppy.jpg" width="640" height="360" alt="Puppy with balloons" />
 ```
 
-…and the [UA stylesheets](https://developer.mozilla.org/docs/Web/CSS/Cascade#User-agent_stylesheets) of all browsers add a [default aspect ratio](https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images) based on the element's existing `width` and `height` attributes:
-
-```css
-img {
-  aspect-ratio: attr(width) / attr(height);
-}
-```
+All browsers will then add a [default aspect ratio](https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images) based on the element's existing `width` and `height` attributes.
 
 This calculates an aspect ratio based on the `width` and `height` attributes before the image has loaded. It provides this information at the very start of layout calculation. As soon as an image is told to be a certain width (for example `width: 100%`), the aspect ratio is used to calculate the height.
 
-Tip: If you're having a hard time understanding aspect ratio, a handy [calculator](https://aspectratiocalculator.com/16-9.html) is available to help.
+This `aspect-ratio` value is calculated by major browsers as the HTML is processed, rather than with a default User Agent stylesheet (see [this post for a deep dive into why](https://jakearchibald.com/2022/img-aspect-ratio/#width--height-presentational-hints)), so are displayed a little differently. For example, Chrome displays it like this in the Styles section of the Element panel:
 
-The above image aspect ratio changes have shipped in [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1547231) and [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=979891), and are coming to [WebKit](https://twitter.com/smfr/status/1220051332767174656) (Safari).
+```css
+img[Attributes Style] {
+  aspect-ratio: auto 640 / 360;
+}
+```
+
+Safari does similarly with a `HTML Attributes` style source. Firefox does not currently display this calculated `aspect-ratio` at all in it's Inspector panel, but does use it for layout.
+
+The `auto` part of the above code, is important and causes the `640 / 360` to be overriden with the image dimensions once the image is downloaded. If the image dimensions are different this will still cause some layout shift after the impage loads, but this ensures the image aspect-ratio is still used ultimately when it becomes available—as it was in the past—in case the HTML is incorrect. Plus, the shift is likely to be a lot smaller than the 0x0 default image size when dimentions are not provided!
+
+Tip: If you're having a hard time understanding aspect ratio, a handy [calculator](https://aspectratiocalculator.com/16-9.html) is available to help.
 
 For a fantastic deep-dive into aspect ratio with further thinking around responsive images, see [jank-free page loading with media aspect ratios](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/).
 
@@ -163,9 +168,23 @@ Pages may wish to include a cropped shot of an image on narrow viewports with th
 </picture>
 ```
 
-It's very possible these images could have different aspect ratios and browsers are still evaluating what the most efficient solution here should be, including if dimensions should be specified on all sources. Until a solution is decided on, relayout is still possible here.
+It's very possible these images could have different aspect ratios and browsers are still evaluating what the most efficient solution here should be, including if dimensions should be specified on all sources.
 
-## Ads, embeds and iframes without dimensions 📢😱
+Chrome and Safari now support setting `width` and `height` on the `source` elements of `<picture>` element:
+
+```html
+<picture>
+  <source media="(max-width: 799px)" srcset="puppy-480w-cropped.jpg" width=480 height=400/>
+  <source media="(min-width: 800px)" srcset="puppy-800w.jpg" width=800 height=400/>
+  <img src="puppy-800w.jpg" alt="Puppy with balloons" width=800 height=400/>
+</picture>
+```
+
+On Firefox, these extra `width` and `height` attributes on `<source>` elements will currently be ignored and only the `width` and `height` attributes on the `<img>` will be used (even if the image itself is loaded from a `<source>` element). That's not great, but when the responsive image is loaded they will be reset, so it will be given the correct dimensions—just later than on Chrome and Safari.
+
+## Ads, embeds and iframes without dimensions
+
+As we have seen images have special considerations, but these are not the only content that can cause layout shifts.
 
 ### Advertisements
 
@@ -219,7 +238,7 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/cX6R4ACb4uVKlUb0cv1c.png", alt="Lighthouse report showing the before/after impact to Cumulative Layout Shift of reserving space for banners like ads", width="800", height="148" %}
   <figcaption>
-    Lighthouse 6.0 impact of reserving space for this banner on CLS
+    Lighthouse impact of reserving space for this banner on CLS
   </figcaption>
 </figure>
 
@@ -227,7 +246,11 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
 
 Statically style slot DOM elements with the same sizes passed to your tag library. This can help ensure the library doesn't introduce layout shifts when it loads. If you don't do this, the library may change the size of the slot element after page layout.
 
+This can be as simple as adding a `min-height` styling to reserve space or, for responsive ad sizings using the new [`aspect-ratio`](https://web.dev/aspect-ratio/) CSS property in a similar manner to the way browsers automatically use this for images with dimensions provided.
+
 Also consider the sizes of smaller ad serves. If a smaller ad is served, a publisher can style the (larger) container to avoid layout shifts. The downside to this approach is that it will increase the amount of blank space, so keep in mind the trade-off here.
+
+Alternatively, set the initial size to the smallest ad size, and accept some level of shift for larger ads. This will not eliminate CLS, but will hopefully reduce the impact of it to a more managable level.
 
 #### Avoid placing ads near the top of the viewport
 
@@ -260,7 +283,7 @@ These embeds often aren't aware in advance just how large an embed will be (for 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/2XaMbZBmUit1Vz8UBshH.png", alt="Lighthouse report showing the before/after impact to Cumulative Layout Shift of reserving space for this embed on CLS", width="800", height="148" %}
   <figcaption>
-    Lighthouse 6.0 impact of reserving space for this embed on CLS
+    Lighthouse impact of reserving space for this embed on CLS
   </figcaption>
 </figure>
 
@@ -271,7 +294,7 @@ To work around this, you can minimize CLS by precomputing sufficient space for e
 
 Take note of the dimensions and style a placeholder for the embed accordingly. You may need to account for subtle differences in ad/placeholder sizes between different form factors using media queries.
 
-### Dynamic content 📐
+### Dynamic content
 
 **Summary:** Avoid inserting new content above existing content, unless in response to a user interaction. This ensures any layout shifts that occur are expected.
 
@@ -295,7 +318,7 @@ If you need to display these types of UI affordances, reserve sufficient space i
 In some cases adding content dynamically is an important part of user experience. For example, when loading more products to a list of items or when updating live feed content. There are several ways to avoid unexpected layout shifts in those cases:
 
 *   Replace the old content with the new content within a fixed size container or use a carousel and remove the old content after the transition. Remember to disable any links and controls until the transition has completed to prevent accidental clicks or taps while the new content is coming in.
-*   Have the user initiate the load of new content, so they are not surprised by the shift (for example with a "Load more" or "Refresh" button). It's recommended to prefetch the content before the user interaction so that it shows up immediately. As a reminder, layout shifts that occur within 500&nbsp;ms of user input are not counted towards CLS.
+*   Have the user initiate the load of new content, so they are not surprised by the shift (for example with a "Load more" or "Refresh" button). It's recommended to prefetch the content before the user interaction so that it shows up immediately. As a reminder, [layout shifts that occur within 500&nbsp;ms](./cls/#user-initiated-layout-shifts) of user input are not counted towards CLS.
 *   Seamlessly load the content offscreen and overlay a notice to the user that it's available (for example, with a "Scroll up" button).
 
 
@@ -306,7 +329,7 @@ In some cases adding content dynamically is an important part of user experience
   </figcaption>
 </figure>
 
-### Web fonts causing FOUT/FOIT 📝
+### Web fonts causing FOUT/FOIT
 
 Downloading and rendering web fonts can cause layout shifts in two ways:
 
@@ -315,7 +338,7 @@ Downloading and rendering web fonts can cause layout shifts in two ways:
 
 The following tools can help you minimize this:
 
-- <code>[font-display](/font-display/)</code> allows you to modify the rendering behavior of custom fonts with values such as <code>auto</code>, <code>swap</code>, <code>block</code>, <code>fallback</code> and <code>optional</code>. Unfortunately, all of these values (except [optional](http://crrev.com/749080)) can cause a re-layout in one of the above ways.
+- [`font-display`](/font-display/) allows you to modify the rendering behavior of custom fonts with values such as `auto`, `swap`, `block`, `fallback` and `optional`. Unfortunately, all of these values (except [`optional`](http://crrev.com/749080)) can cause a re-layout in one of the above ways.
 - The [Font Loading API](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#the_font_loading_api) can reduce the time it takes to get necessary fonts.
 
 As of Chrome 83, I can recommend the following too:
@@ -323,32 +346,38 @@ As of Chrome 83, I can recommend the following too:
 - Using `<link rel=preload>` on the key web fonts: a preloaded font will have a higher chance to meet the first paint, in which case there's no layout shifting.
 - Combining `<link rel=preload>` and `font-display: optional`
 
-Read [Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts](/preload-optional-fonts/) for more details.
+Read [Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts](/preload-optional-fonts/) for more details, and [Best practices for fonts](./font-best-practices/) for other font best practices.
 
-### Animations 🏃‍♀️
+### Animations
 
 **Summary:** Prefer `transform` animations to animations of properties that trigger layout changes.
 
 Changes to CSS property values can require the browser to react to these changes. A number of values trigger re-layout, paint and composite such as `box-shadow` and `box-sizing`. A number of CSS properties can be changed in a less costly manner.
 
-To learn more about what CSS properties trigger layout, see [CSS Triggers](https://csstriggers.com/) and [High-performance animations](https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/).
+To learn more about what CSS properties trigger layout, see [CSS Triggers](https://csstriggers.com/) and [High-performance animations](/animations-guide/).
 
-### Developer Tools 🔧
+### Developer Tools
 
 I'm happy to share there are a number of tools available to measure and debug Cumulative Layout Shift (CLS).
 
-[Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) [6.0](https://github.com/GoogleChrome/lighthouse/releases) and above include support for measuring CLS in a lab setting. This release will also highlight the nodes that cause the most layout shifting.
+[Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) includes support for measuring CLS in a lab setting. It will also highlight the nodes that cause the most layout shifting.
 
-{% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/J11KOGFVAOjRMdihwX5t.jpg", alt="Lighthouse 6.0 includes support for measuring CLS in the metrics section", width="800", height="309" %}
+{% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/J11KOGFVAOjRMdihwX5t.jpg", alt="Lighthouse includes support for measuring CLS in the metrics section", width="800", height="309" %}
 
-The [Performance panel](https://developer.chrome.com/docs/devtools/evaluate-performance/) in DevTools highlights layout shifts in the **Experience** section as of Chrome 84. The **Summary** view for a `Layout Shift` record includes the cumulative layout shift score as well as a rectangle overlay showing the affected regions.
+The [Performance panel](https://developer.chrome.com/docs/devtools/evaluate-performance/) in DevTools highlights layout shifts in the **Experience** section. The **Summary** view for a `Layout Shift` record includes the cumulative layout shift score as well as a rectangle overlay showing the affected regions.
 
 <figure>
   {% Img src="image/admin/ApDKifKCRNGWI2SXSR1g.jpg", alt="Layout Shift records being displayed in the Chrome DevTools performance panel when expanding the Experience section", width="800", height="438" %}
   <figcaption>After recording a new trace in the Performance panel, the <b>Experience</b> section of the results is populated with a red-tinted bar displaying a <code>Layout Shift</code> record. Clicking the record allows you to drill down into impacted elements (e.g. note the moved from/to entries).</figcaption>
 </figure>
 
+The newer [Performance Insights panel](https://developer.chrome.com/docs/devtools/performance-insights/) also includes full support for identifying shifts.
+
 Measuring real-world CLS aggregated at an origin-level is also possible using the [Chrome User Experience Report](/chrome-ux-report-bigquery/). CrUX CLS data is available via BigQuery and a [sample query](https://github.com/GoogleChrome/CrUX/blob/main/sql/cls-summary.sql) to look at CLS performance is available to use.
+
+## Conclusion
+
+There are a number of techniques to improve CLS as detailed above. There are allowances built into Core Web Vitals, so even if you cannot eliminate CLS completely, using some of these techniques should allow you to reduce the impact. This will be better for your users and hopefully allow you to stay within those limits.
 
 That's it for this guide. I hope it helps keep your pages just a little less shifty :)
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -16,7 +16,7 @@ tags:
   - web-vitals
 ---
 
-{% YouTube id='AQqFZ5t8uNc', startTime='88' %}
+{% YouTube id='AQqFZ5t8uNc', startTime='88', width=2482, height=1396 %}
 
 "I was about to click that! Why did it move? 😭"
 
@@ -49,7 +49,9 @@ The most common causes of a poor CLS are:
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/8wKRITUkK3Zrp5jvQ1Xw.jpg",
       controls=true,
       loop=true,
-      muted=true %}
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Images without width and height specified.
     </figcaption>
@@ -61,7 +63,9 @@ The most common causes of a poor CLS are:
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/wm4VqJtKvove6qjiIjic.jpg",
       controls=true,
       loop=true,
-      muted=true %}
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Images with width and height specified.
     </figcaption>
@@ -217,19 +221,23 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
       poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rW77UoJQBHHehihkw2Rd.jpg",
       controls=true,
       loop=true,
-      muted=true %}
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Ads without sufficient space reserved.
     </figcaption>
   </figure>
 
   <figure>
-      {% Video
-        src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/tyUFKrue5vI9o5qKjP42.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/hVxty51kdN1w5BuUvj2O.mp4"],
-        poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rW77UoJQBHHehihkw2Rd.jpg",
-        controls=true,
-        loop=true,
-        muted=true %}
+    {% Video
+      src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/tyUFKrue5vI9o5qKjP42.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/hVxty51kdN1w5BuUvj2O.mp4"],
+      poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/rW77UoJQBHHehihkw2Rd.jpg",
+      controls=true,
+      loop=true,
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Ads with sufficient space reserved.
     </figcaption>
@@ -246,7 +254,7 @@ Some sites may find collapsing the slot initially can reduce layout shifts if th
 
 Statically style slot DOM elements with the same sizes passed to your tag library. This can help ensure the library doesn't introduce layout shifts when it loads. If you don't do this, the library may change the size of the slot element after page layout.
 
-This can be as simple as adding a `min-height` styling to reserve space or, for responsive ad sizings using the new [`aspect-ratio`](https://web.dev/aspect-ratio/) CSS property in a similar manner to the way browsers automatically use this for images with dimensions provided.
+This can be as simple as adding a `min-height` styling to reserve space or, for responsive ad sizings using the new [`aspect-ratio`](/aspect-ratio/) CSS property in a similar manner to the way browsers automatically use this for images with dimensions provided.
 
 Also consider the sizes of smaller ad serves. If a smaller ad is served, a publisher can style the (larger) container to avoid layout shifts. The downside to this approach is that it will increase the amount of blank space, so keep in mind the trade-off here.
 
@@ -267,14 +275,28 @@ Embeddable widgets allow you to embed portable web content in your page (for exa
 These embeds often aren't aware in advance just how large an embed will be (for example, in the case of a social media post - does it have an embedded image? video? multiple rows of text?). As a result, platforms offering embeds do not always reserve enough space for their embeds and can cause layout shifts when they finally load.
 
   <figure>
-    {% Video src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/NRhY88MbNJxe4o0F52eS.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/PzOpQnPH88Ymbe3MCH7B.mp4"], poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/w0TM1JilKPQktQgb94un.jpg", controls=true, loop=true, muted=true %}
+    {% Video
+      src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/NRhY88MbNJxe4o0F52eS.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/PzOpQnPH88Ymbe3MCH7B.mp4"],
+      poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/w0TM1JilKPQktQgb94un.jpg",
+      controls=true,
+      loop=true,
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Embed without space reserved.
     </figcaption>
   </figure>
 
   <figure>
-    {% Video src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/aA8IoNeQTCEudE45hYzh.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/xjCWjSv4Z3YB29jSDGae.mp4"], poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/gtYqKkoEse47ErJPqVjg.jpg", controls=true, loop=true, muted=true %}
+    {% Video
+      src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/aA8IoNeQTCEudE45hYzh.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/xjCWjSv4Z3YB29jSDGae.mp4"],
+      poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/gtYqKkoEse47ErJPqVjg.jpg",
+      controls=true,
+      loop=true,
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Embed with space reserved.
     </figcaption>
@@ -307,7 +329,14 @@ You've probably experienced layout shifts due to UI that pops-in at the top or b
 - "GDPR notice"
 
   <figure>
-    {% Video src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/LEicZ7zHqGFrXl67Olve.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/XFvOHc2OB8vUD9GbpL2w.mp4"], poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PF9ulVHDQOvoWendb6ea.jpg", controls=true, loop=true, muted=true %}
+    {% Video
+      src=["video/tcFciHGuF3MxnTr1y5ue01OGLBn2/LEicZ7zHqGFrXl67Olve.webm", "video/tcFciHGuF3MxnTr1y5ue01OGLBn2/XFvOHc2OB8vUD9GbpL2w.mp4"],
+      poster="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PF9ulVHDQOvoWendb6ea.jpg",
+      controls=true,
+      loop=true,
+      muted=true,
+      width=2482,
+      height=1396 %}
    <figcaption>
       Dynamic content without space reserved.
     </figcaption>

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -387,7 +387,7 @@ To learn more about what CSS properties trigger layout, see [CSS Triggers](https
 
 ### bfcache
 
-The baxck/forward cache, or bfcache keeps pages in browsers memory for a short period so if you return to them, then they will be restored exactly as you left them. This means the fully loaded page is instantly available - without any shifts which may be normally seen during load to to any of the reason above. When this was rolled out to Chrome, we saw [noticeable improvements in CLS](https://twitter.com/anniesullie/status/1491399685961293828?s=20&t=Qj_nzSRZD0_c-HaAnfr98Q).
+The back/forward cache, or bfcache keeps pages in browsers memory for a short period so if you return to them, then they will be restored exactly as you left them. This means the fully loaded page is instantly available—without any shifts which may be normally seen during load to to any of the reason above. When this was rolled out to Chrome, we saw [noticeable improvements in CLS](https://twitter.com/anniesullie/status/1491399685961293828?s=20&t=Qj_nzSRZD0_c-HaAnfr98Q).
 
 However, some sites are inelgible for the bfcache. Ensuring your site is eligible is a sure fire way to keep CLS scores down. Read [the bfcache article](/bfcache/) for more details on how to test and identify any issues preventing bfcache usage.
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -368,9 +368,9 @@ Downloading and rendering web fonts can cause layout shifts in two ways:
 The following tools can help you minimize this:
 
 - [`font-display`](/font-display/) allows you to modify the rendering behavior of custom fonts with values such as `auto`, `swap`, `block`, `fallback` and `optional`. Unfortunately, all of these values (except [`optional`](http://crrev.com/749080)) can cause a re-layout in one of the above ways.
-- The [Font Loading API](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#the_font_loading_api) can reduce the time it takes to get necessary fonts.
+- The [Font Loading API](./optimize-webfont-loading/#the-font-loading-api) can reduce the time it takes to get necessary fonts.
 
-As of Chrome 83, I can recommend the following too:
+We recommend the following too to reduce CLS for fonts:
 
 - Using `<link rel=preload>` on the key web fonts: a preloaded font will have a higher chance to meet the first paint, in which case there's no layout shifting.
 - Combining `<link rel=preload>` and `font-display: optional`
@@ -387,7 +387,7 @@ To learn more about what CSS properties trigger layout, see [CSS Triggers](https
 
 ### Developer Tools
 
-I'm happy to share there are a number of tools available to measure and debug Cumulative Layout Shift (CLS).
+There are a number of tools available to measure and debug Cumulative Layout Shift (CLS).
 
 [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) includes support for measuring CLS in a lab setting. It will also highlight the nodes that cause the most layout shifting.
 
@@ -408,6 +408,6 @@ Measuring real-world CLS aggregated at an origin-level is also possible using th
 
 There are a number of techniques to improve CLS as detailed above. There are allowances built into Core Web Vitals, so even if you cannot eliminate CLS completely, using some of these techniques should allow you to reduce the impact. This will be better for your users and hopefully allow you to stay within those limits.
 
-That's it for this guide. I hope it helps keep your pages just a little less shifty :)
+That's it for this guide. We hope it helps keep your pages just a little less shifty :)
 
 _With thanks to Philip Walton, Kenji Baheux, Warren Maresca, Annie Sullivan, Steve Kobes and Gilberto Cocchi for their helpful reviews._

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -129,7 +129,7 @@ img[Attributes Style] {
 }
 ```
 
-Safari does similarly with a `HTML Attributes` style source. Firefox does not currently display this calculated `aspect-ratio` at all in it's Inspector panel, but does use it for layout.
+Safari behaves similarly by using a `HTML Attributes` style source. Firefox does not currently display this calculated `aspect-ratio` at all in it's Inspector panel, but does use it for layout.
 
 The `auto` part of the above code, is important and causes the `640 / 360` to be overriden with the image dimensions once the image is downloaded. If the image dimensions are different this will still cause some layout shift after the impage loads, but this ensures the image aspect-ratio is still used ultimately when it becomes available—as it was in the past—in case the HTML is incorrect. Plus, the shift is likely to be a lot smaller than the 0x0 default image size when dimentions are not provided!
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -121,7 +121,7 @@ All browsers will then add a [default aspect ratio](https://html.spec.whatwg.org
 
 This calculates an aspect ratio based on the `width` and `height` attributes before the image has loaded. It provides this information at the very start of layout calculation. As soon as an image is told to be a certain width (for example `width: 100%`), the aspect ratio is used to calculate the height.
 
-This `aspect-ratio` value is calculated by major browsers as the HTML is processed, rather than with a default User Agent stylesheet (see [this post for a deep dive into why](https://jakearchibald.com/2022/img-aspect-ratio/#width--height-presentational-hints)), so are displayed a little differently. For example, Chrome displays it like this in the Styles section of the Element panel:
+This `aspect-ratio` value is calculated by major browsers as the HTML is processed, rather than with a default User Agent stylesheet (see [this post for a deep dive into why](https://jakearchibald.com/2022/img-aspect-ratio/#width--height-presentational-hints)), so the value is displayed a little differently. For example, Chrome displays it like this in the Styles section of the Element panel:
 
 ```css
 img[Attributes Style] {

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -5,7 +5,7 @@ authors:
   - addyosmani
   - tunetheweb
 date: 2020-05-05
-updated: 2022-10-24
+updated: 2022-10-25
 hero: image/admin/74TRx6aETydsBGa2IZ7R.png
 description: |
   Cumulative Layout Shift (CLS) is a metric that quantifies how often users experience sudden shifts in page content. In this guide, we'll cover optimizing common causes of CLS such as images and iframes without dimensions or dynamic content.
@@ -256,9 +256,16 @@ Statically style slot DOM elements with the same sizes passed to your tag librar
 
 This can be as simple as adding a `min-height` styling to reserve space or, for responsive ad sizings using the new [`aspect-ratio`](/aspect-ratio/) CSS property in a similar manner to the way browsers automatically use this for images with dimensions provided.
 
+<figure>
+  {% Img src="image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/ThcGvVp0RiiABpmnWz7u.svg", alt="Three mobile devices with jjst text content in the first device, this is shifted down in the second device, and reserving space with a placehodler as shown in the third device prevents the shift", width="295", height="150" %}
+  <figcaption>
+    Reserving space for ads can prevent layout shifts
+  </figcaption>
+</figure>
+
 Also consider the sizes of smaller ad serves. If a smaller ad is served, a publisher can style the (larger) container to avoid layout shifts. The downside to this approach is that it will increase the amount of blank space, so keep in mind the trade-off here.
 
-Alternatively, set the initial size to the smallest ad size, and accept some level of shift for larger ads. This will not eliminate CLS, but will hopefully reduce the impact of it to a more managable level.
+Alternatively, set the initial size to the smallest ad size, and accept some level of shift for larger ads. This will not fully eliminate CLS, but will hopefully reduce the impact of it to a more managable level.
 
 #### Avoid placing ads near the top of the viewport
 

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -370,7 +370,7 @@ The following tools can help you minimize this:
 - [`font-display`](/font-display/) allows you to modify the rendering behavior of custom fonts with values such as `auto`, `swap`, `block`, `fallback` and `optional`. Unfortunately, all of these values (except [`optional`](http://crrev.com/749080)) can cause a re-layout in one of the above ways.
 - The [Font Loading API](./optimize-webfont-loading/#the-font-loading-api) can reduce the time it takes to get necessary fonts.
 
-We recommend the following too to reduce CLS for fonts:
+More recommendations for reducing font-related CLS:
 
 - Using `<link rel=preload>` on the key web fonts: a preloaded font will have a higher chance to meet the first paint, in which case there's no layout shifting.
 - Combining `<link rel=preload>` and `font-display: optional`

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -385,6 +385,12 @@ Changes to CSS property values can require the browser to react to these changes
 
 To learn more about what CSS properties trigger layout, see [CSS Triggers](https://csstriggers.com/) and [High-performance animations](/animations-guide/).
 
+### bfcache
+
+The baxck/forward cache, or bfcache keeps pages in browsers memory for a short period so if you return to them, then they will be restored exactly as you left them. This means the fully loaded page is instantly available - without any shifts which may be normally seen during load to to any of the reason above. When this was rolled out to Chrome, we saw [noticeable improvements in CLS](https://twitter.com/anniesullie/status/1491399685961293828?s=20&t=Qj_nzSRZD0_c-HaAnfr98Q).
+
+However, some sites are inelgible for the bfcache. Ensuring your site is eligible is a sure fire way to keep CLS scores down. Read [the bfcache article](/bfcache/) for more details on how to test and identify any issues preventing bfcache usage.
+
 ### Developer Tools
 
 There are a number of tools available to measure and debug Cumulative Layout Shift (CLS).

--- a/src/site/content/en/blog/optimize-cls/index.md
+++ b/src/site/content/en/blog/optimize-cls/index.md
@@ -375,7 +375,7 @@ More recommendations for reducing font-related CLS:
 - Using `<link rel=preload>` on the key web fonts: a preloaded font will have a higher chance to meet the first paint, in which case there's no layout shifting.
 - Combining `<link rel=preload>` and `font-display: optional`
 
-Read [Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts](/preload-optional-fonts/) for more details, and [Best practices for fonts](./font-best-practices/) for other font best practices.
+Read [Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts](/preload-optional-fonts/) for more details, and [Best practices for fonts](/font-best-practices/) for other font best practices.
 
 ### Animations
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove Emojis from article headings. They're fun, but lead to weird URLs. And the Lighthouse links don't work because of them (which was the original small thing I came to fix, but as ever couldn't hold myself back from doing other changes while in here!).
- Update `aspect/ratio` info following @jakearchibald 's [recent post on this](https://jakearchibald.com/2022/img-aspect-ratio/).
- Add info on `<source>` support for art direction which has been added since this article was published.
- Add width and height to videos (should really practice what we preach!), though they all use 16/9 so have correct space reserved anyway.
- Remove references to Lighthouse 6 and Chrome 84 as those really are quite old by now. Think it's safe to just say Lighthouse and Chrome now.
- Add reference to Performance Insight's panel.

