### PR TITLE
Learn images

### DIFF
--- a/src/site/content/en/learn/images/automating/index.md
+++ b/src/site/content/en/learn/images/automating/index.md
@@ -175,7 +175,7 @@ Populating `srcset` attributes will typically be a straightforward manual proces
 information about the configuration you’ve already done when generating your sources. In the tasks above, we’ve established
 the file names and width information that our attribute will follow:
 
-```
+```html
 srcset="filename-1000.jpg 1000w, filename-800.jpg 800w, filename-400.jpg 400w"
 ```
 
@@ -206,7 +206,7 @@ still need a fallback, or we could run the risk of a broken image in especially 
 Because scaling an image downwards is _visually_ seamless and JPEG encoding is universally supported, the largest JPEG is
 a sensible choice.
 
-```
+```html
 <picture>
   <source type="image/webp" srcset="filename-1000.webp 1000w, filename-800.webp 800w, filename-400.webp 400w">
   <img src="filename-1000.jpg" srcset="filename-1000.jpg 1000w, filename-800.jpg 800w, filename-400.jpg 400w" sizes="…" alt="…">

--- a/src/site/content/en/learn/images/automating/index.md
+++ b/src/site/content/en/learn/images/automating/index.md
@@ -60,7 +60,7 @@ converting, modifying, and editing images in batches, competing on speed, effici
 libraries will allow you to apply encoding and compression settings to whole directories of images at once, without the
 need to open image editing software, and in a way that preserves your original image sources should those settings need
 to be adjusted on-the-fly. They’re intended to run in a range of contexts, from your local development environment to the
-web server itself—for example, the compression-focused [ImageMin](https://web.dev/use-imagemin-to-compress-images/) for
+web server itself—for example, the compression-focused [ImageMin](/use-imagemin-to-compress-images/) for
 Node.js can be extended to suit specific applications through an array of [plugins](https://www.npmjs.com/search?q=keywords:imageminplugin),
 while the cross-platform [ImageMagick](https://imagemagick.org/) and the Node.js based [Sharp](https://sharp.pixelplumbing.com/)
 come with a staggering number of features right out of the box.

--- a/src/site/content/en/learn/images/cms/index.md
+++ b/src/site/content/en/learn/images/cms/index.md
@@ -8,11 +8,120 @@ tags:
   - images
 ---
 
+While certainly an improvement over manually saving alternate cuts of each image and hand-optimizing them through a tool like 
+[Squoosh.app](https://squoosh.app/), automating image compression as a step in the development process has some limitations. For one, you may not 
+always have full control over the images used throughout a site—most user-facing images on the web are _content_ concerns more 
+than development concerns, uploaded by users or editors, rather than living in a repository alongside development assets like 
+JavaScript and stylesheets.
+
+This will typically necessitate more than one process for image management: a development-level task for the image assets used in 
+building and maintaining a site—backgrounds, icons, logos, and so on—and another concerned with image assets generated through _use_
+ of the site, such as photographs embedded in a post by an editorial team, or an avatar uploaded by a user. While the context may 
+ differ, the end goals are the same: automated encoding and compression based on settings defined by the development team.
+
+Fortunately, the image processing libraries you’ve come to understand from your local development workflows can be used in any number
+ of contexts. And while there can never be a one-size-fits-all approach to your responsive image markup, these systems provide sensible
+  defaults, configuration options, and API hooks to ease their implementation.
+
+## Static Site Generators
+
+Compared to task-runners, there’s some similarity in the way static site generators such as Jekyll or Eleventy approach images. Using 
+these tools to produce a deployment-ready website requires management of assets, including CSS minification or transpiling and bundling 
+of JavaScript. As you might imagine, this means these tools enable you to process image assets the same way, using many of the libraries 
+you’ve already learned about.
+
+The official [image plugin for Eleventy](https://www.11ty.dev/docs/plugins/image/) uses [Sharp](https://www.npmjs.com/package/sharp) to provide resizing, generation of multiple source sizes, re-encoding, and compression, just like some of the tasks you’ve learned about here.
+
+Unlike a task-runner, a static site generator has direct insight into both the configuration and usage of those libraries,
+ and the markup being generated for the production site—meaning it can do a great deal more to automate our responsive image 
+ markup. For example, when [invoked as part of a shortcode for displaying images](https://www.aleksandrhovhannisyan.com/blog/eleventy-image-plugin/), this plugin will output HTML according 
+ to the configuration options passed along to Sharp.
+
+```javascript
+
+const Image = require("@11ty/eleventy-img");
+module.exports = function(eleventyConfig) {
+
+async function imageShortcode(src, alt, sizes="100vw") {
+  let metadata = await Image(src, {
+  formats: ["avif", "webp", "jpeg"],
+  widths: [1000, 800, 400],
+  outputDir: "_dist/img/",
+  filenameFormat: function( id, src, width, format, options ) {
+      const ext = path.extname( src ),
+        name = path.basename( src, ext );
+
+      return `${name}-${width}.${format}`
+  }
+  });
+
+  let imageAttributes = {
+  alt,
+  sizes,
+  loading: "lazy"
+  };
+
+  return Image.generateHTML(metadata, imageAttributes);
+}
+
+eleventyConfig.addAsyncShortcode("respimg", imageShortcode);
+};
+```
+
+This shortcode could then be used in place of the default image syntax:
+
+```markdown
+{‌% respimg "img/butterfly.jpg", "Alt attribute.", "(min-width: 30em) 800px, 80vw" %}
+```
+
+If configured to output multiple encodings, as above, the generated markup will be a `<picture>` element containing
+ corresponding `<source>` elements, `type` attributes, and `srcset` attributes already fully populated with a list of 
+  generated candidate sizes. 
+
+```html
+<picture><source type="image/avif" srcset="/img/butterfly-400.avif 400w, /img/butterfly-800.avif 800w, /img/butterfly-1000.avif 1000w" sizes="(min-width: 30em) 800px, 80vw"><source type="image/webp" srcset="/img/butterfly-400.webp 400w, /img/butterfly-800.webp 800w, /img/butterfly-1000.webp 1000w" sizes="(min-width: 30em) 800px, 80vw"><source type="image/jpeg" srcset="/img/butterfly-400.jpeg 400w, /img/butterfly-800.jpeg 800w, /img/butterfly-1000.jpeg 1000w" sizes="(min-width: 30em) 800px, 80vw"><img alt="Alt attribute." loading="lazy" src="/img/butterfly-400.jpeg" width="1000" height="846"></picture>
+```
+
+Of course, this plugin won’t be able to _generate_ a viable `sizes` attribute, as it can’t know the ultimate size and position 
+of the image in the rendered layout, but it does accept one as input when generating your markup—another job for RespImageLint.
+
+## Frameworks
+
+Client-side rendering frameworks will require a task-runner or bundler like Webpack to edit, encode, and compress image assets 
+themselves. [Responsive-loader](https://www.npmjs.com/package/responsive-loader), for example, also uses the Sharp library to re-save image assets. It then allows you to 
+then `import` your images as objects:
+
+```javascript
+  import imageAVIF from 'img/butterfly.jpg?sizes[]=400,sizes[]=800,sizes[]=1000&format=avif';
+  import imageWebP from 'img/butterfly.jpg?sizes[]=400,sizes[]=800,sizes[]=1000&format=webp';
+  import imageDefault from 'img/butterfly.jpg?sizes[]=400,sizes[]=800,sizes[]=1000';
+````
+
+These imported images can then be used through abstractions like [React’s Image component](https://reactnative.dev/docs/image), or to populate your responsive 
+image markup directly:
+
+```html
+<picture>
+  <source type='image/avif' srcSet={imageAVIF.srcSet} sizes='…' />
+  <source type='image/webp' srcSet={imageWebp.srcSet} sizes='…' />
+  <img
+    src={imageDefault.src}
+    srcSet={imageDefault.srcSet}
+    width={imageDefault.width}
+    height={imageDefault.height}
+    sizes='…'
+    loading="lazy"
+  />
+```
+A framework that does client side rendering is a strong candidate for [Lazysizes](https://www.npmjs.com/package/lazysizes) and `sizes="auto"`—giving you almost fully
+automated responsive images.
+
+## Content Management Systems
+
 WordPress was one of the earliest adopters of native responsive images markup, and the API has gone largely unchanged since
-being [introduced in WordPress 4.4](https://make.wordpress.org/core/2015/11/10/responsive-images-in-wordpress-4-4/). The WordPress
-core is designed to make use of the [ImageMagick PHP extension](https://www.php.net/manual/en/book.imagick.php) (or, absent
-that, [GD](https://www.php.net/manual/en/book.image.php)), allowing settings like [compression level](https://developer.wordpress.org/reference/hooks/jpeg_quality/)
-to be configured alongside other core configuration options.
+being [introduced in WordPress 4.4](https://make.wordpress.org/core/2015/11/10/responsive-images-in-wordpress-4-4/). The WordPress core is designed to make use of the [ImageMagick PHP extension](https://www.php.net/manual/en/book.imagick.php) 
+(or, absent that, the [GD](https://www.php.net/manual/en/book.image.php) library), allowing settings like [compression level](https://developer.wordpress.org/reference/hooks/jpeg_quality/) to be configured alongside other 
+core configuration options.
 
 ```php
 add_filter( 'jpeg_quality', 65 );

--- a/src/site/content/en/learn/images/webp/index.md
+++ b/src/site/content/en/learn/images/webp/index.md
@@ -33,7 +33,7 @@ the missing part of the image. The results provided by each prediction mode are 
 predictive match is selected.
 
 <div style="background: #fff;">
-{% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/t8neUw7UOsUNTF3uxe08.png", alt="A diagram of some of the steps in WebP lossy compression", width="800", height="509" %}
+{% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/t8neUw7UOsUNTF3uxe08.png", alt="A diagram of WebP’s various block prediction methods.", width="800", height="509" %}
 </div>
 
 Even the closest predictive match isn't going to be completely right, of course, so the differences between the predicted and

--- a/src/site/content/en/learn/images/webp/index.md
+++ b/src/site/content/en/learn/images/webp/index.md
@@ -32,7 +32,9 @@ blocks' data and then attempts to populate the current block by way of several d
 the missing part of the image. The results provided by each prediction mode are then compared to the real image data, and the closest
 predictive match is selected.
 
+<div style="background: #fff;">
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/t8neUw7UOsUNTF3uxe08.png", alt="A diagram of some of the steps in WebP lossy compression", width="800", height="509" %}
+</div>
 
 Even the closest predictive match isn't going to be completely right, of course, so the differences between the predicted and
 actual values of that block are encoded in the file. When decoding the image, the rendering engine uses the same data to apply


### PR DESCRIPTION
4a74bc1 Restores the sections of “Site generators, frameworks, and CMSes” that went missing.
19875a2 Adds correct syntax highlighting to several snippets in “Automating compression and encoding”
54ab806 Quick kludge to ensure sufficient contrast on the transparent PNG we snagged from https://developers.google.com/speed/webp/docs/compression
+ @AaronForinton @rachelandrew 