### PR TITLE
Improve navigation drawer performance, remove/update old polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "unistore": "^3.4.1",
         "web-vitals": "^3.1.0",
         "webdev-infra": "1.0.42",
-        "wicg-inert": "^3.0.1",
+        "wicg-inert": "^3.1.2",
         "yaml-front-matter": "^4.0.0"
       },
       "devDependencies": {
@@ -28666,9 +28666,9 @@
       "dev": true
     },
     "node_modules/wicg-inert": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
+      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -51823,9 +51823,9 @@
       "dev": true
     },
     "wicg-inert": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
+      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "fast-glob": "^3.2.7",
         "firebase": "^9.0.0-beta.7",
         "firebase-tools": "^9.3.0",
-        "focus-visible": "^5.0.2",
         "gorko": "^0.8.0",
         "gray-matter": "^4.0.3",
         "gulp": "^4.0.0",
@@ -10412,11 +10411,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.14.1",
@@ -37406,11 +37400,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
-    "focus-visible": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "follow-redirects": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "fast-glob": "^3.2.7",
     "firebase": "^9.0.0-beta.7",
     "firebase-tools": "^9.3.0",
-    "focus-visible": "^5.0.2",
     "gorko": "^0.8.0",
     "gray-matter": "^4.0.3",
     "gulp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "unistore": "^3.4.1",
     "web-vitals": "^3.1.0",
     "webdev-infra": "1.0.42",
