### PR TITLE
Log 404 pages in Google Analytics

### DIFF
--- a/src/site/content/en/404.md
+++ b/src/site/content/en/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/en/404.md
+++ b/src/site/content/en/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/en/404.md
+++ b/src/site/content/en/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/es/404.md
+++ b/src/site/content/es/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/es/404.md
+++ b/src/site/content/es/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/es/404.md
+++ b/src/site/content/es/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ja/404.md
+++ b/src/site/content/ja/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/ja/404.md
+++ b/src/site/content/ja/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ja/404.md
+++ b/src/site/content/ja/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ko/404.md
+++ b/src/site/content/ko/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/ko/404.md
+++ b/src/site/content/ko/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ko/404.md
+++ b/src/site/content/ko/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/pl/404.md
+++ b/src/site/content/pl/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/pl/404.md
+++ b/src/site/content/pl/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/pl/404.md
+++ b/src/site/content/pl/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/pt/404.md
+++ b/src/site/content/pt/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/pt/404.md
+++ b/src/site/content/pt/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/pt/404.md
+++ b/src/site/content/pt/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ru/404.md
+++ b/src/site/content/ru/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/ru/404.md
+++ b/src/site/content/ru/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/ru/404.md
+++ b/src/site/content/ru/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/zh/404.md
+++ b/src/site/content/zh/404.md
@@ -9,7 +9,7 @@ subhead: Sorry, we couldn't find that page.
 
 {% set script %}
   ga('send', 'event', {
-      eventCategory: '404',
+      eventCategory: '404 Error',
       eventAction: window.location.pathname,
       eventValue: 1,
       eventLabel: document.referrer,

--- a/src/site/content/zh/404.md
+++ b/src/site/content/zh/404.md
@@ -6,3 +6,15 @@ description: |
 noindex: true
 subhead: Sorry, we couldn't find that page.
 ---
+
+{% set script %}
+  ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: window.location.pathname,
+      eventValue: 1,
+      eventLabel: document.referrer,
+      // Use a non-interaction event to avoid affecting bounce rate.
+      nonInteraction: true,
+    });
+{% endset %}
+<script>{{ script | minifyJs | cspHash | safe }}</script>

--- a/src/site/content/zh/404.md
+++ b/src/site/content/zh/404.md
@@ -11,10 +11,8 @@ subhead: Sorry, we couldn't find that page.
   ga('send', 'event', {
       eventCategory: '404 Error',
       eventAction: window.location.pathname,
-      eventValue: 1,
       eventLabel: document.referrer,
-      // Use a non-interaction event to avoid affecting bounce rate.
-      nonInteraction: true,
+      eventValue: 1,
     });
 {% endset %}
 <script>{{ script | minifyJs | cspHash | safe }}</script>


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a 404 event to make it easier to see 404 pages.

You can see these by searching for Page Title of "404" but can't then see referrer. Having as an event is easier.
