### PR TITLE
`/import-maps-in-all-modern-browsers/`: Fix examples by replacing `lodash` with `d3-array`.

### DIFF
--- a/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
+++ b/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
@@ -31,7 +31,7 @@ corresponding URLs. For example:
 <script type="importmap">
   {
     "imports": {
-      "lodash": "https://unpkg.com/lodash@4.17.21/lodash.js"
+      "d3-array/": "https://unpkg.com/d3-array@3.2.3/src/"
     }
   }
 </script>
@@ -44,9 +44,9 @@ include the lodash library in your code. Note that the `import` keyword is only 
 
 ```html
 <script type="module">
-  import _ from 'lodash';
+  import map from 'd3-array/map.js';
 
-  console.log(_.map([1, 2, 3], (n) => n * 2));
+  console.log(map([1, 2, 3], (n) => n * 2));
 </script>
 ```
 

--- a/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
+++ b/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
@@ -38,8 +38,8 @@ corresponding URLs. For example:
 ```
 
 This code defines a single external module named `"browser-fs-access"` and maps it to the URL of the
-Browser-FS-Access library on the unpkg CDN. With this mapping in place, you can now use the `import`
-keyword to include the Browser-FS-Access library in your code. Note that the `import` keyword is
+[browser-fs-access](https://github.com/GoogleChromeLabs/browser-fs-access) library, hosted on the unpkg CDN. With this mapping in place, you can now use the `import`
+keyword to include the browser-fs-access library in your code. Note that the `import` keyword is
 only available inside a `script` tag with the `type="module"` attribute.
 
 ```html

--- a/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
+++ b/src/site/content/en/blog/import-maps-in-all-modern-browsers/index.md
@@ -31,22 +31,29 @@ corresponding URLs. For example:
 <script type="importmap">
   {
     "imports": {
-      "d3-array/": "https://unpkg.com/d3-array@3.2.3/src/"
+      "browser-fs-access": "https://unpkg.com/browser-fs-access@0.33.0/dist/index.modern.js"
     }
   }
 </script>
 ```
 
-This code defines a single external module named `"lodash"` and maps it to the URL of the lodash
-library on the unpkg CDN. With this mapping in place, you can now use the `import` keyword to
-include the lodash library in your code. Note that the `import` keyword is only available inside a
-`script` tag with the `type="module"` attribute.
+This code defines a single external module named `"browser-fs-access"` and maps it to the URL of the
+Browser-FS-Access library on the unpkg CDN. With this mapping in place, you can now use the `import`
+keyword to include the Browser-FS-Access library in your code. Note that the `import` keyword is
+only available inside a `script` tag with the `type="module"` attribute.
 
 ```html
+<button>Select a text file</button>
 <script type="module">
-  import map from 'd3-array/map.js';
+  import {fileOpen} from 'browser-fs-access';
 
-  console.log(map([1, 2, 3], (n) => n * 2));
+  const button = document.querySelector('button');
+  button.addEventListener('click', async () => {
+    const file = await fileOpen({
+      mimeTypes: ['text/plain'],
+    });
+    console.log(await file.text());
+  });
 </script>
 ```
 


### PR DESCRIPTION
The snippets in this article don't work together because the URL for `lodash` used points to a file that's not a module and contains no exports. Simply replacing `lodash` with `lodash-es` causes the example to work, but `lodash`'s main file transitively imports over 600 internal modules - which seems like a bad example to set. Even importing `lodash-es/map.js` directly still transitively imports over 100 modules. To both fix the example and avoid loading an unnecessarily large dependency tree for such a simple example, I've replaced `lodash` with `browser-fs-access`, which is a module and has no transitive imports.

Fixes #9856

Changes proposed in this pull request:

- Replace use of `lodash` in the `/import-maps-in-all-modern-browsers/` article with `browser-fs-access`.

Edit: `d3-array` was replaced with `browser-fs-access`.