-    "wicg-inert": "^3.0.1",
+    "wicg-inert": "^3.1.2",
     "yaml-front-matter": "^4.0.0"
   },
   "devDependencies": {

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -115,7 +115,8 @@ export const requestFetchReports = store.action((_, url, startDate) => {
  */
 const disablePage = () => {
   // Setting the majority of the page as inert can have a significant perf hit when
-  // trying to animate e.g. the navigation drawer, so do it in the frame after this.
+  // trying to animate e.g. the navigation drawer, so do it in the frame after this
+  // to avoid blocking on interaction and incurring an INP delay.
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       const main = document.querySelector('main');

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -114,28 +114,33 @@ export const requestFetchReports = store.action((_, url, startDate) => {
  * This is used when we open the navigation drawer or show a modal dialog.
  */
 const disablePage = () => {
-  /** @type {HTMLElement|object} */
-  const main = document.querySelector('main') || {};
-  /** @type {HTMLElement|object} */
-  const footer = document.querySelector('.w-footer') || {};
+  // Setting the majority of the page as inert can have a significant perf hit when
+  // trying to animate e.g. the navigation drawer, so do it in the frame after this.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const main = document.querySelector('main');
+      const footer = document.querySelector('footer');
 
-  document.body.classList.add('overflow-hidden');
-  main.inert = true;
-  footer.inert = true;
+      if (main) main.inert = true;
+      if (footer) footer.inert = true;
+    });
+  });
 };
 
 /**
  * Uninert the page so scrolling and pointer events work again.
  */
 const enablePage = () => {
-  /** @type {HTMLElement|object} */
-  const main = document.querySelector('main') || {};
-  /** @type {HTMLElement|object} */
-  const footer = document.querySelector('.w-footer') || {};
+  // Similar to disablePage(), go inert in the next frame to avoid the perf hit.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const main = document.querySelector('main');
+      const footer = document.querySelector('footer');
 
-  document.body.classList.remove('overflow-hidden');
-  main.inert = false;
-  footer.inert = false;
+      if (main) main.inert = false;
+      if (footer) footer.inert = false;
+    });
+  });
 };
 
 export const openNavigationDrawer = store.action(() => {

--- a/src/lib/components/CourseSearchResults/index.js
+++ b/src/lib/components/CourseSearchResults/index.js
@@ -5,7 +5,6 @@
 import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {SearchResults} from '../SearchResults';
-import 'focus-visible';
 
 /**
  * An Algolia search box for courses drawer.

--- a/src/lib/components/Search/index.js
+++ b/src/lib/components/Search/index.js
@@ -7,7 +7,6 @@ import {BaseStateElement} from '../BaseStateElement';
 import {store} from '../../store';
 import {debounce} from '../../utils/debounce';
 import {logError} from '../../analytics';
-import 'focus-visible';
 
 let algoliaIndexPromise;
 

--- a/src/lib/components/SearchResults/index.js
+++ b/src/lib/components/SearchResults/index.js
@@ -6,7 +6,6 @@ import {html} from 'lit';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {BaseElement} from '../BaseElement';
 import {allowHtml, escapeHtml} from '../../../lib/utils/escape-html';
-import 'focus-visible';
 
 /**
  * An Algolia search box.

--- a/src/lib/components/SelectGroup/_styles.scss
+++ b/src/lib/components/SelectGroup/_styles.scss
@@ -147,10 +147,6 @@ input[type='radio'] ~ .web-select-group__selector::after {
   border-color: $FOCUS_COLOR;
 }
 
-.js-focus-visible .web-select-group__input:focus:not(.focus-visible) ~ .web-select-group__selector::before {
-  border-color: transparent;
-}
-
 input[type='radio']:checked ~ .web-select-group__selector::after {
   transform: scale(1);
 }

--- a/src/lib/components/SelectGroup/index.js
+++ b/src/lib/components/SelectGroup/index.js
@@ -1,7 +1,6 @@
 import {html} from 'lit';
 import {BaseElement} from '../BaseElement';
 import {generateIdSalt} from '../../utils/generate-salt';
-import 'focus-visible';
 
 /**
  * Element that renders a radio group or checkbox group.

--- a/src/lib/components/Tabs/index.js
+++ b/src/lib/components/Tabs/index.js
@@ -2,7 +2,6 @@ import {html} from 'lit';
 import {BaseElement} from '../BaseElement';
 import {checkOverflow} from '../../utils/check-overflow';
 import {generateIdSalt} from '../../utils/generate-salt';
-import 'focus-visible';
 
 /**
  * Element that wraps each child element in a tab panel

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -52,10 +52,6 @@
   outline-offset: -3px;
 }
 
-.js-focus-visible .w-button:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
-  outline: none;
-}
-
 .w-button[disabled] {
   background: $GREY_300;
   box-shadow: none;
@@ -181,11 +177,6 @@
 .w-button--svg:focus {
   box-shadow: 0 0 0 1px $FOCUS_COLOR;
   outline: none;
-}
-
-.js-focus-visible .w-button--icon:focus:not(.focus-visible), // sass-lint:disable-line class-name-format
-.js-focus-visible .w-button--svg:focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
-  box-shadow: none;
 }
 
 // A round button.

--- a/src/styles/components/_details.scss
+++ b/src/styles/components/_details.scss
@@ -41,11 +41,6 @@ $CHEVRON_MARGIN: 12px;
     box-shadow: 0 0 0 1px $FOCUS_COLOR;
   }
 
-  .js-focus-visible &:focus:not(.focus-visible) .w-details__header::after {
-    // sass-lint:disable-line class-name-format
-    box-shadow: none;
-  }
-
   &:active .w-details__header::after {
     background: $WEB_PRIMARY_COLOR_100;
   }

--- a/src/styles/components/_self-assessment-hint.scss
+++ b/src/styles/components/_self-assessment-hint.scss
@@ -71,10 +71,6 @@ $BORDER_COLOR: $GREY_300;
     box-shadow: 0 0 0 1px $FOCUS_COLOR;
   }
 
-  .js-focus-visible &:focus:not(.focus-visible)::after { // sass-lint:disable-line class-name-format
-    box-shadow: none;
-  }
-
   &:active::after {
     background: $GREEN_100;
   }

--- a/src/styles/components/_tooltips.scss
+++ b/src/styles/components/_tooltips.scss
@@ -71,9 +71,3 @@
 :focus .w-tooltip--right {
   transform: translateX(-100%) scale(1);
 }
-
-// sass-lint:disable-block class-name-format
-.js-focus-visible :focus:not(.focus-visible) .w-tooltip {
-  opacity: 0;
-  visibility: hidden;
-}

--- a/src/styles/generic/_shared.scss
+++ b/src/styles/generic/_shared.scss
@@ -26,12 +26,6 @@
   outline: none !important;
 }
 
-// This will hide the focus indicator if the element receives focus via the
-// mouse, but it will still show up on keyboard focus.
-.js-focus-visible :focus:not(.focus-visible) { // sass-lint:disable-line class-name-format
-  outline: none;
-}
-
 div,
 dl,
 dt,


### PR DESCRIPTION
web.dev has "needs improvement" INP for both the home page and the origin as a whole

<img width="311" alt="PageSpeed Insights INP diagram showing a 'needs improvement' INP of 288 milliseconds" src="https://user-images.githubusercontent.com/316891/212377877-2118e80f-e358-4524-a4a5-fb39c5c34f39.png">

@philipwalton identified the cookie consent banner and navigation drawer as two sources of INP from [web-vitals.js element attribution data](https://github.com/GoogleChrome/web-vitals#send-attribution-data), and noticed that both the `focus-visible` and `wicg-inert` polyfills were major parts of the task blocking the main thread on interactions with those components. This PR focuses on the navigation drawer first because its performance appears worse than the consent banner and (in theory) it will be interacted with much more often than the consent banner.

@tunetheweb and I failed to coordinate, so this overlaps with #9408

## Changes proposed in this pull request (split up by commit for easier review):

### Remove `focus-visible` polyfill

This polyfill runs whether or not the browser had built-in support for `:focus-visible`, causing extra work for no benefit. There was [discussion about how to make it polyfill only when needed](https://github.com/WICG/focus-visible/issues/237), but as of March 2022, [all the major browsers support `:focus-visible`](https://caniuse.com/css-focus-visible) and it's unnecessary ([the readme now even tells you to not use it](https://github.com/WICG/focus-visible#support)).

I also removed the polyfill-specific CSS rules that would not have any effect after the polyfill is gone. I was trying to be careful and not break any side effects of the rules, but then I noticed that none of them are actually shipped in the current web.dev anyways and `next.css` seems written for current browsers that all support `:focus-visble`. As a result, there shouldn't be any observable changes.

### Update `wicg-inert` polyfill

Unfortunately [Firefox's implementation of `inert`](https://bugzilla.mozilla.org/show_bug.cgi?id=1764263) is still ongoing, so this polyfill can't be removed without breaking behavior. However, [there was a bug that caused this polyfill to also run whether or not the browser had built-in support for `inert`](https://github.com/WICG/inert/pull/182), so e.g. Chrome and Safari have been paying the cost for both the built-in and polyfill `inert` implementations. This commit updates the polyfill after that issue was fixed, and so (in updated browsers) the polyfill should only run in Firefox.

(this does mean that Firefox is still running the relatively slow polyfill, but the next commit will help ameliorate that)

### Async page inert when nav drawer is opened

Turns out even the built-in `inert` causes pretty significant main-thread work. It just shows up as a large "Recalculate Style" block in DevTools due to changing `main.inert`, and it's not clear why it's so slow (I did not expect going `inert` would require a large style recalc). Assuming we still want the rest of the page to be inert when the drawer is open, the best thing to do is then break the long task up. Here it's using a double `requestAnimationFrame` to schedule the `inert` change on the _next_ frame so that the click handler can return control of the main thread immediately. This will also help Firefox with the polyfill, as that work will also happen async.

## Comparison

Both screenshots are the nav drawer open interaction on my desktop machine with 4x CPU slowdown, roughly directly comparable because they're zoomed to show ~130ms.

**Before:**
<img width="963" alt="DevTools trace showing a 108 millisecond interaction and a flame chart of js and style tasks below it" src="https://user-images.githubusercontent.com/316891/212392881-61b32b32-3317-4bdb-8db6-4e3e7d2ff663.png">
([view trace](https://trace.cafe/t/JB99k3QlLo))

**After:**
<img width="963" alt="DevTools trace showing a 44 millisecond interaction and a flame chart of js and style tasks below it, with considerably less depth to the CPU tasks" src="https://user-images.githubusercontent.com/316891/212392937-c90739a6-80ca-426a-8440-e59cf92ba151.png">
([view trace](https://trace.cafe/t/mAAHkfYFWF))

The light green blocks (mostly `wicg-inert`) is gone. The large "Recalculate Stye" block still occurs due to applying `inert`, but it's now moved out of the interaction and so multiple frames are no longer dropped.

---
Alternative to consider:
- Drop `inert` for the nav drawer. While it's probably the right thing to use here, AFAIK it's relatively uncommon to use that for menus as long as the focus is correctly placed in the menu, the menu is dismissible, etc. The performance hit also seems weirdly high and can hopefully be fixed at the browser level to encourage use for large portions of the DOM like this.

   The current nav drawer has also been buggy for a while, trying to make the `<footer>` also `inert`, but using a selector for the old `footer.njk` instead of the newer `site-footer.njk` and so the footer has not been inert since switching.

Remaining issues:
- There's still a decent chunk of (I believe) `lit` code running on every open/close of the drawer. It's hard to follow what it's doing, but it seems like it would be unnecessary for a static drawer reveal/hide
- On the homepage, `recaptcha` also shows up in the trace of these interactions, tracking attribute changes (like `inert`) across the whole page with mutation observers. It's not a huge amount of work, but again seems completely unnecessary for this interaction. Should recaptcha be loaded more on demand, maybe once a user starts interacting with the form at the bottom of the page?
- I need to measure this, but I suspect the blur and shadow being applied to page contents behind the drawer are also a perf hit we might consider reducing (especially since it's almost always only seen on mobile devices)