### PR TITLE
fix: do not use html markup for symbol in code snippet

### DIFF
--- a/src/site/content/en/blog/pagevisibility-intro/index.md
+++ b/src/site/content/en/blog/pagevisibility-intro/index.md
@@ -50,7 +50,7 @@ function getHiddenProp(){
     if ('hidden' in document) return 'hidden';
 
     // otherwise loop over all the known prefixes until we find one
-    for (var i = 0; i &lt; prefixes.length; i++){
+    for (var i = 0; i < prefixes.length; i++){
         if ((prefixes[i] + 'Hidden') in document)
             return prefixes[i] + 'Hidden';
     }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Changes proposed in this pull request:

- fix code snippet in doc "Using the Page Visibility API": do not use `&lt;`, use the symbol directly

