### PR TITLE
Fix fetchpriority on new home page

### DIFF
--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -33,7 +33,7 @@ externalScripts:
                 <source src="{{ featuredCard.video }}" type="video/mp4;">
               </video>
             {% elif featuredCard.background %}
-            {% Img src="image/SZHNhsfjU9RbCestTGZU6N7JEWs1/8JNKYwBSBG5CtMo2KxkB.png", alt=featuredCard.alt, width="800", height="434", class="feature-card__background" %}
+            {% Img src=featuredCard.background, alt=featuredCard.alt, width="800", height="434", class="feature-card__background", fetchpriority="high" %}
             {% endif %}
           </a>
 

--- a/src/site/_includes/partials/picked-case-study.njk
+++ b/src/site/_includes/partials/picked-case-study.njk
@@ -8,7 +8,7 @@
 <a class="feature-card" href="{{ pickedItem.url }}" data-treatment="bg-image">
   <span class="feature-card__eyebrow">Case study</span>
   <h3 class="feature-card__title">{{ pickedItem.data.title }}</h3>
-  {% if featureCard and featureCard.video %}
+  {% if featuredCard.video %}
   {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background", fetchpriority="high"%}
   {% else %}
   {% Img src=pickedItem.data.hero, alt="", width="570", height="330", class="feature-card__background", loading="eager" %}


### PR DESCRIPTION
The new home page redesign seems to have lost a couple of recent fetchpriority changes. This restores them.

Also the first featured card has a hardcoded background image (not an issue now as it's showing a video instead of an image but will be an issue if we revert to an image in future).

