### PR TITLE
Fix circular dependency in build

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -6,7 +6,6 @@ import {localStorage} from './utils/storage';
 import cookies from 'js-cookie';
 import {ids} from 'webdev_analytics';
 import {isProd} from 'webdev_config';
-import {setConfig} from './analytics';
 
 export const clearSignedInState = store.action(() => {
   const {isSignedIn} = store.getState();
@@ -232,7 +231,6 @@ export const setLanguage = store.action((state, language) => {
 export const loadAnalyticsScript = store.action(() => {
   const {gtmScriptLoaded} = store.getState();
   if (!gtmScriptLoaded && isProd) {
-    setConfig();
     loadScript(`https://www.googletagmanager.com/gtm.js?id=${ids.GTM}`, null);
     return {
       gtmScriptLoaded: true,

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -303,7 +303,7 @@ function getMeta(name) {
  * Sets the config for a given analytics measurement ID,
  * configured for the web.dev accounts.
  */
-export function setConfig() {
+function setConfig() {
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({measurement_version: version});
   window.dataLayer.push({navigation_type: getNavigationType()});
@@ -330,6 +330,8 @@ export function setConfig() {
 async function initAnalytics() {
   // If prerendering then only init once the page is activated
   await whenPageActivated;
+
+  setConfig();
 
   addClickEventListener();
   addPageShowEventListener();


### PR DESCRIPTION
Noticed this bug in the build:

```
> rollup -c


./src/lib/app.js, src/lib/pages/about.js, src/lib/pages/content.js, src/lib/pages/course.js, src/lib/pages/default.js, src/lib/pages/design-system.js, src/lib/pages/explore.js, src/lib/pages/home.js, src/lib/pages/learn.js, src/lib/pages/measure.js, src/lib/pages/newsletter.js → dist/js...
(!) Circular dependency
src/lib/actions.js -> src/lib/analytics.js -> src/lib/actions.js
created dist/js in 447ms
```

We don't actually need to set the config at this step so moving this back to analytics.js
