### PR TITLE
Adds a note on responsiveness thresholds and INP in the RAIL documentation.

### DIFF
--- a/src/site/content/en/fast/rail/index.md
+++ b/src/site/content/en/fast/rail/index.md
@@ -123,6 +123,10 @@ processing time:
   <figcaption>How idle tasks affect input response budget.</figcaption>
 </figure>
 
+{% Aside 'important' %}
+The 50 millisecond threshold for responding to interactions is great when conditions are ideal. For users on hardware with less memory and processing power, this threshold can be very difficult to achieve. This is why the [Interaction to Next Paint (INP)](/inp/) metric's "good" threshold is set to 200 milliseconds or less.
+{% endAside %}
+
 ## Animation: produce a frame in 10&nbsp;ms
 
 **Goals**:


### PR DESCRIPTION
Changes proposed in this pull request:

- The [RAIL documentation](https://web.dev/rail/) currently advises developers to respond to user inputs within 50 milliseconds, but this conflicts with the [INP thresholds](https://web.dev/inp/#whats-a-good-inp-value) which state that 200 milliseconds or less is fine. This PR adds an aside to clarify this.