### PR TITLE
Fix incorrect title for WebWorker article

### DIFF
--- a/src/site/content/en/blog/workers-basics/index.md
+++ b/src/site/content/en/blog/workers-basics/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introducing WebSockets - Bringing Sockets to the Web
+title: The Basics of Web Workers
 authors:
   - malteubl
   - agektmr


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

It appears that in the batch H5R migration done in #8036, the title for the WebSocket article was mistakingly used for the WebWorker article as well. This PR restores the title from the original H5R post.

Changes proposed in this pull request:

- Fix the incorrect title in the following article: https://web.dev/workers-basics/

