### PR TITLE
Rename Priority Hints to Fetch Priority

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -479,6 +479,8 @@ redirects:
     destination: /reduce-network-payloads-using-text-compression/
   - source: /webperformance-basics/
     destination: /navigation-and-resource-timing/
+  - source: /priority-hints/
+    destination: /fetch-priority/
 
   # Redirects scrolling performance post to the Intersection Observer post
   - source: /speed-scrolling/

--- a/src/site/content/en/blog/better-youtube-web-part1/index.md
+++ b/src/site/content/en/blog/better-youtube-web-part1/index.md
@@ -82,11 +82,11 @@ resulting in two big discoveries.
 1. The first discovery was that they could improve performance by moving the HTML for the Video Player above the script that makes the Video Player interactive. Lab tests indicated that this could improve both FCP and LCP from 4.4 seconds to 1.1 seconds.
 
 1. The second discovery was that LCP only [considers](/lcp/#what-elements-are-considered) `<video>` element poster images and not frames from the video stream itself. YouTube has traditionally optimized for the fastest time until the video starts playing, so to improve LCP the team started also optimizing how quickly they could deliver their poster image. They experimented with a few variations of poster images and picked the one that scored the best in user testing. As a result of this work, both FCP and LCP showed marked improvement, with field LCP improving from 4.6 seconds to 2.0 seconds.
-  
+
 <figure>
 {% Img src="image/1L2RBhCLSnXjCnSlevaDjy3vba73/wJKAgsXRqrexp9yDJ4T1.jpg", alt="Watch Page LCP Experiment for mobile web showing control, experiment A (image thumbnail) and experiment B (black thumbnail)", width="800", height="514" %}
   <figcaption>
-    In the lab, we observed an improvement in FCP and LCP from 4.4s to 1.1s after this change landed. Experiment A: Using the actual video thumbnail works well on pages where the video starts out paused, but for auto-play video pages like the watch page it performed poorly in user studies. It also resulted in a drop in active users. Experiment B: Using a solid black poster image showed the best results in user studies. Users found the transition from solid black to the first frame of the video to be a less-jarring experience for autoplay videos. 
+    In the lab, we observed an improvement in FCP and LCP from 4.4s to 1.1s after this change landed. Experiment A: Using the actual video thumbnail works well on pages where the video starts out paused, but for auto-play video pages like the watch page it performed poorly in user studies. It also resulted in a drop in active users. Experiment B: Using a solid black poster image showed the best results in user studies. Users found the transition from solid black to the first frame of the video to be a less-jarring experience for autoplay videos.
   </figcaption>
 </figure>
 
@@ -98,7 +98,7 @@ resulting in two big discoveries.
 </figure>
 
 {% Aside%}
-While bringing these optimizations to all platforms, YouTube also took advantage of the new [Priority Hints](/priority-hints/) `fetchpriority` attribute, which we use with `<link rel=preload>` to prioritize discovering and loading the poster image early:
+While bringing these optimizations to all platforms, YouTube also took advantage of the new [`fetchpriority` attribute](/fetch-priority/), which we use with `<link rel=preload>` to prioritize discovering and loading the poster image early:
 
 <pre class="language-html"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>link</span> <span class="token attr-name">as</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>image<span class="token punctuation">"</span></span> <span class="token attr-name">rel</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>preload<span class="token punctuation">"</span></span> <span class="token attr-name">href</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>poster.jpg<span class="token punctuation">"</span></span> <span class="token attr-name">fetchpriority</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>high<span class="token punctuation">"</span></span><span class="token punctuation">&gt;</span></span></code></pre>
 {% endAside %}
@@ -131,7 +131,7 @@ initial rendering times.
 YouTube was experiencing performance issues due to its player controls,
 especially on older devices. Code analysis showed that the player, which allows
 users to control features such as playback speed and progress, had become
-over-componentized over time. 
+over-componentized over time.
 
 
 <figure>
@@ -147,7 +147,7 @@ extra style recalculations and took 21.17 ms during performance test runs in the
 <figure>
 {% Img src="image/1L2RBhCLSnXjCnSlevaDjy3vba73/vCTMilflEoDnkw1p8EuU.png", alt="21.17 ms event shown on the Performance timeline.", width="800", height="202" %}
   <figcaption>
-    Chrome DevTools with a 4 times CPU slow-down performance run. 
+    Chrome DevTools with a 4 times CPU slow-down performance run.
   </figcaption>
 </figure>
 

--- a/src/site/content/en/blog/optimize-lcp/index.md
+++ b/src/site/content/en/blog/optimize-lcp/index.md
@@ -223,7 +223,7 @@ For example, you can delay your LCP image via HTML if you set [`loading="lazy"`]
 Never lazy-load your LCP image, as that will always lead to unnecessary resource load delay, and will have a negative impact on LCP.
 {% endAside %}
 
-Even without lazy loading, images are not initially loaded with the highest priority by browsers as they are not render-blocking resources. You can hint to the browser as to which resources are most important via the [`fetchpriority`](/priority-hints/) attribute for resources that could benefit from a higher priority:
+Even without lazy loading, images are not initially loaded with the highest priority by browsers as they are not render-blocking resources. You can hint to the browser as to which resources are most important via the [`fetchpriority`](/fetch-priority/) attribute for resources that could benefit from a higher priority:
 
 ```html
 <img fetchpriority="high" src="/path/to/hero-image.webp">
@@ -357,7 +357,7 @@ While image CDNs are a great way to reduce resource load times, using a third-pa
 
 Even if you've reduced the size of your resource and the distance it has to travel, a resource can still take a long time to load if you're loading many other resources at the same time. This problem is known as _network contention_.
 
-If you've given your LCP resource a [high `fetchpriority`](/priority-hints/) and [started loading it as soon as possible](#1-eliminate-resource-load-delay) then the browser will do its best to prevent lower-priority resources from competing with it. However, if you're loading many resources with high `fetchpriority`, or if you're just loading a lot of resources in general, then it could affect how quickly the LCP resource loads.
+If you've given your LCP resource a [high `fetchpriority`](/fetch-priority/) and [started loading it as soon as possible](#1-eliminate-resource-load-delay) then the browser will do its best to prevent lower-priority resources from competing with it. However, if you're loading many resources with high `fetchpriority`, or if you're just loading a lot of resources in general, then it could affect how quickly the LCP resource loads.
 
 #### Eliminate the network time entirely
 

--- a/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
+++ b/src/site/content/en/blog/preconnect-and-dns-prefetch/index.md
@@ -152,7 +152,7 @@ Implementing `dns-prefetch` fallback in the same `<link>` tag causes a bug in Sa
 
 Using `dns-prefetch` and `preconnect` allows sites to reduce the amount of time it takes to connect to another origin. The ultimate aim is that the time to load a resource from another origin should be minimized as much as possible.
 
-Where [Largest Contentful Paint (LCP)](/lcp/) is concerned, it is better that resources are immediately discoverable, since [LCP candidates](/lcp/#what-elements-are-considered) are crucial parts of the user experience. A [`fetchpriority` value of `"high"`](/priority-hints/#when-would-you-need-priority-hints) on LCP resources can further improve this by signaling the importance of this asset to the browser so it can fetch it early.
+Where [Largest Contentful Paint (LCP)](/lcp/) is concerned, it is better that resources are immediately discoverable, since [LCP candidates](/lcp/#what-elements-are-considered) are crucial parts of the user experience. A [`fetchpriority` value of `"high"`](/fetch-priority/#when-would-you-need-fetch-priority) on LCP resources can further improve this by signaling the importance of this asset to the browser so it can fetch it early.
 
 Where it is not possible to make LCP assets immediately discoverable, a [`preload`](/preload-critical-assets/) link&mdash;also with the `fetchpriority` value of `"high"`&mdash;still allows the browser to load the resource as soon as possible.
 

--- a/src/site/content/en/blog/top-cwv-2023/index.md
+++ b/src/site/content/en/blog/top-cwv-2023/index.md
@@ -71,7 +71,7 @@ Making sure the LCP resource can be discovered from the HTML source is a critica
 
 For example, even if your LCP image is present in the HTML source using a standard `<img>` tag, if your page includes a dozen `<script>` tags in the `<head>` of your document before that `<img>` tag, it may be a while before your image resource starts loading.
 
-The easiest way to solve this problem is to provide a hint to the browser about what resources are the highest priority by setting the new [`fetchpriority="high"`](/priority-hints/) attribute on the `<img>` or `<link>` tag that loads your LCP image. This instructs the browser to load it earlier, rather than waiting for those scripts to complete.
+The easiest way to solve this problem is to provide a hint to the browser about what resources are the highest priority by setting the new [`fetchpriority="high"`](/fetch-priority/) attribute on the `<img>` or `<link>` tag that loads your LCP image. This instructs the browser to load it earlier, rather than waiting for those scripts to complete.
 
 According to the Web Almanac, only [0.03%](https://almanac.httparchive.org/en/2022/performance#lcp-prioritization) of eligible pages are taking advantage of this new API, meaning there is plenty of opportunity for most sites on the web to improve LCP with very little work. While the `fetchpriority` attribute is currently only supported in Chromium-based browsers, this API is a progressive enhancement that other browsers just ignore, so we strongly recommend developers use it now.
 

--- a/src/site/content/en/blog/web-platform-04-2022/index.md
+++ b/src/site/content/en/blog/web-platform-04-2022/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: "New to the web platform in April"
 subhead: >
-  Discover some of the interesting features that landed in stable and beta web browsers during April 2022. 
+  Discover some of the interesting features that landed in stable and beta web browsers during April 2022.
 description: >
   Discover some of the interesting features that landed in stable and beta web browsers during April 2022.
 date: 2022-04-29
@@ -31,13 +31,13 @@ To learn more about `hwb()`, read this article by [Stefan Judis](https://twitter
 
 {% BrowserCompat 'css.types.color.hwb' %}
 
-Also in Chrome 101 is the [Priority Hints](/priority-hints/) feature. This gives you a way to hint to the browser which order resources should be downloaded in, by using the `fetchpriority` attribute. In the example below, a low priority image is indicated with `fetchpriority="low"`.
+Also in Chrome 101 is the [Fetch Priority](/fetch-priority/) feature. This gives you a way to hint to the browser which order resources should be downloaded in, by using the `fetchpriority` attribute. In the example below, a low priority image is indicated with `fetchpriority="low"`.
 
 ```html
 <img src="/images/in_viewport_but_not_important.svg" fetchpriority="low" alt="I'm an unimportant image!">
 ```
 
-Priority Hints aren't yet available in other browsers, however you can start using them right now to benefit anyone with a browser based on Chromium 101.
+Fetch Priority isn't yet available in other browsers, however you can start using them right now to benefit anyone with a browser based on Chromium 101.
 
 {% BrowserCompat 'api.HTMLImageElement.fetchPriority' %}
 
@@ -55,9 +55,9 @@ if (!navigator.pdfViewerEnabled) {
 
 Beta browser versions give you a preview of things that will be in the next stable version of the browser. It's a great time to test new features, or removals, that could impact your site before the world gets that release.
 
-New betas in April were [Chrome 102](https://blog.chromium.org/2022/04/chrome-102-window-controls-overlay-host.html), [Firefox 100](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100), and [Safari 15.5](https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes). 
+New betas in April were [Chrome 102](https://blog.chromium.org/2022/04/chrome-102-window-controls-overlay-host.html), [Firefox 100](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100), and [Safari 15.5](https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes).
 
-Chrome 102, Safari 15.5, and Firefox preview versions include [the `inert` attribute](https://developer.chrome.com/blog/inert/). This removes elements from the tab order and accessibility tree if they are non-interactive. For example, an element that is currently offscreen or hidden. 
+Chrome 102, Safari 15.5, and Firefox preview versions include [the `inert` attribute](https://developer.chrome.com/blog/inert/). This removes elements from the tab order and accessibility tree if they are non-interactive. For example, an element that is currently offscreen or hidden.
 
 Chrome 102 includes the new value `until-found` for the HTML `hidden` attribute. This enables find-in-page and scroll to text fragment on text that is inside a collapsed area of the page, as you might find in an accordion pattern. Find out more in the post [Making collapsed content accessible with hidden=until-found](https://developer.chrome.com/blog/hidden-until-found/).
 
@@ -68,5 +68,4 @@ Chrome 102 also includes the [Local Font Access API](/local-fonts/), which allow
 These beta features will land in stable browsers soon.
 
 _Hero image by [Jason Leung](https://unsplash.com/@ninjason)_
-  
-  
+

--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -85,7 +85,7 @@ The `eager` value is simply an instruction to load the image as usual, without d
 
 Browsers prioritize resources based on various heuristics, and the `loading` attribute just states _when_ the image resource is queued, not _how_ it is prioritized in that queue. `eager` just implies the usual eager queueing browsers use by default.
 
-If you want to increase the fetch priority of an important image (for example the LCP image), then [Priority Hints](/priority-hints/) should be used with `fetchpriority="high"`.
+If you want to increase the fetch priority of an important image (for example the LCP image), then [Fetch Priority](/fetch-priority/) should be used with `fetchpriority="high"`.
 
 Note that an image with `loading="lazy"` and `fetchpriority="high"` will still be delayed while it is off-screen, and then fetched with a high priority when it is nearly within the viewport. It would likely be fetched with a high priority in this case anyway, so this combination should not really be needed nor used.
 

--- a/src/site/content/en/fast/fetch-priority/index.md
+++ b/src/site/content/en/fast/fetch-priority/index.md
@@ -1,14 +1,15 @@
 ---
 layout: post
-title: Optimizing resource loading with Priority Hints
+title: Optimizing resource loading with the Fetch Priority API
 authors:
   - leenasohoni
   - addyosmani
   - patmeenan
-description: Priority Hints indicate the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
-subhead: Priority Hints indicate the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
+  - tunetheweb
+description: The Fetch Priority API indicates the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
+subhead: The Fetch Priority API indicates the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
 date: 2021-10-20
-updated: 2023-03-08
+updated: 2023-04-18
 hero: image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/WqBkrvs5LRwPIfrSOQyz.jpg
 alt: A photo of a brown wooden plank fence, with a signboard attached to it. The signboard reads 'this way', with an arrow pointing to the right.
 tags:
@@ -21,27 +22,31 @@ tags:
 
 When a browser parses a web page and begins to discover and download resources such as images, scripts, or CSS, it assigns them a fetch `priority` in an attempt to download resources in an optimal order. These priorities can depend on the kind of resource and where it is in the document. For example, in-viewport images may have a `High` priority while the priority for early loaded, render-blocking CSS via `<link>`s in the `<head>` could be `Very High`. Browsers are pretty good at assigning priorities that work well but may not be optimal in all cases.
 
-In this article, we'll discuss Priority Hints and the `fetchpriority` attribute, which allow you to hint at the relative priority of a resource (`high` or `low`). Priority Hints can help optimize the Core Web Vitals.
+In this article, we'll discuss the Fetch Priority API and the `fetchpriority` HTML attribute, which allow you to hint at the relative priority of a resource (`high` or `low`). Fetch Priority can help optimize the Core Web Vitals.
+
+{% Aside %}
+This feature was originally called Priority Hints but was renamed to Fetch Priority after standardization. See [history](#history) below for more details.
+{% endAside %}
 
 <figure>
-  {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/UQ60oFwWrVCPbFYx3pJY.png", alt="A filmstrip view comparing two tests of the Google Flights homepage. At bottom, Priority Hints are used to boost the priority of the hero image, resulting in a 0.7 second decrease in LCP.
+  {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/UQ60oFwWrVCPbFYx3pJY.png", alt="A filmstrip view comparing two tests of the Google Flights homepage. At bottom, Fetch Priority are used to boost the priority of the hero image, resulting in a 0.7 second decrease in LCP.
 ", width="800", height="400" %}
-  <figcaption>Priority Hints improving Largest Contentful Paint from 2.6&nbsp;s to 1.9&nbsp;s in a test of Google Flights</figcaption>
+  <figcaption>Fetch Priority improving Largest Contentful Paint from 2.6&nbsp;s to 1.9&nbsp;s in a test of Google Flights</figcaption>
 </figure>
 
 ## Summary
 
-**A few key areas where Priority Hints can help:**
+**A few key areas where Fetch Priority can help:**
 
 - Boost the priority of the LCP image by specifying `fetchpriority="high"` on the image element, causing LCP to happen sooner.
 - Increase the priority of `async` scripts using better semantics than the current hack that is commonly used (inserting a <code>&lt;link rel="preload"&gt;</code> for the `async` script).
 - Decrease the priority of late-body scripts to allow for better sequencing with images.
 
-Historically, developers have had some, but limited, influence over resource priority using [preload](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preload/) and [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/). Priority Hints complement these [Resource Hints](https://www.w3.org/TR/resource-hints/), but it's essential to understand where they all fit in. Preload lets you tell the browser about critical resources you want to load early before they are discovered naturally. This is especially useful for resources that are not easily discovered, such as fonts included in stylesheets, background images, or resources loaded from a script. Preconnect helps warm up connections to cross-origin servers and can help improve metrics like [Time-to-first-byte](/ttfb/) and is useful when you know an origin but not necessarily the exact URL of a resource that will be needed.
+Historically, developers have had some, but limited, influence over resource priority using [preload](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preload/) and [preconnect](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preconnect/). Fetch Priority complements these [Resource Hints](https://www.w3.org/TR/resource-hints/), but it's essential to understand where they all fit in. Preload lets you tell the browser about critical resources you want to load early before they are discovered naturally. This is especially useful for resources that are not easily discovered, such as fonts included in stylesheets, background images, or resources loaded from a script. Preconnect helps warm up connections to cross-origin servers and can help improve metrics like [Time-to-first-byte](/ttfb/) and is useful when you know an origin but not necessarily the exact URL of a resource that will be needed.
 
-Priority Hints are a markup-based signal (available through the `fetchpriority` attribute) that developers can use to indicate the relative priority of a particular resource. You can also use these hints via JavaScript and the [Fetch API](/introduction-to-fetch/) with the `priority` property to influence the priority of resource fetches made for data. Priority Hints can also complement preload. Take a Largest Contentful Paint image, which, when preloaded, will still get a low priority. If it is pushed back by other early low-priority resources, using Priority Hints can help how soon the image gets loaded.
+Fetch Priority is a markup-based signal (available through the `fetchpriority` attribute) that developers can use to indicate the relative priority of a particular resource. You can also use these hints via JavaScript and the [Fetch API](/introduction-to-fetch/) with the `priority` property to influence the priority of resource fetches made for data. Fetch Priority can also complement preload. Take a Largest Contentful Paint image, which, when preloaded, will still get a low priority. If it is pushed back by other early low-priority resources, using Fetch Priority can help how soon the image gets loaded.
 
-Priority Hints are [available](https://www.chromestatus.com/feature/5273474901737472) in Chrome 101 or later.
+Fetch Priority is [available](https://www.chromestatus.com/feature/5273474901737472) in Chrome 101 or later.
 
 ## Resource priority
 
@@ -208,7 +213,7 @@ The browser downloads resources with the same computed priority in the order the
   <figcaption>Priority for resource type = &quot;script&quot; on BBC news detail page</figcaption>
 </figure>
 
-## When would you need Priority Hints?
+## When would you need Fetch Priority?
 
 Knowledge of the browser's prioritization logic provides you with a few existing knobs to tweak the order of downloads. You can
 
@@ -219,17 +224,17 @@ Knowledge of the browser's prioritization logic provides you with a few existing
 
 These techniques help to control the browser's priority computation, thereby improving performance and [Core Web Vitals](/vitals/). For example, when a critical background image is preloaded, it can be discovered much earlier, improving the Largest Contentful Paint ([LCP](/lcp/)).
 
-Sometimes these handles may not be enough to prioritize resources optimally for your application. Here are some of the scenarios where Priority Hints could be helpful:
+Sometimes these handles may not be enough to prioritize resources optimally for your application. Here are some of the scenarios where Fetch Priority could be helpful:
 
 1. You have several above-the-fold images, but all of them need not have the same priority. For example, in an image carousel, only the first visible image needs a higher priority compared to the others.
-2. Hero images inside the viewport start at a "Low" priority. After the layout is complete, Chrome discovers they are in the viewport and boosts their priority (unfortunately, dev tools only shows the final priority—WebPageTest will show both). This usually adds a significant delay to loading the image. Providing the Priority Hint in markup lets the image start at a "High" priority and start loading much earlier.<br><br>Note that preload is still required for the early discovery of LCP images included as CSS backgrounds and can be combined with Priority Hints by including the `fetchpriority='high'` on the preload, otherwise it will still start with the default "Low" priority for images.
+2. Hero images inside the viewport start at a "Low" priority. After the layout is complete, Chrome discovers they are in the viewport and boosts their priority (unfortunately, dev tools only shows the final priority—WebPageTest will show both). This usually adds a significant delay to loading the image. Providing the Fetch Priority in markup lets the image start at a "High" priority and start loading much earlier.<br><br>Note that preload is still required for the early discovery of LCP images included as CSS backgrounds and can be combined with Fetch Priority by including the `fetchpriority='high'` on the preload, otherwise it will still start with the default "Low" priority for images.
 3. Declaring scripts as `async` or `defer` tells the browser to load them asynchronously. However, as seen in the figure above, these scripts are also assigned a "low" priority. You may want to bump up their priority while ensuring asynchronous download, particularly for any scripts that are critical for the user experience.
-4. You may use the JavaScript [`fetch()`](/introduction-to-fetch/) API to fetch resources or data asynchronously. Fetch is assigned a "High" priority by the browser. There may be situations where you do not want all your fetches to be executed with "High" priority and prefer using different Priority Hints instead. This can be helpful when running background API calls and mixing them with API calls that are responding to user input, like with autocomplete. The background API calls can be tagged as "Low" priority and the interactive API calls marked as "High" priority.
-5. The browser assigns CSS and fonts a "High" priority, but all such resources may not be equally important or required for LCP. You can use Priority Hints to lower the priority of some of these resources.
+4. You may use the JavaScript [`fetch()`](/introduction-to-fetch/) API to fetch resources or data asynchronously. Fetch is assigned a "High" priority by the browser. There may be situations where you do not want all your fetches to be executed with "High" priority and prefer using different Fetch Priority instead. This can be helpful when running background API calls and mixing them with API calls that are responding to user input, like with autocomplete. The background API calls can be tagged as "Low" priority and the interactive API calls marked as "High" priority.
+5. The browser assigns CSS and fonts a "High" priority, but all such resources may not be equally important or required for LCP. You can use Fetch Priority to lower the priority of some of these resources.
 
 ## The `fetchpriority` attribute
 
-You can provide a Priority Hint using the `fetchpriority` HTML attribute. You can use the attribute with `link`, `img`, `script`, and `iframe` tags. The attribute allows you to specify the priority for resource types such as CSS, fonts, scripts, images, and iframe when downloaded using the supported tags.
+You can provide a Fetch Priority using the `fetchpriority` HTML attribute. You can use the attribute with `link`, `img`, and `script` tags. The attribute allows you to specify the priority for resource types such as CSS, fonts, scripts, and images when downloaded using the supported tags.
 The `fetchpriority` attribute accepts one of three values:
 
 - `high`: You consider the resource a high priority and want the browser to prioritize it as long as the browser's heuristics don't prevent that from happening.
@@ -251,14 +256,7 @@ Here are a few examples of using the `fetchpriority` attribute in markup and the
     // Trigger a low priority fetch
   });
 </script>
-
-<!-- The third-party contents of this iframe can load with a low priority -->
-<iframe src="https://example.com" width="600" height="400" fetchpriority="low"></iframe>
 ```
-
-{% Aside %}
-When a Priority Hint is set on an `iframe`, the priority is applied only to the main resource for the iframe. All of the subresources that the `iframe` loads will be prioritized using the same rules that apply to all other resources.
-{% endAside %}
 
 ### Browser priority and `fetchpriority`
 
@@ -471,11 +469,11 @@ You can specify `fetchpriority="high"` to boost the priority of the LCP or other
 <img src="lcp-image.jpg" fetchpriority="high">
 ```
 
-The following comparison shows the Google Flights page with an LCP background image loaded with and without Priority Hints. With the priority set to high, the [LCP improved from 2.6s to 1.9s](https://www.webpagetest.org/video/compare.php?tests=211006_AiDcG3_40871b05d6040112a05be4524565cf5d%2C211006_BiDcHR_bebed947f1b6607f2d97e8a899fdc36b&thumbSize=200&ival=100&end=visual).
+The following comparison shows the Google Flights page with an LCP background image loaded with and without Fetch Priority. With the priority set to high, the [LCP improved from 2.6s to 1.9s](https://www.webpagetest.org/video/compare.php?tests=211006_AiDcG3_40871b05d6040112a05be4524565cf5d%2C211006_BiDcHR_bebed947f1b6607f2d97e8a899fdc36b&thumbSize=200&ival=100&end=visual).
 
 <figure>
   {% Video src="video/1L2RBhCLSnXjCnSlevaDjy3vba73/BCngJfoVOy0YbUz8wFrM.mp4", autoplay=true, muted=true, playsinline=true, loop=true, controls=true %}
-  <figcaption>An experiment conducted using Cloudflare workers to rewrite the Google Flights page to use Priority Hints.</figcaption>
+  <figcaption>An experiment conducted using Cloudflare workers to rewrite the Google Flights page to use Fetch Priority.</figcaption>
 </figure>
 
 #### Lower the priority of above-the-fold images
@@ -494,7 +492,7 @@ You can use `fetchpriority="low"` to lower the priority of above-the-fold images
 In an earlier experiment with the [Oodle](https://github.com/google/oodle-demo) app, we used this to lower the priority of images that do not appear on load. It helped to cut down the load time by 2 seconds.
 
 <figure>
-  {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/Tn4OkGpqPbrSQtd1j3GV.png", alt="A side-by-side comparison of Priority Hints when used on the Oodle app's image carousel. On the left, the browser sets default priorities for carousel images, but downloads and paints those images around two seconds slower than the example on the right, which sets a higher priority on only the first carousel image.", width="800", height="460" %}
+  {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/Tn4OkGpqPbrSQtd1j3GV.png", alt="A side-by-side comparison of Fetch Priority when used on the Oodle app's image carousel. On the left, the browser sets default priorities for carousel images, but downloads and paints those images around two seconds slower than the example on the right, which sets a higher priority on only the first carousel image.", width="800", height="460" %}
 </figure>
 
 #### Lower the priority of preloaded resources
@@ -536,43 +534,43 @@ let authenticate = await fetch('/user');
 let suggestedContent = await fetch('/content/suggested', {priority: 'low'});
 ```
 
-## Priority Hints implementation notes
+## Fetch Priority implementation notes
 
-Priority Hints can improve performance in specific use cases, as discussed above. There are some things to be aware of:
+Fetch Priority can improve performance in specific use cases, as discussed above. There are some things to be aware of:
 
 - The `fetchpriority` attribute is a hint and not a directive. The browser will try to respect the developer's preference. It is also possible that the browser will apply its preferences for resource priority as deemed necessary in case of conflicts.
-- Priority Hints should not be confused with a preload. They are both distinct because:
+- Fetch Priority should not be confused with a preload. They are both distinct because:
     - Preload is a mandatory fetch and not a hint.
-    - Preload allows the browser to discover the resource early, but it will still fetch it with the default priority. Conversely, Priority Hints do not aid discoverability, but do allow you to increase or decrease the fetch priority.
+    - Preload allows the browser to discover the resource early, but it will still fetch it with the default priority. Conversely, Fetch Priority does not aid discoverability, but does allow you to increase or decrease the fetch priority.
     - It is easier to observe and measure the effects of a preload.
 
-  Priority Hints can complement preloads by increasing the granularity of prioritization. If you had already specified a preload as one of the first items in the `<head>` for an LCP image, then a `high` Priority Hint may not result in significant gains. However, if the preload was after other resources, then a `high` Priority Hint can improve the LCP. If a critical image is a CSS background image, you should preload it with `fetchpriority = "high"`.
+  Fetch Priority can complement preloads by increasing the granularity of prioritization. If you had already specified a preload as one of the first items in the `<head>` for an LCP image, then a `high` Fetch Priority may not result in significant gains. However, if the preload was after other resources, then a `high` Fetch Priority can improve the LCP. If a critical image is a CSS background image, you should preload it with `fetchpriority = "high"`.
 - The noticeable gains due to prioritization will be more relevant in environments where more resources contend for the available network bandwidth. This is common for HTTP/1.x connections where parallel downloads are not possible or in low bandwidth HTTP/2 connections. Prioritization can resolve bottlenecks in these conditions.
-- CDNs do [not uniformly implement HTTP/2 prioritization](https://github.com/andydavies/http2-prioritization-issues#cdns--cloud-hosting-services). Even if the browser communicates the priority suggested using Priority Hints; the CDN may not reprioritize resources in the required order. This makes testing of Priority Hints difficult. The priorities are applied both internally within the browser and with protocols that support prioritization (HTTP/2 and HTTP/3). It is still worth using even for just the internal browser prioritization independent of CDN or origin support, as that will often change when resources are requested by the browser—for example low priority resources like images are often held back from being requested while the browser processes the critical `<head>` items.
-- It may not be possible to introduce Priority Hints as a best practice in your initial design. It is an optimization that you can apply later in the development cycle. You can check the priorities being assigned to different resources on the page, and if they do not match your expectations, you could introduce Priority Hints for further optimization.
+- CDNs do [not uniformly implement HTTP/2 prioritization](https://github.com/andydavies/http2-prioritization-issues#cdns--cloud-hosting-services). Even if the browser communicates the priority suggested using Fetch Priority; the CDN may not reprioritize resources in the required order. This makes testing of Fetch Priority difficult. The priorities are applied both internally within the browser and with protocols that support prioritization (HTTP/2 and HTTP/3). It is still worth using even for just the internal browser prioritization independent of CDN or origin support, as that will often change when resources are requested by the browser—for example low priority resources like images are often held back from being requested while the browser processes the critical `<head>` items.
+- It may not be possible to introduce Fetch Priority as a best practice in your initial design. It is an optimization that you can apply later in the development cycle. You can check the priorities being assigned to different resources on the page, and if they do not match your expectations, you could introduce Fetch Priority for further optimization.
 
 ### Using Preload after Chrome 95
 
-The Priority Hints feature was available for trial in Chrome 73 to 76 but was not released due to prioritization issues with preloads fixed in Chrome 95. Prior to Chrome 95, requests issued via `<link rel=preload>` always start before other requests seen by the preload scanner, even if the other requests have a higher priority.
+The Fetch Priority feature was available for trial in Chrome 73 to 76 but was not released due to prioritization issues with preloads fixed in Chrome 95. Prior to Chrome 95, requests issued via `<link rel=preload>` always start before other requests seen by the preload scanner, even if the other requests have a higher priority.
 
-With the fix in Chrome 95 and the enhancement for Priority Hints, we hope that developers will start using preload for its [intended purpose](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/#loading-of-late-discovered-resources)—to preload resources not detected by the parser (fonts, imports, background LCP images). The placement of the `preload` hint will affect when the resource is preloaded. Some key points on using preload are:
+With the fix in Chrome 95 and the enhancement for Fetch Priority, we hope that developers will start using preload for its [intended purpose](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/#loading-of-late-discovered-resources)—to preload resources not detected by the parser (fonts, imports, background LCP images). The placement of the `preload` hint will affect when the resource is preloaded. Some key points on using preload are:
 
 - Including the preload in HTTP headers will cause it to jump ahead of everything else.
 - Generally, preloads will load in the order the parser gets to them for anything above &quot;Medium&quot; priority—so be careful if you are including preloads at the beginning of the HTML.
 - Font preloads will probably work best towards the end of the head or beginning of the body.
 - Import preloads (dynamic `import()` or `modulepreload`) should be done after the script tag that needs the import (so the actual script gets loaded/parsed first). Basically, if the script tag loads a script that will trigger the load of dependencies, make sure the `<link rel=preload>` for the dependencies is after the parent script tag, otherwise the dependencies may end up loading before the main script. In the proper order, the main script can be parsed/eval'd while the dependencies are loading.
-- Image preloads will have a "Low" priority (without Priority Hints) and should be ordered relative to async scripts and other low or lowest priority tags.
+- Image preloads will have a "Low" priority (without Fetch Priority) and should be ordered relative to async scripts and other low or lowest priority tags.
 
 ## History
 
-Priority Hints was first experimented with in Chrome as an origin trial in 2018 and then again in 2021 using the `importance` attribute. The interface has since changed to `fetchpriority` for HTML and `priority` for JavaScript's Fetch API as part of the web standards process.
+Fetch Priority was first experimented with in Chrome as an origin trial in 2018 and then again in 2021 using the `importance` attribute. At this time it was known as [Priority Hints](https://github.com/WICG/priority-hints). The interface has since changed to `fetchpriority` for HTML and `priority` for JavaScript's Fetch API as part of the web standards process. To reduce confusion we now refer to this API as Fetch Priority.
 
 ## Browser compatibility
 
 {% BrowserCompat 'api.HTMLImageElement.fetchPriority' %}
 
-As of this writing, Priority Hints are only available in Chromium-based browsers. Other browser engines or earlier versions of Chromium browsers will ignore the attribute and use their default prioritization heuristics. Until another browser implements Priority Hints, you may notice some references—[such as MDN](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority)—mark this as [_Experimental_](https://developer.mozilla.org/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), however Priority Hints are now standardized and included in the [HTML living standard](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes) and [Fetch living standard](https://fetch.spec.whatwg.org/#request-priority).
+As of this writing, Fetch Priority is only available in Chromium-based browsers. Other browser engines or earlier versions of Chromium browsers will ignore the attribute and use their default prioritization heuristics. Until another browser implements Fetch Priority, you may notice some references—[such as MDN](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority)—mark this as [_Experimental_](https://developer.mozilla.org/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), however Fetch Priority is now standardized and included in the [HTML living standard](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes) and [Fetch living standard](https://fetch.spec.whatwg.org/#request-priority).
 
 ## Conclusion
 
-Developers are likely to be interested in Priority Hints with the fixes in preload behavior and the recent focus on Core Web Vitals and LCP. They now have additional knobs available to achieve their desired loading sequence.
+Developers are likely to be interested in Fetch Priority with the fixes in preload behavior and the recent focus on Core Web Vitals and LCP. They now have additional knobs available to achieve their desired loading sequence.

--- a/src/site/content/en/fast/fetch-priority/index.md
+++ b/src/site/content/en/fast/fetch-priority/index.md
@@ -20,13 +20,13 @@ tags:
 
 {% BrowserCompat 'api.HTMLImageElement.fetchPriority' %}
 
-When a browser parses a web page and begins to discover and download resources such as images, scripts, or CSS, it assigns them a fetch `priority` in an attempt to download resources in an optimal order. These priorities can depend on the kind of resource and where it is in the document. For example, in-viewport images may have a `High` priority while the priority for early loaded, render-blocking CSS via `<link>`s in the `<head>` could be `Very High`. Browsers are pretty good at assigning priorities that work well but may not be optimal in all cases.
-
-In this article, we'll discuss the Fetch Priority API and the `fetchpriority` HTML attribute, which allow you to hint at the relative priority of a resource (`high` or `low`). Fetch Priority can help optimize the Core Web Vitals.
-
 {% Aside %}
 This feature was originally called Priority Hints but was renamed to Fetch Priority after standardization. See [History](#history) below for more details.
 {% endAside %}
+
+When a browser parses a web page and begins to discover and download resources such as images, scripts, or CSS, it assigns them a fetch `priority` in an attempt to download resources in an optimal order. These priorities can depend on the kind of resource and where it is in the document. For example, in-viewport images may have a `High` priority while the priority for early loaded, render-blocking CSS via `<link>`s in the `<head>` could be `Very High`. Browsers are pretty good at assigning priorities that work well but may not be optimal in all cases.
+
+In this article, we'll discuss the Fetch Priority API and the `fetchpriority` HTML attribute, which allow you to hint at the relative priority of a resource (`high` or `low`). Fetch Priority can help optimize the Core Web Vitals.
 
 <figure>
   {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/UQ60oFwWrVCPbFYx3pJY.png", alt="A filmstrip view comparing two tests of the Google Flights homepage. At bottom, Fetch Priority are used to boost the priority of the hero image, resulting in a 0.7 second decrease in LCP.

--- a/src/site/content/en/fast/fetch-priority/index.md
+++ b/src/site/content/en/fast/fetch-priority/index.md
@@ -6,8 +6,8 @@ authors:
   - addyosmani
   - patmeenan
   - tunetheweb
-description: The Fetch Priority API indicates the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
-subhead: The Fetch Priority API indicates the relative priority of resources to the browser. They can enable optimal loading and improve Core Web Vitals.
+description: The Fetch Priority API indicates the relative priority of resources to the browser. It can enable optimal loading and improve Core Web Vitals.
+subhead: The Fetch Priority API indicates the relative priority of resources to the browser. It can enable optimal loading and improve Core Web Vitals.
 date: 2021-10-20
 updated: 2023-04-18
 hero: image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/WqBkrvs5LRwPIfrSOQyz.jpg
@@ -25,7 +25,7 @@ When a browser parses a web page and begins to discover and download resources s
 In this article, we'll discuss the Fetch Priority API and the `fetchpriority` HTML attribute, which allow you to hint at the relative priority of a resource (`high` or `low`). Fetch Priority can help optimize the Core Web Vitals.
 
 {% Aside %}
-This feature was originally called Priority Hints but was renamed to Fetch Priority after standardization. See [history](#history) below for more details.
+This feature was originally called Priority Hints but was renamed to Fetch Priority after standardization. See [History](#history) below for more details.
 {% endAside %}
 
 <figure>
@@ -563,7 +563,7 @@ With the fix in Chrome 95 and the enhancement for Fetch Priority, we hope that d
 
 ## History
 
-Fetch Priority was first experimented with in Chrome as an origin trial in 2018 and then again in 2021 using the `importance` attribute. At this time it was known as [Priority Hints](https://github.com/WICG/priority-hints). The interface has since changed to `fetchpriority` for HTML and `priority` for JavaScript's Fetch API as part of the web standards process. To reduce confusion we now refer to this API as Fetch Priority.
+Fetch Priority was first experimented with in Chrome as an origin trial in 2018 and then again in 2021 using the `importance` attribute. At that time it was known as [Priority Hints](https://github.com/WICG/priority-hints). The interface has since changed to `fetchpriority` for HTML and `priority` for JavaScript's Fetch API as part of the web standards process. To reduce confusion we now refer to this API as Fetch Priority.
 
 ## Browser compatibility
 

--- a/src/site/content/en/fast/image-cdns/index.md
+++ b/src/site/content/en/fast/image-cdns/index.md
@@ -101,7 +101,7 @@ Trying them out yourself before making a decision can also be helpful. Below you
 Images are a vital part of the user experience on many websites, and thus factor into how well sites do when it comes to [Largest Contentful Paint](/lcp/). Here are a few things to keep in mind if you decide to use an image CDN:
 
 1. Images served from CDNs may come from a cross-origin server, which involves extra connection setup time. When possible, try to use an image CDN that proxies through the primary origin so that you're not adding extra origins for the browser to connect to. This has the same effect as self-hosting images on the primary origin.
-2. Consider using a [`fetchpriority` attribute value of `"high"`](/priority-hints/#summary) on the LCP image element so that the browser can begin loading that image as soon as possible.
+2. Consider using a [`fetchpriority` attribute value of `"high"`](/fetch-priority/#summary) on the LCP image element so that the browser can begin loading that image as soon as possible.
 3. If an image is not immediately discoverable in the initial HTML, consider using a [`rel=preload`](https://developer.chrome.com/docs/lighthouse/performance/uses-rel-preload/) hint for your LCP candidate image so that the browser can load that image ahead of time.
 4. If proxying through your origin is not possible, and the exact image to be loaded will not be known until later during page load, [you should set up a connection to the cross-origin image CDN as early as possible](/preconnect-and-dns-prefetch/) to shorten the resource loading phase of what could be your page's LCP candidate image.
 

--- a/src/site/content/en/fast/lazy-loading-video/index.md
+++ b/src/site/content/en/fast/lazy-loading-video/index.md
@@ -36,7 +36,7 @@ on the `<video>` element may be desirable:
 ```
 
 {% Aside 'important' %}
-A video `poster` image can qualify as an [LCP candidates](/lcp/#what-elements-are-considered). If your `poster` image is an LCP candidate, you should [preload it](/preload-critical-assets/) with a [`fetchpriority` attribute value of `"high"`](/priority-hints/#the-fetchpriority-attribute) so the user sees it as soon as possible.
+A video `poster` image can qualify as an [LCP candidates](/lcp/#what-elements-are-considered). If your `poster` image is an LCP candidate, you should [preload it](/preload-critical-assets/) with a [`fetchpriority` attribute value of `"high"`](/fetch-priority/#the-fetchpriority-attribute) so the user sees it as soon as possible.
 {% endAside %}
 
 The example above uses a `preload` attribute with a value of `none` to prevent browsers

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -165,9 +165,9 @@ For a hero image above the fold, `loading` should not be used. If your site auto
 >
 ```
 
-### Priority hints
+### Fetch Priority
 
-For important images-such as the [LCP](/lcp/) image, you can further prioritise the loading using [Priority Hints](/priority-hints/) by setting the `fetchpriority` attribute to `high`:
+For important images-such as the [LCP](/lcp/) image, you can further prioritise the loading using [Fetch Priority](/fetch-priority/) by setting the `fetchpriority` attribute to `high`:
 
 ```html/5-6
 <img

--- a/src/site/content/en/learn/design/responsive-images/index.md
+++ b/src/site/content/en/learn/design/responsive-images/index.md
@@ -167,7 +167,7 @@ For a hero image above the fold, `loading` should not be used. If your site auto
 
 ### Fetch Priority
 
-For important images-such as the [LCP](/lcp/) image, you can further prioritise the loading using [Fetch Priority](/fetch-priority/) by setting the `fetchpriority` attribute to `high`:
+For important images-such as the [LCP](/lcp/) image, you can further prioritize the loading using [Fetch Priority](/fetch-priority/) by setting the `fetchpriority` attribute to `high`:
 
 ```html/5-6
 <img

--- a/src/site/content/en/learn/images/performance-issues/index.md
+++ b/src/site/content/en/learn/images/performance-issues/index.md
@@ -2,7 +2,7 @@
 title: 'Key performance issues'
 authors:
   - matmarquis
-description: Learn ways to ensure that your image requests are as small and performant as possible. 
+description: Learn ways to ensure that your image requests are as small and performant as possible.
 date: 2023-02-01
 tags:
   - images
@@ -36,7 +36,7 @@ There's a catch, however: deferring those requests means not taking advantage of
 images as early as possible. If `loading="lazy"` is used on `img` elements toward the top of the layout—and thus more likely
 to be in the user's viewport when the page is first loaded—these images can feel significantly slower to the end user.
 
-## Priority hints
+## Fetch Priority
 
 The `loading` attribute is an example of a larger web standards effort to give developers more power over how web browsers
 prioritize requests.
@@ -47,8 +47,8 @@ external JavaScript file just above `</body>` will be deferred until render is c
 the associated image request will be deferred until the browser determines that it will be shown to a user. Otherwise, that image will have the same
 priority as any other image on the page.
 
-The [experimental](https://caniuse.com/mdn-html_elements_img_fetchpriority) `fetchpriority` attribute is intended to give
-developers [finer-grained control over the priority of assets](/priority-hints/), allowing you to flag resources
+The [`fetchpriority` attribute](https://caniuse.com/mdn-html_elements_img_fetchpriority) is intended to give
+developers [finer-grained control over the priority of assets](/fetch-priority/), allowing you to flag resources
 as 'high' and 'low' priority relative to resources of the same type. The use cases for `fetchpriority` are similar to the `loading`
 attribute, though much more broad. For example, you might use `fetchpriority="low"` on an image only revealed following user interaction
 (whether that image falls within the user's viewport or not) in order to prioritize visible images elsewhere on the page, or `fetchpriority="high"`

--- a/src/site/content/en/newsletter/archive/2022/05/index.njk
+++ b/src/site/content/en/newsletter/archive/2022/05/index.njk
@@ -402,7 +402,7 @@ display: none !important;
 </td>
 </tr>
 <tr>
-<td align="center" class="padtop12 padR" dir="ltr" style="font-family:Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color:#202124; line-height:24px; mso-line-height-rule: exactly; padding-top: 20px;padding-left: 3px;padding-right: 3px " valign="top">Chrome ships hwb color notation and Priority Hints, and Firefox lands pdfViewerEnabled. Just some of the interesting features that landed in stable and beta web browsers during April.
+<td align="center" class="padtop12 padR" dir="ltr" style="font-family:Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color:#202124; line-height:24px; mso-line-height-rule: exactly; padding-top: 20px;padding-left: 3px;padding-right: 3px " valign="top">Chrome ships hwb color notation and Fetch Priority, and Firefox lands pdfViewerEnabled. Just some of the interesting features that landed in stable and beta web browsers during April.
 </td>
 </tr>
 <tr>

--- a/src/site/content/en/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/en/react/route-prefetching-in-nextjs/index.md
@@ -86,9 +86,8 @@ check the `README.md` in Glitch examples. {% endAside %}
 
 {% Aside %} Because `<link rel="preload">` requests resources with high
 priority, the browser expects them to be used right away, which triggers
-Console warnings. [Priority
-hints](/priority-hints/) will
-soon become available in Chrome, which will allow Next.js to indicate lower
+Console warnings. [Fetch Priority](/fetch-priority/) will
+is available in Chrome, which will allow Next.js to indicate lower
 priority for resources that are not needed immediately with `<link rel="preload"
 fetchpriority="low">`. {% endAside %}
 

--- a/src/site/content/es/react/route-prefetching-in-nextjs/index.md
+++ b/src/site/content/es/react/route-prefetching-in-nextjs/index.md
@@ -56,7 +56,7 @@ Next.js solo *lee* JavaScript; no lo ejecuta. De esa manera, no descargará ning
 
 {% Aside 'caution' %} Los ejemplos de fallas se ejecutan en modo de producción porque la precarga depende de las condiciones de navegación y está habilitada solo en compilaciones de producción optimizadas. Para cambiar al modo de desarrollo, verifique el archivo `README.md` en los ejemplos de Glitch. {% endAside %}
 
-{% Aside %} Debido a que `<link rel="preload">` solicita recursos con prioridad alta, el navegador espera que se utilicen de inmediato, lo que activa las advertencias de la consola. Las [sugerencias de prioridad](/priority-hints/) pronto estarán disponibles en Chrome, lo que permitirá que Next.js indique una prioridad más baja para los recursos que no se necesitan de inmediato con `<link rel="preload" fetchpriority="low">`. {% endAside %}
+{% Aside %} Debido a que `<link rel="preload">` solicita recursos con prioridad alta, el navegador espera que se utilicen de inmediato, lo que activa las advertencias de la consola. Las [sugerencias de prioridad](/fetch-priority/) pronto estarán disponibles en Chrome, lo que permitirá que Next.js indique una prioridad más baja para los recursos que no se necesitan de inmediato con `<link rel="preload" fetchpriority="low">`. {% endAside %}
 
 ## Evite la precarga innecesaria
 


### PR DESCRIPTION
As part of standardization the Priority Hints spec was moved into the HTML and Fetch specs and no longer exists as a separate specification (the [old specification was archived](https://github.com/WICG/priority-hints)). Additionally the HTML attribution was renamed from `priority` to `fetchpriority` (though the fetch attribute remains `priority` since the "fetch" part is redundant).

To reduce confusion, we have recently taken the decision to refer to this feature as "Fetch Priority" going forward (note the API is Fetch Priority and the attribute is `fetchpriority` for HTML and `priority` for Fetch).

Changes proposed in this pull request:

- Rename Priority Hints article to Fetch Priority since this is the main reference point for this feature.
- Update the main article slug from `/priority-hints/` to `/fetch-priority/`
- Added a redirect
- Update other references
- Removed references to iframe, which was removed as part of standardizations due to complications (@pmeenan can you confirm this piece?)
