### PR TITLE
Fix a redirect for WebOTP

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -435,7 +435,7 @@ redirects:
     destination: https://developer.chrome.com/docs/web-platform/web-bundles/
   - source: /webtransport
     destination: https://developer.chrome.com/articles/webtransport/
-  - source: /identity/web-otp
+  - source: /web-otp
     destination: https://developer.chrome.com/articles/web-otp/
   - source: /hid-examples/
     destination: https://developer.chrome.com/articles/hid-examples/


### PR DESCRIPTION
A redirect to web-otp article is not happening.
This pull request fixes it.