### PR TITLE
feat: add youtube fallback styling

### DIFF
--- a/src/scss/next.scss
+++ b/src/scss/next.scss
@@ -710,6 +710,19 @@ video,
   aspect-ratio: 16/9;
 }
 
+.youtube-fallback {
+  align-items: center;
+  aspect-ratio: 16 / 9;
+  background-color: var(--color-shades-charcoal);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  justify-content: center;
+  padding: 1em;
+  text-decoration: none;
+}
+
 /// COMPOSITIONS
 @import 'compositions/auto-grid';
 @import 'compositions/breakout';


### PR DESCRIPTION
Fixes [#6193]https://github.com/GoogleChrome/developer.chrome.com/issues/6193

Changes proposed in this pull request:
- Implements some fallback styling for web.dev for youtube lite

How to test
1. Clone webdev-infra and checkout branch `6193_youtube_embed_should_show_fallback_link`
2. Clone web.dev repository and checkout branch `6193_youtube_embed_should_show_fallback_when_js_is_disabled`
3. Setup a sym link between the webdev-infra and web.dev repository
4. Navigate to /advancing-framework-ecosystem-cds-2019/ with javascript enabled, you should see the youtube video as expected
5. Disable javascript
6. Refresh the page, you should now see the fallback text in place of the youtube video