### PR TITLE
Rail -> Core Web Vitals updates

### DIFF
--- a/src/site/_data/i18n/paths/fast.yml
+++ b/src/site/_data/i18n/paths/fast.yml
@@ -35,6 +35,15 @@ topics:
     ru: Введение
     zh: 介绍
 
+  core_web_vitals:
+    en: Core Web Vitals
+    es: Core Web Vitals
+    ja: Core Web Vitals
+    ko: Core Web Vitals
+    pt: Core Web Vitals
+    ru: Core Web Vitals
+    zh: Core Web Vitals
+
   set_performance_budgets:
     en: Set performance budgets
     es: Definir los presupuestos de rendimiento

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -2,7 +2,7 @@
   "slug": "fast",
   "cover": "image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/fjFJRFnHXiem8yF0GGQ9.svg",
   "title": "i18n.paths.fast.title",
-  "updated": "November 10, 2022",
+  "updated": "January 6, 2023",
   "description": "i18n.paths.fast.description",
   "overview": "i18n.paths.fast.overview",
     "topics": [
@@ -12,8 +12,18 @@
         "why-speed-matters",
         "what-is-speed",
         "how-to-measure-speed",
-        "how-to-stay-fast",
-        "rail"
+        "how-to-stay-fast"
+      ]
+    },
+    {
+      "title": "i18n.paths.fast.topics.core_web_vitals",
+      "pathItems": [
+        "vitals",
+        "user-centric-performance-metrics",
+        "defining-core-web-vitals-thresholds",
+        "lcp",
+        "cls",
+        "fid"
       ]
     },
     {
@@ -116,7 +126,9 @@
         "chrome-ux-report-data-studio-dashboard",
         "chrome-ux-report-pagespeed-insights",
         "chrome-ux-report-bigquery",
-        "chrome-ux-report-api"
+        "chrome-ux-report-api",
+        "lab-and-field-data-differences",
+        "crux-and-rum-differences"
       ]
     },
     {

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -2,7 +2,7 @@
   "slug": "fast",
   "cover": "image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/fjFJRFnHXiem8yF0GGQ9.svg",
   "title": "i18n.paths.fast.title",
-  "updated": "January 6, 202",
+  "updated": "January 6, 2022",
   "description": "i18n.paths.fast.description",
   "overview": "i18n.paths.fast.overview",
     "topics": [

--- a/src/site/_data/paths/fast.json
+++ b/src/site/_data/paths/fast.json
@@ -2,7 +2,7 @@
   "slug": "fast",
   "cover": "image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/fjFJRFnHXiem8yF0GGQ9.svg",
   "title": "i18n.paths.fast.title",
-  "updated": "January 6, 2023",
+  "updated": "January 6, 202",
   "description": "i18n.paths.fast.description",
   "overview": "i18n.paths.fast.overview",
     "topics": [
@@ -23,7 +23,10 @@
         "defining-core-web-vitals-thresholds",
         "lcp",
         "cls",
-        "fid"
+        "fid",
+        "optimize-lcp",
+        "optimize-cls",
+        "optimize-fid"
       ]
     },
     {
@@ -66,6 +69,7 @@
       "title": "i18n.paths.fast.topics.optimize_your_javascript",
       "pathItems": [
         "optimize-long-tasks",
+        "optimize-inp",
         "apply-instant-loading-with-prpl",
         "reduce-javascript-payloads-with-code-splitting",
         "remove-unused-code",

--- a/src/site/content/en/blog/off-main-thread/index.md
+++ b/src/site/content/en/blog/off-main-thread/index.md
@@ -42,7 +42,7 @@ from hyper-constrained feature phones to high-powered,
 high-refresh-rate flagship machines.
 
 If we want sophisticated web apps to reliably meet performance guidelines
-like the [RAIL model](/rail/)—which
+like the [Core Web Vitals](/vitals/)—which
 is based on empirical data about human perception and psychology—we
 need ways to execute our code **off the main thread (OMT)**.
 

--- a/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
+++ b/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
@@ -46,7 +46,7 @@ Informing the browser of your intention is as simple as adding a `<link>` tag to
 
 {% Img src="image/admin/988BgvmiVEAp2YVKt2jq.png", alt="A diagram showing how the download doesn't start for a while after the connection is established.", width="800", height="539" %}
 
-You can speed up the load time by 100–500 ms by establishing early connections to important third-party origins. These numbers might seem small, but they make a difference in how [users perceive web page performance](/rail/#focus-on-the-user).
+You can speed up the load time by 100–500 ms by establishing early connections to important third-party origins. These numbers might seem small, but they make a difference in how [users perceive web page performance](/user-centric-performance-metrics/).
 
 {% Aside %}
 chrome.com [improved Time To Interactive](https://twitter.com/addyosmani/status/1090874825286000640) by almost 1 s by pre-connecting to important origins.

--- a/src/site/content/en/fast/extract-critical-css/index.md
+++ b/src/site/content/en/fast/extract-critical-css/index.md
@@ -39,7 +39,7 @@ Inlining extracted styles in the `<head>` of the HTML document eliminates the ne
     </figcaption>
 </figure>
 
-Improving render times can make a huge difference in [perceived performance](/rail/#focus-on-the-user), especially under poor network conditions. On mobile networks, high latency is an issue regardless of bandwidth.
+Improving render times can make a huge difference in [perceived performance](/user-centric-performance-metrics/), especially under poor network conditions. On mobile networks, high latency is an issue regardless of bandwidth.
 
 <figure>
   {% Img src="image/admin/NdQz49RVgdHoh3Fff0yr.png", alt="Filmstrip view comparison of loading a page with render-blocking CSS (top) and the same page with inlined critical CSS (bottom) on a 3G connection. Top filmstrip shows six blank frames before finally displaying content. Bottom filmstrip displays meaningful content in the first frame.", width="800", height="363" %}

--- a/src/site/content/en/fast/rail/index.md
+++ b/src/site/content/en/fast/rail/index.md
@@ -304,7 +304,7 @@ The following DevTools features are especially relevant:
 ### Lighthouse
 
 [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) is available in
-Chrome DevTools,  at [https://pagespeed.web.dev/](PageSpeed Insights), as a
+Chrome DevTools,  at [PageSpeed Insights](https://pagespeed.web.dev/), as a
 Chrome Extension, as a Node.js module, and within WebPageTest. You give it a
 URL, it simulates a mid-range device with a slow 3G connection, runs a series of
 audits on the page, and then gives you a report on load performance, as well as

--- a/src/site/content/en/fast/rail/index.md
+++ b/src/site/content/en/fast/rail/index.md
@@ -123,6 +123,10 @@ processing time:
   <figcaption>How idle tasks affect input response budget.</figcaption>
 </figure>
 
+{% Aside 'important' %}
+The 50 millisecond threshold for responding to interactions is great when conditions are ideal. For users on hardware with less memory and processing power, this threshold can be very difficult to achieve. This is why the [Interaction to Next Paint (INP)](/inp/) metric's "good" threshold is set to 200 milliseconds or less.
+{% endAside %}
+
 ## Animation: produce a frame in 10&nbsp;ms
 
 **Goals**:

--- a/src/site/content/en/fast/rail/index.md
+++ b/src/site/content/en/fast/rail/index.md
@@ -4,6 +4,7 @@ title: Measure performance with the RAIL model
 description: |
   RAIL model enables designers and developers to reliably target the performance optimization work that has the highest impact on user experience. Learn what goals and guidelines the RAIL model sets out and which tools you can use to achieve them.
 date: 2020-06-10
+updated: 2023-01-06
 tags:
   - performance
   - animations
@@ -20,6 +21,10 @@ tags:
 thinking about performance. The model breaks down the user's experience into key
 actions (for example, tap, scroll, load) and helps you define performance goals
 for each of them.
+
+{% Aside 'important' %}
+[Core Web Vitals](/vitals/) is a newer initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web. It is the recommended approach for defining performance goals over RAIL, and has [different thresholds](/defining-core-web-vitals-thresholds/) than those detailed here.
+{% endAside %}
 
 RAIL stands for four distinct aspects of web app life cycle: response,
 animation, idle, and load. Users have different performance expectations for
@@ -122,10 +127,6 @@ processing time:
   {% Img src="image/admin/I7HDZ9qGxe0jAzz6PxNq.png", alt="Diagram showing how input received during an idle task is queued, reducing available input processing time to 50ms", width="800", height="400" %}
   <figcaption>How idle tasks affect input response budget.</figcaption>
 </figure>
-
-{% Aside 'important' %}
-The 50 millisecond threshold for responding to interactions is great when conditions are ideal. For users on hardware with less memory and processing power, this threshold can be very difficult to achieve. This is why the [Interaction to Next Paint (INP)](/inp/) metric's "good" threshold is set to 200 milliseconds or less.
-{% endAside %}
 
 ## Animation: produce a frame in 10&nbsp;ms
 
@@ -303,7 +304,7 @@ The following DevTools features are especially relevant:
 ### Lighthouse
 
 [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) is available in
-Chrome DevTools,  at [web.dev/measure](/measure/), as a
+Chrome DevTools,  at [https://pagespeed.web.dev/](PageSpeed Insights), as a
 Chrome Extension, as a Node.js module, and within WebPageTest. You give it a
 URL, it simulates a mid-range device with a slow 3G connection, runs a series of
 audits on the page, and then gives you a report on load performance, as well as

--- a/src/site/content/en/progressive-web-apps/pwa-checklist/index.md
+++ b/src/site/content/en/progressive-web-apps/pwa-checklist/index.md
@@ -53,7 +53,7 @@ application to how it actually performs.
 
 While all applications have different needs, the performance audits in
 Lighthouse are based on the
-[RAIL user-centric performance model](/rail/),
+[Core Web Vitals](/vitals/),
 and scoring high on those audits will make it more likely that your users have
 an enjoyable experience. You can also use
 [PageSpeed Insights](https://pagespeed.web.dev/)


### PR DESCRIPTION
As discussed in #9336, the RAIL guidance is pre-Core Web Vitals and that should be our preference performance guidance over RAIL.

Changes proposed in this pull request:

- Updates the [Fast](https://web.dev/fast/) page to remove RAIL and adds CWV section instead (plus another couple of references I noticed were missing). [Preview](https://deploy-preview-9352--web-dev-staging.netlify.app/fast/)
- Adds a note at the top of the [RAIL](https://web.dev/rail/) page about CWV (but keeps the page as linked a lot externally). [Preview](https://deploy-preview-9352--web-dev-staging.netlify.app/rail/)
- Updates most RAIL references to CWV links

