### PR TITLE
Passkeys update

### DIFF
--- a/src/site/content/en/identity/passkey-form-autofill/index.md
+++ b/src/site/content/en/identity/passkey-form-autofill/index.md
@@ -5,7 +5,7 @@ subhead: Create a sign in experience that leverages passkeys while still accommo
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2022-12-08
+updated: 2023-03-16
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/n2fXJDSlefAg8EPLkqEr.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how  how a passwordless sign-in with passkeys should be designed while accommodating existing password users.
@@ -165,6 +165,28 @@ Fetch a challenge from the RP server that is required to call
   replay attacks. Make sure to generate a new challenge on every sign-in attempt 
   and disregard it after a certain duration or after a sign-in attempt fails to 
   validate. Consider it like a CSRF token.
+* **[`allowCredentials`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-allowcredentials)**:
+  This property is used to find authenticators eligible for this authentication.
+  Pass an empty array or leave it unspecified to let the browser show an account
+  selector.
+* **[`userVerification`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-userverification)**:
+  Set to a `"preferred"` value or omit it as it's the default. This indicates
+  whether a user verification using the device's screen lock is `"required"`,
+  `"preferred"` or `"discouraged"`. Setting `"preferred"` requests user
+  verification when the device is capable.
+
+{% Aside 'caution' %}
+
+On a device that doesn't support a biometric sensor (e.g. iMac), setting the
+`userVerification` to `"preferred"` results in no user verification requested to
+the user, immediately returning a credential that contains the [UV (user
+verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag `false`.
+
+If you'd like to always require a user verification, pass an `userVerification:
+"required"` property. Don't forget to check that the UV flag is `true` on the
+server as well.
+
+{% endAside %}
 
 {% Aside %}
 

--- a/src/site/content/en/identity/passkey-form-autofill/index.md
+++ b/src/site/content/en/identity/passkey-form-autofill/index.md
@@ -170,7 +170,7 @@ Fetch a challenge from the RP server that is required to call
   array to let the user select an available passkey from a list shown by the
   browser.
 * **[`userVerification`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-userverification)**:
-  Indicates whether a user verification using the device screen lock is
+  Indicates whether user verification using the device screen lock is
   `"required"`, `"preferred"` or `"discouraged"`. The default is `"preferred"`,
   which means the authenticator may skip user verification. Set this to
   `"preferred"` or omit the property. 
@@ -179,8 +179,8 @@ Fetch a challenge from the RP server that is required to call
 
 For requests with `userVerification` set to `"preferred"`, authenticators may
 skip the user verification check, for example if the device doesn't have any
-biometric sensor, the user hasn't set it up (e.g. no enrolled fingerprints), or
-if the sensor is temporarily unavailable (e.g. laptop running with a closed
+biometric sensors, the user hasn't set it up (no enrolled fingerprints), or
+if the sensor is temporarily unavailable (a laptop running with a closed
 display lid). The [UV bit in the authenticator data of the
 response](https://w3c.github.io/webauthn/#authdata-flags-uv) always indicates
 whether user verification was performed.

--- a/src/site/content/en/identity/passkey-form-autofill/index.md
+++ b/src/site/content/en/identity/passkey-form-autofill/index.md
@@ -172,7 +172,7 @@ Fetch a challenge from the RP server that is required to call
 * **[`userVerification`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-userverification)**:
   Set to a `"preferred"` value or omit it as it's the default. This indicates
   whether a user verification using the device's screen lock is `"required"`,
-  `"preferred"` or `"discouraged"`. Setting `"preferred"` requests user
+  `"preferred"` or `"discouraged"`. Setting to `"preferred"` value requests user
   verification when the device is capable.
 
 {% Aside 'caution' %}

--- a/src/site/content/en/identity/passkey-form-autofill/index.md
+++ b/src/site/content/en/identity/passkey-form-autofill/index.md
@@ -5,7 +5,7 @@ subhead: Create a sign in experience that leverages passkeys while still accommo
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2023-03-16
+updated: 2023-04-11
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/n2fXJDSlefAg8EPLkqEr.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how  how a passwordless sign-in with passkeys should be designed while accommodating existing password users.

--- a/src/site/content/en/identity/passkey-form-autofill/index.md
+++ b/src/site/content/en/identity/passkey-form-autofill/index.md
@@ -5,7 +5,7 @@ subhead: Create a sign in experience that leverages passkeys while still accommo
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2023-04-11
+updated: 2023-04-25
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/n2fXJDSlefAg8EPLkqEr.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how  how a passwordless sign-in with passkeys should be designed while accommodating existing password users.
@@ -166,25 +166,28 @@ Fetch a challenge from the RP server that is required to call
   and disregard it after a certain duration or after a sign-in attempt fails to 
   validate. Consider it like a CSRF token.
 * **[`allowCredentials`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-allowcredentials)**:
-  This property is used to find authenticators eligible for this authentication.
-  Pass an empty array or leave it unspecified to let the browser show an account
-  selector.
+  An array of acceptable credentials for this authentication. Pass an empty
+  array to let the user select an available passkey from a list shown by the
+  browser.
 * **[`userVerification`](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-userverification)**:
-  Set to a `"preferred"` value or omit it as it's the default. This indicates
-  whether a user verification using the device's screen lock is `"required"`,
-  `"preferred"` or `"discouraged"`. Setting to `"preferred"` value requests user
-  verification when the device is capable.
+  Indicates whether a user verification using the device screen lock is
+  `"required"`, `"preferred"` or `"discouraged"`. The default is `"preferred"`,
+  which means the authenticator may skip user verification. Set this to
+  `"preferred"` or omit the property. 
 
 {% Aside 'caution' %}
 
-On a device that doesn't support a biometric sensor (e.g. iMac), setting the
-`userVerification` to `"preferred"` results in no user verification requested to
-the user, immediately returning a credential that contains the [UV (user
-verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag `false`.
+For requests with `userVerification` set to `"preferred"`, authenticators may
+skip the user verification check, for example if the device doesn't have any
+biometric sensor, the user hasn't set it up (e.g. no enrolled fingerprints), or
+if the sensor is temporarily unavailable (e.g. laptop running with a closed
+display lid). The [UV bit in the authenticator data of the
+response](https://w3c.github.io/webauthn/#authdata-flags-uv) always indicates
+whether user verification was performed.
 
-If you'd like to always require a user verification, pass an `userVerification:
-"required"` property. Don't forget to check that the UV flag is `true` on the
-server as well.
+If you'd like to always require a user verification, set `userVerification` to
+`"required"`. Don't forget to check that the UV flag is `true` on the server as
+well.
 
 {% endAside %}
 

--- a/src/site/content/en/identity/passkey-registration/index.md
+++ b/src/site/content/en/identity/passkey-registration/index.md
@@ -226,22 +226,23 @@ The parameters not explained above are:
   stores user information to the passkey and lets users select the account upon 
   authentication.
 * **[`authenticatorSelection.userVerification`](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-userverification)**:
-  Set to a `"preferred"` value or omit it as it's the default. This indicates
-  whether a user verification using the device's screen lock is `"required"`,
-  `"preferred"` or `"discouraged"`. Setting `"preferred"` requests user
-  verification when the device is capable.
+  Set to a `"preferred"` value or omit it because it's the default value. This
+  indicates whether a user verification that uses the device's screen lock is
+  `"required"`, `"preferred"` or `"discouraged"`. Setting to a `"preferred"`
+  value requests user verification when the device is capable.
 
 {% Aside 'caution' %}
 
 On a device that doesn't support a biometric sensor (e.g. iMac), setting the
-`authenticatorSelection.userVerification` to `"preferred"` results in no user
-verification requested to the user, immediately returning a credential that
-contains the [UV (user
-verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag `false`.
+`authenticatorSelection.userVerification` parameter to `"preferred"` value
+results in no user verification requested to the user, which immediately returns
+a credential that contains the [UV (user
+verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag with a
+`false` value.
 
-If you'd like to always require a user verification, pass an
-`authenticatorSelection.userVerification: "required"` property. Don't forget to
-check that the UV flag is `true` on the server as well.
+If you want to always require a user verification, set the
+`authenticatorSelection.userVerification` property to `"required"`. Don't forget
+to check that the UV flag is `true` on the server as well.
 
 {% endAside %}
 

--- a/src/site/content/en/identity/passkey-registration/index.md
+++ b/src/site/content/en/identity/passkey-registration/index.md
@@ -235,8 +235,8 @@ The parameters not explained above are:
 
 For requests with `userVerification` set to `"preferred"`, authenticators may
 skip the user verification check, for example if the device doesn't have any
-biometric sensor, the user hasn't set it up (e.g. no enrolled fingerprints), or
-if the sensor is temporarily unavailable (e.g. laptop running with a closed
+biometric sensors, the user hasn't set it up (no enrolled fingerprints), or
+if the sensor is temporarily unavailable (laptop running with a closed
 display lid). The [UV bit in the authenticator data of the
 response](https://w3c.github.io/webauthn/#authdata-flags-uv) always indicates
 whether user verification was performed. 

--- a/src/site/content/en/identity/passkey-registration/index.md
+++ b/src/site/content/en/identity/passkey-registration/index.md
@@ -5,7 +5,7 @@ subhead: Passkeys make user accounts safer, simpler, easier to use.
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2023-03-16
+updated: 2023-04-11
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/ESXHlkzce7qhQSqQHacV.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how to allow users to create passkeys for your website.

--- a/src/site/content/en/identity/passkey-registration/index.md
+++ b/src/site/content/en/identity/passkey-registration/index.md
@@ -5,7 +5,7 @@ subhead: Passkeys make user accounts safer, simpler, easier to use.
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2022-12-15
+updated: 2023-03-16
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/ESXHlkzce7qhQSqQHacV.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how to allow users to create passkeys for your website.
@@ -218,13 +218,33 @@ The parameters not explained above are:
   This specifies support for ECDSA with P-256 and RSA PKCS\#1 and supporting 
   these gives complete coverage.
 * **[`authenticatorSelection.authenticatorAttachment`](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-authenticatorattachment)**: 
-  Set it to "platform". This indicates that we want an authenticator that is 
+  Set it to `"platform"`. This indicates that we want an authenticator that is 
   embedded into the platform device, and the user will not be prompted to insert 
   e.g. a USB security key.
 * **[`authenticatorSelection.requireResidentKey`](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-residentkey)**: 
   Set it to a boolean "true". A discoverable credential (resident key) 
   stores user information to the passkey and lets users select the account upon 
   authentication.
+* **[`authenticatorSelection.userVerification`](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-userverification)**:
+  Set to a `"preferred"` value or omit it as it's the default. This indicates
+  whether a user verification using the device's screen lock is `"required"`,
+  `"preferred"` or `"discouraged"`. Setting `"preferred"` requests user
+  verification when the device is capable.
+
+{% Aside 'caution' %}
+
+On a device that doesn't support a biometric sensor (e.g. iMac), setting the
+`authenticatorSelection.userVerification` to `"preferred"` results in no user
+verification requested to the user, immediately returning a credential that
+contains the [UV (user
+verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag `false`.
+
+If you'd like to always require a user verification, pass an
+`authenticatorSelection.userVerification: "required"` property. Don't forget to
+check that the UV flag is `true` on the server as well.
+
+{% endAside %}
+
 
 {% Aside %}
 

--- a/src/site/content/en/identity/passkey-registration/index.md
+++ b/src/site/content/en/identity/passkey-registration/index.md
@@ -5,7 +5,7 @@ subhead: Passkeys make user accounts safer, simpler, easier to use.
 authors:
   - agektmr
 date: 2022-10-12
-updated: 2023-04-11
+updated: 2023-04-25
 hero: image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/ESXHlkzce7qhQSqQHacV.jpg
 description: |
   Passkeys make a website's user accounts safer, simpler, easier to use and passwordless. This article discusses how to allow users to create passkeys for your website.
@@ -226,23 +226,24 @@ The parameters not explained above are:
   stores user information to the passkey and lets users select the account upon 
   authentication.
 * **[`authenticatorSelection.userVerification`](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-userverification)**:
-  Set to a `"preferred"` value or omit it because it's the default value. This
-  indicates whether a user verification that uses the device's screen lock is
-  `"required"`, `"preferred"` or `"discouraged"`. Setting to a `"preferred"`
-  value requests user verification when the device is capable.
+  Indicates whether a user verification using the device screen lock is
+  `"required"`, `"preferred"` or `"discouraged"`. The default is `"preferred"`,
+  which means the authenticator may skip user verification. Set this to
+  `"preferred"` or omit the property.
 
 {% Aside 'caution' %}
 
-On a device that doesn't support a biometric sensor (e.g. iMac), setting the
-`authenticatorSelection.userVerification` parameter to `"preferred"` value
-results in no user verification requested to the user, which immediately returns
-a credential that contains the [UV (user
-verification)](https://w3c.github.io/webauthn/#authdata-flags-uv) flag with a
-`false` value.
+For requests with `userVerification` set to `"preferred"`, authenticators may
+skip the user verification check, for example if the device doesn't have any
+biometric sensor, the user hasn't set it up (e.g. no enrolled fingerprints), or
+if the sensor is temporarily unavailable (e.g. laptop running with a closed
+display lid). The [UV bit in the authenticator data of the
+response](https://w3c.github.io/webauthn/#authdata-flags-uv) always indicates
+whether user verification was performed. 
 
-If you want to always require a user verification, set the
-`authenticatorSelection.userVerification` property to `"required"`. Don't forget
-to check that the UV flag is `true` on the server as well.
+If you'd like to always require a user verification, set `userVerification` to
+`"required"`. Don't forget to check that the UV flag is `true` on the server as
+well.
 
 {% endAside %}
 


### PR DESCRIPTION
Update passkeys articles to explain the caveats of the difference between user verification being `preferred` and `required`.

