### PR TITLE
updating learn pwa to remove sw as a requirement for installability

### DIFF
--- a/src/site/content/en/learn/pwa/assets-and-data/index.md
+++ b/src/site/content/en/learn/pwa/assets-and-data/index.md
@@ -76,8 +76,7 @@ Users expect your application to offer a fast and always-ready experience.
 That means your app should work offline.
 
 Being offline-ready doesn't mean that all your content or services should be available without a network connection.
-Having at least a basic experience when the user is offline, like a page that asks you to connect to the Internet to continue,
-is one of the [requirements](/learn/pwa/getting-started/) of being a Progressive Web App.
+However having at least a basic experience when the user is offline, like a page that asks you to connect to the Internet to continue, will provide for a better user experience, keeping the user within the experience of your app instead of a generic browser error.
 In some browsers this is a must-have feature to pass the PWA installation criteria.
 Displaying your PWA's user interface, along with cached content, is better.
 Letting users continue using your whole PWA and syncing server changes when they're back online is the gold standard for working offline.

--- a/src/site/content/en/learn/pwa/index.md
+++ b/src/site/content/en/learn/pwa/index.md
@@ -19,7 +19,6 @@ Use the menu pane to navigate the modules. (The menu is at left on desktop or be
 
 You'll learn PWA fundamentals like the Web App Manifest,
 service workers, how to design with an app in mind,
-what's different from a classic web app,
 how to use other tools to test and debug your PWA.
 After these fundamentals, you'll learn about integration with the platform and operating system,
 how to enhance your PWA's installation and usage experience, and how to offer an offline experience.

--- a/src/site/content/en/learn/pwa/installation/index.md
+++ b/src/site/content/en/learn/pwa/installation/index.md
@@ -26,12 +26,7 @@ The metadata for your PWA is set by a JSON-based file known as the Web App Manif
 
 As a minimum requirement for installability, most browsers that support it use the Web App Manifest file and certain properties such as the name of the app, and configuration of the installed experience. An exception to this is Safari for macOS, which does not support installability.
 
-Chromium-based browsers on desktop and Android, including Google Chrome, Samsung Internet, and Microsoft Edge, have additional requirements, such as:
-
-- Serving the web app on HTTPS.
-- At least one icon in the correct format and size.
-- A registered service worker.
-- A `fetch` event handler in the service worker to provide a basic offline experience.
+The requirements to allow installation differ among the different browsers, [this article](/install-criteria/) details the criteria for Google Chrome and includes links to requirements for other browsers.
 
 Because the test that a PWA meets installability requirements can take several seconds, installability itself may not be available as soon as a URLs response is received.
 


### PR DESCRIPTION
We had updated the documentation pages in /pwa but we were missing the /learn/pwa bits, this PR takes care of it.

