### PR TITLE
Minor improvement to example in source-maps article

### DIFF
--- a/src/site/content/en/blog/source-maps/index.md
+++ b/src/site/content/en/blog/source-maps/index.md
@@ -84,9 +84,9 @@ These source map files contain essential information about how the compiled code
 ```js
 {
   "mappings": "AAAAA,SAASC,cAAc,WAAWC, ...",
-   "sources": ["src/script.ts"],
+  "sources": ["src/script.ts"],
   "sourcesContent": ["document.querySelector('button')..."],
-  "names": ["document","querySelector", …],
+  "names": ["document","querySelector", ...],
   "version": 3,
   "file": "example.min.js.map"
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/100634371/229126801-438dfe88-0aa2-44a2-8659-c355df90c1ca.png)

After:
![image](https://user-images.githubusercontent.com/100634371/229127182-0d3aee9c-91b6-47e5-980a-2a01c3567838.png)
