### PR TITLE
Add Private Aggregation API testing

### DIFF
--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -45,6 +45,13 @@
 {# Script loader for sourced scripts, as they cannot be authorized by a CSP hash. #}
 {% include 'partials/script-loader.njk' %}
 
+{# Private Aggregation API testing script #}
+{# The testing will run until mid-April 2023 #}
+{% set paaScript %}
+  loadScript('https://shared-storage-demo-content-producer.web.app/paa/scripts/private-aggregation-test.js', null);
+{% endset %}
+<script>{{ paaScript | minifyJs | cspHash | safe }}</script>
+
 {% include 'partials/analytics.njk' %}
 
 {# Dogfood document speculation rules origin trial #}
@@ -74,3 +81,4 @@
 }
 {% endset %}
 <script type="speculationrules">{{ speculationRules | minifyJSON | cspHash | safe }}</script>
+


### PR DESCRIPTION
This PR adds Private Aggregation API (PAA) testing.

* Related DCC PR: https://github.com/GoogleChrome/developer.chrome.com/pull/5304
* Related Shared Storage Demo (SSD) PR: https://github.com/GoogleChromeLabs/shared-storage-demo/pull/17

---

[Private Aggregation API](https://developer.chrome.com/docs/privacy-sandbox/private-aggregation/) allows users to report cross-site data in [Shared Storage](https://developer.chrome.com/en/docs/privacy-sandbox/shared-storage/).  

This test adds a Private Aggregation API call that reports randomly generated key/value pairs.  The reports are not collected.  

The PAA test script is injected as a third-party script.  The 3p script contains its own 3p origin trial token.

---

To test, visit the staging link (TBD), then open up `chrome://private-aggregation-internals` page to check the reported values. 