### PR TITLE
Clarify confusing wording on bfcache article about noopener

### DIFF
--- a/src/site/content/en/blog/bfcache/index.md
+++ b/src/site/content/en/blog/bfcache/index.md
@@ -8,7 +8,7 @@ authors:
   - philipwalton
   - tunetheweb
 date: 2020-11-10
-updated: 2023-02-10
+updated: 2023-05-25
 hero: image/admin/Qoeb8x3a11BdGgRzYJbY.png
 alt: Back and forward buttons
 tags:
@@ -357,12 +357,12 @@ risk](https://mathiasbynens.github.io/rel-noopener/), a page with a non-null
 reference cannot safely be put into the bfcache because that could break any
 pages attempting to access it.
 
-As a result, it's best to avoid creating `window.opener` references by using
+As a result, it's best to avoid creating `window.opener` references. You can do this by using
 `rel="noopener"` whenever possible. If your site requires opening a window and
 controlling it through
 [`window.postMessage()`](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 or directly referencing the window object, neither the opened window nor the
-opener will be eligible for bfcache.
+opener will be eligible for the bfcache.
 
 ### Always close open connections before the user navigates away
 


### PR DESCRIPTION
As raised by @aarontgrogg the current wording is confusing:

> Trying to get a better grasp of bfcache, but really confused when reading this page/section:
https://web.dev/bfcache/#avoid-windowopener-references
I get that I should try not to use `window.open()` or `target="_blank"`.
But if I must use one of them, is it saying I should or shouldn't use `rel="noopener"` ?
"Should" seems to make more sense, in order to sever the tie between pages, but just wanting to verify...

Changes proposed in this pull request:

- Improve wording to make it clearer

