### PR TITLE
Fix redirects without slash

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -202,7 +202,7 @@ redirects:
   - source: /progressive-web-apps/#installable
     destination: /progressive-web-apps/#make-it-installable
 
-  - source: /push-notifications/
+  - source: /push-notifications
     destination: /push-notifications-overview/
 
   # Redirect for spec name changes
@@ -439,7 +439,7 @@ redirects:
     destination: https://developer.chrome.com/articles/webtransport/
   - source: /web-otp
     destination: https://developer.chrome.com/articles/web-otp/
-  - source: /hid-examples/
+  - source: /hid-examples
     destination: https://developer.chrome.com/articles/hid-examples/
 
 
@@ -465,33 +465,33 @@ redirects:
     destination: /browser-level-image-lazy-loading/
 
   # Redirects an old performance guides to more recent documentation
-  - source: /performance-get-started/
+  - source: /performance-get-started
     destination: /fast/
-  - source: /performance-get-started-graphicalcontent-4/
+  - source: /performance-get-started-graphicalcontent-4
     destination: /choose-the-right-image-format/
-  - source: /performance-get-started-httpcaching-6/
+  - source: /performance-get-started-httpcaching-6
     destination: /http-cache/
-  - source: /performance-get-started-httprequests-5/
+  - source: /performance-get-started-httprequests-5
     destination: /optimizing-content-efficiency-eliminate-downloads/
-  - source: /performance-get-started-textcontent-3/
+  - source: /performance-get-started-textcontent-3
     destination: /optimizing-content-efficiency-optimize-encoding-and-transfer/
-  - source: /performance-get-started-wrapup-7/
+  - source: /performance-get-started-wrapup-7
     destination: /fast/
-  - source: /speed-txt-compression/
+  - source: /speed-txt-compression
     destination: /reduce-network-payloads-using-text-compression/
-  - source: /webperformance-basics/
+  - source: /webperformance-basics
     destination: /navigation-and-resource-timing/
-  - source: /priority-hints/
+  - source: /priority-hints
     destination: /fetch-priority/
 
   # Redirects scrolling performance post to the Intersection Observer post
-  - source: /speed-scrolling/
+  - source: /speed-scrolling
     destination: /intersectionobserver/
 
   # Redirects for outdated usage of "Web Vitals"
-  - source: /learn-web-vitals/
+  - source: /learn-web-vitals
     destination: /learn-core-web-vitals/
-  - source: /debug-web-vitals-in-the-field/
+  - source: /debug-web-vitals-in-the-field
     destination: /debug-performance-in-the-field/
 
   # Redirects for patterns
@@ -792,27 +792,27 @@ redirects:
     destination: https://developer.chrome.com/docs/lighthouse/pwa/works-offline/
 
   # CrUX guides
-  - source: /chrome-ux-report-api/
+  - source: /chrome-ux-report-api
     destination: https://developer.chrome.com/blog/chrome-ux-report-api/
-  - source: /chrome-ux-report-bigquery/
+  - source: /chrome-ux-report-bigquery
     destination: https://developer.chrome.com/blog/chrome-ux-report-bigquery/
-  - source: /chrome-ux-report-data-studio-dashboard/
+  - source: /chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/es/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/es/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/es/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/es/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/es/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/es/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/ja/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/ja/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/ja/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/ko/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/ko/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/ko/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/pt/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/pt/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/pt/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/ru/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/ru/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/ru/chrome-ux-report-looker-studio-dashboard/
-  - source: /i18n/zh/chrome-ux-report-data-studio-dashboard/
+  - source: /i18n/zh/chrome-ux-report-data-studio-dashboard
     destination: https://developer.chrome.com/blog/zh/chrome-ux-report-looker-studio-dashboard/
-  - source: /chrome-ux-report-pagespeed-insights/
+  - source: /chrome-ux-report-pagespeed-insights
     destination: https://developer.chrome.com/blog/chrome-ux-report-pagespeed-insights/
 
   # Redirects for blogs
@@ -824,7 +824,7 @@ redirects:
     destination: /blog/fullscreen
   - source: /blog/native-hardware-user-location
     destination: /blog/user-location
-  - source: /speculative-prerendering/
+  - source: /speculative-prerendering
     destination: https://developer.chrome.com/blog/prerender-pages/
   - source: /blog/javascript-async-functions
     destination: /blog/async-functions


### PR DESCRIPTION
Fixes https://twitter.com/programmingart/status/1655483178147094529?s=20

Changes proposed in this pull request:

- Allow slash-less redirects to work. For example, https://web.dev/priority-hints will now work as well as https://web.dev/priority-hints/ and both will redirect to https://web.dev/fetch-priority/

