### PR TITLE
Update all web-vitals getXXX calls to onXXX

### DIFF
--- a/src/site/content/es/blog/debug-web-vitals-in-the-field/index.md
+++ b/src/site/content/es/blog/debug-web-vitals-in-the-field/index.md
@@ -126,7 +126,7 @@ Para determinar el elemento candidato de LCP en JavaScript, puede usar la [API L
 Dada una lista de las entradas `largest-contentful-paint`, puede determinar el elemento candidato de LCP actual si mira la última entrada:
 
 ```js
-function getLCPDebugTarget(entries) {
+function onLCPDebugTarget(entries) {
   const lastEntry = entries[entries.length - 1];
   return lastEntry.element;
 }
@@ -192,7 +192,7 @@ Estos ejemplos están diseñados para funcionar bien con la [biblioteca web-vita
 Si combina los ejemplos enumerados anteriormente con las funciones de estadísticas `web-vitals`, el resultado final se verá así:
 
 ```js
-import {getLCP, getFID, getCLS} from 'web-vitals';
+import {onLCP, onFID, onCLS} from 'web-vitals';
 
 function getSelector(node, maxLen = 100) {
   let sel = '';
@@ -273,9 +273,9 @@ function sendToAnalytics({name, value, entries}) {
   });
 }
 
