### PR TITLE
Remove outdated install criteria links

### DIFF
--- a/src/site/content/en/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/en/progressive-web-apps/install-criteria/index.md
@@ -71,8 +71,6 @@ minor differences. Check the respective sites for full details:
 * [Edge](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps#requirements)
 * [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 * [Opera](https://dev.opera.com/articles/installable-web-apps/)
-* [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
-* [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %}
 On Android, if the web app manifest includes `related_applications` and

--- a/src/site/content/es/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/es/progressive-web-apps/install-criteria/index.md
@@ -43,7 +43,5 @@ Otros navegadores tienen criterios similares de instalación, aunque puede haber
 - [Edge](https://docs.microsoft.com/microsoft-edge/progressive-web-apps#requirements)
 - [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 - [Opera](https://dev.opera.com/articles/installable-web-apps/)
-- [Internet de Samsung](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} En Android, si el manifiesto de la aplicación web incluye `related_applications` y `"prefer_related_applications": true`, el usuario se dirigirá a la tienda de Google Play y [se le pedirá que instale la aplicación de Android especificada](https://developer.chrome.com/blog/app-install-banners-native/). {% endAside %}

--- a/src/site/content/ja/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/ja/progressive-web-apps/install-criteria/index.md
@@ -43,7 +43,5 @@ Chrome では、プログレッシブ Web アプリは `beforeinstallprompt` イ
 - [Edge](https://docs.microsoft.com/microsoft-edge/progressive-web-apps#requirements)
 - [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 - [Opera](https://dev.opera.com/articles/installable-web-apps/)
-- [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} Androidでは、Web アプリのマニフェストに `related_applications` と `"prefer_related_applications": true` が含まれている場合、ユーザーは Google Play ストアに移動し、代わりに[指定された Android アプリをインストールするよう求められます](https://developer.chrome.com/blog/app-install-banners-native/)。 {% endAside %}

--- a/src/site/content/ko/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/ko/progressive-web-apps/install-criteria/index.md
@@ -45,7 +45,5 @@ tags:
 - [Edge](https://docs.microsoft.com/microsoft-edge/progressive-web-apps#requirements)
 - [파이어폭스](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 - [오페라](https://dev.opera.com/articles/installable-web-apps/)
-- [삼성인터넷](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC 브라우저](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} Android에서 웹 앱 매니페스트에 `related_applications` 및 `"prefer_related_applications": true` 포함되어 있으면 사용자는 Google Play 스토어로 이동하고 [대신 지정된 Android 앱을 설치하라는 메시지가 표시](https://developer.chrome.com/blog/app-install-banners-native/)됩니다. {% endAside %}

--- a/src/site/content/pt/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/pt/progressive-web-apps/install-criteria/index.md
@@ -45,7 +45,5 @@ Outros navegadores têm critérios de instalação semelhantes, embora possa hav
 - [Edge](https://docs.microsoft.com/microsoft-edge/progressive-web-apps#requirements)
 - [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 - [Opera](https://dev.opera.com/articles/installable-web-apps/)
-- [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} No Android, se o manifesto do aplicativo da web incluir `related_applications` e `"prefer_related_applications": true` , o usuário será direcionado para a Google Play Store e [solicitado a instalar o aplicativo Android especificado](https://developer.chrome.com/blog/app-install-banners-native/). {% endAside %}

--- a/src/site/content/ru/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/ru/progressive-web-apps/install-criteria/index.md
@@ -45,7 +45,5 @@ tags:
 - [Edge](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps#requirements)
 - [Firefox](https://developer.mozilla.org/docs/Web/Progressive_web_apps/Installable_PWAs)
 - [Opera](https://dev.opera.com/articles/installable-web-apps/)
-- [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} На Android, если манифест веб-приложения включает `related_applications` и `"prefer_related_applications": true`, пользователь будет перенаправлен в магазин Google Play и вместо этого ему будет предложено [установить указанное приложение Android.](https://developer.chrome.com/blog/app-install-banners-native/) {% endAside %}

--- a/src/site/content/zh/progressive-web-apps/install-criteria/index.md
+++ b/src/site/content/zh/progressive-web-apps/install-criteria/index.md
@@ -43,7 +43,5 @@ tags:
 - Edge
 - Firefox
 - [Opera](https://dev.opera.com/articles/installable-web-apps/)
-- [Samsung Internet](https://hub.samsunginter.net/docs/ambient-badging/)
-- [UC Browser](https://plus.ucweb.com/docs/pwa/docs-en/zvrh56)
 
 {% Aside %} 在 Android 上，如果 Web 应用程序清单包括 `related_applications` 和 `"prefer_related_applications": true`，则会将用户引导至 Google Play 商店，并[提示安装指定 Android 应用程序](https://developer.chrome.com/blog/app-install-banners-native/)。{% endAside %}


### PR DESCRIPTION
Related to [#9651](https://github.com/GoogleChrome/web.dev/issues?q=is%3Aissue+is%3Aopen+criteria).  

Changes proposed in this pull request:

- Remove outdated link to Samsung Internet docs. I have found [this](https://developer.samsung.com/automation/progressive-web-app.html) section about PWA as the most relevant substitution for the deleted link, but it is a user guide and does not have any mention about install criteria.
- Remove outdated link to UC Browser docs. The deleted link led to the inactive [plus.ucweb.com](plus.ucweb.com). It seems  that UC Browser no longer have an active website with the docs.

