### PR TITLE
Add flex-wrap to images for the Learn HTML: Forms

### DIFF
--- a/src/site/content/en/learn/html/forms/index.md
+++ b/src/site/content/en/learn/html/forms/index.md
@@ -306,7 +306,7 @@ the default dynamic keyboard for `url` input types.
 
 Keyboards for `<input type="tel">` on iPhone and two different Android phones:
 
-<div style="display: flex;">
+<div style="display: flex; flex-wrap: wrap;">
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/BK9EPsgyPy0Wt2jmp0lp.png", alt="iPhone keyboard showing input type=tel.", width="194", height="400", style="max-width: 194px; margin: 0 auto;" %}
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/8ECZmU9gqR4X6ppGk3v4.png", alt="Android keyboard showing input type=tel.", width="194", height="400", style="max-width: 194px; margin: 0 auto;" %}
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/dODUYXx0VDxVwBMP0e59.png", alt="Android keyboard showing input type=tel.", width="194", height="400", style="max-width: 194px; margin: 0 auto;" %}
@@ -314,7 +314,7 @@ Keyboards for `<input type="tel">` on iPhone and two different Android phones:
 
 Keyboards for `<input type="email">` on iPhone and two different Android phones:
 
-<div style="display: flex;">
+<div style="display: flex; flex-wrap: wrap;">
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/Zd2yPTG7QT74AIvyCJrU.png", alt="iPhone keyboard showing input type=email.", width="194", height="400", style="max-width: 194px; margin: 0 auto;"  %}
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/bofzFSrrNK55RW1FesAg.png", alt="Android keyboard showing input type=email.", width="194", height="400", style="max-width: 194px; margin: 0 auto;"  %}
 {% Img src="image/cGQxYFGJrUUaUZyWhyt9yo5gHhs1/4ZwT1lrxJ4owTP0FjGWf.png", alt="Android keyboard showing input type=email.", width="194", height="400", style="max-width: 194px; margin: 0 auto;"  %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Image gallery wraps on a mobile viewport

Before/after

![before-after](https://user-images.githubusercontent.com/105274/220330649-82f686b4-b23a-4bb5-95b8-962dde612bb7.png)