### PR TITLE
Improve wording

### DIFF
--- a/src/site/content/en/blog/optimize-long-tasks/index.md
+++ b/src/site/content/en/blog/optimize-long-tasks/index.md
@@ -304,7 +304,7 @@ Fortunately, there is a dedicated scheduler API that is currently in development
 
 ### A dedicated scheduler API
 
-The scheduler API currently offers the `postTask()` function which, at the time of writing, is available in Chromium browsers and Firefox behind a flag. `postTask()` allows for finer-grained scheduling of tasks, and is one way to help the browser prioritize work so that low priority tasks yield to the main thread. `postTask()` uses promises, and accepts a `priority` setting.
+The scheduler API currently offers the `postTask()` function which, at the time of writing, is available in Chromium browsers, and in Firefox behind a flag. `postTask()` allows for finer-grained scheduling of tasks, and is one way to help the browser prioritize work so that low priority tasks yield to the main thread. `postTask()` uses promises, and accepts a `priority` setting.
 
 The `postTask()` API has three priorities you can use:
 


### PR DESCRIPTION
> The scheduler API currently offers the postTask() function which, at the time of writing, is available in Chromium browsers and Firefox behind a flag.

This is too ambiguous. People may assume that postTask is behind flag in *both* Chromium and Firefox.

