### PR TITLE
Further tweaks to CWV 2023 recommendations

### DIFF
--- a/src/site/content/en/blog/top-cwv-2023/index.md
+++ b/src/site/content/en/blog/top-cwv-2023/index.md
@@ -59,7 +59,7 @@ As a general rule, if your LCP element is an image, the image's URL should alway
 
 - **Prefer server-side rendering (SSR) over client-side rendering (CSR),** as SSR implies that the full page markup (including the image) is present in the HTML source. CSR solutions require JavaScript to run before the image can be discovered.
 
-- **If your image needs to be referenced from an external CSS or JS file, you can still include it in the HTML source via a `<link rel="preload">` tag.** Note that resources referenced by inline styles are usually not discoverable by the browser's [preload scanner](/preload-scanner/), so even though they're found in the HTML source, discovery of them might still be blocked on the loading of other resources, so preloading can help in these cases.
+- **If your image needs to be referenced from an external CSS or JS file, you can still include it in the HTML source via a `<link rel="preload">` tag.** Note that images referenced by inline styles are not discoverable by the browser's [preload scanner](/preload-scanner/), so even though they're found in the HTML source, discovery of them might still be blocked on the loading of other resources, so preloading can help in these cases.
 
 To help you understand if your LCP image has discoverability problems, Lighthouse will be releasing a [new audit](https://github.com/GoogleChrome/lighthouse/issues/13738) in version 10.0 (expected January 2023).
 

--- a/src/site/content/en/index.md
+++ b/src/site/content/en/index.md
@@ -28,12 +28,12 @@ platformNews:
   subTitle: Keep up to date with the latest news from the major browser engines.
   pickedLeft:
     url: '/interop-2022-wrapup/'
-  pickedRight: 
+  pickedRight:
     url: '/web-platform-12-2022/'
 
 themes:
   - category: CSS and UI
-    cards: 
+    cards:
       - url: /new-patterns-july-2022/
         eyebrow:
           icon: featured
@@ -86,8 +86,8 @@ themes:
         description: Make an animated gradient text effect with scoped custom properties and background-clip.
 
   - category: Performance
-    cards: 
-      - url: /optimize-inp/
+    cards:
+      - url: /top-cwv-2023/
         eyebrow:
           icon: featured
           text: Featured
@@ -106,13 +106,13 @@ themes:
         eyebrow:
           icon: blog
           text: Case Study
-      - url: /optimize-long-tasks/
+      - url: /optimize-inp/
         eyebrow:
           icon: blog
           text: Blog
 
   - category: Web Apps
-    cards: 
+    cards:
       - url: /learn/pwa/
         eyebrow:
           icon: featured
@@ -139,7 +139,7 @@ themes:
         theme: blue
 
   - category: Accessibility
-    cards: 
+    cards:
       - url: /community-highlight-elisa/
         eyebrow:
           icon: blog
@@ -165,7 +165,7 @@ themes:
           text: Blog
 
   - category: Payments and Identity
-    cards: 
+    cards:
       - url: /payment-and-address-form-best-practices/
         eyebrow:
           icon: featured
@@ -178,7 +178,7 @@ themes:
       - url: /passkey-form-autofill/
         eyebrow:
           icon: blog
-          text: Blog 
+          text: Blog
       - url: /web-payments-overview/
         thumbnail: image/SZHNhsfjU9RbCestTGZU6N7JEWs1/HnOjEdC3jd3ozeEFFWvb.png
         eyebrow:
@@ -189,7 +189,7 @@ themes:
         column: '2'
 
   - category: Ecosystem and community
-    cards: 
+    cards:
       - url: /advancing-framework-ecosystem-cds-2019/
         eyebrow:
           icon: featured


### PR DESCRIPTION
Changes proposed in this pull request:

- Make the 2023 CWV recommendations the featured post on the Performance section of the home page
- This drops Long Tasks post and makes Optimizing INP the second featured post. Open to swapping those if people wish? 
- Makes a small tweak to the discoverability of inline styles text after more thoughts from yesterday's conversations.

<img width="1358" alt="image" src="https://user-images.githubusercontent.com/10931297/212041138-cd9307ac-2c60-4e39-b992-ed0b719c7b71.png">
