### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/blog/structured-clone/index.md
+++ b/src/site/content/en/blog/structured-clone/index.md
@@ -97,7 +97,7 @@ However, it still has some limitations that may catch you off-guard:
  
 - **Prototypes**: If you use `structuredClone()` with a class instance, you’ll get a plain object as the return
 value, as structured cloning discards the object’s prototype chain. 
-- **Functions**: If your object contains functions, they will be _quietly_ discarded.
+- **Functions**: If your object contains functions, `structuredClone()` will throw a `DataCloneError` exception.
 - **Non-cloneables**: Some values are not structured cloneable, most notably `Error` and DOM nodes. It
 will cause `structuredClone()` to throw.
  


### PR DESCRIPTION
If an object contains functions, then the `structuredClone` API actually throws a `DataCloneError` exception error, so functions are not quietly discarded. It might also be correct to say that "API attemps to throw a `DataCloneError` exception`.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Content update: How `structuredClone` deals with functions inside an object.

