### PR TITLE
Fix broken links and indentation in old WC articles

### DIFF
--- a/src/site/content/en/blog/customelements/index.md
+++ b/src/site/content/en/blog/customelements/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 {% Aside 'warning' %}
-This article describes an old version of Custom Elements (v0). If you're interested in using Custom Elements, check out our new article, "[Custom Elements v1 - Reusable Web Components](/custom-elements-v1/)". It covers everything in the newer Custom Elements v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
+This article describes an old version of Custom Elements (v0). If you're interested in using Custom Elements, check out our new article, "[Custom Elements v1 - Reusable Web Components](/custom-elements-v1/)." It covers everything in the newer Custom Elements v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
 {% endAside %}
 
 ## Introduction

--- a/src/site/content/en/blog/customelements/index.md
+++ b/src/site/content/en/blog/customelements/index.md
@@ -9,6 +9,10 @@ tags:
   - blog
 ---
 
+{% Aside 'warning' %}
+This article describes an old version of Custom Elements (v0). If you're interested in using Custom Elements, check out our new article, "[Custom Elements v1 - Reusable Web Components](/custom-elements-v1/)". It covers everything in the newer Custom Elements v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
+{% endAside %}
+
 ## Introduction
 
 The web severely lacks expression. To see what I mean, take a peek at a "modern" web app like GMail:
@@ -17,7 +21,7 @@ The web severely lacks expression. To see what I mean, take a peek at a "modern"
   {% Img src="image/T4FyVKpzu4WKF1kBNvXepbi08t52/xDJlKi0xvNl9gqZ6tDGB.png", alt="Gmail", width="800", height="470" %}
 </figure>
 
-There's nothing modern about `<div>` soup. And yet, this is how we build web apps. It's sad. 
+There's nothing modern about `<div>` soup. And yet, this is how we build web apps. It's sad.
 Shouldn't we demand more from our platform?
 
 ### Sexy markup. Let's make it a thing
@@ -48,8 +52,8 @@ just by examining its declarative backbone.
 
 ## Getting started
 
