### PR TITLE
[Text Fragments article] Use browser compat widget

### DIFF
--- a/src/site/content/en/blog/text-fragments/index.md
+++ b/src/site/content/en/blog/text-fragments/index.md
@@ -8,7 +8,7 @@ subhead: |
 authors:
   - thomassteiner
 date: 2020-06-17
-updated: 2022-06-29
+updated: 2022-10-26
 hero: image/admin/Y4NLEbOwgTWdMNoxRYXw.jpg
 alt:
 description: |
@@ -107,9 +107,7 @@ user agent can emphasize and/or bring it to the user's attention.
 
 ### Browser compatibility
 
-The Text Fragments feature is supported in version 80 and beyond of Chromium-based browsers. At the
-time of writing, Safari and Firefox have not publicly signaled an intent to implement the feature.
-See [Related links](#related-links) for pointers to the Safari and Firefox discussions.
+{% BrowserCompat 'css.selectors.target-text' %}
 
 {% Aside 'success' %} These links used to not work when served across
 [client-side redirects](https://developer.mozilla.org/docs/Web/HTTP/Redirections#Alternative_way_of_specifying_redirections)


### PR DESCRIPTION
Use browser compat widget

**TODO:** Replace with proper compat for the feature per se, not the styling, once @chrisdavidmills has gotten to [documenting it](https://docs.google.com/spreadsheets/d/1vfkeHf5MEcxrAr6hle3vPb8YvHQXf5UqEAjAjTHET0E/edit#gid=0&range=27:27).
