### PR TITLE
Add three articles to /fast/ page

### DIFF
--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -96,8 +96,8 @@
     {
       "title": "i18n.paths.fast.topics.optimize_webfonts",
       "pathItems": [
+        "font-best-practices/",
         "avoid-invisible-text",
-        "optimize-webfont-loading",
         "reduce-webfont-size"
       ]
     },

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -96,8 +96,9 @@
     {
       "title": "i18n.paths.fast.topics.optimize_webfonts",
       "pathItems": [
-        "font-best-practices/",
+        "font-best-practices",
         "avoid-invisible-text",
+        "optimize-webfont-loading",
         "reduce-webfont-size"
       ]
     },

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -55,6 +55,7 @@
     {
       "title": "i18n.paths.fast.topics.optimize_your_javascript",
       "pathItems": [
+        "optimize-long-tasks",
         "apply-instant-loading-with-prpl",
         "reduce-javascript-payloads-with-code-splitting",
         "remove-unused-code",

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -89,7 +89,8 @@
       "pathItems": [
         "third-party-javascript",
         "identify-slow-third-party-javascript",
-        "efficiently-load-third-party-javascript"
+        "efficiently-load-third-party-javascript",
+        "tag-best-practices"
       ]
     },
     {

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -2,7 +2,7 @@
   "slug": "fast",
   "cover": "image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/fjFJRFnHXiem8yF0GGQ9.svg",
   "title": "i18n.paths.fast.title",
-  "updated": "July 17, 2020",
+  "updated": "November 10, 2022",
   "description": "i18n.paths.fast.description",
   "overview": "i18n.paths.fast.overview",
     "topics": [


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds [Optimize long tasks](https://web.dev/optimize-long-tasks/link) to [Fast -> Optimize Your Javascript](https://web.dev/fast/#optimize-your-javascript)
- Adds [Best practices for tags and tag managers](https://web.dev/tag-best-practices/) link to [Fast -> Optimize your third-party resources](https://web.dev/fast/#optimize-your-third-party-resources)
- Adds [Best practices for fonts](https://web.dev/font-best-practices/) to [Fast -> Optimize WebFonts](https://web.dev/fast/#optimize-webfonts)

