### PR TITLE
Adding links to HowTo components to the overview page

### DIFF
--- a/src/site/content/en/blog/components-examples-overview/index.md
+++ b/src/site/content/en/blog/components-examples-overview/index.md
@@ -24,6 +24,14 @@ Our aim is to demonstrate best practices for writing robust components that are
 accessible, performant, maintainable, and easy to style. Each component is
 completely self-contained so it can serve as a reference implementation.
 
+## Components
+
+* [`<howto-checkbox>`](/components-howto-checkbox/): represents a boolean option in a form. The most common type of
+checkbox is a dual-type which allows the user to toggle between two choices—checked and unchecked.
+* [`<howto-tabs>`](/components-howto-tabs/): limits visible content by separating it into multiple panels.
+* [`<howto-tooltip>`](/components-howto-tooltip/): a popup that displays information related to an element when the element
+receives keyboard focus or the mouse hovers over it.
+
 ### Accessibility
 
 The components closely follow the [WAI ARIA Authoring
@@ -53,7 +61,7 @@ explaining why that is.
 
 ### Maintainable code
 
-As HowTo: Components is aimed to be read and function as a reference
+As HowTo: Components is a reference
 implementation, we spent extra time on writing readable and easily
 comprehensible code that is densely commented.
 
@@ -64,8 +72,8 @@ comprehensible code that is densely commented.
 `<howto>` components are not published on npm, bower or any other platform
 because they are not meant to be used in production. For the sake of terse,
 readable code, we are using modern JavaScript APIs and are supporting modern
-browsers which implement the Web Components standards. The idea is that you, the
-reader, are able adapt the code to fit your own needs after reading these
+browsers which implement the Web Components standards. You
+will be able to adapt the code to fit your own needs after reading these
 implementations.
 
 ### Be backwards compatible


### PR DESCRIPTION

Fixes #9270

