### PR TITLE
feat: stop the sidebar from collapsing eagerly

### DIFF
--- a/src/site/_includes/partials/toc-side.njk
+++ b/src/site/_includes/partials/toc-side.njk
@@ -3,7 +3,7 @@
   Set `tocTitle` to ovverride default title of ToC.
 #}
 {% if tocContents %}
-  <nav class="course__toc toc over-scroll hidden-yes xl:hidden-no" data-type="side" aria-label="{{ tocTitle if tocTitle else 'i18n.toc.toc' | i18n(locale) }}">
+  <nav class="course__toc toc over-scroll hidden-yes lg:hidden-no" data-type="side" aria-label="{{ tocTitle if tocTitle else 'i18n.toc.toc' | i18n(locale) }}">
     <div class="course-toc__heading font-google-sans weight-medium">{{ tocTitle if tocTitle else 'i18n.toc.toc' | i18n(locale) }}</div>
     <web-scroll-spy>
       <div class="toc__wrapper flow-recursive">


### PR DESCRIPTION
Fixes #9995

Changes proposed in this pull request:
- Change the xl:hidden-no to lg:hidden-no

To test this change:
1. Head to any page on the site containing a side bar, such as /vitals/
2. See the sidebar on smaller devices such as a 14 inch laptop screen
3. Should not see it on mobile or tablet devices