### PR TITLE
Update learn accessibility footnote on `<section>` requiring a name attribute

### DIFF
--- a/src/site/content/en/learn/accessibility/structure/index.md
+++ b/src/site/content/en/learn/accessibility/structure/index.md
@@ -106,7 +106,7 @@ counterpart ARIA landmark roles.
       </tr>
   </tbody>
   <caption>
-    <sup>1</sup> Requires inclusion of the `name` attribute to be accessible. Only when a `section` is <a href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#whatareaccessiblenamesanddescriptions?">accessibly-named</a>, its implicit ARIA role of <a href="https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Roles/region_role">`region`</a> will be visible to assistive technology.
+    <sup>1</sup> Requires inclusion of the `name` attribute to be accessible. A `section` must be <a href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#whatareaccessiblenamesanddescriptions?">accessibly-named</a> for its implicit ARIA role of <a href="https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Roles/region_role">`region`</a> to be visible to assistive technology.
   </caption>
 </table>
 </div>

--- a/src/site/content/en/learn/accessibility/structure/index.md
+++ b/src/site/content/en/learn/accessibility/structure/index.md
@@ -106,7 +106,7 @@ counterpart ARIA landmark roles.
       </tr>
   </tbody>
   <caption>
-    <sup>1</sup> Requires inclusion of the `name` attribute to be accessible.
+    <sup>1</sup> Requires inclusion of the `name` attribute to be accessible. Only when a `section` is <a href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#whatareaccessiblenamesanddescriptions?">accessibly-named</a>, its implicit ARIA role of <a href="https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Roles/region_role">`region`</a> will be visible to assistive technology.
   </caption>
 </table>
 </div>


### PR DESCRIPTION
Fixes #9881
