### PR TITLE
update legacy go get syntax, add note

### DIFF
--- a/src/site/content/en/blog/web-bundles/index.md
+++ b/src/site/content/en/blog/web-bundles/index.md
@@ -118,8 +118,10 @@ specification built in [Go](https://golang.org/).
 1. Install `go/bundle`.
 
    ```bash
-   go get -u github.com/WICG/webpackage/go/bundle/cmd/...
+   go install github.com/WICG/webpackage/go/bundle/cmd/...@latest
    ```
+   -   This will install the command at $GOPATH/bin or $HOME/go/bin depending on if $GOPATH 
+       is set.
 
 1. Clone the [preact-todomvc](https://github.com/developit/preact-todomvc) repository and build
    the web app to get ready to bundle the resources.
@@ -134,7 +136,7 @@ specification built in [Go](https://golang.org/).
 2. Use the `gen-bundle` command to build a `.wbn` file.
 
     ```bash
-    gen-bundle -dir build -baseURL https://preact-todom.vc/ -primaryURL https://preact-todom.vc/ -o todomvc.wbn
+    ~/go/bin/gen-bundle -dir build -baseURL https://preact-todom.vc/ -primaryURL https://preact-todom.vc/ -o todomvc.wbn
     ```
 
 Congratulations! TodoMVC is now a Web Bundle.
@@ -181,7 +183,7 @@ Everything magically works.
   </figcaption>
 </figure>
 
-You could also try out other sample web bundles:
+You could also try out other sample web bundles (these no longer seem to work on Android Chrome):
 
 - [web.dev.wbn](https://storage.googleapis.com/web-dev-assets/web-bundles/web.dev.wbn) is a
    snapshot of the entire web.dev site, as of 2019 October 15.


### PR DESCRIPTION
web bundle files linked did not work on Android, but one i built myself works fine. Example web bundles will need to be updated

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


Changes proposed in this pull request:

- `go get` no longer works outside of a module. thus, I used `go install` which `go get` recommends.
- web bundles linked no longer work on android, so i mentioned that in article

