### PR TITLE
Learn HTML: change <script> href attribute to src

### DIFF
--- a/src/site/content/en/learn/html/document-structure/index.md
+++ b/src/site/content/en/learn/html/document-structure/index.md
@@ -253,7 +253,7 @@ There are two attributes that can reduce the blocking nature of JavaScript downl
 To include MLW's JavaScript in an external file, you could write:
 
 ```html
-<script href="js/switch.js" defer>
+<script src="js/switch.js" defer>
 ```
 Adding the [`defer`](https://developer.mozilla.org/docs/Learn/JavaScript/First_steps/What_is_JavaScript#script_loading_strategies) attribute defers the execution of the script until after everything is rendered, preventing the script from harming performance. The `async` and `defer` attributes are only valid on external scripts.
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #9221

Changes proposed in this pull request:

-change <script href> attribute to <script src>
