### PR TITLE
Fix build warnings

### DIFF
--- a/src/site/_collections/authors.js
+++ b/src/site/_collections/authors.js
@@ -75,7 +75,7 @@ module.exports = (collections) => {
     if (elements.length > 0) {
       date = elements.slice(-1).pop().data.date;
       const tempUpdated = elements.slice(0, 1).pop().data.date;
-      if (date !== tempUpdated) {
+      if (tempUpdated && date !== tempUpdated) {
         updated = tempUpdated;
       }
     }
@@ -99,11 +99,20 @@ module.exports = (collections) => {
     };
 
     // If author has no posts, point to their Twitter
-    if (author.elements.length === 0 && author.twitter) {
-      author.href = `https://twitter.com/${author.twitter}`;
+    if (author.elements.length === 0) {
+      if (author.twitter) {
+        author.href = `https://twitter.com/${author.twitter}`;
+      } else if (author.homepage) {
+        author.href = author.homepage;
+      }
     }
 
-    if (author.elements.length > 0 || !collections || author.twitter) {
+    if (
+      author.elements.length > 0 ||
+      !collections ||
+      author.twitter ||
+      author.homepage
+    ) {
       authors[author.key] = author;
     }
   });

--- a/src/site/_data/i18n/authors.yml
+++ b/src/site/_data/i18n/authors.yml
@@ -364,7 +364,7 @@ paulkinlan:
   description:
     en: Developer Advocate
   bio:
-    en: 
+    en:
       - I lead the Chrome Developer Relations team at Google.
       - We want people to have the best experience possible on the web without having to install a native app or produce content in a walled garden.
       - Our team tries to make it easier for developers to build on the web by supporting every Chrome release, creating great content to support developers on web.dev, contributing to MDN, helping to improve browser compatibility, and some of the best developer tools like Lighthouse, Workbox, Squoosh to name just a few.
@@ -1244,7 +1244,6 @@ tunetheweb:
     pt: Developer Advocate para o Google
     ru: Developer Advocate по вопросам Google
     zh: 负责 Google 的开发技术推广工程师
-
 
 ekharvey:
   title:

--- a/src/site/_filters/expand-authors.js
+++ b/src/site/_filters/expand-authors.js
@@ -13,7 +13,7 @@ module.exports = (authorSlugs = [], authorsCollection, lang) => {
       const profile = authorsCollection[authorKey];
 
       if (!profile) {
-        console.log(`Author '${authorKey}'pages`);
+        console.log(`Author '${authorKey}' pages`);
       } else if (profile.twitter) {
         authors.push(`@${profile.twitter}`);
       } else {

--- a/src/site/_filters/expand-authors.js
+++ b/src/site/_filters/expand-authors.js
@@ -13,7 +13,7 @@ module.exports = (authorSlugs = [], authorsCollection, lang) => {
       const profile = authorsCollection[authorKey];
 
       if (!profile) {
-        console.log(`Author '${authorKey}' pages`);
+        console.log(`Cannot find author '${authorKey}' in authorsCollection`);
       } else if (profile.twitter) {
         authors.push(`@${profile.twitter}`);
       } else {

--- a/src/site/_includes/partials/paged.njk
+++ b/src/site/_includes/partials/paged.njk
@@ -14,7 +14,7 @@
         alt: data.alt or data.title or '',
         authors: data.authors,
         tags: data.tags,
-        date: element.date,
+        date: data.date,
         updated: data.updated,
         draft: data.draft
       }) }}


### PR DESCRIPTION
This annoys me:

```
Eleventy is building, please wait…
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Author 'matmarquis'pages
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
Date passed to prettyDate filter was undefined or null.
[11ty] Copied 76 files / Wrote 3809 files in 31.21 seconds (8.2ms each, v1.0.2)
```

Changes proposed in this pull request:

- Allows homepage to be used if no Twitter page passed (Fixes `matmarquis` line above)
- Adds a space in the `matmarquis` line above.
- Fixes incorrect date reference (fixes `prettyDate` line above and also adds dates to [the only page using that feature](https://web.dev/handbook/content-types/example-landing-page/)).

