### PR TITLE
Remove zero-width spaces to fix the code block preview for accessibility page

### DIFF
--- a/src/site/content/en/learn/design/accessibility/index.md
+++ b/src/site/content/en/learn/design/accessibility/index.md
@@ -289,7 +289,7 @@ Make sure that every form field has an associated `<label>` element. You can ass
 
 {% Compare 'better' %}
 ```html
-<label for=​​"name">Your name</label>
+<label for="name">Your name</label>
 <input id="name" type="text">
 ```
 {% endCompare %}


### PR DESCRIPTION
Remove zero-width spaces to fix the code block preview for accessibility page in Learn Responsive Design section.

![Screenshot 2023-05-19 at 15 29 41](https://github.com/GoogleChrome/web.dev/assets/5150636/8dc95433-0cd1-46f5-82c0-10241ed605d6)

Before:
![Screenshot 2023-05-19 at 15 50 03](https://github.com/GoogleChrome/web.dev/assets/5150636/a42ab145-bca7-4291-8833-4e06aead19bd)

After:
![Screenshot 2023-05-19 at 15 49 40](https://github.com/GoogleChrome/web.dev/assets/5150636/6a7ccdda-8d78-4227-8c58-eb95cf41d0ec)
