### PR TITLE
Stop over minifying HTML

### DIFF
--- a/src/site/_transforms/minify-html.js
+++ b/src/site/_transforms/minify-html.js
@@ -37,6 +37,8 @@ const minifyHtml = (content, outputPath) => {
           do_not_minify_doctype: true,
           ensure_spec_compliant_unquoted_attribute_values: true,
           keep_spaces_between_attributes: true,
+          keep_html_and_head_opening_tags: true,
+          keep_closing_tags: true,
         })
         .toString('utf-8');
     } catch (err) {


### PR DESCRIPTION
Fixes #10218

Changes proposed in this pull request:

- Stop over-stripping HTML tags. Yes technically the browser will fill them in again but it's just confusing!


