### PR TITLE
Update responsiveness post to link to long tasks guide

### DIFF
--- a/src/site/content/en/blog/better-responsiveness-metric/index.md
+++ b/src/site/content/en/blog/better-responsiveness-metric/index.md
@@ -67,7 +67,7 @@ interaction with a site. In other words, FID is a lower bound on the amount of t
 after interacting.
 
 Other metrics like [Total Blocking Time (TBT)](/tbt/) and [Time To Interactive (TTI)](/tti/) are based
-on [long tasks](https://developer.mozilla.org/docs/Web/API/Long_Tasks_API) and, like FID, also
+on [long tasks](/optimize-long-tasks/) and, like FID, also
 measure main thread blocking time during load. Since these metrics can be measured in both the field
 and the lab, many developers have asked why we don't prefer one of these over FID.
 


### PR DESCRIPTION
The [responsiveness](https://web.dev/better-responsiveness-metric/) post mentions long tasks but links to MDN docs. This change updates the link to point to our more relevant long tasks guide.