### PR TITLE
Make navigation visible when focus is in it

### DIFF
--- a/src/scss/web-components/_web-navigation-drawer.scss
+++ b/src/scss/web-components/_web-navigation-drawer.scss
@@ -59,7 +59,8 @@ web-navigation-drawer[open]::before {
   opacity: 1;
 }
 
-web-navigation-drawer[open] [data-drawer-container] {
+web-navigation-drawer[open] [data-drawer-container],
+web-navigation-drawer:focus-within [data-drawer-container] {
   transform: none;
 }
 


### PR DESCRIPTION
Right now, if the user tabs thru the navigation using a keyboard, the sidebar stays hidden. For 20 clicks. This forces the navigation to be visible when the focus is that sidebar.
