### PR TITLE
Re-enable newsletter sign-up form

### DIFF
--- a/src/site/_includes/homepage.njk
+++ b/src/site/_includes/homepage.njk
@@ -133,6 +133,5 @@ pageScripts:
   </section>
   {# Chrome developers end #}
 
-  {# Temporary disable #}
-  {# {% include 'partials/subscribe.njk' %} #}
+  {% include 'partials/subscribe.njk' %}
 </div>

--- a/src/site/_includes/item-page.njk
+++ b/src/site/_includes/item-page.njk
@@ -123,8 +123,7 @@ eleventyComputed:
 
   <div class="docked-actions flow flow-space-base">
     <div>
-      {# Temporary disable #}
-      {# {% include 'partials/subscribe-action.njk' %} #}
+      {% include 'partials/subscribe-action.njk' %}
     </div>
   </div>
 </div>

--- a/src/site/_includes/partials/post.njk
+++ b/src/site/_includes/partials/post.njk
@@ -193,8 +193,7 @@
           </share-action>
         </div>
         <div>
-          {# Temporary disable #}
-          {# {% include 'partials/subscribe-action.njk' %} #}
+          {% include 'partials/subscribe-action.njk' %}
         </div>
       </div>
     </article>

--- a/src/site/content/en/newsletter/index.njk
+++ b/src/site/content/en/newsletter/index.njk
@@ -14,8 +14,7 @@ pagination:
   addAllPagesToCollections: true
 ---
 <div class="landing-page">
-  {# Temporary disable #}
-  {# {% include 'partials/subscribe.njk' %} #}
+  {% include 'partials/subscribe.njk' %}
 
   {# Hero starts #}
   <header class="region bg-mid-bg">


### PR DESCRIPTION
This brings back the newsletter form after having been disabled in https://github.com/GoogleChrome/web.dev/pull/10120.