### PR TITLE
Remove focus-visible and wcig-inert polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "fast-glob": "^3.2.7",
         "firebase": "^9.0.0-beta.7",
         "firebase-tools": "^9.3.0",
-        "focus-visible": "^5.0.2",
         "gorko": "^0.8.0",
         "gray-matter": "^4.0.3",
         "gulp": "^4.0.0",
@@ -69,7 +68,6 @@
         "unistore": "^3.4.1",
         "web-vitals": "^3.1.0",
         "webdev-infra": "^1.0.32",
-        "wicg-inert": "^3.0.1",
         "yaml-front-matter": "^4.0.0"
       },
       "devDependencies": {
@@ -10190,11 +10188,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.14.1",
@@ -28200,11 +28193,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
-    },
-    "node_modules/wicg-inert": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -51073,11 +51061,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
-    },
-    "wicg-inert": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "unistore": "^3.4.1",
     "web-vitals": "^3.1.0",
     "webdev-infra": "^1.0.32",
-    "wicg-inert": "^3.0.1",
     "yaml-front-matter": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "fast-glob": "^3.2.7",
     "firebase": "^9.0.0-beta.7",
     "firebase-tools": "^9.3.0",
-    "focus-visible": "^5.0.2",
     "gorko": "^0.8.0",
     "gray-matter": "^4.0.3",
     "gulp": "^4.0.0",

--- a/src/lib/components/AudioFab/index.js
+++ b/src/lib/components/AudioFab/index.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import 'wicg-inert';
 import {BaseElement} from '../BaseElement';
 
 /**

--- a/src/lib/components/BaseModalElement/index.js
+++ b/src/lib/components/BaseModalElement/index.js
@@ -15,7 +15,6 @@
  */
 
 import {BaseElement} from '../BaseElement';
-import 'wicg-inert';
 import {checkOverflow} from '../../utils/check-overflow';
 import {openModal} from '../../actions';
 import {closeModal} from '../../actions';

--- a/src/lib/components/CourseSearchResults/index.js
+++ b/src/lib/components/CourseSearchResults/index.js
@@ -5,7 +5,6 @@
 import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {SearchResults} from '../SearchResults';
-import 'focus-visible';
 
 /**
  * An Algolia search box for courses drawer.

--- a/src/lib/components/NavigationDrawer/index.js
+++ b/src/lib/components/NavigationDrawer/index.js
@@ -17,7 +17,6 @@
 /* eslint lit-a11y/click-events-have-key-events: 0 */
 
 import {BaseStateElement} from '../BaseStateElement';
-import 'wicg-inert';
 import {closeNavigationDrawer} from '../../actions';
 
 export const NAVIGATION_DRAWER_TYPE = {

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -7,7 +7,6 @@ import {BaseStateElement} from '../BaseStateElement';
 import {store} from '../../store';
 import {debounce} from '../../utils/debounce';
 import {logError} from '../../analytics';
-import 'focus-visible';
 
 let algoliaIndexPromise;
 

--- a/src/lib/components/SearchResults/index.js
+++ b/src/lib/components/SearchResults/index.js
@@ -6,7 +6,6 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {BaseElement} from '../BaseElement';
 import {allowHtml, escapeHtml} from '../../../lib/utils/escape-html';
-import 'focus-visible';
 
 /**
  * An Algolia search box.

--- a/src/lib/components/SelectGroup/_styles.scss
+++ b/src/lib/components/SelectGroup/_styles.scss
@@ -147,10 +147,6 @@ input[type='radio'] ~ .web-select-group__selector::after {
   border-color: $FOCUS_COLOR;
 }
 
-.js-focus-visible .web-select-group__input:focus:not(.focus-visible) ~ .web-select-group__selector::before {
-  border-color: transparent;
-}
-
 input[type='radio']:checked ~ .web-select-group__selector::after {
   transform: scale(1);
 }

--- a/src/lib/components/SelectGroup/index.js
+++ b/src/lib/components/SelectGroup/index.js
@@ -1,7 +1,6 @@
 import {html} from 'lit';
 import {BaseElement} from '../BaseElement';
 import {generateIdSalt} from '../../utils/generate-salt';
-import 'focus-visible';
 
 /**
  * Element that renders a radio group or checkbox group.

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -2,7 +2,6 @@ import {html} from 'lit';
 import {BaseElement} from '../BaseElement';
 import {checkOverflow} from '../../utils/check-overflow';
 import {generateIdSalt} from '../../utils/generate-salt';
-import 'focus-visible';
 
 /**
  * Element that wraps each child element in a tab panel


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove `focus-visible` polyfill as no longer required - it's got [great browser support now](https://caniuse.com/css-focus-visible) and was always a nice to have anyway. The old owner of the library (👋 @robdodson ) [doesn't even recommend it anymore](https://github.com/WICG/focus-visible#support).
- Remove `wicg-inert` polyfill as no longer required - it's got [less browser support now](https://caniuse.com/css-focus-visible) so we lose FireFox support but think that's OK.
 
It's suspected that these polyfills are contributing to low INP scores on web.dev
