### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/learn/html/metadata/index.md
+++ b/src/site/content/en/learn/html/metadata/index.md
@@ -213,7 +213,7 @@ Your HTML now looks something like this:
 </html>
 ```
 
-It's pretty long, but it's done. It would have been much longer, but you've summed up all the icons, short name, etc. in a [manifest file](/add-manifest/), enabling you to omit many `<meta>` and `<link>` tags,
+It's pretty long, but it's done.
 
 Now that your `<head>` is mostly complete, you can dive into some [semantic HTML](/learn/html/semantic-html/).
 


### PR DESCRIPTION
Fixed inconsistency and incomplete sentence in the last section of Learn HTML 003 - Metadata

Fixes Issue #10284 

Changes proposed in this pull request:

The current instruction about the of the demo website indicates web manifests are a useful tool, but are not under the purview of this module, and as such the element is somewhat long and unwieldy. This tracks with the code block shown at the end of the page.

However, the following paragraph inconsistently states:
It's pretty long, but it's done. It would have been much longer, but you've summed up all the icons, short name, etc. in a manifest file, enabling you to omit many and tags,

Including the sentence fragment - "tags," is the end of a paragraph, so this content is clearly unfinished, as well as inconsistent.

Since web manifests are covered in the PWA series and relevant articles are already linked, it seems the solution is changing this penultimate paragraph of the article to state instead:

"It's pretty long, but it's done."

