### PR TITLE
9932 display external feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "scripts": {
     "algolia": "node ./run-algolia.js",
-    "build": "npm-run-all clean gulp ignore rollup eleventy gulp:default-locale firebase-config",
+    "build": "npm-run-all clean gulp feeds ignore rollup eleventy gulp:default-locale firebase-config",
     "clean": "rimraf dist",
     "cloud-secrets": "node ./cloud-secrets.js",
     "coverage:integration": "c8 npm-run-all test:lib test:unit test:integration",
@@ -44,6 +44,7 @@
     "test:unit": "mocha ./test/unit",
     "test": "npm-run-all test:unit test:lib test:integration",
     "translated": "node ./tools/update-translated/index.js",
+    "feeds": "node ./tools/external-posts/index.js",
     "updated": "node ./tools/update-updated/index.js",
     "version-check": "node version-check.js",
     "watch:eleventy": "chokidar \"src/site/**/*\" -c \"npm run eleventy\"",

--- a/src/site/_collections/hooks/authors.js
+++ b/src/site/_collections/hooks/authors.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {feed, index, individual} = require('./utils');
+const {feed, index, authorIndividual} = require('./utils');
 
 /**
  * @param {AuthorsItem[]} authors
@@ -45,7 +45,7 @@ const authorsIndex = (authors) => {
  * @param {string} lang
  * @return {Paginated[]}
  */
-const authorsIndividual = (authors, lang) => individual(authors, lang, true);
+const authorsIndividual = (authors, lang) => authorIndividual(authors, lang, true);
 
 module.exports = {
   feed: authorsFeed,

--- a/src/site/_collections/hooks/authors.js
+++ b/src/site/_collections/hooks/authors.js
@@ -45,7 +45,8 @@ const authorsIndex = (authors) => {
  * @param {string} lang
  * @return {Paginated[]}
  */
-const authorsIndividual = (authors, lang) => authorIndividual(authors, lang, true);
+const authorsIndividual = (authors, lang) =>
+  authorIndividual(authors, lang, true);
 
 module.exports = {
   feed: authorsFeed,

--- a/src/site/_collections/hooks/utils.js
+++ b/src/site/_collections/hooks/utils.js
@@ -18,8 +18,6 @@
 /**
  * Reusable hooks for authors and tags
  */
-
-const path = require('path');
 const fs = require('fs');
 const authorsDataFile = './src/site/_data/external-posts.json';
 const {PAGINATION_COUNT} = require('../../_utils/constants');
@@ -95,7 +93,6 @@ const individual = (items, lang, indexedOnly = false) => {
   return paginated;
 };
 
-
 /**
  * @param {AuthorsItem[]} items
  * @param {string} lang
@@ -107,13 +104,13 @@ const authorIndividual = (items, lang, indexedOnly = false) => {
   const authorsFeeds = JSON.parse(fs.readFileSync(authorsDataFile, 'utf-8'));
 
   for (const item in items) {
-    authorsFeeds.map(authorFeeds => {
+    authorsFeeds.map((authorFeeds) => {
       for (const author in authorFeeds) {
         if (items[item].key === author) {
           items[item] = items[item] || {};
           const feeds = authorFeeds[author];
 
-          feeds.forEach(feed => {
+          feeds.forEach((feed) => {
             const element = {
               date: new Date(feed.date),
               url: feed.url,
@@ -121,8 +118,8 @@ const authorIndividual = (items, lang, indexedOnly = false) => {
                 title: feed.title,
                 subhead: feed.summary,
                 source: feed.source,
-                lang: defaultLocale
-              }
+                lang: defaultLocale,
+              },
             };
             (items[item].elements = items[item].elements || []).push(element);
           });

--- a/src/site/_filters/filter-by-lang.js
+++ b/src/site/_filters/filter-by-lang.js
@@ -16,6 +16,8 @@ module.exports = function filterByLang(posts, lang = defaultLocale) {
         filteredPosts.set(defaultUrl, post);
       } else if (!filteredPosts.has(defaultUrl)) {
         filteredPosts.set(defaultUrl, post);
+      } else {
+        filteredPosts.set(post.url, post);
       }
     }
   }

--- a/src/site/_includes/macros/post-card.njk
+++ b/src/site/_includes/macros/post-card.njk
@@ -4,6 +4,7 @@
   @typedef {string} param.title - The title of the card, like a show's name or a post's title.
   @typedef {string} param.subhead - A description or short summary.
   @typedef {string} param.url - The url for the page the card is previewing.
+  @typedef {string} param.source - The external RSS feeds source, such as bram.us.
   @typedef {string|null} param.thumbnail - An relevant image to be displayed in the card.
   @typedef {string|null} param.alt - Alt text for image. If no thumbnail is provided, this can be null.
   @typedef {string[]|null} param.authors - An array of author ids for the authors who wrote the post.
@@ -35,6 +36,10 @@
   {% endif %}
 
   <div class="card__content flow">
+    {% if param.source %}
+      <p class="type--caption gap-bottom-100"> Source: {{ param.source }} </p>
+    {% endif %}
+
     <h2 class="card__heading text-size-3">
       <a href="{{ param.url }}">{{ param.title }}</a>
     </h2>

--- a/src/site/_includes/partials/paged.njk
+++ b/src/site/_includes/partials/paged.njk
@@ -15,6 +15,7 @@
         authors: data.authors,
         tags: data.tags,
         date: element.date,
+        source: data.source,
         updated: data.updated,
         draft: data.draft
       }) }}

--- a/tools/external-posts/index.js
+++ b/tools/external-posts/index.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Fetch the RSS feeds.
+ */
+
+const fs = require('fs');
+const {rssFeeds} = require('webdev-infra/utils/rss-feeds');
+
+async function run() {
+  const raw = fs.readFileSync('./src/site/_data/authorsData.json', 'utf8');
+  const authorsData = JSON.parse(raw);
+  const feeds = {};
+
+  for (const author in authorsData) {
+    if (authorsData[author].external) {
+      feeds[author] = authorsData[author].external;
+    }
+  }
+
+  const authorsFeeds = await rssFeeds(feeds);
+
+  fs.writeFileSync('./src/site/_data/external-posts.json',
+    JSON.stringify(authorsFeeds)
+  );
+}
+
+run();

--- a/tools/external-posts/index.js
+++ b/tools/external-posts/index.js
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-
 /**
  * @fileoverview Fetch the RSS feeds.
  */
-
 const fs = require('fs');
 const {rssFeeds} = require('webdev-infra/utils/rss-feeds');
 
@@ -35,8 +33,9 @@ async function run() {
 
   const authorsFeeds = await rssFeeds(feeds);
 
-  fs.writeFileSync('./src/site/_data/external-posts.json',
-    JSON.stringify(authorsFeeds)
+  fs.writeFileSync(
+    './src/site/_data/external-posts.json',
+    JSON.stringify(authorsFeeds),
   );
 }
 


### PR DESCRIPTION
Fixes #9932 

The author profile should be able to display the external RSS feeds.

The propose of this PR is utilising the  method in the webdev-infra to loops over authors in "authorsData.json" file and looks for a `external` key, which contains the configurable list of XML sources. Lastly, write a new “external-posts.json” file, containing all data needed for the updated author page layout, to ./src/site/_data/external-posts.json.

Then create a new function named  `authorIndividual` in ./src/site/_collections/hooks/utils.js and add the logic to combine the external feeds of each author from the "external-posts.json" with the current articles of each author in the author collection, and display all articles in the individual author page. Please see [paulkinlan](http://localhost:8080/authors/paulkinlan/).

