### PR TITLE
Removed references to Chrome's Lite mode

### DIFF
--- a/src/site/content/en/blog/iframe-lazy-loading/index.md
+++ b/src/site/content/en/blog/iframe-lazy-loading/index.md
@@ -94,20 +94,10 @@ Using the `loading` attribute on iframes works as follows:
 <iframe src="https://example.com"
         width="600"
         height="400"></iframe>
-
-<!-- or use loading="eager" to opt out of automatic
-lazy-loading in Lite Mode -->
-<iframe src="https://example.com"
-        loading="eager"
-        width="600"
-        height="400"></iframe>
 ```
 
 Not specifying the attribute at all will have the same impact as explicitly
-eagerly loading the resource, except for [Lite
-Mode](https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html)
-users, where Chrome will use the `auto` value to decide whether it should be
-lazy-loaded.
+eagerly loading the resource.
 
 If you need to _dynamically_ create iframes via JavaScript, setting
 `iframe.loading = 'lazy'` on the element is also


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed references to Chrome's Lite mode since this is no longer supported.

Source: [Sunsetting Chrome Lite mode in M100 and older ](https://support.google.com/chrome/thread/151853370?sjid=11700345581091715097-EU)
