### PR TITLE
Update page to current firefox' capabilities

### DIFF
--- a/src/site/content/en/blog/earth-webassembly/index.md
+++ b/src/site/content/en/blog/earth-webassembly/index.md
@@ -50,7 +50,7 @@ Edge is on the verge of becoming two distinct development experiences based on M
 Chrome has strong support for WebAssembly, including multi-threading on desktop, so you can expect Earth to run smoother as a result. However, we look forward to Chrome adding support for dynamic memory allocation with multi-threading in WebAssembly. Until then, Earth may fail to start on devices with limited amounts of memory (such as 32-bit machines).
 
 ### Firefox
-Firefox offers good support for WebAssembly, but has disabled support for multi-threading. As a result, you can expect a slower experience with Earth. We look forward to Mozilla bringing back support for multi-threading in future versions. On the upside, Firefox does support dynamic memory allocation.
+Firefox offers good support for WebAssembly, but has had disabled support for multi-threading when Earth was released. However support for SharedArrayBuffer was re-enabled long ago with Firefox 79, release on June 2020. Yet, despite the 2,5 years that have passed, Google Earth still runs in single-threaded mode on Firefox. On the upside, Firefox does support dynamic memory allocation.
 
 ### Opera
 Opera is based on Chromium just as Chrome is, along with upcoming versions of Edge. However, the current version of Opera only offers single-threaded support of WebAssembly. Earth does run in Opera, but at a somewhat degraded experience. Hopefully newer versions of Opera will have support for multi-threading and more robust WebAssembly support.


### PR DESCRIPTION
for years multi-threading has been disabled running in firefox, despite the technical issues have been solved for 2,5 years. update the article to reflect the current situation. it seems even mozilla contacted google regarding the issue 8 months ago and nothing has changed. https://bugzilla.mozilla.org/show_bug.cgi?id=1633244

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-

