### PR TITLE
Wording suggestion: the user accepting the prompts

### DIFF
--- a/src/site/content/en/learn/pwa/getting-started/index.md
+++ b/src/site/content/en/learn/pwa/getting-started/index.md
@@ -110,7 +110,7 @@ Users should be able to switch between input types while using your application 
 
 #### Provides context for permission requests
 
-Only trigger prompts for permissions like notifications, geolocation, and credentials, after providing in-context rationale to improve chances of accepting the prompts from the user.
+Only trigger prompts for permissions like notifications, geolocation, and credentials, after providing in-context rationale to improve chances of the user accepting the prompts.
 
 #### Follows best practices for healthy code
 


### PR DESCRIPTION
I remember having a good experience with the [web.dev CSS course](https://web.dev/learn/css/), so I'm going through the [PWA course](https://web.dev/learn/pwa/) to fill gaps in my knowledge. I noticed a sentence with some phrasing that made me do a double-take. I figured my edit might be closer to the intended meaning, given the rest of the sentence.

https://web.dev/learn/pwa/getting-started/#:~:text=to%20improve%20chances%20of%20accepting%20the%20prompts%20from%20the%20user