### PR TITLE
Disable autoplay when using prefers reduced motion

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -13,6 +13,14 @@ import removeServiceWorkers from './utils/sw-remove';
 // See .unsupported-notice in _page-header.scss
 document.body.classList.remove('unresolved');
 
+
+// Although discouraged (especially for longer videos), some video clips may have
+// autoplace enabled. Disable it when prefers-reduced-motion is set, and ensure
+// controls are set once disabled.
+if ( matchMedia('(prefers-reduced-motion)').matches ) {
+  document.querySelectorAll('video[autoplay]').forEach(b=>{b.removeAttribute('autoplay');b.setAttribute('controls', '')});
+}
+
 function onGlobalStateChanged({cookiePreference}) {
   if (cookiePreference === 'accepts') {
     loadAnalyticsScript();

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -13,12 +13,14 @@ import removeServiceWorkers from './utils/sw-remove';
 // See .unsupported-notice in _page-header.scss
 document.body.classList.remove('unresolved');
 
-
 // Although discouraged (especially for longer videos), some video clips may have
-// autoplace enabled. Disable it when prefers-reduced-motion is set, and ensure
-// controls are set once disabled.
-if ( matchMedia('(prefers-reduced-motion)').matches ) {
-  document.querySelectorAll('video[autoplay]').forEach(b=>{b.removeAttribute('autoplay');b.setAttribute('controls', '')});
+// autoplay enabled. Disable it when prefers-reduced-motion is set, and ensure
+// controls are enabled.
+if (matchMedia('(prefers-reduced-motion)').matches) {
+  document.querySelectorAll('video[autoplay]').forEach((b) => {
+    b.removeAttribute('autoplay');
+    b.setAttribute('controls', '');
+  });
 }
 
 function onGlobalStateChanged({cookiePreference}) {


### PR DESCRIPTION
Fixes #9388

Changes proposed in this pull request:

- Adds a bit of JavaScript to display `autoplay` on videos (and ensures `control` attribute is also set) when `prefers-reduced-motion` is enabled.

Note: `autoplay` is discouraged, and should only be used for short clips without considerable motion (if even then).
