### PR TITLE
Use AudioWorklet instead of ScriptProcessor

### DIFF
--- a/src/site/content/en/blog/media-recording-audio/index.md
+++ b/src/site/content/en/blog/media-recording-audio/index.md
@@ -133,7 +133,7 @@ ultimately to a speaker so that the user can hear it.
 One of the nodes that you can connect is an `AudioWorkletNode`. This node gives
 you the low-level capability for custom audio processing. The actual audio
 processing happens in the `process()` callback method in the `AudioWorkletProcessor`.
-This function is called to feed inputs and parameters and fetch outputs.
+Call this function to feed inputs and parameters and fetch outputs.
 
 Checkout [Enter Audio Worklet](https://developer.chrome.com/blog/audio-worklet/)
 to learn more.

--- a/src/site/content/en/blog/media-recording-audio/index.md
+++ b/src/site/content/en/blog/media-recording-audio/index.md
@@ -135,7 +135,7 @@ you the low-level capability for custom audio processing. The actual audio
 processing happens in the `process()` callback method in the `AudioWorkletProcessor`.
 Call this function to feed inputs and parameters and fetch outputs.
 
-Checkout [Enter Audio Worklet](https://developer.chrome.com/blog/audio-worklet/)
+Check out [Enter Audio Worklet](https://developer.chrome.com/blog/audio-worklet/)
 to learn more.
 
 ```html


### PR DESCRIPTION
This PR promotes `AudioWorklet` instead of `ScriptProcessor` in the "Access the raw data from the microphone" section from "Recording Audio from the User" blog posts.

Live preview: https://deploy-preview-9175--web-dev-staging.netlify.app/media-recording-audio/#access-the-raw-data-from-the-microphone