### PR TITLE
Fix typo in learn/css/pseudo-classes

### DIFF
--- a/src/site/content/en/learn/css/pseudo-classes/pseudo-classes.assess.yml
+++ b/src/site/content/en/learn/css/pseudo-classes/pseudo-classes.assess.yml
@@ -32,7 +32,7 @@ questions:
   - type: multiple-choice
     cardinality: "1+"
     correctAnswers: "0,3,4"
-    stem: Which of the following psuedo-classes are due to a user-interaction?
+    stem: Which of the following pseudo-classes are due to a user-interaction?
     options:
       - content: "`:hover`"
         rationale: "🎉"


### PR DESCRIPTION
Fixes #9188

