### PR TITLE
Update Compat widget on Contructable Style Sheets Doc

### DIFF
--- a/src/site/content/en/blog/constructable-stylesheets/index.md
+++ b/src/site/content/en/blog/constructable-stylesheets/index.md
@@ -5,7 +5,7 @@ subhead: Seamless reusable styles.
 authors:
   - developit
 date: 2019-02-08
-updated: 2022-02-23
+updated: 2022-12-14
 description: Constructable Stylesheets provide a seamless way to create and distribute styles to documents or shadow roots without worrying about FOUC.
 tags:
   - blog
@@ -17,12 +17,10 @@ way to create and distribute reusable styles when using [Shadow
 DOM](/shadowdom-v1/).
 
 {% Aside %}
-Constructable Stylesheets are available in Chromium
-(versions 73 and higher), and in Firefox from version 75 behind the
-`layout.css.constructable-stylesheets.enabled` flag.
+Constructable Stylesheets are available in Chromium and Firefox
 {% endAside %}
 
-{% BrowserCompat 'api.CSSStyleSheet' %}
+{% BrowserCompat 'api.CSSStyleSheet.CSSStyleSheet' %}
 
 It has always been possible to create stylesheets using JavaScript. However, the
 process has historically been to create a `<style>` element using

--- a/src/site/content/en/blog/constructable-stylesheets/index.md
+++ b/src/site/content/en/blog/constructable-stylesheets/index.md
@@ -16,10 +16,6 @@ tags:
 way to create and distribute reusable styles when using [Shadow
 DOM](/shadowdom-v1/).
 
-{% Aside %}
-Constructable Stylesheets are available in Chromium and Firefox
-{% endAside %}
-
 {% BrowserCompat 'api.CSSStyleSheet.CSSStyleSheet' %}
 
 It has always been possible to create stylesheets using JavaScript. However, the


### PR DESCRIPTION
Noticed this had the wrong BCD link - it likes to CSS support (which ALL browsers support).

Also removed the version number info as no longer relevant (especially with the correct BCD data).
