### PR TITLE
Use the `href` attribute instead of the `src` attribute to specify th…

### DIFF
--- a/src/site/content/en/learn/html/document-structure/index.md
+++ b/src/site/content/en/learn/html/document-structure/index.md
@@ -285,7 +285,7 @@ The code now looks like this:
     <meta charset="utf-8" />
     <title>Machine Learning Workshop</title>
     <meta name="viewport" content="width=device-width" />
-    <link rel="stylesheet" src="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <link rel="alternate" href="https://www.machinelearningworkshop.com/fr/" hreflang="fr-FR" />
     <link rel="alternate" href="https://www.machinelearningworkshop.com/pt/" hreflang="pt-BR" />


### PR DESCRIPTION
The `src` attribute was incorrectly used instead of `href` to specify the URL of the external stylesheet we are linking to the document. This is an error because the `<link>` tag does not have an `src` attribute.