### PR TITLE
9874-mobile-menu-tooltip-cropped

### DIFF
--- a/src/site/_includes/partials/site-header.njk
+++ b/src/site/_includes/partials/site-header.njk
@@ -2,9 +2,9 @@
 
 <web-header role="banner" class="site-header">
   <div class="cluster gutter-base">
-    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right">
+    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right" role='tooltip'>
       {% include "icons/menu.svg" %}
-      <span class="tooltip__content" id="menu-button-toolip">Open menu</span>
+      <span class="tooltip__content" id="menu-button-tooltip">Open menu</span>
     </button>
     <a href="/" class="site-header__brand brand">
       {{ svg('../../images/logo.svg', {label: 'web.dev'}) }}

--- a/src/site/_includes/partials/site-header.njk
+++ b/src/site/_includes/partials/site-header.njk
@@ -2,7 +2,7 @@
 
 <web-header role="banner" class="site-header">
   <div class="cluster gutter-base">
-    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right" role='tooltip'>
+    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right" role="tooltip">
       {% include "icons/menu.svg" %}
       <span class="tooltip__content" id="menu-button-tooltip">Open menu</span>
     </button>


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #9874 

Changes proposed in this pull request:

- prevented mobile menu button tooltip from cropping
- fixed typo in menu-button-tooltip name
