### PR TITLE
fix code in /learn/html/links

### DIFF
--- a/src/site/content/en/learn/html/links/index.md
+++ b/src/site/content/en/learn/html/links/index.md
@@ -186,7 +186,7 @@ The `links` attribute returns an `HTMLCollection` matching `a` and `area` elemen
 ```js
 let a = document.links[0]; // obtain the first link in the document
 
-a.href = newpage.html'; // change the destination URL of the link
+a.href = 'newpage.html'; // change the destination URL of the link
 a.protocol = 'ftp'; // change just the scheme part of the URL
 a.setAttribute('href', 'https://machinelearningworkshop.com/'); // change the attribute content directly
 ```


### PR DESCRIPTION
there's a code assigning a string to `a.href` in https://web.dev/learn/html/links/#links-and-javascript ; however the string misses an opening quote.

<img width="796" alt="Screenshot: part of learn/html/links where there's an error in sytax" src="https://user-images.githubusercontent.com/413984/206890898-93554de8-8b44-4035-8fb0-d25c11389d06.png">

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- fix code in example