### PR TITLE
Disable DevRel ribbon in current form

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -750,7 +750,6 @@ video,
 @import 'blocks/pill';
 @import 'blocks/preview-pagination';
 @import 'blocks/prose';
-@import 'blocks/ribbon';
 @import 'blocks/site-footer';
 @import 'blocks/site-header';
 @import 'blocks/skip-link';

--- a/src/site/_includes/base.njk
+++ b/src/site/_includes/base.njk
@@ -17,8 +17,6 @@ tags: []
     #}
     <web-snackbar-container></web-snackbar-container>
 
-    {% include 'partials/devrel-ribbon.njk' %}
-
     {{ content | safe }}
   </body>
 </html>

--- a/src/site/_includes/core.njk
+++ b/src/site/_includes/core.njk
@@ -19,8 +19,6 @@ tags: []
     #}
     <web-snackbar-container></web-snackbar-container>
 
-    {% include 'partials/devrel-ribbon.njk' %}
-
     {{ content | safe }}
   </body>
 </html>


### PR DESCRIPTION
Related to https://github.com/GoogleChrome/web.dev/issues/9589 and https://github.com/GoogleChrome/web.dev/issues/9551.

This disables the ribbon on the right hand side for now to internally test out some variants first.