### PR TITLE
Add coming soon to placeholder content

### DIFF
--- a/src/site/content/en/learn/accessibility/assitive-technology/index.md
+++ b/src/site/content/en/learn/accessibility/assitive-technology/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/automated-test/index.md
+++ b/src/site/content/en/learn/accessibility/automated-test/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/design-test/index.md
+++ b/src/site/content/en/learn/accessibility/design-test/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/forms/index.md
+++ b/src/site/content/en/learn/accessibility/forms/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/javascript/index.md
+++ b/src/site/content/en/learn/accessibility/javascript/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/manual-test/index.md
+++ b/src/site/content/en/learn/accessibility/manual-test/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/patterns/index.md
+++ b/src/site/content/en/learn/accessibility/patterns/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.

--- a/src/site/content/en/learn/accessibility/user-test/index.md
+++ b/src/site/content/en/learn/accessibility/user-test/index.md
@@ -8,3 +8,5 @@ placeholder: true
 tags:
   - accessibility
 ---
+
+This content is coming soon.


### PR DESCRIPTION
Add coming soon language to Learn a11y content not yet published. It's still possible for users to get to those pages, so we should indicate why the page is blank.

Pages which will be updated this week do not have this addition.

For example https://deploy-preview-8929--web-dev-staging.netlify.app/learn/accessibility/forms/
