### PR TITLE
Fix incorrect page view event name

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -174,7 +174,7 @@ function addPageShowEventListener() {
      */
     (e) => {
       if (e.persisted) {
-        logEvent('pageview', {
+        logEvent('page_view', {
           [dimensions.NAVIGATION_TYPE]: 'back-forward-cache',
         });
       }


### PR DESCRIPTION
After looking at some of the initial data coming into GA4, I noticed I missed updating this name from `pageview` to `page_view`.