### PR TITLE
Add redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -254,6 +254,8 @@ redirects:
   # Redirects for vanity URLs
   - source: /scale-on-web
     destination: /tags/scale-on-web
+  - source: /wordpress-on-wasm
+    destination: /wordpress-playground
 
   # Redirect for the renamed WebTransport API.
   - source: /quictransport


### PR DESCRIPTION
@ThomasTheDane recorded his I/O talk and used the link "web.dev/wordpress-on-wasm" on the slide. Set up forwarding on web.dev such that this link goes to "https://web.dev/wordpress-playground/".