### PR TITLE
Added missing course link/intro to Critical Rendering Path page

### DIFF
--- a/src/site/content/en/blog/critical-rendering-path/index.md
+++ b/src/site/content/en/blog/critical-rendering-path/index.md
@@ -27,6 +27,17 @@ the **critical rendering path**.
 By optimizing the critical rendering path we can significantly improve the
 time to first render of our pages. Further, understanding the critical
 rendering path also serves as a foundation for building well-performing
-interactive applications. The interactive updates process is the same, just done in a continuous loop and ideally at 60 frames per second! But first, an overview of how the browser displays a simple page.
+interactive applications. The interactive updates process is the same, just done in a continuous loop and ideally at 60 frames per second!
+But first, an overview of how the browser displays a simple page.
+
+## Critical Rendering Path
+
+You will learn how to optimize any website for speed by diving into the details of how mobile and desktop browsers render pages.
+You’ll learn about the Critical Rendering Path, or the set of steps browsers must take to convert HTML, CSS and JavaScript into living,
+breathing websites. From there, you’ll start exploring and experimenting with tools to measure performance and simple strategies to deliver the first
+pixels to the screen as early as possible. You’ll learn how to dive into recommendations from PageSpeed Insights and the Timeline view of Google Chrome’s Developer
+Tools to find the data you need to achieve immediate performance boosts!
+
+This is a free course offered through [Udacity](https://www.udacity.com/course/website-performance-optimization--ud884).
 
 ## Feedback {: #feedback }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8805

Original content retrieved [here](https://web.archive.org/web/20220326164156/https://developers.google.com/web/fundamentals/performance/critical-rendering-path/).
