### PR TITLE
chore(content): clarify meaning of LightWallet

### DIFF
--- a/src/site/content/en/fast/use-lighthouse-for-performance-budgets/index.md
+++ b/src/site/content/en/fast/use-lighthouse-for-performance-budgets/index.md
@@ -14,7 +14,7 @@ tags:
   - performance
 ---
 
-[Lighthouse](https://github.com/GoogleChrome/lighthouse) now supports performance budgets. This feature, [LightWallet](/use-lighthouse-for-performance-budgets/), can be set up in under five minutes and provides feedback on performance metrics and the size and quantity of page resources.
+[Lighthouse](https://github.com/GoogleChrome/lighthouse) now supports performance budgets. This feature, known as LightWallet, can be set up in under five minutes and provides feedback on performance metrics and the size and quantity of page resources.
 
 {% Aside 'important' %}
 While Lighthouse is an excellent tool for identifying performance improvement


### PR DESCRIPTION
When reading the article and clicking on the link to LightWallet, my first reaction was that the link was incorrectly marked up.

In its current state, it links to the article the reader is reading. This was not what I was expecting. After reading the article, I realized that LightWallet is the name used to define and test against a predefined performance budget with the Lighthouse CLI.

The update here attempts to clarify this upfront and removes the link to avoid confusion.