### PR TITLE
Use the correct origin trial token

### DIFF
--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -49,7 +49,7 @@
 
 {# Dogfood document speculation rules origin trial #}
 <!-- web.dev origin trial token - valid until 22 Mar 2023 -->
-<meta http-equiv="origin-trial" content="AuvDj0sNbsmN01Zw2Gg1+wDt6DampaNwj+ydUpWmsL2l1Ritum74apPitLRO0FL3VwFRqpVPTZXhPlxCl23vhwIAAACIeyJvcmlnaW4iOiJodHRwczovL2RlcGxveS1wcmV2aWV3LTk1MzItLXdlYi1kZXYtc3RhZ2luZy5uZXRsaWZ5LmFwcDo0NDMiLCJmZWF0dXJlIjoiU3BlY3VsYXRpb25SdWxlc1ByZWZldGNoRnV0dXJlIiwiZXhwaXJ5IjoxNjk0MTMxMTk5fQ==">
+<meta http-equiv="origin-trial" content="Ah3H7DwyoUUsaRQdSySa1hMCS/JFQn/VVmrQODVDnRJGH9mU/uG6G0Uhh+4atnFGAoiEwDq+r9TzCyBi7f7wRw4AAABfeyJvcmlnaW4iOiJodHRwczovL3dlYi5kZXY6NDQzIiwiZmVhdHVyZSI6IlNwZWN1bGF0aW9uUnVsZXNQcmVmZXRjaEZ1dHVyZSIsImV4cGlyeSI6MTY5NDEzMTE5OX0=">
 {# Exclude the /patterns/ section as a control #}
 {% set speculationRules %}
 {


### PR DESCRIPTION
The origin trial token added in #9532 was the test site one, not the production one 🤦‍♂️

This PR fixes that.