### PR TITLE
[Async clipboard article] Document the option to write a promise to the clipboard

### DIFF
--- a/src/site/content/en/blog/async-clipboard/index.md
+++ b/src/site/content/en/blog/async-clipboard/index.md
@@ -108,7 +108,7 @@ try {
 }
 ```
 
-Alternatively, you can also write a promise to the `ClipboardItem` object.
+Alternatively, you can write a promise to the `ClipboardItem` object.
 For this pattern, you need to know the MIME type of the data beforehand.
 
 ```js


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/9806.

Changes proposed in this pull request:

- Document the option to write a promise to the clipboard.