### PR TITLE
Check cookies before loading gtm

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -7,7 +7,7 @@ import {
   onTTFB,
 } from 'web-vitals/attribution';
 import {store} from './store';
-import {checkIfUserAcceptsCookies} from './actions.js'
+import {checkIfUserAcceptsCookies} from './actions.js';
 import {version, dimensions} from 'webdev_analytics';
 
 // A function that should be called once all all analytics code has been

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -7,6 +7,7 @@ import {
   onTTFB,
 } from 'web-vitals/attribution';
 import {store} from './store';
+import {checkIfUserAcceptsCookies} from './actions.js'
 import {version, dimensions} from 'webdev_analytics';
 
 // A function that should be called once all all analytics code has been
@@ -320,8 +321,11 @@ export function setConfig() {
   if (location.hostname === 'localhost') {
     window.dataLayer.push({debug_mode: true});
   }
+  checkIfUserAcceptsCookies();
   const {cookiePreference} = store.getState();
   window.dataLayer.push({cookiePreference: cookiePreference});
+
+  logEvent('webdev_analytics_configed');
 }
 
 async function initAnalytics() {
@@ -337,10 +341,9 @@ async function initAnalytics() {
   onINP(sendToGoogleAnalytics);
   onLCP(sendToGoogleAnalytics);
   onTTFB(sendToGoogleAnalytics);
+  markAnalyticsInitialized();
 
   logPrerenders();
-
-  markAnalyticsInitialized();
 }
 
 // Some pages on web.dev include the full site JS but don't load

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -341,9 +341,10 @@ async function initAnalytics() {
   onINP(sendToGoogleAnalytics);
   onLCP(sendToGoogleAnalytics);
   onTTFB(sendToGoogleAnalytics);
-  markAnalyticsInitialized();
 
   logPrerenders();
+
+  markAnalyticsInitialized();
 }
 
 // Some pages on web.dev include the full site JS but don't load


### PR DESCRIPTION
Currently Google Tag Manager (which loads Google Analytics) is loading before the cookie state has been got. This means we always assume cookies are set to no

Changes proposed in this pull request:

- Check cookie acceptance as part of analytics initialisation
- Fire an event when analytics is configured, so we can delay GA4 initialisation until this event is sent