-getLCP(sendToAnalytics);
-getFID(sendToAnalytics);
-getCLS(sendToAnalytics);
+onLCP(sendToAnalytics);
+onFID(sendToAnalytics);
+onCLS(sendToAnalytics);
 ```
 
 El formato específico requerido para enviar los datos variará según la herramienta de análisis, pero el código anterior debería ser suficiente para obtener los datos necesarios, independientemente de los requisitos de formato.

--- a/src/site/content/es/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/es/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ Para los pasos 1 y 3, puede consultar la documentación de su herramienta de an�
 El siguiente ejemplo de código muestra lo fácil que puede ser realizar un seguimiento de estas métricas en el código y enviarlas a un servicio de análisis.
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## Asegúrese de que puede reportar una distribución

--- a/src/site/content/es/metrics/cls/index.md
+++ b/src/site/content/es/metrics/cls/index.md
@@ -252,14 +252,14 @@ Para manejar estos casos, se debe informar CLS cada vez que una página está en
 En vez de memorizar y lidiar con todos estos casos usted mismo, los desarrolladores pueden usar la [biblioteca JavaScript de `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir CLS, que da cuenta de todo lo mencionado anteriormente:
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // Measure and log CLS in all situations
 // where it needs to be reported.
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-Puede consultar [el código fuente de `getCLS)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts) para obtener un ejemplo completo de cómo medir CLS en JavaScript.
+Puede consultar [el código fuente de `onCLS)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts) para obtener un ejemplo completo de cómo medir CLS en JavaScript.
 
 {% Aside %} En algunos casos (como los iframes de origen cruzado) no es posible medir CLS en JavaScript. Consulte la sección de [limitaciones](https://github.com/GoogleChrome/web-vitals#limitations) de la biblioteca de `web-vitals` para obtener más información. {% endAside %}
 

--- a/src/site/content/es/metrics/fcp/index.md
+++ b/src/site/content/es/metrics/fcp/index.md
@@ -82,13 +82,13 @@ En la siguiente sección se enumeran las diferencias entre lo que reporta la API
 En vez de memorizar todas estas diferencias sutiles, los desarrolladores pueden utilizar la [Biblioteca de JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir FCP, que maneja estas diferencias por usted (cuando sea posible):
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // Measure and log FCP as soon as it's available.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-Puede consultar [el código fuente de `getFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts) para obtener un ejemplo completo de cómo medir FCP en JavaScript.
+Puede consultar [el código fuente de `onFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts) para obtener un ejemplo completo de cómo medir FCP en JavaScript.
 
 {% Aside %} En algunos casos (como los iframes de origen cruzado) no es posible medir LCP en JavaScript. Consulte la sección de [limitaciones](https://github.com/GoogleChrome/web-vitals#limitations) `web-vitals` para obtener más información. {% endAside %}
 

--- a/src/site/content/es/metrics/fid/index.md
+++ b/src/site/content/es/metrics/fid/index.md
@@ -156,13 +156,13 @@ La siguiente sección enumera las diferencias entre lo que informa la API y cóm
 En vez de memorizar todas estas diferencias sutiles, los desarrolladores pueden usar la [biblioteca de JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir FID, que maneja estas diferencias por usted (cuando sea posible):
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // Measure and log FID as soon as it's available.
-getFID(console.log);
+onFID(console.log);
 ```
 
-Puede consultar [el código fuente de `getFID)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts) para obtener un ejemplo completo de cómo medir FID en JavaScript.
+Puede consultar [el código fuente de `onFID)`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts) para obtener un ejemplo completo de cómo medir FID en JavaScript.
 
 {% Aside %} En algunos casos (como los iframes de origen cruzado) no es posible medir FID en JavaScript. Consulte la sección de [limitaciones](https://github.com/GoogleChrome/web-vitals#limitations) de los `web-vitals` para obtener más información. {% endAside %}
 

--- a/src/site/content/es/metrics/lcp/index.md
+++ b/src/site/content/es/metrics/lcp/index.md
@@ -166,13 +166,13 @@ En la siguiente sección se enumeran las diferencias entre lo que reporta la API
 En vez de memorizar todas estas diferencias sutiles, los desarrolladores pueden usar la [Biblioteca JavaScript de `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir LCP, que maneja estas diferencias por usted (cuando sea posible):
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // Measure and log LCP as soon as it's available.
-getLCP(console.log);
+onLCP(console.log);
 ```
 
-Puede consultar [el código fuente de `getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts) para obtener un ejemplo completo de cómo medir LCP en JavaScript.
+Puede consultar [el código fuente de `onLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts) para obtener un ejemplo completo de cómo medir LCP en JavaScript.
 
 {% Aside %} En algunos casos (como los iframes de origen cruzado) no es posible medir LCP en JavaScript. Consulte la sección de [limitaciones](https://github.com/GoogleChrome/web-vitals#limitations) `web-vitals` para obtener más información. {% endAside %}
 

--- a/src/site/content/es/vitals/index.md
+++ b/src/site/content/es/vitals/index.md
@@ -91,7 +91,7 @@ La forma más sencilla de medir todos los Core Web Vitals es utilizar la bibliot
 Con la [biblioteca web-vitals](https://github.com/GoogleChrome/web-vitals), medir cada métrica es tan simple como llamar a una sola función (consulte la documentación para conocer el [uso](https://github.com/GoogleChrome/web-vitals#usage) completo y los detalles de la [API):](https://github.com/GoogleChrome/web-vitals#api)
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 Una vez que haya configurado su sitio para usar la biblioteca [web-vitals](https://github.com/GoogleChrome/web-vitals) para medir y enviar sus datos de Core Web Vitals a un punto final de análisis, el siguiente paso es agregar y hacer un reporte sobre esos datos para ver si sus páginas cumplen con los umbrales recomendados para al menos el 75% de las visitas a la página.

--- a/src/site/content/ja/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/ja/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ Core Web Vitals 指標をサポートしているアナリティクス ツール
 次のコード サンプルでは、コードでこれらの指標を追跡し、アナリティクス サービスへと送信することがいかに簡単かを示しています。
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## 分布のレポート方法

--- a/src/site/content/ja/metrics/cls/index.md
+++ b/src/site/content/ja/metrics/cls/index.md
@@ -246,14 +246,14 @@ new PerformanceObserver((entryList) => {
 開発者がこれらのケースをすべて記憶して対処する必要はありません。[`web-vitals` JavaScript ライブラリ](https://github.com/GoogleChrome/web-vitals)を使用すれば、上記すべてが考慮された状態で CLS の測定を行うことができます。
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // CLS のレポートが必要なすべての状況で
 // CLS を測定し、ログとして記録します。
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-JavaScript を使用して CLS を測定する方法に関する詳細な例については、[`getCLS()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts)を参照してください。
+JavaScript を使用して CLS を測定する方法に関する詳細な例については、[`onCLS()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts)を参照してください。
 
 {% Aside %}場合によっては (クロスオリジン iframe など)、JavaScript を使用して CLS を測定することはできません。詳細については、`web-vitals` ライブラリの「[制限事項](https://github.com/GoogleChrome/web-vitals#limitations)」セクションを参照してください。{% endAside %}
 

--- a/src/site/content/ja/metrics/fcp/index.md
+++ b/src/site/content/ja/metrics/fcp/index.md
@@ -82,13 +82,13 @@ new PerformanceObserver((entryList) => {
 こういった微妙な違いをすべて記憶していなくても、[`web-vitals` JavaScript ライブラリ](https://github.com/GoogleChrome/web-vitals)を使用して FCP を測定すれば、これらの違いを (可能な限り) 処理してくれます。
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // 実行可能となった時点ですぐに FCP の測定やログ記録を実行します。
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-JavaScript を使用して FCP を測定する方法に関する詳細な例については、[`getFCP()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts)を参照してください。
+JavaScript を使用して FCP を測定する方法に関する詳細な例については、[`onFCP()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts)を参照してください。
 
 {% Aside %}場合によっては (クロスオリジン iframe など)、JavaScript を使用して FCP を測定することはできません。詳細については、`web-vitals` ライブラリの「[制限事項](https://github.com/GoogleChrome/web-vitals#limitations)」セクションを参照してください。{% endAside %}
 

--- a/src/site/content/ja/metrics/fid/index.md
+++ b/src/site/content/ja/metrics/fid/index.md
@@ -156,13 +156,13 @@ new PerformanceObserver((entryList) => {
 こういった微妙な違いをすべて記憶していなくても、[`web-vitals` JavaScript ライブラリ](https://github.com/GoogleChrome/web-vitals)を使用して FID を測定すれば、これらの違いを (可能な限り) 処理してくれます。
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // 実行可能となった時点ですぐに FID の測定やログ記録を実行します。
-getFID(console.log);
+onFID(console.log);
 ```
 
-JavaScript を使用して FID を測定する方法に関する詳細な例については、[`getFID()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts)を参照してください。
+JavaScript を使用して FID を測定する方法に関する詳細な例については、[`onFID()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts)を参照してください。
 
 {% Aside %}場合によっては (クロスオリジン iframe など)、JavaScript を使用して FID を測定することはできません。詳細については、`web-vitals` ライブラリの「[limitations](https://github.com/GoogleChrome/web-vitals#limitations) (制限事項)」セクションを参照してください。{% endAside %}
 

--- a/src/site/content/ja/metrics/lcp/index.md
+++ b/src/site/content/ja/metrics/lcp/index.md
@@ -166,13 +166,13 @@ new PerformanceObserver((entryList) => {
 こういった微妙な違いをすべて記憶していなくても、[`web-vitals` JavaScript ライブラリ](https://github.com/GoogleChrome/web-vitals)を使用して LCP を測定すれば、これらの違いを (可能な限り) 処理してくれます。
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // 実行可能となった時点ですぐに LCP の測定やログ記録を実行します。
-getLCP(console.log);
+onLCP(console.log);
 ```
 
-JavaScript を使用して LCP を測定する方法に関する詳細な例については、[`getLCP()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts)を参照してください。
+JavaScript を使用して LCP を測定する方法に関する詳細な例については、[`onLCP()` のソース コード](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts)を参照してください。
 
 {% Aside %}場合によっては (クロスオリジン iframe など)、JavaScript を使用して LCP を測定することはできません。詳細については、`web-vitals` ライブラリの「[limitations](https://github.com/GoogleChrome/web-vitals#limitations) (制限事項)」セクションを参照してください。{% endAside %}
 

--- a/src/site/content/ja/vitals/index.md
+++ b/src/site/content/ja/vitals/index.md
@@ -91,7 +91,7 @@ Core Web Vitals の各指標をすべて測定するためには、[web-vitals](
 [Web-vitals](https://github.com/GoogleChrome/web-vitals) ライブラリを使用することにより、各指標の測定は単一の関数の呼び出しと同じくらい簡単になります (詳細な[使用方法](https://github.com/GoogleChrome/web-vitals#usage)および [API](https://github.com/GoogleChrome/web-vitals#api) に関する詳細については、ドキュメントを参照してください)。
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 [Web-Vitals](https://github.com/GoogleChrome/web-vitals) ライブラリを使用して Core Web Vitals データを測定し、アナリティクス エンドポイントへと送信するようサイトを構成したら、次のステップはそのデータの集計およびレポートを実施し、推奨しきい値 (ページ別訪問数の少なくとも 75%) を満たしているかどうかを確認することです。

--- a/src/site/content/ko/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/ko/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ Core Web Vitals 메트릭을 지원하는 분석 도구를 사용하는 것이 �
 다음 코드 샘플은 코드에서 이러한 메트릭을 추적하고 분석 서비스로 보내는 것이 얼마나 쉬운지를 보여줍니다.
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## 분포를 보고할 수 있는지 확인

--- a/src/site/content/ko/metrics/cls/index.md
+++ b/src/site/content/ko/metrics/cls/index.md
@@ -246,14 +246,14 @@ new PerformanceObserver((entryList) => {
 개발자는 이러한 모든 경우를 직접 암기하고 고심하지 않아도, [`web-vitals` JavaScript 라이브러리](https://github.com/GoogleChrome/web-vitals)를 사용해 위에서 언급한 모든 것을 처리하는 CLS를 측정할 수 있습니다.
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // Measure and log CLS in all situations
 // where it needs to be reported.
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-JavaScript에서 CLS를 측정하는 방법에 대한 전체 예제는 [`getCLS)` 의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts)를 참조하세요.
+JavaScript에서 CLS를 측정하는 방법에 대한 전체 예제는 [`onCLS)` 의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts)를 참조하세요.
 
 {% Aside %} 일부 경우(예: 교차 원본 iframe) JavaScript에서 CLS를 측정할 수 없습니다. 자세한 내용은 `web-vitals` 라이브러리의 [제한 사항](https://github.com/GoogleChrome/web-vitals#limitations) 섹션을 참조하세요. {% endAside %}
 

--- a/src/site/content/ko/metrics/fcp/index.md
+++ b/src/site/content/ko/metrics/fcp/index.md
@@ -82,13 +82,13 @@ new PerformanceObserver((entryList) => {
 개발자는 이러한 미묘한 차이점을 모두 기억하는 대신 가능한 경우 다음과 같은 차이점을 대신 처리해주는 [`web-vitals` JavaScript 라이브러리](https://github.com/GoogleChrome/web-vitals)를 사용하여 FCP를 측정할 수 있습니다.
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // FCP를 이용 가능하게 되면 바로 측정 및 기록합니다.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-JavaScript에서 FCP를 측정하는 방법에 대한 전체 예제는 [`getFCP()`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts)를 참조하세요.
+JavaScript에서 FCP를 측정하는 방법에 대한 전체 예제는 [`onFCP()`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts)를 참조하세요.
 
 {% Aside %} 일부 경우(예: 교차 원본 iframe) JavaScript에서 FCP를 측정할 수 없습니다. 자세한 내용은 `web-vitals` 라이브러리의 [제한 사항](https://github.com/GoogleChrome/web-vitals#limitations) 섹션을 참조하세요. {% endAside %}
 

--- a/src/site/content/ko/metrics/fid/index.md
+++ b/src/site/content/ko/metrics/fid/index.md
@@ -156,13 +156,13 @@ new PerformanceObserver((entryList) => {
 개발자는 이러한 미묘한 차이점을 모두 기억하는 대신 가능한 경우 다음과 같은 차이점을 처리해주는 [`web-vitals` JavaScript 라이브러리](https://github.com/GoogleChrome/web-vitals)를 사용하여 FID를 측정할 수 있습니다.
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // FID를 이용 가능하게 되면 바로 측정 및 기록합니다.
-getFID(console.log);
+onFID(console.log);
 ```
 
-JavaScript에서 FID를 측정하는 방법에 대한 전체 예제는 [`getFID)`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts)를 참조하세요.
+JavaScript에서 FID를 측정하는 방법에 대한 전체 예제는 [`onFID)`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts)를 참조하세요.
 
 {% Aside %} 일부 경우(예: 교차 원본 iframe) JavaScript에서 FID를 측정할 수 없습니다. 자세한 내용은 `web-vitals` 라이브러리의 [제한 사항](https://github.com/GoogleChrome/web-vitals#limitations) 섹션을 참조하세요. {% endAside %}
 

--- a/src/site/content/ko/metrics/lcp/index.md
+++ b/src/site/content/ko/metrics/lcp/index.md
@@ -166,13 +166,13 @@ new PerformanceObserver((entryList) => {
 개발자는 이러한 미묘한 차이점을 모두 기억하는 대신 가능한 경우 다음과 같은 차이점을 대신 처리해주는 [`web-vitals` JavaScript 라이브러리](https://github.com/GoogleChrome/web-vitals)를 사용하여 LCP를 측정할 수 있습니다.
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // LCP를 이용 가능하게 되면 바로 측정 및 기록합니다.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-JavaScript에서 LCP를 측정하는 방법에 대한 전체 예제는 [`getLCP()`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts)를 참조하세요.
+JavaScript에서 LCP를 측정하는 방법에 대한 전체 예제는 [`onLCP()`의 소스 코드](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts)를 참조하세요.
 
 {% Aside %} 일부 경우(예: 교차 원본 iframe) JavaScript에서 LCP를 측정할 수 없습니다. 자세한 내용은 `web-vitals` 라이브러리의 [제한 사항](https://github.com/GoogleChrome/web-vitals#limitations) 섹션을 참조하세요. {% endAside %}
 

--- a/src/site/content/ko/vitals/index.md
+++ b/src/site/content/ko/vitals/index.md
@@ -91,7 +91,7 @@ Chrome User Experience Report의 데이터는 사이트의 성능을 빠르게 �
 [web-vitals](https://github.com/GoogleChrome/web-vitals) 라이브러리를 사용하면 각 메트릭을 측정하는 것이 단일 함수를 호출하는 것만큼 간단해집니다(완전한 [사용 방법](https://github.com/GoogleChrome/web-vitals#usage) 및 [API](https://github.com/GoogleChrome/web-vitals#api) 세부 정보는 해당 문서 참조).
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 [web-vitals](https://github.com/GoogleChrome/web-vitals) 라이브러리를 사용하여 Core Web Vitals 데이터를 측정하고 분석 엔드포인트로 전송하도록 사이트를 구성했다면, 다음 단계는 해당 데이터를 집계하고 보고하여 페이지가 페이지 방문의 최소 75%에 대해 권장 임계값을 충족하는지 확인하는 것입니다.

--- a/src/site/content/pt/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/pt/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ Para as etapas 1 e 3, você pode consultar a documentação da ferramenta de an�
 O trecho de código a seguir mostra como é fácil rastrear essas métricas no código e enviá-las a um serviço de análise.
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## Garanta que você possa relatar uma distribuição

--- a/src/site/content/pt/metrics/cls/index.md
+++ b/src/site/content/pt/metrics/cls/index.md
@@ -246,14 +246,14 @@ Para lidar com esses casos, a CLS deve ser relatada sempre que uma página entra
 Em vez de memorizar e lidar com todos esses casos você mesmo, os desenvolvedores podem usar a [biblioteca JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir a CLS, que é responsável por tudo o que foi mencionado acima:
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // Measure and log CLS in all situations
 // where it needs to be reported.
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-Para um exemplo completo de como medir a CLS em JavaScript, consulte [o código-fonte de `getCLS()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts).
+Para um exemplo completo de como medir a CLS em JavaScript, consulte [o código-fonte de `onCLS()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts).
 
 {% Aside %} Em alguns casos (como iframes de origem cruzada), não é possível medir a CLS em JavaScript. Consulte a seção de [limitações](https://github.com/GoogleChrome/web-vitals#limitations) da biblioteca `web-vitals` para mais detalhes. {% endAside %}
 

--- a/src/site/content/pt/metrics/fcp/index.md
+++ b/src/site/content/pt/metrics/fcp/index.md
@@ -82,13 +82,13 @@ A seção a seguir lista as diferenças entre o que a API informa e como a métr
 Em vez de memorizar todas essas diferenças sutis, os desenvolvedores podem usar a [biblioteca JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir a FCP, que já lida com essas diferenças (onde for possível):
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // Measure and log FCP as soon as it's available.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-Para um exemplo completo de como medir a FCP em JavaScript, consulte [o código-fonte de `getFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts).
+Para um exemplo completo de como medir a FCP em JavaScript, consulte [o código-fonte de `onFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts).
 
 {% Aside %} Em alguns casos (como iframes de origem cruzada), não é possível medir a FCP em JavaScript. Consulte a seção de [limitações](https://github.com/GoogleChrome/web-vitals#limitations) da biblioteca `web-vitals` para mais detalhes. {% endAside %}
 

--- a/src/site/content/pt/metrics/fid/index.md
+++ b/src/site/content/pt/metrics/fid/index.md
@@ -156,13 +156,13 @@ A seção a seguir lista as diferenças entre o que a API informa e como a métr
 Em vez de memorizar todas essas diferenças sutis, os desenvolvedores podem usar a [biblioteca JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir a FID, que já lida com essas diferenças (onde for possível):
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // Measure and log FID as soon as it's available.
-getFID(console.log);
+onFID(console.log);
 ```
 
-Para um exemplo completo de como medir a FID em JavaScript, consulte [o código-fonte de `getFID()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts).
+Para um exemplo completo de como medir a FID em JavaScript, consulte [o código-fonte de `onFID()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts).
 
 {% Aside %} Em alguns casos (como iframes de origem cruzada), não é possível medir a FID em JavaScript. Consulte a seção de [limitações](https://github.com/GoogleChrome/web-vitals#limitations) da biblioteca `web-vitals` para mais detalhes. {% endAside %}
 

--- a/src/site/content/pt/metrics/lcp/index.md
+++ b/src/site/content/pt/metrics/lcp/index.md
@@ -166,13 +166,13 @@ A seção a seguir lista as diferenças entre o que a API informa e como a métr
 Em vez de memorizar todas essas diferenças sutis, os desenvolvedores podem usar a [biblioteca JavaScript `web-vitals`](https://github.com/GoogleChrome/web-vitals) para medir a LCP, que já lida com essas diferenças (onde for possível):
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // Measure and log LCP as soon as it's available.
-getLCP(console.log);
+onLCP(console.log);
 ```
 
-Para um exemplo completo de como medir a LCP em JavaScript, consulte [o código-fonte de `getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts).
+Para um exemplo completo de como medir a LCP em JavaScript, consulte [o código-fonte de `onLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts).
 
 {% Aside %} Em alguns casos (como iframes de origem cruzada), não é possível medir a LCP em JavaScript. Consulte a seção de [limitações](https://github.com/GoogleChrome/web-vitals#limitations) da biblioteca `web-vitals` para mais detalhes. {% endAside %}
 

--- a/src/site/content/pt/vitals/index.md
+++ b/src/site/content/pt/vitals/index.md
@@ -91,7 +91,7 @@ A maneira mais fácil de medir todas as Core Web Vitals é usar a biblioteca Jav
 Com a biblioteca [web-vitals](https://github.com/GoogleChrome/web-vitals), medir cada métrica é tão simples quanto chamar uma função (consulte a documentação para detalhes completos sobre o [uso](https://github.com/GoogleChrome/web-vitals#usage) e sobre a [API](https://github.com/GoogleChrome/web-vitals#api)):
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 Depois que você configurar seu site para usar a biblioteca [web-vitals](https://github.com/GoogleChrome/web-vitals) para medir e enviar seus dados de Core Web Vitals para um endpoint de análises, a próxima etapa é agregar e relatar sobre esses dados para saber se suas páginas estão alcançando os limites recomendados para pelo menos 75% das visitas à página.

--- a/src/site/content/ru/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/ru/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ tags:
 В следующем примере кода показано, насколько легко можно отслеживать эти метрики в коде и отправлять их в службу аналитики.
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## Убедитесь, что вы можете составить отчет о распределении

--- a/src/site/content/ru/metrics/cls/index.md
+++ b/src/site/content/ru/metrics/cls/index.md
@@ -246,14 +246,14 @@ new PerformanceObserver((entryList) => {
 Вместо того чтобы запоминать все эти тонкости, разработчики могут использовать для измерения CLS [JavaScript-библиотеку `web-vitals`](https://github.com/GoogleChrome/web-vitals), которая учитывает вышеупомянутые моменты:
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // Measure and log CLS in all situations
 // where it needs to be reported.
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-Полный пример измерения CLS в JavaScript приводится в [исходном коде `getCLS()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts).
+Полный пример измерения CLS в JavaScript приводится в [исходном коде `onCLS()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts).
 
 {% Aside %} В некоторых случаях (например, в iframe с перекрестным происхождением) невозможно измерить CLS в JavaScript. См. подробности в разделе [«Ограничения»](https://github.com/GoogleChrome/web-vitals#limitations) библиотеки `web-vitals`. {% endAside %}
 

--- a/src/site/content/ru/metrics/fcp/index.md
+++ b/src/site/content/ru/metrics/fcp/index.md
@@ -82,13 +82,13 @@ new PerformanceObserver((entryList) => {
 Чтобы не запоминать все эти тонкости, разработчики могут использовать для измерения FCP [JavaScript-библиотеку `web-vitals`](https://github.com/GoogleChrome/web-vitals), которая обрабатывает эти случаи (где это возможно):
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // Measure and log FCP as soon as it's available.
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-Полный пример измерения FCP в JavaScript приводится в [исходном коде `getFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts).
+Полный пример измерения FCP в JavaScript приводится в [исходном коде `onFCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts).
 
 {% Aside %} В некоторых случаях (например, в iframe с перекрестным происхождением) невозможно измерить FCP в JavaScript. См. подробности в разделе [«Ограничения»](https://github.com/GoogleChrome/web-vitals#limitations) библиотеки `web-vitals`. {% endAside %}
 

--- a/src/site/content/ru/metrics/fid/index.md
+++ b/src/site/content/ru/metrics/fid/index.md
@@ -156,13 +156,13 @@ new PerformanceObserver((entryList) => {
 Чтобы не запоминать все эти тонкости, разработчики могут использовать для измерения FID [JavaScript-библиотеку `web-vitals`](https://github.com/GoogleChrome/web-vitals), которая обрабатывает эти случаи (где это возможно):
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // Measure and log FID as soon as it's available.
-getFID(console.log);
+onFID(console.log);
 ```
 
-Полный пример измерения FID в JavaScript приводится в [исходном коде `getFID()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts).
+Полный пример измерения FID в JavaScript приводится в [исходном коде `onFID()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts).
 
 {% Aside %} В некоторых случаях (например, в iframe с перекрестным происхождением) невозможно измерить FID в JavaScript. См. подробности в разделе [«Ограничения»](https://github.com/GoogleChrome/web-vitals#limitations) библиотеки `web-vitals` {% endAside %}
 

--- a/src/site/content/ru/metrics/lcp/index.md
+++ b/src/site/content/ru/metrics/lcp/index.md
@@ -166,13 +166,13 @@ new PerformanceObserver((entryList) => {
 Чтобы не запоминать все эти тонкости, разработчики могут использовать для измерения LCP [JavaScript-библиотеку `web-vitals`](https://github.com/GoogleChrome/web-vitals), которая обрабатывает эти случаи (где это возможно):
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // Measure and log LCP as soon as it's available.
-getLCP(console.log);
+onLCP(console.log);
 ```
 
-Полный пример измерения LCP в JavaScript приводится в [исходном коде `getLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts).
+Полный пример измерения LCP в JavaScript приводится в [исходном коде `onLCP()`](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts).
 
 {% Aside %} В некоторых случаях (например, в iframe с перекрестным происхождением) невозможно измерить LCP в JavaScript. См. подробности в разделе  [«Ограничения»](https://github.com/GoogleChrome/web-vitals#limitations) библиотеки `web-vitals`. {% endAside %}
 

--- a/src/site/content/ru/vitals/index.md
+++ b/src/site/content/ru/vitals/index.md
@@ -91,7 +91,7 @@ Google верит, что показатели Core Web Vitals критичес�
 С библиотекой [web-vitals](https://github.com/GoogleChrome/web-vitals) измерение каждой метрики сводится к простому вызову функции (см. документацию об [использовании](https://github.com/GoogleChrome/web-vitals#usage) и подробные сведения об [API](https://github.com/GoogleChrome/web-vitals#api)):
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 После настройки сайта на использование библиотеки [web-vitals](https://github.com/GoogleChrome/web-vitals) для измерения и отправки данных Core Web Vitals в конечную точку аналитики, следующий шаг - агрегирование этих данных и создание отчетов по ним, чтобы увидеть, соответствуют ли ваши страницы рекомендуемым пороговым значениям по крайней мере для 75% посещений страниц.

--- a/src/site/content/zh/blog/vitals-field-measurement-best-practices/index.md
+++ b/src/site/content/zh/blog/vitals-field-measurement-best-practices/index.md
@@ -37,7 +37,7 @@ tags:
 以下代码示例展示了在代码中跟踪这些指标并将其发送到分析服务十分轻松简单。
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics({name, value, id}) {
   const body = JSON.stringify({name, value, id});
@@ -46,9 +46,9 @@ function sendToAnalytics({name, value, id}) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 ## 确保您可以报告分布情况

--- a/src/site/content/zh/metrics/cls/index.md
+++ b/src/site/content/zh/metrics/cls/index.md
@@ -257,14 +257,14 @@ new PerformanceObserver((entryList) => {
 开发者不必记住所有这些情况并独自应付，而是可以使用[`web-vitals` JavaScript 库](https://github.com/GoogleChrome/web-vitals)来测量 CLS，库会自行处理上述所有情况：
 
 ```js
-import {getCLS} from 'web-vitals';
+import {onCLS} from 'web-vitals';
 
 // 在所有需要汇报 CLS 的情况下
 // 对其进行测量和记录。
-getCLS(console.log);
+onCLS(console.log);
 ```
 
-您可以参考[`getCLS)`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts)，了解如何在 JavaScript 中测量 CLS 的完整示例。
+您可以参考[`onCLS)`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts)，了解如何在 JavaScript 中测量 CLS 的完整示例。
 
 {% Aside %}在某些情况下（例如跨域 iframe），CLS 无法在 JavaScript 中进行测量。详情请参阅`web-vitals`库的[局限性](https://github.com/GoogleChrome/web-vitals#limitations)部分。 {% endAside %}
 

--- a/src/site/content/zh/metrics/fcp/index.md
+++ b/src/site/content/zh/metrics/fcp/index.md
@@ -82,13 +82,13 @@ new PerformanceObserver((entryList) => {
 开发者不必记住所有这些细微差异，而是可以使用[`web-vitals` JavaScript 库](https://github.com/GoogleChrome/web-vitals)来测量 FCP，库会自行处理这些差异（在可能的情况下）：
 
 ```js
-import {getFCP} from 'web-vitals';
+import {onFCP} from 'web-vitals';
 
 // 当 FCP 可用时立即进行测量和记录。
-getFCP(console.log);
+onFCP(console.log);
 ```
 
-您可以参考[`getFCP()`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFCP.ts)，了解如何在 JavaScript 中测量 FCP 的完整示例。
+您可以参考[`onFCP()`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFCP.ts)，了解如何在 JavaScript 中测量 FCP 的完整示例。
 
 {% Aside %}
 在某些情况下（例如跨域 iframe），FCP 无法在 JavaScript 中进行测量。详情请参阅`web-vitals`库的[局限性](https://github.com/GoogleChrome/web-vitals#limitations)部分。

--- a/src/site/content/zh/metrics/fid/index.md
+++ b/src/site/content/zh/metrics/fid/index.md
@@ -154,13 +154,13 @@ new PerformanceObserver((entryList) => {
 开发者不必记住所有这些细微差异，而是可以使用[`web-vitals` JavaScript 库](https://github.com/GoogleChrome/web-vitals)来测量 FID，库会自行处理这些差异（在可能的情况下）：
 
 ```js
-import {getFID} from 'web-vitals';
+import {onFID} from 'web-vitals';
 
 // 当 FID 可用时立即进行测量和记录。
-getFID(console.log);
+onFID(console.log);
 ```
 
-您可以参考[`getFID)`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/getFID.ts)，了解如何在 JavaScript 中测量 FID 的完整示例。
+您可以参考[`onFID)`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/onFID.ts)，了解如何在 JavaScript 中测量 FID 的完整示例。
 
 {% Aside %}在某些情况下（例如跨域 iframe），FID 无法在 JavaScript 中进行测量。详情请参阅`web-vitals`库的[局限性](https://github.com/GoogleChrome/web-vitals#limitations)部分。 {% endAside %}
 

--- a/src/site/content/zh/metrics/lcp/index.md
+++ b/src/site/content/zh/metrics/lcp/index.md
@@ -166,13 +166,13 @@ new PerformanceObserver((entryList) => {
 开发者不必记住所有这些细微差异，而是可以使用[`web-vitals` JavaScript 库](https://github.com/GoogleChrome/web-vitals)来测量 LCP，库会自行处理这些差异（在可能的情况下）：
 
 ```js
-import {getLCP} from 'web-vitals';
+import {onLCP} from 'web-vitals';
 
 // 当 LCP 可用时立即进行测量和记录。
-getLCP(console.log);
+onLCP(console.log);
 ```
 
-您可以参考[`getLCP()`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/getLCP.ts)，了解如何在 JavaScript 中测量 LCP 的完整示例。
+您可以参考[`onLCP()`的源代码](https://github.com/GoogleChrome/web-vitals/blob/main/src/onLCP.ts)，了解如何在 JavaScript 中测量 LCP 的完整示例。
 
 {% Aside %}在某些情况下（例如跨域 iframe），LCP 无法在 JavaScript 中进行测量。详情请参阅`web-vitals`库的[局限性](https://github.com/GoogleChrome/web-vitals#limitations)部分。 {% endAside %}
 

--- a/src/site/content/zh/metrics/ttfb/index.md
+++ b/src/site/content/zh/metrics/ttfb/index.md
@@ -101,10 +101,10 @@ new PerformanceObserver((entryList) => {
 [`web-vitals` JavaScript library](https://github.com/GoogleChrome/web-vitals) 也能在浏览器内测量 TTFB 指标，代码将更加简洁：
 
 ```javascript
-import {getTTFB} from 'web-vitals';
+import {onTTFB} from 'web-vitals';
 
 // Measure and log TTFB as soon as it's available.
-getTTFB(console.log);
+onTTFB(console.log);
 ```
 
 ### Measuring resource requests

--- a/src/site/content/zh/vitals/index.md
+++ b/src/site/content/zh/vitals/index.md
@@ -91,7 +91,7 @@ Chrome 用户体验报告提供的数据带来了一种快速评估网站性能�
 通过使用[web-vitals](https://github.com/GoogleChrome/web-vitals)库，测量每项指标就像调用单个函数一样简单（有关完整[用法](https://github.com/GoogleChrome/web-vitals#usage)和[API](https://github.com/GoogleChrome/web-vitals#api)详情，请参阅文档）：
 
 ```js
-import {getCLS, getFID, getLCP} from 'web-vitals';
+import {onCLS, onFID, onLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
   const body = JSON.stringify(metric);
@@ -100,9 +100,9 @@ function sendToAnalytics(metric) {
       fetch('/analytics', {body, method: 'POST', keepalive: true});
 }
 
-getCLS(sendToAnalytics);
-getFID(sendToAnalytics);
-getLCP(sendToAnalytics);
+onCLS(sendToAnalytics);
+onFID(sendToAnalytics);
+onLCP(sendToAnalytics);
 ```
 
 当您将网站配置为使用[web-vitals](https://github.com/GoogleChrome/web-vitals)库来测量您的核心 Web 指标数据并将其发送到分析端后，下一步是对数据进行汇总和报告，从而查看您的页面是否在至少 75% 的页面访问中都满足建议阈值。


### PR DESCRIPTION
The web-vitals library has deprecated the getXXX calls (e.g. getLCP) and replaces with onXXX calls (e.g. onLCP)

Changes proposed in this pull request:

- Update all references in non-english languages

Replaces #9536 

