### PR TITLE
Remove course analytics gtags

### DIFF
--- a/src/lib/components/CourseLinks/index.js
+++ b/src/lib/components/CourseLinks/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #9277

Changes proposed in this pull request:

- Remove gtag calls as currently not working and turns out they are not actually used!
- I've left the percentage calculation in there, just in case we want to surface it in the front end in future.

