### PR TITLE
Add links to soft navs experiment to SPA CWV guide and CrUX v RUM post

### DIFF
--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -6,7 +6,7 @@ authors:
   - philipwalton
   - yoavweiss
 date: 2021-09-14
-updated: 2022-07-18
+updated: 2023-02-04
 hero: image/eqprBhZUGfb8WYnumQ9ljAxRrA72/FITOGeO0PDyPrBveixB7.jpeg
 alt: "Exterior view of the Walt Disney Concert Hall"
 tags:
@@ -36,6 +36,11 @@ Vitals initiative is to provide metrics that measure the experience independent
 of the technology. While this is not possible in every case today (due to
 limitations in the web platform), we are [actively working on closing those
 gaps](#what-is-google-doing-to-ensure-mpas-do-not-have-an-unfair-advantage-compared-to-spas).
+
+{% Aside %}
+Update: The work is anow available for sites to experiment with. See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more details.
+{% endAside %}
+
 
 ## Frequently asked questions
 
@@ -303,6 +308,10 @@ possible to aggregate SPA route transition time into the same bucket as
 same-origin page loads in an MPA. This is exciting because it would allow a site
 migrating from an MPA to an SPA to actually compare the performance before and
 after.
+
+{% Aside %}
+Update: See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information on a new "soft-navigations" API that is intended to allow better SPA measurement of the Core Web Vitals.
+{% endAside %}
 
 Of course, more research is needed before we'll know whether we can accurately
 make these determinations. If you have suggestions or feedback on these

--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -38,7 +38,7 @@ limitations in the web platform), we are [actively working on closing those
 gaps](#what-is-google-doing-to-ensure-mpas-do-not-have-an-unfair-advantage-compared-to-spas).
 
 {% Aside %}
-Update: The work is anow available for sites to experiment with. See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more details.
+Update: The work is now available for sites to experiment with. See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more details.
 {% endAside %}
 
 

--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -6,7 +6,7 @@ authors:
   - philipwalton
   - yoavweiss
 date: 2021-09-14
-updated: 2023-02-04
+updated: 2023-02-10
 hero: image/eqprBhZUGfb8WYnumQ9ljAxRrA72/FITOGeO0PDyPrBveixB7.jpeg
 alt: "Exterior view of the Walt Disney Concert Hall"
 tags:
@@ -38,7 +38,7 @@ limitations in the web platform), we are [actively working on closing those
 gaps](#what-is-google-doing-to-ensure-mpas-do-not-have-an-unfair-advantage-compared-to-spas).
 
 {% Aside %}
-Update: The work is now available for sites to experiment with. See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more details.
+Update (February 2023): The work is now available for sites to experiment with. See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more details.
 {% endAside %}
 
 
@@ -310,7 +310,7 @@ migrating from an MPA to an SPA to actually compare the performance before and
 after.
 
 {% Aside %}
-Update: See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information on a new "soft-navigations" API that is intended to allow better SPA measurement of the Core Web Vitals.
+Update (February 2023): See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information on a new "soft-navigations" API that is intended to allow better SPA measurement of the Core Web Vitals.
 {% endAside %}
 
 Of course, more research is needed before we'll know whether we can accurately

--- a/src/site/content/en/blog/vitals-spa-faq/index.md
+++ b/src/site/content/en/blog/vitals-spa-faq/index.md
@@ -310,7 +310,7 @@ migrating from an MPA to an SPA to actually compare the performance before and
 after.
 
 {% Aside %}
-Update (February 2023): See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information on a new "soft-navigations" API that is intended to allow better SPA measurement of the Core Web Vitals.
+Update (February 2023): See the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information on a new "soft-navigations" API that is intended to allow better Core Web Vitals measurements for SPAs.
 {% endAside %}
 
 Of course, more research is needed before we'll know whether we can accurately

--- a/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
+++ b/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
@@ -8,7 +8,7 @@ description: |
 authors:
   - tunetheweb
 date: 2022-08-15
-#updated: 2022-07-18
+updated: 2022-02-04
 hero: image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/Q7jtkHwdv8dmhz1KhaiD.jpg
 alt: Runnings racing each other on a track
 tags:
@@ -158,7 +158,7 @@ Getting an understanding from your RUM provider as to when Core Web Vitals are m
 
 #### Single-page applications
 
-Single-page applications (SPA) work by updating the content on the current page, rather than performing traditional page navigation at the browser level. This means the browser does not see these as page navigations, despite users experiencing them as such. The [Core Web Vitals APIs provided by the browser will not take these into consideration](/vitals-spa-faq/), and therefore CrUX does not currently support these page navigations. Work is currently underway to resolve this issue.
+Single-page applications (SPA) work by updating the content on the current page, rather than performing traditional page navigation at the browser level. This means the browser does not see these as page navigations, despite users experiencing them as such. The [Core Web Vitals APIs provided by the browser will not take these into consideration](/vitals-spa-faq/), and therefore CrUX does not currently support these page navigations. Work is currently underway to resolve this issue—see the [Experimenting with measuring soft navigations](https://developer.chrome.com/blog/soft-navigations-experiment/) post for more information.
 
 Some RUM providers do attempt to detect "soft navigations" in SPAs, but if they're also attributing Core Web Vitals metrics to those "soft navigations" it will lead to differences with CrUX since the underlying APIs do not support this.
 

--- a/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
+++ b/src/site/content/en/learn-core-web-vitals/crux-and-rum-differences/index.md
@@ -8,7 +8,7 @@ description: |
 authors:
   - tunetheweb
 date: 2022-08-15
-updated: 2022-02-04
+updated: 2022-02-10
 hero: image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/Q7jtkHwdv8dmhz1KhaiD.jpg
 alt: Runnings racing each other on a track
 tags:


### PR DESCRIPTION
Fixes #9510

Changes proposed in this pull request:

- Adds like to Soft Navs post to [How SPA architectures affect Core Web Vitals](https://web.dev/vitals-spa-faq/) post
- Similar for [Why is CrUX data different from my RUM data?](https://web.dev/crux-and-rum-differences/) post (added two references here).

