### PR TITLE
fix/chore: update example to latest version

### DIFF
--- a/src/site/content/en/fast/use-imagemin-to-compress-images/index.md
+++ b/src/site/content/en/fast/use-imagemin-to-compress-images/index.md
@@ -174,17 +174,20 @@ This code uses the "imagemin-mozjpeg" plugin to compress JPEG files to a quality
 of 50 ('0' being the worst; '100' being the best):
 
 ```js
-const imagemin = require('imagemin');
-const imageminMozjpeg = require('imagemin-mozjpeg');
-
-(async() => {
-  const files = await imagemin(
-      ['source_dir/*.jpg', 'another_dir/*.jpg'],
-      {
-        destination: 'destination_dir',
-        plugins: [imageminMozjpeg({quality: 50})]
-      }
-  );
-  console.log(files);
+import imageminMozjpeg from 'imagemin-mozjpeg';
+import imagemin from 'imagemin';
+(async () => {
+    try {
+        const files = await imagemin(
+            ['source_dir/*.jpg', 'another_dir/*.jpg'],
+            {
+                destination: 'destination_dir',
+                plugins: [imageminMozjpeg({ quality: 50 })]
+            }
+        );
+        console.log(files);
+    } catch (error) {
+        console.log({ error })
+    }
 })();
 ```


### PR DESCRIPTION
The current code example throws several errors when installing using version 16+ of Node LTS together with the latest versions of `imagemin` and `imagemin-mozjpeg`. This code example update outputs the same minified images, like the previous examples, but removes the errors. 

Tested on Node LTS v16.17.1 with imagemin ^8.0.1 and imagemin-mozjpeg ^10.0.0.