### PR TITLE
web-platform-mar-2023: fix link to browsercompat color-mix

### DIFF
--- a/src/site/content/en/blog/web-platform-03-2023/index.md
+++ b/src/site/content/en/blog/web-platform-03-2023/index.md
@@ -49,7 +49,7 @@ Find out more in the launch post [SPA view transitions land in Chrome 111](https
 
 Also included in Chrome 111 are a whole new set of ways to use color on the web. Chrome now supports color spaces that access colors outside of the RGB gamut, along with the `color()` and `color-mix()` functions. Learn more in our [High definition CSS color guide](https://developer.chrome.com/articles/high-definition-css-color-guide/) and [blog post on `color-mix()`](https://developer.chrome.com/blog/css-color-mix/).
 
-{% BrowserCompat 'css.types.color_value.color-mix' %}
+{% BrowserCompat 'css.types.color.color-mix' %}
 
 The Chrome release also includes [new DevTools](https://developer.chrome.com/blog/new-in-devtools-111/#color) to help you work with this new color functionality.
 


### PR DESCRIPTION
Currently it shows no browser supports the new color feature.

<img width="785" alt="Screenshot: color section in the march 2023 web platform updates post" src="https://user-images.githubusercontent.com/413984/229118344-e0811bf8-e520-439d-a4a2-736a7589d4d9.png">

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- fix link to bcd for `color-mix()` function