### PR TITLE
Update responsive images guidance

### DIFF
--- a/src/site/content/en/blog/preload-responsive-images/index.md
+++ b/src/site/content/en/blog/preload-responsive-images/index.md
@@ -4,12 +4,13 @@ title: Preloading responsive images
 subhead: Starting in Chrome 73, link rel="preload" and responsive images can be combined in order to load images faster.
 authors:
   - yoavweiss
+  - tunetheweb
 description: |
   Learn about new and exciting possibilities for preloading responsive images to ensure great user experience.
 hero: image/admin/QDCTiiyXE11bYSZMP3Yt.jpg
 alt: A wall with a bunch of image frames in different sizes.
 date: 2019-09-30
-updated: 2022-09-27
+updated: 2023-03-08
 tags:
   - blog # blog is a required tag for the article to show up in the blog.
   - performance
@@ -17,6 +18,8 @@ tags:
 feedback:
   - api
 ---
+
+{% BrowserCompat 'api.HTMLLinkElement.imageSrcset' %}
 
 This article gives me an opportunity to discuss two of my favorite things: responsive images *and* preload. As someone who was heavily involved in developing both of those features, I'm super excited to see them working together!
 
@@ -129,8 +132,10 @@ You can inspect this issue on an example website with [responsive background ima
 Responsive image preloading provides a simple and hack-free way to load those images faster.
 
 ```html
-<link rel=preload href=cat.png as=image imagesrcset="cat.png 1x, cat-2x.png 2x">
+<link rel=preload as=image imagesrcset="cat.png 1x, cat-2x.png 2x">
 ```
+
+Note that by excluding the `href` attribute, you can ensure the browsers that do not support `imagesrcset` on the `<link>` elment, but do support `image-set` in CSS, will not download an incorrect source. However, they will also not benefit from the preload in this case.
 
 You can inspect how the previous example behaves with [preloaded responsive background image](https://responsive-preload.glitch.me/background_preload.html).
 
@@ -186,6 +191,12 @@ Because responsive preload has no notion of "order" or "first match", the breakp
 <link rel="preload" href="medium_cat.jpg" as="image" media="(min-width: 400.1px) and (max-width: 800px)">
 <link rel="preload" href="large_cat.jpg" as="image" media="(min-width: 800.1px)">
 ```
+
+### Preload and `type`
+
+The `<picture>` element also supports matching on the first `type`, to allow different image formats to be provided and the browser to pick the first image format it supports. This use case is not currently supported with preload.
+
+For sites using this, avoiding preload is the best option, and instead having the [preload scanner](https://web.dev/preload-scanner/) pick these up from the `<picture>` and `<source>` elements instead. This is a best practice anyway, particular with the support of [Priority Hints](./priority-hints/) which allows the appropriate image to be prioritised in a better manner than preload alone.
 
 ## Effects on Largest Contentful Paint (LCP)
 

--- a/src/site/content/en/blog/preload-responsive-images/index.md
+++ b/src/site/content/en/blog/preload-responsive-images/index.md
@@ -132,7 +132,7 @@ You can inspect this issue on an example website with [responsive background ima
 Responsive image preloading provides a simple and hack-free way to load those images faster.
 
 ```html
-<link rel=preload as=image imagesrcset="cat.png 1x, cat-2x.png 2x">
+<link rel="preload" as="image" imagesrcset="cat.png 1x, cat-2x.png 2x">
 ```
 
 Note that by excluding the `href` attribute, you can ensure the browsers that do not support `imagesrcset` on the `<link>` elment, but do support `image-set` in CSS, will not download an incorrect source. However, they will also not benefit from the preload in this case.
@@ -196,7 +196,7 @@ Because responsive preload has no notion of "order" or "first match", the breakp
 
 The `<picture>` element also supports matching on the first `type`, to allow different image formats to be provided and the browser to pick the first image format it supports. This use case is not currently supported with preload.
 
-For sites using this, avoiding preload is the best option, and instead having the [preload scanner](/preload-scanner/) pick these up from the `<picture>` and `<source>` elements instead. This is a best practice anyway, particular with the support of [Priority Hints](./priority-hints/) which allows the appropriate image to be prioritised in a better manner than preload alone.
+For sites using this, avoiding preload is the best option, and instead having the [preload scanner](/preload-scanner/) pick these up from the `<picture>` and `<source>` elements instead. This is a best practice anyway, particular with the support of [Priority Hints](/priority-hints/) which allows the appropriate image to be prioritised in a better manner than preload alone.
 
 ## Effects on Largest Contentful Paint (LCP)
 

--- a/src/site/content/en/blog/preload-responsive-images/index.md
+++ b/src/site/content/en/blog/preload-responsive-images/index.md
@@ -196,7 +196,7 @@ Because responsive preload has no notion of "order" or "first match", the breakp
 
 The `<picture>` element also supports matching on the first `type`, to allow different image formats to be provided and the browser to pick the first image format it supports. This use case is not currently supported with preload.
 
-For sites using this, avoiding preload is the best option, and instead having the [preload scanner](https://web.dev/preload-scanner/) pick these up from the `<picture>` and `<source>` elements instead. This is a best practice anyway, particular with the support of [Priority Hints](./priority-hints/) which allows the appropriate image to be prioritised in a better manner than preload alone.
+For sites using this, avoiding preload is the best option, and instead having the [preload scanner](/preload-scanner/) pick these up from the `<picture>` and `<source>` elements instead. This is a best practice anyway, particular with the support of [Priority Hints](./priority-hints/) which allows the appropriate image to be prioritised in a better manner than preload alone.
 
 ## Effects on Largest Contentful Paint (LCP)
 

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -194,7 +194,7 @@ Some images may not be available in the initial HTML—if they are added by Java
 
 Again this should be used sparingly, to avoid overriding the browsers prioritisation heuristics too much, which may result in performance degredation.
 
-Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers for the `x` descriptor](https://web.dev/preload-responsive-images/) but not all:
+Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers for the `x` descriptor](/preload-responsive-images/) but not all:
 
 <link rel="preload" imagesrcset="hero_sm.jpg 1x hero_med.jpg 2x hero_lg.jpg 3x" as="image" fetchpriority="high">
 

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -194,13 +194,13 @@ Some images may not be available in the initial HTML—if they are added by Java
 
 Again this should be used sparingly, to avoid overriding the browsers prioritisation heuristics too much, which may result in performance degredation.
 
-Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers for the `x` descriptor](/preload-responsive-images/) but not all:
+Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers](/preload-responsive-images/), but not all:
 
 <link rel="preload" imagesrcset="hero_sm.jpg 1x hero_med.jpg 2x hero_lg.jpg 3x" as="image" fetchpriority="high">
 
 By excluding the `href` fallback you can ensure browsers that do not support this do not preload the incorrect image.
 
-Preloading based on the `w` descriptor, or different image formats based on browser support of those images is not currently supported and may result in extra downloads.
+Preloading based on different image formats based on browser support of those images is not currently supported and may result in extra downloads.
 
 The ideal is to avoid preload where possible, and have the image available in the initial HTML, to avoid repeating code, and to allow access to the full range of options the browser supports.
 

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -180,7 +180,7 @@ For important images-such as the (LCP)[/lcp/] image, you can further prioritise 
 >
 ```
 
-This will tell the browser to fetch the image right away, and at high priority, rather than waiting until the browsder has completed layout when images are normally fetched.
+This will tell the browser to fetch the image right away, and at high priority, rather than waiting until the browser has completed layout when images are normally fetched.
 
 But remember: when you ask the browser to prioritize downloading one resource—like an image—the browser will have to de-prioritize another resource such as a script or a font file. Only set `fetchpriority="high"` on an image if it is truly vital.
 
@@ -192,7 +192,7 @@ Some images may not be available in the initial HTML—if they are added by Java
 <link rel="preload" href="hero.jpg" as="image" fetchpriority="high">
 ```
 
-Again this should be used sparingly, to avoid overriding the browsers prioritisation heuristics too much, which may result in performance degredation.
+Again this should be used sparingly to avoid overriding the browsers prioritisation heuristics too much, which may result in performance degredation.
 
 Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers](/preload-responsive-images/), but not all:
 

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -4,7 +4,9 @@ description: >
   Give your visitors the most appropriate images for their devices and screens.
 authors:
   - adactio
+  - tunetheweb
 date: 2021-12-09
+updated: 2022-03-08
 ---
 
 Text on the web automatically wraps at the edge of the screen so that it doesn't overflow. It's different with images. Images have an intrinsic size. If an image is wider than the screen, the image will overflow, causing a horizontal scrollbar to appear.
@@ -93,7 +95,6 @@ img {
 </figure>
 
 
-
 If the cropping at the top and bottom evenly is an issue, use the [object-position](https://developer.mozilla.org/docs/Web/CSS/object-position) CSS property to adjust the focus of the crop.
 {% BrowserCompat 'css.properties.object-position' %}
 
@@ -138,7 +139,7 @@ If you know the dimensions of the image you should include `width` and `height` 
 
 ### Loading hints
 
-Use the `loading` attribute to tell the browser how urgently you want it to load an image. For images below the fold, use a value of `lazy`. The browser won't load lazy images until the user has scrolled far down enough that the image is about to come into view. If the user never scrolls, the image never loads.
+Use the `loading` attribute to tell the browser whether to delay loading the image until it is in or near the viewport. For images below the fold, use a value of `lazy`. The browser won't load lazy images until the user has scrolled far down enough that the image is about to come into view. If the user never scrolls, the image never loads.
 
 ```html/5-5
 <img
@@ -152,7 +153,7 @@ Use the `loading` attribute to tell the browser how urgently you want it to load
 
 {% Video src="video/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/jazsyaOjXfHS0g8yUijR.mp4", controls=true, loop=true %}
 
-For a hero image above the fold, use a `loading` value of `eager`.
+For a hero image above the fold, `loading` should not be used. If you site automatically applies the `loading="lazy"` attribute, you can often set the `eager` attribute (which is the default) to prevent this from being applied:
 
 ```html/5-5
 <img
@@ -164,13 +165,44 @@ For a hero image above the fold, use a `loading` value of `eager`.
 >
 ```
 
-For an important image you can tell the browser to pre-fetch the image in the head of your document.
+### Priority hints
 
-```html
-<link rel="prefetch" href="hero.jpg" as="image">
+For important images-such as the (LCP)[/lcp/] image, you can further prioritise the loading using [Priority Hints](/priority-hints/) by setting the `fetchpriority` attribute to `high`:
+
+```html/5-6
+<img
+ src="hero.jpg"
+ alt="A description of the image."
+ width="1200"
+ height="800"
+ loading="eager"
+ fetchpriority="high"
+>
 ```
 
-But remember: when you ask the browser to prioritize downloading one resource—like an image—the browser will have to de-prioritize another resource such as a script or a font file. Only prefetch an image if it is truly vital.
+This will tell the browser to fetch the image right away, and at high priority, rather than waiting until the browsder has completed layout when images are normally fetched.
+
+But remember: when you ask the browser to prioritize downloading one resource—like an image—the browser will have to de-prioritize another resource such as a script or a font file. Only set `fetchpriority="high"` on an image if it is truly vital.
+
+### Preloading hints
+
+Some images may not be available in the initial HTML—if they are added by JavaScript, or as a [background image](#background-images) in CSS. You can also use preload to allow these important images to be fetched ahead of time. This can be combined with the `fetchpriority` attribute for really important images:
+
+```html
+<link rel="preload" href="hero.jpg" as="image" fetchpriority="high">
+```
+
+Again this should be used sparingly, to avoid overriding the browsers prioritisation heuristics too much, which may result in performance degredation.
+
+Preloading responsive images based on srcset (which is discussed below) via the `imagesrcset` and `imagesizes` attributes is more advanced and is [supported in some browsers for the `x` descriptor](https://web.dev/preload-responsive-images/) but not all:
+
+<link rel="preload" imagesrcset="hero_sm.jpg 1x hero_med.jpg 2x hero_lg.jpg 3x" as="image" fetchpriority="high">
+
+By excluding the `href` fallback you can ensure browsers that do not support this do not preload the incorrect image.
+
+Preloading based on the `w` descriptor, or different image formats based on browser support of those images is not currently supported and may result in extra downloads.
+
+The ideal is to avoid preload where possible, and have the image available in the initial HTML, to avoid repeating code, and to allow access to the full range of options the browser supports.
 
 ### Image decoding
 
@@ -199,6 +231,12 @@ You can use the `sync` value if the image itself is the most important piece of 
  decoding="sync"
 >
 ```
+
+The `decoding` attribute will not change how fast the image decodes, but merely whether the browser waits for this image decoding to happen before rendering other content.
+
+In most cases this will have little impact, however in certain scenarios it can allow the image or content to be displayed slightly faster. For example, for a large document with lots of elements that take time to render, and with large images that take a while to decode, setting `sync` on important images will tell the browser to wait for the image and render both at once. Alternatively, setting `async` can allow the content to be displayed faster without waiting for the image decode.
+
+However, the better option is usually to try to [avoid excessive DOM sizes](https://developer.chrome.com/docs/lighthouse/performance/dom-size/) and ensure responsive images are used to reduce decoding time meaning the decoding attribute will have little effect.
 
 ## Responsive images with `srcset`
 

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -153,7 +153,7 @@ Use the `loading` attribute to tell the browser whether to delay loading the ima
 
 {% Video src="video/KT4TDYaWOHYfN59zz6Rc0X4k4MH3/jazsyaOjXfHS0g8yUijR.mp4", controls=true, loop=true %}
 
-For a hero image above the fold, `loading` should not be used. If you site automatically applies the `loading="lazy"` attribute, you can often set the `eager` attribute (which is the default) to prevent this from being applied:
+For a hero image above the fold, `loading` should not be used. If your site automatically applies the `loading="lazy"` attribute, you can often set the `eager` attribute (which is the default) to prevent this from being applied:
 
 ```html/5-5
 <img


### PR DESCRIPTION
Fixes #8228 
Fixes #6150

Changes proposed in this pull request:

Updates [Preload Responsive Images](https://web.dev/preload-responsive-images/) article to:
- Add Browser compat widget
- Add note about not including `href` to avoid downloading incorrect image on some browsers
- Add a note about lack of `type` support

Updates [Learn->Design->Responsive Images](https://web.dev/learn/design/responsive-images/) article to:
- Clarify `loading`
- Add note on `fetchpriority`
- Rewrite preloading section
- Add mroe context to `decoding` section

