### PR TITLE
fixing minor typo 

### DIFF
--- a/src/site/content/en/learn/html/attributes/index.md
+++ b/src/site/content/en/learn/html/attributes/index.md
@@ -389,7 +389,7 @@ To toggle between states, query the value of the [HTMLElement.isContentEditable]
 ```js
 const editor = document.getElementById("myElement");
 if(editor.contentEditable) {
-    editor.setAttribute("contenteditable", "false);
+    editor.setAttribute("contenteditable", "false");
 } else {
    editor.setAttribute("contenteditable", "");
 }


### PR DESCRIPTION
Fixes #9332

Changes proposed in this pull request:

- Fixed a typo, by adding a missing quotation mark on the learn HTML contenteditable section.

- This is the current code containing the typo:
`const editor = document.getElementById("myElement");
if(editor.contentEditable) {
    editor.setAttribute("contenteditable", "false); **here is the typo**
} else {
   editor.setAttribute("contenteditable", "");
}`

- Below is the link to the section.
  [(https://web.dev/learn/html/attributes/#contenteditable)]