### PR TITLE
Fix deadline updates logic after yield

### DIFF
--- a/src/site/content/en/blog/optimize-long-tasks/index.md
+++ b/src/site/content/en/blog/optimize-long-tasks/index.md
@@ -276,7 +276,7 @@ async function saveSettings () {
       await yieldToMain();
 
       // Extend the deadline:
-      deadline += 50;
+      deadline = performance.now() + 50;
 
       // Stop the execution of the current loop and
       // move onto the next iteration:


### PR DESCRIPTION
Deadline was extended by 50ms from the original timestamp before yielding, it puts us under the risk of yielding twice without get any of our task run if the other main thread works we yielded to occupied more than 50ms.
This fix gives us a brand new 50ms deadline every time we got resumed.