### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    pull-request-branch-name:
+      separator: "/"
+    labels:
+      - "eng"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@11ty/eleventy"
+      - dependency-name: "webdev-infra"
+      - dependency-name: "@mdn/browser-compat-data"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@google-cloud/cloudbuild": "^2.6.0",
         "@google-cloud/error-reporting": "^2.0.3",
         "@google-cloud/secret-manager": "^3.10.0",
+        "@mdn/browser-compat-data": "5.2.35",
         "@minify-html/node": "^0.9.2",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -66,7 +67,7 @@
         "truncate-utf8-bytes": "^1.0.2",
         "unistore": "^3.4.1",
         "web-vitals": "^3.1.0",
-        "webdev-infra": "1.0.42",
+        "webdev-infra": "1.0.44",
         "wicg-inert": "^3.1.2",
         "yaml-front-matter": "^4.0.0"
       },
@@ -1657,9 +1658,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.23",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
-      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
+      "version": "5.2.35",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.35.tgz",
+      "integrity": "sha512-WMGl70X/upKye9Ix0xQtaKzNsFJE6I4ZEexypk1gyiB5REQZv9BI3Stw8Tby25YSGJ7OuYG0+5oCnkv1A+3kRA=="
     },
     "node_modules/@minify-html/node": {
       "version": "0.9.2",
@@ -28454,15 +28455,15 @@
       "integrity": "sha512-zCeQ+bOjWjJbXv5ZL0r8Py3XP2doCQMZXNKlBGfUjPAVZWokApdeF/kFlK1peuKlCt8sL9TFkKzyXE9/cmNJQA=="
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
-      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.44.tgz",
+      "integrity": "sha512-RQS7QAjAjBFneQr6NnS8hWFpvwiRj/fGhCxhgsBwqherHjmxIqPF3dwSlVeEtum0d26rYidlpRW5KqEonbuJbg==",
       "dependencies": {
         "@11ty/eleventy": "1.0.2",
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
-        "@mdn/browser-compat-data": "5.2.23",
+        "@mdn/browser-compat-data": "5.2.x",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",
@@ -28482,6 +28483,14 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@mdn/browser-compat-data": "5.2.x"
+      },
+      "peerDependenciesMeta": {
+        "@mdn/browser-compat-data": {
+          "optional": false
+        }
       }
     },
     "node_modules/webdev-infra/node_modules/argparse": {
@@ -30532,9 +30541,9 @@
       "integrity": "sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw=="
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.23",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
-      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
+      "version": "5.2.35",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.35.tgz",
+      "integrity": "sha512-WMGl70X/upKye9Ix0xQtaKzNsFJE6I4ZEexypk1gyiB5REQZv9BI3Stw8Tby25YSGJ7OuYG0+5oCnkv1A+3kRA=="
     },
     "@minify-html/node": {
       "version": "0.9.2",
@@ -51653,15 +51662,15 @@
       "integrity": "sha512-zCeQ+bOjWjJbXv5ZL0r8Py3XP2doCQMZXNKlBGfUjPAVZWokApdeF/kFlK1peuKlCt8sL9TFkKzyXE9/cmNJQA=="
     },
     "webdev-infra": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
-      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.44.tgz",
+      "integrity": "sha512-RQS7QAjAjBFneQr6NnS8hWFpvwiRj/fGhCxhgsBwqherHjmxIqPF3dwSlVeEtum0d26rYidlpRW5KqEonbuJbg==",
       "requires": {
         "@11ty/eleventy": "1.0.2",
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
-        "@mdn/browser-compat-data": "5.2.23",
+        "@mdn/browser-compat-data": "5.2.x",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -110,9 +110,10 @@
     "truncate-utf8-bytes": "^1.0.2",
     "unistore": "^3.4.1",
     "web-vitals": "^3.1.0",
-    "webdev-infra": "1.0.42",
+    "webdev-infra": "1.0.44",
     "wicg-inert": "^3.1.2",
-    "yaml-front-matter": "^4.0.0"
+    "yaml-front-matter": "^4.0.0",
+    "@mdn/browser-compat-data": "5.2.35"
   },
   "devDependencies": {
     "@actions/core": "^1.9.1",


### PR DESCRIPTION
Follow-up to https://github.com/GoogleChrome/developer.chrome.com/pull/5237. Configures dependabot to have PRs to update @mdn/browser-compat-data and 11ty and webdev-infra.