### PR TITLE
Fix: fallback for upcoming src syntax

### DIFF
--- a/src/site/content/en/blog/variable-fonts/index.md
+++ b/src/site/content/en/blog/variable-fonts/index.md
@@ -327,8 +327,8 @@ static web fonts, but with two new enhancements:
 ```css
 @font-face {
 	font-family: 'Roboto Flex';
-	src: url('RobotoFlex-VF.woff2') format('woff2') tech('variations'),
-	     url('RobotoFlex-VF.woff2') format('woff2-variations');
+	src: url('RobotoFlex-VF.woff2') format('woff2-variations');
+	src: url('RobotoFlex-VF.woff2') format('woff2') tech('variations');
 	font-weight: 100 1000;
 	font-stretch: 25% 151%;
 }


### PR DESCRIPTION
## Changes proposed in this pull request

Add a second `src` definition for the fallback instead of defining them inline.

## Reason:
Original solution didn't work. 'Example 22' in the [linked working draft](https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing) also suggests using two definitions.