### PR TITLE
Updated prerender experiment to use prerender instead of prefetch

### DIFF
--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -46,7 +46,7 @@
 {# Exclude the /patterns/ section as a control #}
 {% set speculationRules %}
 {
-  "prefetch": [
+  "prerender": [
    {
       "source": "document",
       "where": {

--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -61,7 +61,8 @@
             }
           }
         ]
-      }
+      },
+      "eagerness": "moderate"
     }
   ]
 }


### PR DESCRIPTION
We are currently running an origin trial added in #9532 to test documentation rules to prefetch next navigations for performance reasons. We have collected data over the last few months and now want to do a full prerender, instead of just a prefetch, and collect more data on that.

We're also set the `eagerness` to `moderate` to allow it to happen on `hover` as well as `mousedown`. 

We have #9559 open to remind us to remove this origin trail after the experiment finishes (or the feature reaches stable - [currently scheduled for Chrome 115](https://chromestatus.com/feature/5112150536749056)).

Note: I opened a similar PR for d.c.c. here: https://github.com/GoogleChrome/developer.chrome.com/pull/6329