### PR TITLE
fix: Update Apple Human Interface Guidelines link

### DIFF
--- a/src/site/content/en/learn/pwa/enhancements/index.md
+++ b/src/site/content/en/learn/pwa/enhancements/index.md
@@ -74,7 +74,7 @@ These images are known as startup images on Apple devices and they use the `rel`
 
 The challenge is that the startup image must have the exact window size that your PWA will have on opening. So, different iOS and iPadOS devices will need different images. More situations need to be covered on the iPad, such as landscape/portrait openings and rendering the PWA in multitask mode (such as 1/3,1/2, or 2/3 of the screen).
 
-You can check an updated list of iOS and iPadOS screen sizes at the [Apple Human Interface Guidelines]( https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/)
+You can check an updated list of iOS and iPadOS screen sizes at the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/layout#Specifications)
 
 Different versions of the launch image can be set with a media query inside the `media` attribute:
 


### PR DESCRIPTION
Fixes the [PWA Splash Screens](https://web.dev/learn/pwa/enhancements/#splash-screens) link to the Apple HCI Guidelines for viewing all device dimensions that currently [404s](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/
):

<img width="995" alt="image" src="https://github.com/GoogleChrome/web.dev/assets/3053339/664e005e-a26a-4cb1-97da-013e227cdad4">


Changes proposed in this pull request:

- Update the Apple HCI link to the new URL

