### PR TITLE
Fix broken link

### DIFF
--- a/src/site/content/en/fast/performance-budgets-101/index.md
+++ b/src/site/content/en/fast/performance-budgets-101/index.md
@@ -50,7 +50,7 @@ Milestone timings mark events that happen during page load, such as [DOMContentL
 
 ### Rule-based metrics 💯
 
-[Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) and [WebPageTest](https://www.webpagetest.org/) calculate [performance scores](hhttps://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring) based on general best practice rules, that you can use as guidelines. As a bonus, Lighthouse also offers you hints for simple optimizations.
+[Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) and [WebPageTest](https://www.webpagetest.org/) calculate [performance scores](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring) based on general best practice rules, that you can use as guidelines. As a bonus, Lighthouse also offers you hints for simple optimizations.
 
 You'll get the best results if you keep track of a combination of quantity-based and user-centric performance metrics. Focus on asset sizes in the early phases of a project and start tracking FCP and TTI as soon as possible.
 


### PR DESCRIPTION
Fixed a broken link performance scores link

Old link: hhttps://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring
Fix  link: https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #9678

Changes proposed in this pull request:
Link performance scores need to update
Current link: hhttps://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring
Needs to update to: https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#perf-scoring

