### PR TITLE
Fix syntax error in origin-private-file-system example

### DIFF
--- a/src/site/content/en/blog/origin-private-file-system/index.md
+++ b/src/site/content/en/blog/origin-private-file-system/index.md
@@ -117,7 +117,7 @@ If you know their name, access previously created files and folders by calling t
 ```js
 const existingFileHandle = await opfsRoot.getFileHandle('my first file');
 const existingDirectoryHandle = await opfsRoot
-    .getDirectoryHandle('my first folder);
+    .getDirectoryHandle('my first folder');
 ```
 
 ### Getting the file associated with a file handle for reading


### PR DESCRIPTION
This just adds a missing quote to close a string in one of the code examples in the Origin Private File System blog post.

I just happened to notice this one while reading the post, but it seems like you could probably add a Remark plugin to flag these errors automatically. If it would be helpful, I’d be happy to take a look at setting up [remark-lint-code](https://github.com/Qard/remark-lint-code) and [remark-lint-code-eslint](https://github.com/Qard/remark-lint-code-eslint) for that (or something custom if you don’t like those or they don’t turn out to work well).