### PR TITLE
Fix social thumbnails for SVG images

### DIFF
--- a/src/site/_includes/components/Meta.js
+++ b/src/site/_includes/components/Meta.js
@@ -56,14 +56,19 @@ module.exports = (locale, page, renderData = {}) => {
       social.description || (social.path && social.path.description),
       forbiddenCharacters,
     );
-    let thumbnail = social.thumbnail || social.hero;
+    let thumbnail = social.thumbnail || social.hero || site.thumbnail;
     const alt = social.alt || site.name;
+    let imgixOptions = {};
 
-    thumbnail = generateImgixSrc(thumbnail || site.thumbnail, {
-      fit: 'max',
-      w: 1200,
-      fm: 'auto',
-    });
+    const IS_SVG_IMG = /\.svg$/i.test(thumbnail);
+    if (!IS_SVG_IMG) {
+      imgixOptions = {
+        fit: 'max',
+        w: 1200,
+        fm: 'auto',
+      };
+    }
+    thumbnail = generateImgixSrc(thumbnail, imgixOptions);
 
     return {title, description, thumbnail, alt};
   }


### PR DESCRIPTION
Noticed this:

<img width="586" alt="image" src="https://github.com/GoogleChrome/web.dev/assets/10931297/093c2776-989b-4b87-8dd2-353b4032d7b0">

This is because the meta data includes imgix params:

<img width="798" alt="image" src="https://github.com/GoogleChrome/web.dev/assets/10931297/f72ac7c6-ec16-47eb-89fc-2161d2c1b613">

https://web-dev.imgix.net/image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/1AtWWHLH0bovMgv44FBU.svg?auto=format&fit=max&w=1200&fm=auto does not work
https://web-dev.imgix.net/image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/1AtWWHLH0bovMgv44FBU.svg works

Looks like there is some logic to strip params from SVGs except if they are explicitly provided. So let's stop providing them for SVGs
