### PR TITLE
Media Session API: Fix code example

### DIFF
--- a/src/site/content/en/blog/media-session/index.md
+++ b/src/site/content/en/blog/media-session/index.md
@@ -455,7 +455,7 @@ browser considers the website to be active.
 ```js
 let isCameraActive = false;
 
-navigator.mediaSession.setActionHandler('togglemicrophone', () => {
+navigator.mediaSession.setActionHandler('togglecamera', () => {
   if (isCameraActive) {
     // Disable the camera.
   } else {


### PR DESCRIPTION
The code example is about the camera being toggled, yet the code snippet incorrectly listens for the `togglemicrophone` action. That should be `togglecamera` instead.