-[Custom Elements](http://w3c.github.io/webcomponents/spec/custom/)
-**allow web developers to define new types of HTML elements**. The spec is one of several new API primitives landing under the [Web Components](http://w3c.github.io/webcomponents/explainer/) umbrella, but it's quite possibly the most important. Web Components don't exist
+[Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html)
+**allow web developers to define new types of HTML elements**. The spec is one of several new API primitives landing under the [Web Components](https://www.w3.org/TR/2012/WD-components-intro-20120522/) umbrella, but it's quite possibly the most important. Web Components don't exist
 without the features unlocked by custom elements:
 
 1. Define new HTML/DOM elements
@@ -73,7 +77,7 @@ compatibility when new tags are added to HTML.
 
 The second argument is an (optional) object describing the element's `prototype`.
 This is the place to add custom functionality (e.g. public properties and methods) to your elements.
-[More on that](#publicapi) later.
+[More on that](#adding-js-properties-and-methods) later.
 
 By default, custom elements inherit from `HTMLElement`. Thus, the previous example is equivalent to:
 
@@ -85,7 +89,7 @@ var XFoo = document.registerElement('x-foo', {
 
 A call to `document.registerElement('x-foo')` teaches the browser about the new element,
 and returns a constructor that you can use to create instances of `<x-foo>`.
-Alternatively, you can use the other [techniques of instantiating elements](#instantiating)
+Alternatively, you can use the other [techniques of instantiating elements](#instantiating-elements)
 if you don't want to use the constructor.
 
 {% Aside %}
@@ -142,12 +146,12 @@ var XFooExtended = document.registerElement('x-foo-extended', {
 });
 ```
 
-See [Adding JS properties and methods](#publicapi) below for more information on creating element prototypes.
+See [Adding JS properties and methods](#adding-js-properties-and-methods) below for more information on creating element prototypes.
 
 ### How elements are upgraded
 
 Have you ever wondered why the HTML parser doesn't throw a fit on non-standard tags?
-For example, it's perfectly happy if we declare `<randomtag>` on the page. According to the [HTML specification](http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#htmlunknownelement):
+For example, it's perfectly happy if we declare `<randomtag>` on the page. According to the [HTML specification](https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement):
 
 {% Aside %}
 The `HTMLUnknownElement` interface must be used for HTML elements that are not defined by this specification.
@@ -180,12 +184,10 @@ These are HTML elements that have a valid custom element name but haven't been r
 
 This table might help keep things straight:
 
-<table>
-  <thead><tr><th>Name</th><th>Inherits from</th><th>Examples</th></tr></thead>
-  <tr><td>Unresolved element</td><td>`HTMLElement`</td><td>`<x-tabs>`, `<my-element>`, `<my-awesome-app>`</td></tr>
-  <tr><td>Unknown element</td><td>`HTMLUnknownElement`</td><td>`<tabs>`, `<foo_bar>`
-</td></tr>
-</table>
+| Name                | Inherits from        | Examples                   |
+| ------------------- | -------------------- | -------------------------- |
+| Unresolved element  | `HTMLElement`        | `<x-tabs>`, `<my-element>` |
+| Unknown element     | `HTMLUnknownElement` | `<tabs>`, `<foo_bar>`      |
 
 {% Aside %}
 Think of unresolved elements as in limbo.
@@ -363,7 +365,7 @@ proto.createdCallback = function() {
 ```
 
 {% Aside %}
-People won't use your elements if 
+People won't use your elements if
 they're clunky. The lifecycle callbacks can help you be a good citizen!
 {% endAside %}
 
@@ -389,19 +391,19 @@ Instantiating this tag and inspecting in the DevTools (right-click, select Inspe
 
 ```html
 ▾<x-foo-with-markup>
-    **I'm an x-foo-with-markup!**
-    </x-foo-with-markup>
+  **I'm an x-foo-with-markup!**
+</x-foo-with-markup>
 ```
 
 ### Encapsulating the internals in Shadow DOM
 
-By itself, [Shadow DOM](/tutorials/webcomponents/shadowdom/) is a powerful tool for
+By itself, [Shadow DOM](/shadowdom/) is a powerful tool for
 encapsulating content. Use it in conjunction with custom elements and things get magical!
 
 Shadow DOM gives custom elements:
 
 1. A way to hide their guts, thus shielding users from gory implementation details.
-1. [Style encapsulation](/tutorials/webcomponents/shadowdom-201/)…fo' free.
+1. [Style encapsulation](/shadowdom-201/)…fo' free.
 
 Creating an element from Shadow DOM is like creating one that
 renders basic markup. The difference is in `createdCallback()`:
@@ -427,39 +429,39 @@ With the "Show Shadow DOM" setting enabled in the DevTools, you'll see a
 
 ```js
 ▾<x-foo-shadowdom>
-    ▾#shadow-root
-        **I'm in the element's Shadow DOM!**
-    </x-foo-shadowdom>
+  ▾#shadow-root
+    **I'm in the element's Shadow DOM!**
+</x-foo-shadowdom>
 ```
 
 That's the Shadow Root!
 
 ### Creating elements from a template
 
-[HTML Templates](http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting-1.html#the-template-element) are another new API primitive that fits nicely into the world of custom elements.
+[HTML Templates](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element) are another new API primitive that fits nicely into the world of custom elements.
 
 **Example:** registering an element created from a `<template>` and Shadow DOM:
 
 ```js
-    <template id="sdtemplate">
-      <style>
-        p { color: orange; }
-      </style>
-      <p>I'm in Shadow DOM. My markup was stamped from a <template&gt;.
-    </template>
+<template id="sdtemplate">
+  <style>
+    p { color: orange; }
+  </style>
+  <p>I'm in Shadow DOM. My markup was stamped from a <template&gt;.
+</template>
 
-    <script>
-    var proto = Object.create(HTMLElement.prototype, {
-      createdCallback: {
-        value: function() {
-          var t = document.querySelector('#sdtemplate');
-          var clone = document.importNode(t.content, true);
-          this.createShadowRoot().appendChild(clone);
-        }
+<script>
+  var proto = Object.create(HTMLElement.prototype, {
+    createdCallback: {
+      value: function() {
+        var t = document.querySelector('#sdtemplate');
+        var clone = document.importNode(t.content, true);
+        this.createShadowRoot().appendChild(clone);
       }
-    });
-    document.registerElement('x-foo-from-template', {prototype: proto});
-    </script>
+    }
+  });
+  document.registerElement('x-foo-from-template', {prototype: proto});
+</script>
 
 <template id="sdtemplate">
   <style>:host p { color: orange; }</style>
@@ -487,26 +489,26 @@ As with any HTML tag, users of your custom tag can style it with selectors:
 
 ```html
 <style>
-    app-panel {
+  app-panel {
     display: flex;
-    }
-    [is="x-item"] {
+  }
+  [is="x-item"] {
     transition: opacity 400ms ease-in-out;
     opacity: 0.3;
     flex: 1;
     text-align: center;
     border-radius: 50%;
-    }
-    [is="x-item"]:hover {
+  }
+  [is="x-item"]:hover {
     opacity: 1.0;
     background: rgb(255, 0, 255);
     color: white;
-    }
-    app-panel > [is="x-item"] {
+  }
+  app-panel > [is="x-item"] {
     padding: 5px;
     list-style: none;
     margin: 0 7px;
-    }
+  }
 </style>
 
 <app-panel>
@@ -519,7 +521,7 @@ As with any HTML tag, users of your custom tag can style it with selectors:
 ### Styling elements that use Shadow DOM
 
 The rabbit hole goes much _much_ deeper when you bring Shadow DOM into the mix.
-[Custom elements that use Shadow DOM](#shadowdom) inherit its great benefits.
+[Custom elements that use Shadow DOM](#encapsulating-the-internals-in-shadow-dom) inherit its great benefits.
 
 Shadow DOM infuses an element with style encapsulation. Styles defined in a Shadow Root don't
 leak out of the host and don't bleed in from the page. **In the case of a custom element, the element itself is the host.** The properties of style encapsulation also allow custom elements to
@@ -528,15 +530,15 @@ define default styles for themselves.
 Shadow DOM styling is a huge topic! If you want to learn more about it, I recommend a few of my other articles:
 
 - "[A Guide to Styling Elements](http://www.polymer-project.org/articles/styling-elements.html)" on [Polymer](http://www.polymer-project.org)'s documentation.
-- "[Shadow DOM 201: CSS & Styling](/tutorials/webcomponents/shadowdom-201/)" here on html5rocks.com
+- "[Shadow DOM 201: CSS & Styling](/shadowdom-201/)" here.
 
 ### FOUC prevention using :unresolved
 
 To mitigate [FOUC](http://en.wikipedia.org/wiki/Flash_of_unstyled_content), custom elements spec
-out a new CSS pseudo class, `:unresolved`. Use it to target [unresolved elements](#unresolvedels), 
-right up until the point where the browser invokes your `createdCallback()` (see [lifecycle methods](#lifecycle)).
+out a new CSS pseudo class, `:unresolved`. Use it to target [unresolved elements](#unresolved-elements),
+right up until the point where the browser invokes your `createdCallback()` (see [lifecycle methods](#lifecycle-callback-methods)).
 Once that happens, the element is no longer an unresolved element. The upgrade process is
-complete and the element has transformed into its definition. 
+complete and the element has transformed into its definition.
 
 {% Aside %}
 CSS `:unresolved` is supported natively in Chrome 29.
@@ -546,37 +548,37 @@ CSS `:unresolved` is supported natively in Chrome 29.
 
 ```html
 <style>
-    x-foo {
+  x-foo {
     opacity: 1;
     transition: opacity 300ms;
-    }
-    x-foo:unresolved {
+  }
+  x-foo:unresolved {
     opacity: 0;
-    }
+  }
 </style>
 ```
 
-Keep in mind that `:unresolved` only applies to [unresolved elements](#unresolvedels),
-not to elements that inherit from `HTMLUnknownElement` (see [How elements are upgraded](#upgrades)).
+Keep in mind that `:unresolved` only applies to [unresolved elements](#unresolved-elements),
+not to elements that inherit from `HTMLUnknownElement` (see [How elements are upgraded](#how-elements-are-upgraded)).
 
 ```html
 <style>
-    /* apply a dashed border to all unresolved elements */
-    :unresolved {
+  /* apply a dashed border to all unresolved elements */
+  :unresolved {
     border: 1px dashed red;
     display: inline-block;
-    }
-    /* x-panel's that are unresolved are red */
-    x-panel:unresolved {
+  }
+  /* x-panel's that are unresolved are red */
+  x-panel:unresolved {
     color: red;
-    }
-    /* once the definition of x-panel is registered, it becomes green */
-    x-panel {
+  }
+  /* once the definition of x-panel is registered, it becomes green */
+  x-panel {
     color: green;
     display: block;
     padding: 5px;
     display: block;
-    }
+  }
 </style>
 
 <panel>
@@ -586,8 +588,6 @@ not to elements that inherit from `HTMLUnknownElement` (see [How elements are up
 
 <x-panel>I'm red because I match x-panel:unresolved.</x-panel>
 ```
-
-For more on `:unresolved`, see Polymer's [A Guide to styling elements](http://www.polymer-project.org/articles/styling-elements.html#preventing-fouc).
 
 ## History and browser support
 
@@ -610,7 +610,7 @@ if (supportsCustomElements()) {
 ### Browser support
 
 `document.registerElement()` first started landing behind a flag in Chrome 27 and Firefox ~23. However, the specification has evolved quite a bit since then. Chrome 31 is the first to have
-true support for the updated spec. 
+true support for the updated spec.
 
 {% Aside %}
 Custom elements can be enabled in Chrome 31 under "Experimental Web Platform features" in `about:flags`.
@@ -629,12 +629,12 @@ It was the bees knees. You could use it to declaratively register new elements:
 </element>
 ```
 
-Unfortunately, there were too many timing issues with the [upgrade process](#upgrades),
+Unfortunately, there were too many timing issues with the [upgrade process](#how-elements-are-upgraded),
 corner cases, and Armageddon-like scenarios to work it all out. `<element>` had to be shelved. In August 2013, Dimitri Glazkov posted to [public-webapps](http://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0287.html) announcing its removal, at least for now.
 
 It's worth noting that Polymer implements a declarative form of element registration
 with `<polymer-element>`. How? It uses `document.registerElement('polymer-element')` and
-the techniques I described in [Creating elements from a template](#fromtemplate).
+the techniques I described in [Creating elements from a template](#creating-elements-from-a-template).
 
 ## Conclusion
 

--- a/src/site/content/en/blog/customelements/index.md
+++ b/src/site/content/en/blog/customelements/index.md
@@ -289,16 +289,18 @@ a fan of creating prototypes like this, here's a more condensed version of the s
 
 ```js
 var XFoo = document.registerElement('x-foo', {
-    prototype: Object.create(HTMLElement.prototype, {
+  prototype: Object.create(HTMLElement.prototype, {
     bar: {
-        get: function() { return 5; }
+      get: function () {
+        return 5;
+      }
     },
     foo: {
-        value: function() {
+      value: function () {
         alert('foo() called');
-        }
+      }
     }
-    })
+  })
 });
 ```
 
@@ -358,9 +360,9 @@ on the element:
 
 ```js
 proto.createdCallback = function() {
-    this.addEventListener('click', function(e) {
+  this.addEventListener('click', function(e) {
     alert('Thanks!');
-    });
+  });
 };
 ```
 

--- a/src/site/content/en/blog/shadowdom-201/index.md
+++ b/src/site/content/en/blog/shadowdom-201/index.md
@@ -11,17 +11,17 @@ tags:
 ---
 
 {% Aside 'warning' %}
-This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipping in Chrome 53, Opera, and Safari 10.
+This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
 {% endAside %}
 
 This article discusses more of the amazing things you can do with Shadow DOM.
-It builds on the concepts discussed in [Shadow DOM 101](https://www.html5rocks.com/tutorials/webcomponents/shadowdom/).
+It builds on the concepts discussed in [Shadow DOM 101](/shadowdom/).
 If you're looking for an introduction, see that article.
 
 ## Introduction
 
-Let's face it. There's nothing sexy about unstyled markup. Lucky for us, [the brilliant folks behind Web Components](http://w3c.github.io/webcomponents/explainer/#acknowledgements)
-foresaw this and didn't leave us hanging. The [CSS Scoping Module](http://dev.w3.org/csswg/css-scoping/) defines many options for styling content in a shadow tree.
+Let's face it. There's nothing sexy about unstyled markup. Lucky for us, [the brilliant folks behind Web Components](https://www.w3.org/TR/2012/WD-components-intro-20120522/#acknowledgements)
+foresaw this and didn't leave us hanging. The [CSS Scoping Module](https://drafts.csswg.org/css-scoping/) defines many options for styling content in a shadow tree.
 
 {% Aside %}
 In Chrome, turn on the "Enable experimental Web Platform features" in about:flags to experiment with everything covered in this article.
@@ -29,7 +29,7 @@ In Chrome, turn on the "Enable experimental Web Platform features" in about:flag
 
 ## Style encapsulation
 
-One of the core features of Shadow DOM is the [shadow boundary](http://w3c.github.io/webcomponents/spec/shadow/#shadow-trees). It has a lot of nice properties,
+One of the core features of Shadow DOM is the [shadow boundary](https://dom.spec.whatwg.org/#shadow-trees). It has a lot of nice properties,
 but one of the best is that it provides style encapsulation for free. Stated another way:
 
 {% Aside %}
@@ -37,11 +37,17 @@ CSS styles defined inside Shadow DOM are scoped to the ShadowRoot. This means st
 {% endAside %}
 
 ```html
-<div><h3>Light DOM</div>
+<div><h3>Light DOM</h3></div>
 <script>
 var root = document.querySelector('div').createShadowRoot();
-root.innerHTML = '<style>h3{ color: red; }</style>' +
-                    '<h3>Shadow DOM';
+root.innerHTML = `
+  <style>
+    h3 {
+      color: red;
+    }
+  </style>
+  <h3>Shadow DOM</h3>
+`;
 </script>
 ```
 
@@ -63,10 +69,14 @@ The `:host` allows you to select and style the element hosting a shadow tree:
 <script>
 var button = document.querySelector('button');
 var root = button.createShadowRoot();
-root.innerHTML = '<style>' +
-    ':host { text-transform: uppercase; }' +
-    '</style>' +
-    '<content></content>';
+root.innerHTML = `
+  <style>
+    :host {
+      text-transform: uppercase;
+    }
+  </style>
+  <content></content>
+`;
 </script>
 ```
 
@@ -87,22 +97,22 @@ The functional form of `:host(<selector>)` allows you to target the host element
 
 ### Reacting to user states
 
-A common use case for `:host` is when you're creating a [Custom Element](https://www.html5rocks.com/tutorials/webcomponents/customelements/) and want to react to different user states (:hover, :focus, :active, etc.).
+A common use case for `:host` is when you're creating a [Custom Element](/customelements/) and want to react to different user states (:hover, :focus, :active, etc.).
 
 ```html
 <style>
-:host {
+  :host {
     opacity: 0.4;
     transition: opacity 420ms ease-in-out;
-}
-:host(:hover) {
+  }
+  :host(:hover) {
     opacity: 1;
-}
-:host(:active) {
+  }
+  :host(:active) {
     position: relative;
     top: 3px;
     left: 3px;
-}
+  }
 </style>
 ```
 
@@ -115,7 +125,7 @@ many people do theming by applying a class to `<html>` or `<body>`:
 
 ```html
 <body class="different">
-    <x-foo></x-foo>
+  <x-foo></x-foo>
 </body>
 ```
 
@@ -123,7 +133,7 @@ You can `:host-context(.different)` to style `<x-foo>` when it's a descendant of
 
 ```css
 :host-context(.different) {
-    color: red;
+  color: red;
 }
 ```
 
@@ -144,7 +154,7 @@ support styling many types of host elements from within the same Shadow DOM.
     /* Same as above. Applies if the host is a <x-foo> element. */
 }
 
-:host(div) {  {
+:host(div) {
     /* Applies if the host element is a <div>. */
 }
 ```
@@ -163,20 +173,22 @@ For example, if an element is hosting a shadow root, you can write `#host::shado
 
 ```html
 <style>
-    #host::shadow span {
+  #host::shadow span {
     color: red;
-    }
+  }
 </style>
 
 <div id="host">
-    <span>Light DOM</span>
+  <span>Light DOM</span>
 </div>
 
 <script>
-    var host = document.querySelector('div');
-    var root = host.createShadowRoot();
-    root.innerHTML = "<span>Shadow DOM</span>" +
-                    "<content></content>";
+  var host = document.querySelector('div');
+  var root = host.createShadowRoot();
+  root.innerHTML = `
+    <span>Shadow DOM</span>
+    <content></content>
+  `;
 </script>
 ```
 
@@ -192,7 +204,7 @@ x-tabs::shadow x-panel::shadow h2 {
 
 The `/deep/` combinator is similar to `::shadow`, but more powerful. It completely ignores all shadow boundaries and crosses into any number of shadow trees. Put simply, `/deep/` allows you to drill into an element's guts and target any node.
 
-The `/deep/` combinator is particularly useful in the world of Custom Elements where it's common to have multiple levels of Shadow DOM. Prime examples are nesting a bunch of custom elements (each hosting their own shadow tree) or creating an element that inherits from another using [`<shadow>`](https://www.html5rocks.com/tutorials/webcomponents/shadowdom-301/#toc-shadow-insertion).
+The `/deep/` combinator is particularly useful in the world of Custom Elements where it's common to have multiple levels of Shadow DOM. Prime examples are nesting a bunch of custom elements (each hosting their own shadow tree) or creating an element that inherits from another using [`<shadow>`](/shadowdom-301/#shadow-insertion-points).
 
 **Example** (custom elements) -  select all `<x-panel>` elements that are descendants of
 `<x-tabs>`, anywhere in the tree:
@@ -213,7 +225,7 @@ body /deep/ .library-theme {
 
 ### Working with querySelector()
 
-Just like [`.shadowRoot`](https://www.html5rocks.com/tutorials/webcomponents/shadowdom-301/#toc-get-shadowroot) opens
+Just like [`.shadowRoot`](/shadowdom-301/#obtaining-a-hosts-shadow-root) opens
 shadow trees up for DOM traversal, the combinators open shadow trees for selector traversal.
 Instead of writing a nested chain of madness, you can write a single statement:
 
@@ -235,7 +247,7 @@ uses Shadow DOM can be styled. Great examples are the `<input>` types and `<vide
 
 ```css
 video /deep/ input[type="range"] {
-    background: hotpink;
+  background: hotpink;
 }
 ```
 
@@ -263,22 +275,22 @@ body /deep/ .library-theme {
 
 ### Using custom pseudo elements
 
-Both [WebKit](http://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css?format=txt) and
-[Firefox](https://developer.mozilla.org/docs/CSS/CSS_Reference/Mozilla_Extensions#Pseudo-elements_and_pseudo-classes) define pseudo elements for styling internal pieces of native browser elements. A good example
-is the `input[type=range]`. You can style the slider thumb <span style="color:blue">blue</span> by targeting `::-webkit-slider-thumb`:
+Both [WebKit](https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css?format=txt) and
+[Firefox](https://developer.mozilla.org/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes) define pseudo elements for styling internal pieces of native browser elements. A good example
+is the `input[type=range]`. You can style the slider thumb `<span style="color:blue">blue</span>` by targeting `::-webkit-slider-thumb`:
 
 ```css
 input[type=range].custom::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    background-color: blue;
-    width: 10px;
-    height: 40px;
+  -webkit-appearance: none;
+  background-color: blue;
+  width: 10px;
+  height: 40px;
 }
 ```
 
 Similar to how browsers provide styling hooks into some internals,
 authors of Shadow DOM content can designate certain elements as styleable by
-outsiders. This is done through [custom pseudo elements](http://www.w3.org/TR/shadow-dom/#custom-pseudo-elements).
+outsiders. This is done through [custom pseudo elements](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Custom-Pseudo-Elements.md).
 
 You can designate an element as a custom pseudo element by using the `pseudo` attribute.
 Its value, or name, needs to be prefixed with "x-". Doing so creates
@@ -290,16 +302,18 @@ its slider thumb blue:
 
 ```html
 <style>
-    #host::x-slider-thumb {
+  #host::x-slider-thumb {
     background-color: blue;
-    }
+  }
 </style>
 <div id="host"></div>
 <script>
-var root = document.querySelector('#host').createShadowRoot();
-root.innerHTML = '<div>' +
-                    '<div pseudo="x-slider-thumb"></div>' +
-                    '</div>';
+  var root = document.querySelector('#host').createShadowRoot();
+  root.innerHTML = `
+    <div>
+      <div pseudo="x-slider-thumb"></div>' +
+    </div>
+  `;
 </script>
 ```
 
@@ -311,14 +325,14 @@ but loosened for custom pseudo element definitions.
 
 ### Using CSS Variables
 
-A powerful way to create theming hooks will be through [CSS Variables](http://dev.w3.org/csswg/css-variables/). Essentially, creating "style placeholders" for other users to fill in.
+A powerful way to create theming hooks will be through [CSS Variables](https://drafts.csswg.org/css-variables/). Essentially, creating "style placeholders" for other users to fill in.
 
 Imagine a custom element author who marks out variable placeholders in their Shadow DOM. One for styling an internal button's font and another for its color:
 
 ```css
 button {
-    color: var(--button-text-color, pink); /* default color will be pink */
-    font-family: var(--button-font);
+  color: var(--button-text-color, pink); /* default color will be pink */
+  font-family: var(--button-font);
 }
 ```
 
@@ -327,8 +341,8 @@ to match the super cool Comic Sans theme of their own page:
 
 ```css
 #host {
-    --button-text-color: green;
-    --button-font: "Comic Sans MS", "Comic Sans", cursive;
+  --button-text-color: green;
+  --button-font: "Comic Sans MS", "Comic Sans", cursive;
 }
 ```
 
@@ -337,26 +351,28 @@ works beautifully! The whole picture looks like this:
 
 ```html
 <style>
-    #host {
+  #host {
     --button-text-color: green;
     --button-font: "Comic Sans MS", "Comic Sans", cursive;
-    }
+  }
 </style>
 <div id="host">Host node</div>
 <script>
-var root = document.querySelector('#host').createShadowRoot();
-root.innerHTML = '<style>' +
-    'button {' +
-        'color: var(--button-text-color, pink);' +
-        'font-family: var(--button-font);' +
-    '}' +
-    '</style>' +
-    '<content></content>';
+  var root = document.querySelector('#host').createShadowRoot();
+  root.innerHTML = `
+    <style>
+      button {
+        color: var(--button-text-color, pink);
+        font-family: var(--button-font);
+      }
+    </style>
+    <content></content>
+  `;
 </script>
 ```
 
 {% Aside %}
-I've already mentioned [Custom Elements](https://www.html5rocks.com//tutorials/webcomponents/customelements/) a few times in this article. For now, just know that Shadow DOM forms their structural foundation
+I've already mentioned [Custom Elements](/customelements/) a few times in this article. For now, just know that Shadow DOM forms their structural foundation
 by providing styling and DOM encapsulation. The concepts here pertain to styling Custom Elements.
 {% endAside %}
 
@@ -375,18 +391,23 @@ Think of it as a way to start fresh when creating a new component.
 Below is a demo that shows how the shadow tree is affected by changing `resetStyleInheritance`:
 
 ```html
-`<div>
+<div>
   <h3>Light DOM</h3>
 </div>
 
 <script>
-var root = document.querySelector('div').createShadowRoot();
-root.resetStyleInheritance = <span id="code-resetStyleInheritance">false</span>;
-root.innerHTML = '<style>h3{ color: red; }</style>' +
-                 '<h3>Shadow DOM</h3>' +
-                 '<content select="h3"></content>';
+  var root = document.querySelector('div').createShadowRoot();
+  root.resetStyleInheritance = <span id="code-resetStyleInheritance">false</span>;
+  root.innerHTML = `
+    <style>
+      h3 {
+        color: red;
+      }
+    </style>
+    <h3>Shadow DOM</h3>
+    <content select="h3"></content>
+  `;
 </script>
-</pre>
 
 <div class="demoarea" style="width:225px;">
   <div id="style-ex-inheritance"><h3 class="border">Light DOM</div>
@@ -396,19 +417,16 @@ root.innerHTML = '<style>h3{ color: red; }</style>' +
 </div>
 
 <script>
-(function() {
-var container = document.querySelector('#style-ex-inheritance');
-var root = container.createShadowRoot();
-//root.resetStyleInheritance = false;
-root.innerHTML = '<style>h3{ color: red; }</style><h3>Shadow DOM<content select="h3"></content>';
+  var container = document.querySelector('#style-ex-inheritance');
+  var root = container.createShadowRoot();
+  //root.resetStyleInheritance = false;
+  root.innerHTML = '<style>h3{ color: red; }</style><h3>Shadow DOM<content select="h3"></content>';
 
-document.querySelector('#demo-resetStyleInheritance').addEventListener('click', function(e) {
-  root.resetStyleInheritance = !root.resetStyleInheritance;
-  e.target.textContent = 'resetStyleInheritance=' + root.resetStyleInheritance;
-  document.querySelector('#code-resetStyleInheritance').textContent = root.resetStyleInheritance;
-});
-
-})();
+  document.querySelector('#demo-resetStyleInheritance').addEventListener('click', function(e) {
+    root.resetStyleInheritance = !root.resetStyleInheritance;
+    e.target.textContent = 'resetStyleInheritance=' + root.resetStyleInheritance;
+    document.querySelector('#code-resetStyleInheritance').textContent = root.resetStyleInheritance;
+  });
 </script>
 ```
 
@@ -427,7 +445,7 @@ If you're unsure about which properties inherit in CSS, check out [this handy li
 
 ## Styling distributed nodes
 
-Distributed nodes are elements that render at an [insertion point](https://www.html5rocks.com/tutorials/webcomponents/shadowdom-301/#toc-distributed-nodes) (a `<content>` element). The `<content>` element allows you to select nodes from the Light DOM and render them at predefined locations in your Shadow DOM. They're not logically in the Shadow DOM; they're still children of the host element. Insertion points are just a rendering thing.
+Distributed nodes are elements that render at an [insertion point](/shadowdom-301/#elementgetdistributednodes) (a `<content>` element). The `<content>` element allows you to select nodes from the Light DOM and render them at predefined locations in your Shadow DOM. They're not logically in the Shadow DOM; they're still children of the host element. Insertion points are just a rendering thing.
 
 Distributed nodes retain styles from the main document. That is, style rules
 from the main page continue to apply to the elements, even when they render at an insertion point.
@@ -447,29 +465,30 @@ Let's see an example:
 
 ```html
 <div>
-    <h3>Light DOM
-    <section>
+  <h3>Light DOM</h3>
+  <section>
     <div>I'm not underlined</div>
     <p>I'm underlined in Shadow DOM!</p>
-    </section>
+  </section>
 </div>
 
 <script>
 var div = document.querySelector('div');
 var root = div.createShadowRoot();
-root.innerHTML = '\
-    <style>\
-        h3 { color: red; }\
-        content[select="h3"]::content > h3 {\
-        color: green;\
-        }\
-        ::content section p {\
-        text-decoration: underline;\
-        }\
-    </style>\
-    <h3>Shadow DOM\
-    <content select="h3"></content>\
-    <content select="section"></content>';
+root.innerHTML = `
+  <style>
+    h3 { color: red; }
+      content[select="h3"]::content > h3 {
+      color: green;
+    }
+    ::content section p {
+      text-decoration: underline;
+    }
+  </style>
+  <h3>Shadow DOM</h3>
+  <content select="h3"></content>
+  <content select="section"></content>
+`;
 </script>
 ```
 

--- a/src/site/content/en/blog/shadowdom-301/index.md
+++ b/src/site/content/en/blog/shadowdom-301/index.md
@@ -11,11 +11,11 @@ tags:
 ---
 
 {% Aside 'warning' %}
-This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipping in Chrome 53, Opera, and Safari 10.
+This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
 {% endAside %}
 
-This article discusses more of the amazing things you can do with Shadow DOM! It builds on the concepts discussed in [Shadow DOM 101](https://www.html5rocks.com/tutorials/webcomponents/shadowdom/)
-and [Shadow DOM 201](https://www.html5rocks.com/tutorials/webcomponents/shadowdom-201/).
+This article discusses more of the amazing things you can do with Shadow DOM! It builds on the concepts discussed in [Shadow DOM 101](/shadowdom/)
+and [Shadow DOM 201](/shadowdom-201/).
 
 {% Aside %}
 In Chrome, turn on the "Enable experimental Web Platform features" in about:flags to experiment with everything covered in this article.
@@ -33,13 +33,12 @@ Let's see what happens if we try to attach multiple shadow roots to a host:
 ```html
 <div id="example1">Light DOM</div>
 <script>
-var container = document.querySelector('#example1');
-var root1 = container.createShadowRoot();
-var root2 = container.createShadowRoot();
-root1.innerHTML = '<div>Root 1 FTW</div>';
-root2.innerHTML = '<div>Root 2 FTW</div>';
+  var container = document.querySelector('#example1');
+  var root1 = container.createShadowRoot();
+  var root2 = container.createShadowRoot();
+  root1.innerHTML = '<div>Root 1 FTW</div>';
+  root2.innerHTML = '<div>Root 2 FTW</div>';
 </script>
-</pre>
 ```
 
 {% Aside %}
@@ -65,7 +64,7 @@ rendering party? Enter shadow insertion points.
 
 ### Shadow Insertion Points
 
-"Shadow insertion points" (`<shadow>`) are similar to normal [insertion points](https://www.html5rocks.com/tutorials/webcomponents/shadowdom/#toc-separation-separate) (`<content>`) in that they're placeholders. However, instead of being placeholders for a host's *content*, they're hosts for other *shadow trees*.
+"Shadow insertion points" (`<shadow>`) are similar to normal [insertion points](/shadowdom/#step-2-separate-content-from-presentation) (`<content>`) in that they're placeholders. However, instead of being placeholders for a host's *content*, they're hosts for other *shadow trees*.
 It's Shadow DOM Inception!
 
 As you can probably imagine, things get more complicated the further you drill down
@@ -108,7 +107,7 @@ Sometimes it's useful to know the older shadow tree being rendered at a `<shadow
 
 ## Obtaining a host's shadow root
 
-If an element is hosting Shadow DOM you can access its [youngest shadow root](#youngest-tree)
+If an element is hosting Shadow DOM you can access its [youngest shadow root](#using-multiple-shadow-roots)
 using `.shadowRoot`:
 
 ```js
@@ -164,7 +163,7 @@ root2.appendChild(shadow);
 </script>
 ```
 
-This example is nearly identical to the one in the [previous section](#toc-shadow-insertion).
+This example is nearly identical to the one in the [previous section](#shadow-insertion-points).
 The only difference is that now I'm using `select` to pull out the newly added `<span>`.
 
 ## Working with insertion points
@@ -256,22 +255,22 @@ a node is distributed into by calling its `.getDestinationInsertionPoints()`:
 
 ```html
 <div id="host">
-    <h2>Light DOM
+  <h2>Light DOM
 </div>
 
 <script>
-    var container = document.querySelector('div');
+  var container = document.querySelector('div');
 
-    var root1 = container.createShadowRoot();
-    var root2 = container.createShadowRoot();
-    root1.innerHTML = '<content select="h2"></content>';
-    root2.innerHTML = '<shadow></shadow>';
+  var root1 = container.createShadowRoot();
+  var root2 = container.createShadowRoot();
+  root1.innerHTML = '<content select="h2"></content>';
+  root2.innerHTML = '<shadow></shadow>';
 
-    var h2 = document.querySelector('#host h2');
-    var insertionPoints = h2.getDestinationInsertionPoints();
-    [].forEach.call(insertionPoints, function(contentEl) {
+  var h2 = document.querySelector('#host h2');
+  var insertionPoints = h2.getDestinationInsertionPoints();
+  [].forEach.call(insertionPoints, function(contentEl) {
     console.log(contentEl);
-    });
+  });
 </script>
 ```
 
@@ -344,6 +343,5 @@ I hope you'll agree that **Shadow DOM is incredibly powerful**. For the first ti
 Shadow DOM is certainly complex beast, but it's a beast worth adding to the web platform.
 Spend some time with it. Learn it. Ask questions.
 
-If you want to learn more, see Dominic's intro article [Shadow DOM 101](https://www.html5rocks.com/tutorials/webcomponents/shadowdom/)
-and my [Shadow DOM 201: CSS &amp; Styling](https://www.html5rocks.com/tutorials/webcomponents/shadowdom-201/) article.
-
+If you want to learn more, see Dominic's intro article [Shadow DOM 101](/shadowdom/)
+and my [Shadow DOM 201: CSS &amp; Styling](/shadowdom-201/) article.

--- a/src/site/content/en/blog/shadowdom/index.md
+++ b/src/site/content/en/blog/shadowdom/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 {% Aside 'warning' %}
-This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipping in Chrome 53, Opera, and Safari 10.
+This article describes an old version of Shadow DOM (v0). If you're interested in using Shadow DOM, check out our new article, "[Shadow DOM v1: self-contained web components](/shadowdom-v1/)". It covers everything in the newer Shadow DOM v1 spec shipped in Chrome 53, Safari 10, and Firefox 63.
 {% endAside %}
 
 ## Introduction
@@ -53,13 +53,11 @@ DOM changes, your styles and scripts might break in unpredictable
 ways.
 {% endAside %}
 
-Web Components is comprised of four
-parts:
+Web Components is comprised of three parts:
 
-1. [Templates](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/templates/index.html)
-1. [Shadow DOM](http://www.w3.org/TR/shadow-dom/)
-1. [Custom Elements](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html)
-1. [Packaging](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/explainer/index.html#external-custom-elements-and-decorators)
+1. [Templates](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element)
+1. [Shadow DOM](https://www.w3.org/TR/shadow-dom/)
+1. [Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html)
 
 
 **Shadow DOM** addresses the DOM tree encapsulation problem. The
@@ -268,11 +266,11 @@ shadow.appendChild(clone);
 
 {% Aside %}
 Templates, like Shadow DOM, are an emerging
-standard. The `<template>` element is available in [many modern browsers](http://caniuse.com/#search=template). You can also populate a shadow root using familiar
+standard. The `<template>` element is available in [many modern browsers](https://caniuse.com/template). You can also populate a shadow root using familiar
 properties and methods like `innerHTML`, `appendChild`, `getElementById`,
 and so on. This article is focused on Shadow DOM, so we won’t go
 further into how the template element works here. If you want to learn
-more about `<template>`, see [HTML's New Template Tag](https://www.html5rocks.com/tutorials/webcomponents/template/).
+more about `<template>`, see [HTML's New Template Tag](/webcomponents-template/).
 {% endAside %}
 
 Now that we have set up a shadow root, the name tag is rendered
@@ -497,7 +495,7 @@ island vacation (you know… with hammocks made out of Red Vines.) You
 set up your document this way:
 
 
-``html
+```html
 <div class="dateRangePicker">
   <label for="start">Start:</label>
   <input type="date" name="startDate" id="start">
@@ -536,5 +534,4 @@ one shadow host, or nested shadows for encapsulation, or architect
 your page using Model-Driven Views (MDV) and Shadow DOM. And Web
 Components are more than just Shadow DOM.
 
-We explain those in later posts. Now,
-follow [Web Components on Google+](https://plus.google.com/103330502635338602217/posts).
+We explain those in later posts.

--- a/src/site/content/en/blog/webcomponents-template/index.md
+++ b/src/site/content/en/blog/webcomponents-template/index.md
@@ -96,11 +96,11 @@ but [content model](http://www.w3.org/TR/html5-diff/#content-model) children. It
 
 ```html
 <table>
-<tr>
+  <tr>
     <template id="cells-to-repeat">
-    <td>some content</td>
+      <td>some content</td>
     </template>
-</tr>
+  </tr>
 </table>
 ```
 
@@ -131,31 +131,32 @@ runs when the button is pressed, stamping out the template.
 <button onclick="useIt()">Use me</button>
 <div id="container"></div>
 <script>
-    function useIt() {
+  function useIt() {
     var content = document.querySelector('template').content;
     // Update something in the template DOM.
     var span = content.querySelector('span');
     span.textContent = parseInt(span.textContent) + 1;
     document.querySelector('#container').appendChild(
-        document.importNode(content, true));
-    }
+      document.importNode(content, true)
+    );
+  }
 </script>
 
 <template>
-    <div>Template used: <span>0</span></div>
-    <script>alert('Thanks!')</script>
+  <div>Template used: <span>0</span></div>
+  <script>alert('Thanks!')</script>
 </template>
 ```
 
 ### Example: Creating Shadow DOM from a template
 
-Most people attach [Shadow DOM](https://www.html5rocks.com/tutorials/webcomponents/shadowdom/) to a host by setting a string of markup to `.innerHTML`:
+Most people attach [Shadow DOM](/shadowdom/) to a host by setting a string of markup to `.innerHTML`:
 
 ```html
 <div id="host"></div>
 <script>
-    var shadow = document.querySelector('#host').createShadowRoot();
-    shadow.innerHTML = '<span>Host node</span>';
+  var shadow = document.querySelector('#host').createShadowRoot();
+  shadow.innerHTML = '<span>Host node</span>';
 </script>
 ```
 
@@ -170,7 +171,7 @@ content to a shadow root:
 ```html
 <template>
 <style>
-    :host {
+  :host {
     background: #f8f8f8;
     padding: 10px;
     transition: all 400ms ease-in-out;
@@ -178,52 +179,52 @@ content to a shadow root:
     border-radius: 5px;
     width: 450px;
     max-width: 100%;
-    }
-    :host(:hover) {
+  }
+  :host(:hover) {
     background: #ccc;
-    }
-    div {
+  }
+  div {
     position: relative;
-    }
-    header {
+  }
+  header {
     padding: 5px;
     border-bottom: 1px solid #aaa;
-    }
-    h3 {
+  }
+  h3 {
     margin: 0 !important;
-    }
-    textarea {
+  }
+  textarea {
     font-family: inherit;
     width: 100%;
     height: 100px;
     box-sizing: border-box;
     border: 1px solid #aaa;
-    }
-    footer {
+  }
+  footer {
     position: absolute;
     bottom: 10px;
     right: 5px;
-    }
+  }
 </style>
 <div>
-    <header>
+  <header>
     <h3>Add a Comment
-    </header>
-    <content select="p"></content>
-    <textarea></textarea>
-    <footer>
+  </header>
+  <content select="p"></content>
+  <textarea></textarea>
+  <footer>
     <button>Post</button>
-    </footer>
+  </footer>
 </div>
 </template>
 
 <div id="host">
-    <p>Instructions go here</p>
+  <p>Instructions go here</p>
 </div>
 
 <script>
-    var shadow = document.querySelector('#host').createShadowRoot();
-    shadow.appendChild(document.querySelector('template').content);
+  var shadow = document.querySelector('#host').createShadowRoot();
+  shadow.appendChild(document.querySelector('template').content);
 </script>
 ```
 
@@ -242,11 +243,11 @@ The only time a template renders is when it goes live.
 
     ```html
     <template>
-        <ul>
+      <ul>
         <template>
-            <li>Stuff</li>
+          <li>Stuff</li>
         </template>
-        </ul>
+      </ul>
     </template>
     ```
 
@@ -267,8 +268,8 @@ DOM and hide it from view using the `hidden` attribute or `display:none`.
 
 ```html
 <div id="mytemplate" hidden>
-    <img src="logo.png">
-    <div class="comment"></div>
+  <img src="logo.png">
+  <div class="comment"></div>
 </div>
 ```
 
@@ -294,8 +295,8 @@ For example:
 
 ```html
 <script id="mytemplate" type="text/x-handlebars-template">
-    <img src="logo.png">
-    <div class="comment"></div>
+  <img src="logo.png">
+  <div class="comment"></div>
 </script>
 ```
 
@@ -322,9 +323,7 @@ full featured is always a good thing in my book.
 ## Additional resources
 
 - [WhatWG Specification][spec-link]
-- [Introduction to Web Components](http://w3c.github.io/webcomponents/explainer/#template-section)
+- [Introduction to Web Components](https://www.w3.org/TR/2012/WD-components-intro-20120522/#template-section)
 - [&lt;web>components&lt;/web>](http://html5-demos.appspot.com/static/webcomponents/index.html) ([video](http://www.youtube.com/watch?v=eJZx9c6YL8k)) - a fantastically comprehensive presentation by yours truly.
 
-[spec-link]: http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting-1.html#the-template-element
-
-
+[spec-link]: https://html.spec.whatwg.org/multipage/scripting.html#the-template-element


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixed a bunch of broken `html5rocks` links and `#` cross references in old articles about Web Components specs,
- Improved code indentation (that apparently was messed up, especially in case of CSS), added missing backticks,
- Removed a few links that are clearly outdated, e.g. Google Plus. Replaced some other links, changed to `https:`,
- Added a missing warning to an old article about Custom Elements (inspired by those in Shadow DOM articles),
- Removed a few closing `</pre>` tags - most likely leftovers from the old website that wasn't using markdown.

