### PR TITLE
stlye: fixed icon size table of contents

### DIFF
--- a/src/scss/pages/_collection.scss
+++ b/src/scss/pages/_collection.scss
@@ -18,6 +18,7 @@
   
     svg {
       fill: get-color('core-primary');
+      flex-shrink: 0;
       margin-right: 6px;
     }
   }


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #8855 

Changes proposed in this pull request:

- fixed the size of the check icon on collections TOCs so that the size remains consistent

