### PR TITLE
Update WebAudio documentation

### DIFF
--- a/src/site/content/en/blog/webaudio-intro/index.md
+++ b/src/site/content/en/blog/webaudio-intro/index.md
@@ -137,8 +137,7 @@ pre-loaded.
 Of course, it would be better to create a more general loading system
 which isn't hard-coded to loading this specific sound. There are many
 approaches for dealing with the many short- to medium-length sounds that
-an audio application or game would use–here's one way using a
-[BufferLoader class][BufferLoader].
+an audio application or game would use–here's one way using a BufferLoader (not part of web standard).
 
 The following is an example of how you can use the `BufferLoader` class.
 Let's create two `AudioBuffers`; and, as soon as they are loaded,


### PR DESCRIPTION
The article mentioned a broken link to BufferLoader as well as not being clear about this class being a non-api feature but custom implementation.

Changes proposed in this pull request:

- WebAudio API documentation