### PR TITLE
Remove favicon from Fetch Priority article

### DIFF
--- a/src/site/content/en/fast/fetch-priority/index.md
+++ b/src/site/content/en/fast/fetch-priority/index.md
@@ -182,14 +182,6 @@ The following table considers such factors to show how most resources are curren
         <td></td>
         <td></td>
       </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>Favicon</td>
-        <td></td>
-        <td></td>
-      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
@pmeenan and I recently discovered that Favicons are no longer treated separately in terms of prioritisation so removing it from the table.


