### PR TITLE
Update window controls overlay incorrect function name

### DIFF
--- a/src/site/content/en/blog/window-controls-overlay/index.md
+++ b/src/site/content/en/blog/window-controls-overlay/index.md
@@ -268,7 +268,7 @@ function handleDisplayModeChange(mql) {
 }
 
 // Run the display mode change handler once.
-handleOrientationChange(mediaQueryList);
+handleDisplayModeChange(mediaQueryList);
 
 // Add the callback function as a listener to the query list.
 mediaQueryList.addEventListener('change', handleDisplayModeChange);


### PR DESCRIPTION
Change `handleOrientationChange ` to `handleDisplayModeChange`

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If your PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes incorrect function name

