### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/blog/creative-list-styling/index.md
+++ b/src/site/content/en/blog/creative-list-styling/index.md
@@ -41,7 +41,7 @@ The unordered list element (`<ul>`) is most useful when the items in the list do
 A more common example on the web is a navigation menu. When building a menu, it is good practice to wrap the `ul` in a `nav` element and to identify the menu with a label, to aid assistive technologies. We should also identify the current page in the menu, which we can do using the `aria-current` attribute:
 
 ```html  
-<nav aria-label="Main navigation">  
+<nav aria-label="Main">  
   <ul>  
     <li>  
       <a href="/page-1" aria-current="page">Menu item 1</a>  


### PR DESCRIPTION
Remove 'navigation' from the `aria-label` so it's not read out twice.

> A brief description of the purpose of the navigation, omitting the term "navigation", as the screen reader will read both the role and the contents of the label. 
> – [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role#associated_wai-aria_roles_states_and_properties)