### PR TITLE
feat: load recaptcha when newsletter form is in view

### DIFF
--- a/src/component-library/spinner/spinner.json
+++ b/src/component-library/spinner/spinner.json
@@ -1,0 +1,12 @@
+{
+  "title": "Spinner",
+  "keyLinks": [
+    {
+      "label": "Sass File",
+      "url": "https://github.com/GoogleChrome/web.dev/tree/main/src/scss/blocks/_spinner.scss"
+    }
+  ],
+  "context": {
+    "title": "A spinner element"
+  }
+}

--- a/src/component-library/spinner/spinner.md
+++ b/src/component-library/spinner/spinner.md
@@ -1,0 +1,1 @@
+To display when content is loading. The `--color` CSS variable can be used to determine the color of the drawn stroke. The CSS `width` property can be used to size the element.

--- a/src/component-library/spinner/spinner.njk
+++ b/src/component-library/spinner/spinner.njk
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 6 6" class="spinner" style="--color: var(--color-highlight-text); width: 50px;">
+  <circle cx="3" cy="3" r="2.5" />
+</svg>

--- a/src/lib/components/Subscribe/index.js
+++ b/src/lib/components/Subscribe/index.js
@@ -33,31 +33,48 @@ class Subscribe extends BaseElement {
     window['recaptchaSuccess'] = this.captchaCheck.bind(this);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    /** @type {HTMLFormElement} */
-    this.form = this.querySelector('form');
-    const intersectionObserver = new IntersectionObserver(([entry]) => {
-      if (!entry.isIntersecting) {
-        return;
+  /**
+   * Called by the IntersectionObserver defined in this#connectedCallback.
+   *
+   * @param {IntersectionObserverEntry[]} entries
+   */
+  onIntersection(entries) {
+    const entry = entries[0];
+    if (!entry.isIntersecting) {
+      return;
+    }
+
+    // can safely assume this.intersectionObserver is defined, since onIntersection is being called
+    this.intersectionObserver.disconnect();
+    window.recaptchaLoadCallback = () => {
+      /** @type {HTMLDivElement} */
+      const recaptchaContainerEl = this.querySelector('.g-recaptcha');
+      // fix for percy re-executing JavaScript with pre-rendered DOM
+      if (!this.hasInitialised) {
+        recaptchaContainerEl.children[0].remove();
+        this.hasInitialised = true;
       }
 
-      intersectionObserver.disconnect();
-      window.recaptchaLoadCallback = () => {
-        /** @type {HTMLDivElement} */
-        const recaptchaContainerEl = this.querySelector('.g-recaptcha');
-        recaptchaContainerEl.children[0].remove();
-        window.grecaptcha.render(recaptchaContainerEl, {
-          sitekey: recaptchaContainerEl.dataset.sitekey,
-        });
-      };
+      window.grecaptcha.render(recaptchaContainerEl, {
+        sitekey: recaptchaContainerEl.dataset.sitekey,
+      });
+    };
 
-      window.loadScript(
-        'https://www.google.com/recaptcha/api.js?onload=recaptchaLoadCallback&render=explicit',
-      );
-    });
+    window.loadScript(
+      'https://www.google.com/recaptcha/api.js?onload=recaptchaLoadCallback&render=explicit',
+    );
+  }
 
-    intersectionObserver.observe(this.form);
+  connectedCallback() {
+    super.connectedCallback();
+    this.hasInitialised = !this.classList.contains('unresolved');
+    /** @type {HTMLFormElement} */
+    this.form = this.querySelector('form');
+    this.intersectionObserver = new IntersectionObserver((entries) =>
+      this.onIntersection(entries),
+    );
+
+    this.intersectionObserver.observe(this.form);
 
     /** @type HTMLElement */
     this.subscribeError = this.querySelector('.subscribe__error');

--- a/src/lib/components/Subscribe/index.js
+++ b/src/lib/components/Subscribe/index.js
@@ -50,10 +50,7 @@ class Subscribe extends BaseElement {
       /** @type {HTMLDivElement} */
       const recaptchaContainerEl = this.querySelector('.g-recaptcha');
       // fix for percy re-executing JavaScript with pre-rendered DOM
-      if (!this.hasInitialised) {
-        recaptchaContainerEl.children[0].remove();
-        this.hasInitialised = true;
-      }
+      recaptchaContainerEl.children[0].remove();
 
       window.grecaptcha.render(recaptchaContainerEl, {
         sitekey: recaptchaContainerEl.dataset.sitekey,
@@ -66,8 +63,11 @@ class Subscribe extends BaseElement {
   }
 
   connectedCallback() {
+    if (!this.classList.contains('unresolved')) {
+      return;
+    }
+
     super.connectedCallback();
-    this.hasInitialised = !this.classList.contains('unresolved');
     /** @type {HTMLFormElement} */
     this.form = this.querySelector('form');
     this.intersectionObserver = new IntersectionObserver((entries) =>

--- a/src/lib/components/Subscribe/index.js
+++ b/src/lib/components/Subscribe/index.js
@@ -37,6 +37,28 @@ class Subscribe extends BaseElement {
     super.connectedCallback();
     /** @type {HTMLFormElement} */
     this.form = this.querySelector('form');
+    const intersectionObserver = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        return;
+      }
+
+      intersectionObserver.disconnect();
+      window.recaptchaLoadCallback = () => {
+        /** @type {HTMLDivElement} */
+        const recaptchaContainerEl = this.querySelector('.g-recaptcha');
+        recaptchaContainerEl.children[0].remove();
+        window.grecaptcha.render(recaptchaContainerEl, {
+          sitekey: recaptchaContainerEl.dataset.sitekey,
+        });
+      };
+
+      window.loadScript(
+        'https://www.google.com/recaptcha/api.js?onload=recaptchaLoadCallback&render=explicit',
+      );
+    });
+
+    intersectionObserver.observe(this.form);
+
     /** @type HTMLElement */
     this.subscribeError = this.querySelector('.subscribe__error');
     this.subscribeMessage = this.querySelector('.subscribe__message');

--- a/src/scss/blocks/_spinner.scss
+++ b/src/scss/blocks/_spinner.scss
@@ -2,12 +2,12 @@
 /// https://web.dev/design-system/component/spinner
 .spinner {
   fill: none;
-  animation: cubic-bezier(0.25, 0, 0.6, 1) infinite both 1.5s spinner--spin;
+  animation: cubic-bezier(0.25, 0, 0.6, 1) infinite both 1.5s spinner__spin;
   stroke: var(--color, black);
   stroke-width: 0.5px;
 }
 
-@-webkit-keyframes spinner--spin {
+@keyframes spinner__spin {
   0% {
     transform: rotate(0);
     stroke-dasharray: 1px, 15px;

--- a/src/scss/blocks/_spinner.scss
+++ b/src/scss/blocks/_spinner.scss
@@ -1,0 +1,22 @@
+/// COMPONENT LIBRARY LOCATION
+/// https://web.dev/design-system/component/spinner
+.spinner {
+  fill: none;
+  animation: cubic-bezier(0.25, 0, 0.6, 1) infinite both 1.5s spinner--spin;
+  stroke: var(--color, black);
+  stroke-width: 0.5px;
+}
+
+@-webkit-keyframes spinner--spin {
+  0% {
+    transform: rotate(0);
+    stroke-dasharray: 1px, 15px;
+    stroke-dashoffset: 1px;
+  }
+
+  100% {
+    transform: rotate(360deg);
+    stroke-dasharray: 15px, 15px;
+    stroke-dashoffset: -15px;
+  }
+}

--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -753,6 +753,7 @@ video,
 @import 'blocks/site-footer';
 @import 'blocks/site-header';
 @import 'blocks/skip-link';
+@import 'blocks/spinner';
 @import 'blocks/stack-nav';
 @import 'blocks/stats';
 @import 'blocks/status-list';

--- a/src/scss/web-components/_web-subscribe.scss
+++ b/src/scss/web-components/_web-subscribe.scss
@@ -23,50 +23,24 @@ web-subscribe {
     max-width: unset;
   }
 
-  .g-recaptcha {
+  .captcha {
     height: 78px;
 
-    &-- {
-      &placeholder {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        color: var(--color-action-bg);
-        align-items: center;
-        max-width: 304px;
-        height: 100%;
-        background-color: var(--color-mid-text);
-        border-radius: 5px;
-      }
+    &__placeholder {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      color: var(--color-action-bg);
+      align-items: center;
+      max-width: 304px;
+      height: 100%;
+      background-color: var(--color-mid-text);
+      border-radius: 5px;
+    }
 
-      &loader-container {
-        width: 100px;
-        background-color: var(--color-accent-bg);
-        border-radius: 20px;
-        padding: 2px;
-      }
-
-      &loader {
-        @keyframes loader {
-          0% {
-            transform: translateX(0);
-          }
-
-          50% {
-            transform: translateX(72px);
-          }
-
-          100% {
-            transform: translateX(0);
-          }
-        }
-
-        height: 2px;
-        border-radius: 20px;
-        width: 25%;
-        background-color: var(--color-mid-text);
-        animation: loader 1s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
-      }
+    .spinner {
+      width: 30px;
+      --color: #3740ff;
     }
   }
 }

--- a/src/scss/web-components/_web-subscribe.scss
+++ b/src/scss/web-components/_web-subscribe.scss
@@ -25,5 +25,48 @@ web-subscribe {
 
   .g-recaptcha {
     height: 78px;
+
+    &-- {
+      &placeholder {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        color: var(--color-action-bg);
+        align-items: center;
+        max-width: 304px;
+        height: 100%;
+        background-color: var(--color-mid-text);
+        border-radius: 5px;
+      }
+
+      &loader-container {
+        width: 100px;
+        background-color: var(--color-accent-bg);
+        border-radius: 20px;
+        padding: 2px;
+      }
+
+      &loader {
+        @keyframes loader {
+          0% {
+            transform: translateX(0);
+          }
+
+          50% {
+            transform: translateX(72px);
+          }
+
+          100% {
+            transform: translateX(0);
+          }
+        }
+
+        height: 2px;
+        border-radius: 20px;
+        width: 25%;
+        background-color: var(--color-mid-text);
+        animation: loader 1s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
+      }
+    }
   }
 }

--- a/src/site/_includes/about-next.njk
+++ b/src/site/_includes/about-next.njk
@@ -3,8 +3,6 @@ layout: 'default-next'
 CSS_ORIGIN: 'next'
 pageScripts:
   - '/js/about.js'
-externalScripts:
-  - 'https://www.google.com/recaptcha/api.js'
 ---
 {% from 'macros/icon.njk' import icon, svg with context %}
 

--- a/src/site/_includes/homepage-next.njk
+++ b/src/site/_includes/homepage-next.njk
@@ -3,8 +3,6 @@ layout: 'default-next'
 CSS_ORIGIN: 'next'
 pageScripts:
   - '/js/home.js'
-externalScripts:
-  - 'https://www.google.com/recaptcha/api.js'
 ---
 {% from 'macros/icon.njk' import icon with context %}
 

--- a/src/site/_includes/partials/subscribe.njk
+++ b/src/site/_includes/partials/subscribe.njk
@@ -55,7 +55,13 @@
           <option selected value="en-US">en-US</option>
         </select>
       </div>
-      <div class="g-recaptcha all-center gap-top-size-1" data-sitekey="{{ site.recaptchaSiteKey }}" data-callback="recaptchaSuccess"></div>
+      <div class="g-recaptcha all-center gap-top-size-1" data-sitekey="{{ site.recaptchaSiteKey }}" data-callback="recaptchaSuccess">
+        <div class="g-recaptcha--placeholder">
+          <div class="g-recaptcha--loader-container">
+            <div class="g-recaptcha--loader"></div>
+          </div>
+        </div>
+      </div>
       <div class="gap-top-size-2">
         <div class="subscribe__error hidden-yes">
           {% Aside 'warning' %}

--- a/src/site/_includes/partials/subscribe.njk
+++ b/src/site/_includes/partials/subscribe.njk
@@ -1,4 +1,4 @@
-<web-subscribe>
+<web-subscribe class="unresolved">
   <div class="wrapper">
     <div class="headline all-center flow">
       <h2 class="headline__title">{{ subscribeTitle | default('Developer Newsletter', false) }}</h2>
@@ -55,11 +55,15 @@
           <option selected value="en-US">en-US</option>
         </select>
       </div>
-      <div class="g-recaptcha all-center gap-top-size-1" data-sitekey="{{ site.recaptchaSiteKey }}" data-callback="recaptchaSuccess">
-        <div class="g-recaptcha--placeholder">
-          <div class="g-recaptcha--loader-container">
-            <div class="g-recaptcha--loader"></div>
-          </div>
+      <div
+        class="g-recaptcha captcha all-center gap-top-size-1"
+        data-sitekey="{{ site.recaptchaSiteKey }}"
+        data-callback="recaptchaSuccess"
+      >
+        <div class="captcha__placeholder">
+          <svg viewBox="0 0 6 6" class="spinner">
+            <circle cx="3" cy="3" r="2.5" />
+          </svg>
         </div>
       </div>
       <div class="gap-top-size-2">

--- a/src/site/content/en/newsletter/index.njk
+++ b/src/site/content/en/newsletter/index.njk
@@ -7,8 +7,6 @@ eleventyComputed:
   noindex: "{{ paged.index > 0 }}"
 pageScripts:
   - '/js/newsletter.js'
-externalScripts:
-  - 'https://www.google.com/recaptcha/api.js'
 pagination:
   data: collections.newsletters
   size: 1

--- a/types/utils/global.d.ts
+++ b/types/utils/global.d.ts
@@ -24,8 +24,8 @@ interface WebComponentsType {
 declare global {
   interface Window extends Window {
     inert: boolean;
-    recaptchaLoadCallback: () => void;
-    loadScript: (url: string, type?: string) => void;
+    recaptchaLoadCallback?: () => void;
+    loadScript?: (url: string, type?: string) => void;
   }
 
   var WebComponents: WebComponentsType;

--- a/types/utils/global.d.ts
+++ b/types/utils/global.d.ts
@@ -24,6 +24,8 @@ interface WebComponentsType {
 declare global {
   interface Window extends Window {
     inert: boolean;
+    recaptchaLoadCallback: () => void;
+    loadScript: (url: string, type?: string) => void;
   }
 
   var WebComponents: WebComponentsType;


### PR DESCRIPTION
Fixes #9528

Changes proposed in this pull request:

- Loads reCAPTCHA .js script when the newsletter form element comes into view (detected via a single use IntersectionObserver)
- Shows a tiny loading animation while the reCAPTCHA script is being fetched/executed
- Tested and working on various browsers

Loading animation placeholder:
![output](https://user-images.githubusercontent.com/42349493/219707952-9cc8f26c-bae9-4d2b-9ef5-f6ba242b20ab.gif)

Recorded using a throttled connection.
