### PR TITLE
fix: page overflow from tootip rendering on web-copy-code element

### DIFF
--- a/src/lib/components/CopyCode/index.js
+++ b/src/lib/components/CopyCode/index.js
@@ -32,7 +32,7 @@ class CopyCode extends BaseElement {
       this.tooltip = document.createElement('span');
       this.tooltip.className = 'tooltip';
       this.tooltip.setAttribute('role', 'tooltip');
-      this.tooltip.setAttribute('data-alignment', 'right');
+      this.tooltip.setAttribute('data-alignment', 'left');
 
       this.tooltipContent = document.createElement('span');
       this.tooltipContent.className = 'tooltip__content';

--- a/src/scss/blocks/_tooltip.scss
+++ b/src/scss/blocks/_tooltip.scss
@@ -1,6 +1,6 @@
 /// PATTERN LIBRARY LOCATION
 /// https://web.dev/design-system/pattern/tooltip
-$tooltip-aligned-side-space: calc(100% + 1rem);
+$tooltip-aligned-side-space: calc(100% + 2.5rem);
 .tooltip {
   position: relative;
   width: max-content;
@@ -37,7 +37,7 @@ $tooltip-aligned-side-space: calc(100% + 1rem);
 }
 
 /// ALIGNMENT EXCEPTIONS
-.tooltip[data-alignment='left'] {
+.tooltip[role='tooltip'][data-alignment='left'] {
   .tooltip__content {
     top: 50%;
     right: $tooltip-aligned-side-space;
@@ -46,7 +46,7 @@ $tooltip-aligned-side-space: calc(100% + 1rem);
   }
 }
 
-.tooltip[data-alignment='right'] {
+.tooltip[role='tooltip'][data-alignment='right'] {
   .tooltip__content {
     top: 50%;
     left: $tooltip-aligned-side-space;

--- a/src/scss/web-components/_web-copy-code.scss
+++ b/src/scss/web-components/_web-copy-code.scss
@@ -31,7 +31,7 @@ web-copy-code {
     }
 
     // We should use these classes in the web component itself
-    [role='tooltip'] {
+    [role='tooltip'] .tooltip__content {
       @extend .tooltip__content;
     }
   }


### PR DESCRIPTION
Fixes #9790 

Any articles which contain the `web-copy-code` element will overflow on mobile view (e.g. https://web.dev/mishipay/). This happened because the button for copying the raw code on the `web-copy-code` element will render the tooltip on the right side of the button which also overflows the code box and article container, as shown in the screenshot below:

<img width="569" alt="Screenshot 2023-03-28 at 18 13 31" src="https://user-images.githubusercontent.com/45324326/228324176-6db15c37-f2c1-4a36-b7c7-81d05bff002f.png">

Changes proposed in this pull request:

- Updates the tooltip alignment for web-copy-code from displaying the text on the right side to left side.
- Specify a more specific selector for the tooltip to be displayed correctly.

The outcome after updated the tooltip shown in the screenshot below:

<img width="524" alt="Screenshot 2023-03-28 at 18 11 28" src="https://user-images.githubusercontent.com/45324326/228324900-ab2a0bb9-cf8b-49a5-9662-aa8803d35c41.png">



