### PR TITLE
Fixing broken link to an article about new viewport units

### DIFF
--- a/src/site/content/en/blog/web-platform-11-2022/index.md
+++ b/src/site/content/en/blog/web-platform-11-2022/index.md
@@ -27,7 +27,7 @@ There's a change to how the Layout Viewport behaves from Chrome 108 on Android w
 
 Also in Chrome 108 are the new CSS Viewport Units. These include small (`svw`, `svh`, `svi`, `svb`, `svmin`, `svmax`), large (`lvw`, `lvh`, `lvi`, `lvb`, `lvmin`, `lvmax`), dynamic (`dvw`, `dvh`, `dvi`, `dvb`, `dvmin`, `dvmax`), and logical (`vi`, `vb`) units. These units are already implemented in Firefox and Safari, meaning that we now have interop across the three main browser engines for these units.
 
-Read [The Large, Small, and Dynamic viewport units](https://developer.chrome.com/docs/lighthouse/pwa/viewport/-units/).
+Read [The large, small, and dynamic viewport units](https://web.dev/viewport-units/).
 
 {% BrowserCompat 'css.types.length.viewport_percentage_units_large' %}
 


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Updating broken link for "The large, small, and dynamic viewport units" article to point to web.dev article about this topic


