### PR TITLE
Fix broken reference links in Identity

### DIFF
--- a/src/site/_data/paths/identity.json
+++ b/src/site/_data/paths/identity.json
@@ -12,19 +12,19 @@
         "sign-in-form-best-practices",
         {
           "title": "[Codelab] Use cross-platform browser features to build a sign-in form",
-          "url": "codelab-sign-in-form-best-practices"
+          "url": "https://web.dev/codelab-sign-in-form-best-practices/"
         },
         "sign-up-form-best-practices",
         {
           "title": "[Codelab] Sign-up form best practices codelab",
-          "url": "codelab-sign-up-form-best-practices"
+          "url": "https://web.dev/codelab-sign-up-form-best-practices/"
         }
       ]
     },
     {
       "title": "i18n.paths.identity.topics.build_authentication_systems_with_modern_APIs",
       "pathItems": [
-        "web-otp",
+        "web-otp", 
         "change-password-url"
       ]
     },


### PR DESCRIPTION
Fixes #9244

Changes proposed in this pull request:
- Fixed reference links on [the Identity url path](https://web.dev/identity/)

<img width="679" alt="Screen Shot 2023-02-17 at 13 09 11" src="https://user-images.githubusercontent.com/37851094/219765229-3ddca727-f4d1-48ff-8d26-dedf756e5c05.png">
