### PR TITLE
Swap video's and update figcaption

### DIFF
--- a/src/site/content/en/blog/min-max-clamp/index.md
+++ b/src/site/content/en/blog/min-max-clamp/index.md
@@ -148,10 +148,10 @@ size by using the `min()` function.
 
 <figure>
   <video controls autoplay loop muted>
-    <source src="https://storage.googleapis.com/web-dev-assets/min-max-clamp/max-width.mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/min-max-clamp/min-width.mp4">
   </video>
   <figcaption>
-    Using the clamp() function to limit a minimum and maximum width.
+    Using the min() function to set a maximum width.
   </figcaption>
 </figure>
 
@@ -162,10 +162,10 @@ be at _least_ `45ch` or larger.
 
 <figure>
   <video controls autoplay loop muted>
-    <source src="https://storage.googleapis.com/web-dev-assets/min-max-clamp/min-width.mp4">
+    <source src="https://storage.googleapis.com/web-dev-assets/min-max-clamp/max-width.mp4">
   </video>
   <figcaption>
-    Using the clamp() function to limit a minimum and maximum width.
+    Using the max() function to set a minimum width.
   </figcaption>
 </figure>
 


### PR DESCRIPTION
The video showing usage of max() was below the paragraph explaining how min() could be used and vice versa, which was confusing. The figcaptions of these videos also both mentioned clamp() while that function was no longer used in those examples, so I've changed those to refer to respectively min() and max() to better indicate the video contents.

Changes proposed in this pull request:

- Swap location of videos
- Update figcaption text for both

Fixes #7734 

