### PR TITLE
ES Modules in service workers: fix compatibility data

### DIFF
--- a/src/site/content/en/blog/es-modules-in-sw/index.md
+++ b/src/site/content/en/blog/es-modules-in-sw/index.md
@@ -104,7 +104,7 @@ workers.
 
 ## Browser support
 
-{% BrowserCompat 'javascript.statements.import' %}
+{% BrowserCompat 'javascript.statements.import.worker_support' %}
 
 ES modules in service workers are supported in Chrome and Edge starting with
 [version 91](https://chromestatus.com/feature/4609574738853888).


### PR DESCRIPTION
The table showed compat data for the import statement, instead of for the import statement in service workers

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

