### PR TITLE
Stop the web.dev homepage LCP image being lazy loaded

### DIFF
--- a/src/site/_includes/partials/picked-case-study.njk
+++ b/src/site/_includes/partials/picked-case-study.njk
@@ -11,7 +11,7 @@
   {% if featureCard and featureCard.video %}
   {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background", fetchpriority="high"%}
   {% else %}
-  {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background" %}
+  {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background", loading="eager" %}
   {% endif %}
 </a>
 {% endif %}

--- a/src/site/_includes/partials/picked-case-study.njk
+++ b/src/site/_includes/partials/picked-case-study.njk
@@ -8,6 +8,10 @@
 <a class="feature-card" href="{{ pickedItem.url }}" data-treatment="bg-image">
   <span class="feature-card__eyebrow">Case study</span>
   <h3 class="feature-card__title">{{ pickedItem.data.title }}</h3>
+  {% if featureCard and featureCard.video %}
+  {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background", fetchpriority="high"%}
+  {% else %}
   {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background" %}
+  {% endif %}
 </a>
 {% endif %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Currently the LCP image on web.dev home page is the second image, as the video doesn't count. The second image is lazy loaded, affecting our LCP :-( This PR fixes that.

