### PR TITLE
Remove mention of JPEG XR

### DIFF
--- a/src/site/content/en/fast/image-cdns/index.md
+++ b/src/site/content/en/fast/image-cdns/index.md
@@ -67,7 +67,7 @@ There tends to be an objectively best setting for performance transformations, s
 * The [User-Agent](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent) request header
 * The [Network Information API](https://developer.mozilla.org/docs/Web/API/Network_Information_API)
 
-For example, the image CDN might serve JPEG XR to an Edge browser, WebP to a Chrome browser, and JPEG to a very old browser. Auto settings are popular because they allow you to take advantage of image CDNs' significant expertise in optimizing images without the need for code changes to adopt new technologies once they're supported by the image CDN.
+For example, the image CDN might serve AVIF to a Chrome browser, WebP to an Edge browser, and JPEG to a very old browser. Auto settings are popular because they allow you to take advantage of image CDNs' significant expertise in optimizing images without the need for code changes to adopt new technologies once they're supported by the image CDN.
 
 ## Types of Image CDNs
 


### PR DESCRIPTION
JPEG XR is not supported by Edge anymore, so I have changed the example to a more common scenario.

