### PR TITLE
Update design system breakout CSS max-width

### DIFF
--- a/src/scss/pages/_design-system.scss
+++ b/src/scss/pages/_design-system.scss
@@ -47,7 +47,7 @@
 }
 
 .design-system .breakout {
-  max-width: 70rem;
+  max-width: 52rem;
 
   details {
     margin-inline: auto;


### PR DESCRIPTION
<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #9072 

Changes proposed in this pull request:

- Change the max-width of .design-system.breakout to 52 rem instead of 74 rem

