### PR TITLE
Fix CrUX-RUM label

### DIFF
--- a/src/site/_data/paths/learn-core-web-vitals.json
+++ b/src/site/_data/paths/learn-core-web-vitals.json
@@ -34,7 +34,6 @@
             "title": "i18n.paths.learn_core_web_vitals.topics.debug_core_web_vitals",
             "pathItems": [
                 "lab-and-field-data-differences",
-                "crux-and-rum-differences",
                 "debug-layout-shifts",
                 "debug-performance-in-the-field"
             ]


### PR DESCRIPTION
Just noticed that the Core Web Vitals label apears on this article twice:

<img width="773" alt="image" src="https://user-images.githubusercontent.com/10931297/235190714-dc4438f7-fa0e-4ecf-a079-a1b5b249d8fb.png">

This is because the page is listed twice on the https://web.dev/learn-core-web-vitals/ page

Changes proposed in this pull request:

- Remove one of references

