### PR TITLE
Fix manifest browser support data source key

### DIFF
--- a/src/site/content/en/progressive-web-apps/add-manifest/index.md
+++ b/src/site/content/en/progressive-web-apps/add-manifest/index.md
@@ -23,7 +23,7 @@ Progressive Web App and how it should behave when installed on the user's
 desktop or mobile device. A typical manifest file includes the app name, the
 icons the app should use, and the URL that should be opened when the
 app is launched, among other things.
-{% BrowserCompat 'html.manifest' %}
+{% BrowserCompat 'html.manifest.name' %}
 
 ## Create the manifest file {: #create }
 


### PR DESCRIPTION
**Describe the bug**
The Browser support widget in the [Add a web app manifest](https://web.dev/add-manifest/) article says that Chrome and Edge do no support Web manifest.

**To Reproduce**
1. Go to the [Add a web app manifest](https://web.dev/add-manifest/) article.
2. Scroll down to Browser support section.
3. Check that Chrome and Edge do not support Web Manifest.

**Expected behavior**
[can-i-use](https://caniuse.com/?search=web%20app%20manifest) says that Chrome and Edge do support web manifest, so it should be displayed in the article as well.

**Screenshots**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/65129988/234338944-3a33f0a4-0185-40b2-8b48-b7642c841711.png">

It seems that the [@mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) package no longer supplies a dedicated `"html.manifest"` data source key.

Since `"html.manifest"` does not exist, I suggest that we use `"html.manifest.<SOME_MANIFEST_KEY>"` to indicate support for the Web Manifest itself.  
Attributes like [`"html.manifest.name"`](https://developer.mozilla.org/en-US/docs/Web/Manifest/name) and [`"html.manifest.icons"`](https://developer.mozilla.org/en-US/docs/Web/Manifest/icons) were introduced at the same time as the Manifest (Chrome 39, Edge 79), so they represent support for the Manifest and are suitable for displaying the Browser support widget in the article.

Result:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/65129988/234361364-5ef4c632-062d-4d7e-b158-1f28244cd487.png">


I am new to working with browser-compat-data, so please let me know if I am using it incorrectly.