### PR TITLE
[Badging API] Actually show spec link

### DIFF
--- a/src/site/content/en/blog/badging-api/index.md
+++ b/src/site/content/en/blog/badging-api/index.md
@@ -5,12 +5,11 @@ authors:
   - petelepage
 description: The App Badging API allows installed web apps to set an application-wide badge, shown in an operating-system-specific place associated with the application, such as the shelf or home screen. Badging makes it easy to subtly notify the user that there is some new activity that might require their attention, or it can be used to indicate a small amount of information, such as an unread count.
 date: 2018-12-11
-updated: 2022-03-28
+updated: 2022-11-01
 tags:
   - blog
   - capabilities
   - progressive-web-apps
-  # - badging
   - notifications
 hero: image/admin/AFvb0uBtN7ZX9qToptEo.jpg
 alt: Neon sign with heart and zero
@@ -194,6 +193,7 @@ it is to support them.
 ## Helpful links {: #helpful }
 
 * [Public explainer][explainer]
+* [Spec draft][spec]
 * [Badging API Demo][demo] | [Badging API Demo source][demo-source]
 * [Tracking bug][cr-bug]
 * [ChromeStatus.com entry][cr-status]


### PR DESCRIPTION
Changes proposed in this pull request:

- Actually show spec link