### PR TITLE
fix: the navigation drawer cannot be closed

### DIFF
--- a/src/lib/components/NavigationDrawer/index.js
+++ b/src/lib/components/NavigationDrawer/index.js
@@ -83,7 +83,7 @@ export class NavigationDrawer extends BaseStateElement {
   addEventListeners() {
     this.drawerContainer.addEventListener('click', this.onBlockClicks);
     this.closeBtn.addEventListener('click', closeNavigationDrawer);
-    this.addEventListener('click', closeNavigationDrawer);
+    this.addEventListener('click', this.onClickOutsideDrawer);
   }
 
   onStateChanged({isNavigationDrawerOpen, currentUrl}) {
@@ -111,6 +111,19 @@ export class NavigationDrawer extends BaseStateElement {
         updated.setAttribute('active', '');
         updated.setAttribute('aria-current', 'page');
       }
+    }
+  }
+
+  onClickOutsideDrawer() {
+    closeNavigationDrawer();
+
+    // When the NavigationDrawer is collapsed, we need to move the focus from
+    // the web-navigation-drawer to web-header.
+
+    /** @type {import('../Header').Header} */
+    const webHeader = document.querySelector('web-header .brand');
+    if (webHeader) {
+      webHeader.focus();
     }
   }
 

--- a/src/lib/components/NavigationDrawer/index.js
+++ b/src/lib/components/NavigationDrawer/index.js
@@ -82,7 +82,7 @@ export class NavigationDrawer extends BaseStateElement {
 
   addEventListeners() {
     this.drawerContainer.addEventListener('click', this.onBlockClicks);
-    this.closeBtn.addEventListener('click', closeNavigationDrawer);
+    this.closeBtn.addEventListener('click', this.onClickOutsideDrawer);
     this.addEventListener('click', this.onClickOutsideDrawer);
   }
 
@@ -115,16 +115,8 @@ export class NavigationDrawer extends BaseStateElement {
   }
 
   onClickOutsideDrawer() {
+    this.blur();
     closeNavigationDrawer();
-
-    // When the NavigationDrawer is collapsed, we need to move the focus from
-    // the web-navigation-drawer to web-header.
-
-    /** @type {import('../Header').Header} */
-    const webHeader = document.querySelector('web-header .brand');
-    if (webHeader) {
-      webHeader.focus();
-    }
   }
 
   onBlockClicks(e) {
@@ -155,15 +147,8 @@ export class NavigationDrawer extends BaseStateElement {
     if (this.open) {
       this.focus();
     } else {
-      // When the NavigationDrawer is collapsed, we need to restore focus to the
-      // hamburger button in the header. It might be more techincally pure to
-      // use a unistore action for this, but it feels like a lot of ceremony
-      // for a small behavior.
-      /** @type {import('../Header').Header} */
-      const webHeader = document.querySelector('web-header');
-      if (webHeader) {
-        webHeader.manageFocus();
-      }
+      // When the NavigationDrawer is collapsed, we need to remove focus on it.
+      this.blur();
     }
     this.inert = !this.open;
     this.removeEventListener('transitionend', this.onTransitionEnd);


### PR DESCRIPTION
Fixes #9639, fixes  #9792 

For #9639, the navigation drawer on the mobile view needs two clicks on the outside of the drawer container to close itself. It should close when clicking just once, which is the same behaviour as when clicking on the close button.

For #9792, the local navigation of the learning courses reopens each time when click the 'Close' icon.

It happens because the focus event is still on the drawer element so it cannot be completely closed. 

Thus, the change proposed in this pull request is removing the focus event from the navigation drawer after clicking the close button or clicking outside the drawer container, using `HTMLElement.blur()`.

