### PR TITLE
fix: menu aria label reference

### DIFF
--- a/src/site/_includes/partials/site-header.njk
+++ b/src/site/_includes/partials/site-header.njk
@@ -2,7 +2,7 @@
 
 <web-header role="banner" class="site-header">
   <div class="cluster gutter-base">
-    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-toolip" data-open-drawer-button data-alignment="right" role="tooltip">
+    <button class="icon-button tooltip color-core-text md:hidden-yes" aria-labelledby="menu-button-tooltip" data-open-drawer-button data-alignment="right" role="tooltip">
       {% include "icons/menu.svg" %}
       <span class="tooltip__content" id="menu-button-tooltip">Open menu</span>
     </button>


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix typo in `aria-labelledby` value to match the referred element `id`


