### PR TITLE
Add space to SignPosts lists

### DIFF
--- a/src/site/_includes/components/SignPosts.js
+++ b/src/site/_includes/components/SignPosts.js
@@ -37,7 +37,7 @@ function SignPosts(slug) {
         >${i18n(paths[pathName].title, locale)}</a
       >`;
     })
-    .join(html`<span class="w-post-signpost__divider">|</span>`);
+    .join(html`<span class="w-post-signpost__divider"> | </span>`);
 
   return html`
     <div class="w-layout-container--narrow w-post-signpost">


### PR DESCRIPTION
This annoys me on [LCP page](https://web.dev/lcp/) for example:

<img width="451" alt="image" src="https://user-images.githubusercontent.com/10931297/215521960-b73ac670-6849-4b43-8f31-898c140fc6d8.png">

This PR adds some spaces:

<img width="456" alt="image" src="https://user-images.githubusercontent.com/10931297/215522112-61c493fd-d074-45cb-b2c8-bdbffc7ed29d.png">

It looks like there was some stuff to set this via CSS here:
https://github.com/GoogleChrome/web.dev/blob/2a0c52d47645b519de8909da46d9baba906e2c06/src/styles/pages/_post.scss#L47-L50

But doesn't look like this is pulled in anymore (I don't really know how our scss builds to be honest) but even then, semantically, I think it should be spaces (for screen readers and the like to read it properly), so went with the simple fix.
