### PR TITLE
Replaced the term "inheritable" with "inherited by default" (#10109)

### DIFF
--- a/src/site/content/en/learn/css/inheritance/index.md
+++ b/src/site/content/en/learn/css/inheritance/index.md
@@ -86,7 +86,7 @@ html {
 } %}
 </figure>
 
-The `color` property is inheritable by other elements.
+The `color` property is inherited by default by other elements.
 The `html` element has `color: lightslategray`,
 therefore all elements that can inherit color will now have a color of `lightslategray`.
 
@@ -129,11 +129,11 @@ Inheritance only flows downwards, not back up to parent elements.
 } %}
 </figure>
 
-## Which properties are inheritable?
+## Which properties are inherited by default?
 
-Not all CSS properties are inheritable,
+Not all CSS properties are inherited by default,
 but there are a lot that are.
-For reference, here is the entire list of inheritable properties,
+For reference, here is the entire list of properties that are inherited by default,
 taken from the W3 reference of all CSS properties:
 
 - [azimuth](https://developer.mozilla.org/docs/Web/SVG/Attribute/azimuth)
@@ -263,14 +263,14 @@ make them normal weight, which is the initial value.
 
 ### The `unset` keyword
 
-The `unset` property behaves differently if a property is inheritable or not.
-If a property is inheritable,
+The `unset` property behaves differently if a property is inherited by default or not.
+If a property is inherited by default,
 the `unset` keyword will be the same as `inherit`.
-If the property is not inheritable, the `unset` keyword is equal to `initial`.
+If the property is not inherited by default, the `unset` keyword is equal to `initial`.
 
-Remembering which CSS properties are inheritable can be hard,
+Remembering which CSS properties are inherited by default can be hard,
 `unset` can be helpful in that context.
-For example, `color` is inheritable,
+For example, `color` is inherited by default,
 but `margin` isn't, so you can write this:
 
 ```css


### PR DESCRIPTION
The Learn CSS article on inheritance (005) uses the term "inheritable" which is both potentially misleading and not used in the CSS spec. This is potentially misleading because the word "inheritable" can be interpreted as "able to be inherited" as opposed to how it is being used here, which is "inherited by default". Additionally the CSS spec does not use the word "inheritable" instead referring to properties that inherit their values by default as "inherited properties".

Fixes #10109

Changes proposed in this pull request:

- Everywhere the word "inheritable" is used, I have replaced it with "inherited by default", which is how the word seems to have been used on this page.  Though the CSS spec refers to "inherited properties", I believe that using the term "inherited by default" is better for learners because it is more explicit as to what is occurring.