### PR TITLE
Upgrade web-vitals to 3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28096,9 +28096,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.0.tgz",
-      "integrity": "sha512-3Gh6rH5aetFYqfkl9V59KCvjj9vp9U2Tkaep9MO+xpAVg+JULmQfi5zEkcPLkE6iU8pNYVwdjHvIU8RFAchYyQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.4.tgz",
+      "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "node_modules/webdev-infra": {
       "version": "1.0.32",
@@ -50981,9 +50981,9 @@
       }
     },
     "web-vitals": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.0.tgz",
-      "integrity": "sha512-3Gh6rH5aetFYqfkl9V59KCvjj9vp9U2Tkaep9MO+xpAVg+JULmQfi5zEkcPLkE6iU8pNYVwdjHvIU8RFAchYyQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.4.tgz",
+      "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "webdev-infra": {
       "version": "1.0.32",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "terser": "^5.9.0",
     "truncate-utf8-bytes": "^1.0.2",
     "unistore": "^3.4.1",
-    "web-vitals": "^3.0.0",
+    "web-vitals": "^3.0.4",
     "webdev-infra": "^1.0.32",
     "wicg-inert": "^3.0.1",
     "yaml-front-matter": "^4.0.0"


### PR DESCRIPTION
Changes proposed in this pull request:

- Prerender2 is coming, and web-vitals 3.0.4 contains some small bug fixes for that so let's upgrade to it.

