### PR TITLE
Fix <title> on collections

### DIFF
--- a/src/site/_includes/collection.njk
+++ b/src/site/_includes/collection.njk
@@ -2,7 +2,7 @@
 layout: default
 algolia_priority: 1.1
 eleventyComputed:
-  pathTitle: "{{paths[pathName].title | i18n(locale)}}"
+  title: "{{paths[pathName].title | i18n(locale)}}"
   description: "{{paths[pathName].description | i18n(locale)}}"
   hero: "{{paths[pathName].cover}}"
 ---
@@ -15,7 +15,6 @@ eleventyComputed:
   <div class="wrapper">
     <div class="hero__content--split">
       <div>
-        {% set title = title or pathTitle %}
         <h1 class="text-size-6">{{ title }}</h1>
         <p>{{path.description | i18n(locale)}}</p>
       </div>


### PR DESCRIPTION
<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #10016

Changes proposed in this pull request:

- Looks like collections were using the wrong variable name so weren't showing properly in `<title>` elements.


