### PR TITLE
Link to web.dev HTML course instead of MDN

### DIFF
--- a/src/site/content/en/learn/css/index.md
+++ b/src/site/content/en/learn/css/index.md
@@ -30,9 +30,7 @@ This course is created for beginner and advanced CSS developers alike.
 You can go through the series from start to finish
 to get a general understanding of CSS from top to bottom,
 or you can use it as a reference for specific styling subjects.
-For those new to web development overall, check out the
-[intro to HTML](https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML)
-course from MDN to learn all about how to write markup and link your stylesheets.
+For those new to web development overall, check out [Learn HTML](/learn/html/) to learn all about how to write markup and link your stylesheets.
 
 Here's what you'll learn:
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #9255

Changes proposed in this pull request:

- Link to Learn HTML web.dev course instead of MDN's Intro to HTML
