### PR TITLE
Add note on unload handlers on mobile to bfcache article

### DIFF
--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -234,7 +234,9 @@ On desktop, Chrome and Firefox have chosen to make pages ineligible for bfcache 
 listener, which is less risky but also disqualifies _a lot_ of pages. Safari
 will attempt to cache some pages with an `unload` event listener, but to reduce
 potential breakage it will not run the `unload` event when a user is navigating
-away, which makes the event very unreliable. Mobile browsers will attempt to cache some pages with an `unload` event listener but the `unload` event is extremely unreliable on mobile as processes are killed to save resources.
+away, which makes the event very unreliable.
+
+On mobile, most browsers will attempt to cache pages with an `unload` event listener since the risk of breakage is lower due to the fact that the `unload` event has always been extremely unreliable on mobile.
 
 Instead of using the `unload` event, use the `pagehide` event. The `pagehide`
 event fires in all cases where the `unload` event currently fires, and it
@@ -531,6 +533,8 @@ the bfcache, including:
 - when the user quits the browser and starts it again
 - when the user duplicates a tab
 - when the user closes a tab and uncloses it
+
+Even without those exclusions the bfcache will be discarded after a period to conserve memory.
 
 So, website owners should not be expecting a 100% bfcache hit ratio for all
 `back_forward` navigations. However, measuring their ratio can be useful to

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -234,7 +234,7 @@ On desktop, Chrome and Firefox have chosen to make pages ineligible for bfcache 
 listener, which is less risky but also disqualifies _a lot_ of pages. Safari
 will attempt to cache some pages with an `unload` event listener, but to reduce
 potential breakage it will not run the `unload` event when a user is navigating
-away, which makes the event very unreliable. Mobile browsers will attempt to cache some pages with an `unload` event listener but the `unload` event is even unreliable on mobile as processes are often killed to save memory.
+away, which makes the event very unreliable. Mobile browsers will attempt to cache some pages with an `unload` event listener but the `unload` event is extremely unreliable on mobile as processes are killed to save resources.
 
 Instead of using the `unload` event, use the `pagehide` event. The `pagehide`
 event fires in all cases where the `unload` event currently fires, and it

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -230,7 +230,7 @@ time](https://developer.chrome.com/blog/page-lifecycle-api/#the-unload-event)).
 So browsers are faced with a dilemma, they have to choose between something that
 can improve the user experience—but might also risk breaking the page.
 
-On Desktop Chrome and Firefox have chosen to make pages ineligible for bfcache if they add an `unload`
+On desktop, Chrome and Firefox have chosen to make pages ineligible for bfcache if they add an `unload`
 listener, which is less risky but also disqualifies _a lot_ of pages. Safari
 will attempt to cache some pages with an `unload` event listener, but to reduce
 potential breakage it will not run the `unload` event when a user is navigating

--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -8,7 +8,7 @@ authors:
   - philipwalton
   - tunetheweb
 date: 2020-11-10
-updated: 2022-10-26
+updated: 2022-11-10
 hero: image/admin/Qoeb8x3a11BdGgRzYJbY.png
 alt: Back and forward buttons
 tags:
@@ -230,11 +230,11 @@ time](https://developer.chrome.com/blog/page-lifecycle-api/#the-unload-event)).
 So browsers are faced with a dilemma, they have to choose between something that
 can improve the user experience—but might also risk breaking the page.
 
-Chrome and Firefox have chosen to make pages ineligible for bfcache if they add an `unload`
+On Desktop Chrome and Firefox have chosen to make pages ineligible for bfcache if they add an `unload`
 listener, which is less risky but also disqualifies _a lot_ of pages. Safari
 will attempt to cache some pages with an `unload` event listener, but to reduce
 potential breakage it will not run the `unload` event when a user is navigating
-away, which makes the event very unreliable.
+away, which makes the event very unreliable. Mobile browsers will attempt to cache some pages with an `unload` event listener but the `unload` event is even unreliable on mobile as processes are often killed to save memory.
 
 Instead of using the `unload` event, use the `pagehide` event. The `pagehide`
 event fires in all cases where the `unload` event currently fires, and it


### PR DESCRIPTION
Fixes #9044

Changes proposed in this pull request:

- Clarifies that unload handler can still allow bfcache on mobile, but that's still not a reason to use it

