### PR TITLE
Add bfcache not restored reasons api

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -274,7 +274,7 @@ function getNavigationType() {
  * value returned by the Navigation Timing API (normalized to use kebab case),
  * but in addition to this it also captures pages that were prerendered
  * as well as page that were restored after a discard.
- * @returns {string}
+ * @returns {string|undefined}
  */
 function getBackForwardNotRestoreReasons() {
   const navEntry =
@@ -287,7 +287,7 @@ function getBackForwardNotRestoreReasons() {
       return navEntry.notRestoredReasons.reasons.toString();
     }
   }
-  return '(not set)';
+  return;
 }
 
 /**

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -88,6 +88,9 @@ function sendToGoogleAnalytics({
   };
 
   let overrides;
+  let debug_input_delay;
+  let debug_processing_time;
+  let debug_presentation_delay;
 
   switch (name) {
     case 'CLS':
@@ -114,20 +117,16 @@ function sendToGoogleAnalytics({
       };
       break;
     case 'INP':
-      overrides = {
-        debug_event: attribution.eventType,
-        debug_time: attribution.eventTime,
-        debug_load_state: attribution.loadState,
-        debug_target: attribution.eventTarget || '(not set)',
-        debug_input_delay: Math.round(
+      if (attribution.eventEntry) {
+        debug_input_delay = Math.round(
           attribution.eventEntry.processingStart -
             attribution.eventEntry.startTime,
-        ),
-        debug_processing_time: Math.round(
+        );
+        debug_processing_time = Math.round(
           attribution.eventEntry.processingEnd -
             attribution.eventEntry.processingStart,
-        ),
-        debug_presentation_delay: Math.round(
+        );
+        debug_presentation_delay = Math.round(
           // RenderTime is an estimate, because duration is rounded, and may get rounded down.
           // In rare cases it can be less than processingEnd and that breaks performance.measure().
           // Lets make sure its at least 4ms in those cases so you can just barely see it.
@@ -135,7 +134,16 @@ function sendToGoogleAnalytics({
             attribution.eventEntry.processingEnd + 4,
             attribution.eventEntry.startTime + attribution.eventEntry.duration,
           ) - attribution.eventEntry.processingEnd,
-        ),
+        );
+      }
+      overrides = {
+        debug_event: attribution.eventType,
+        debug_time: attribution.eventTime,
+        debug_load_state: attribution.loadState,
+        debug_target: attribution.eventTarget || '(not set)',
+        debug_input_delay: debug_input_delay,
+        debug_processing_time: debug_processing_time,
+        debug_presentation_delay: debug_presentation_delay,
       };
       break;
     case 'LCP':
@@ -262,6 +270,27 @@ function getNavigationType() {
 }
 
 /**
+ * Gets the type of navigation for this page. In most cases this is the
+ * value returned by the Navigation Timing API (normalized to use kebab case),
+ * but in addition to this it also captures pages that were prerendered
+ * as well as page that were restored after a discard.
+ * @returns {string}
+ */
+function getBackForwardNotRestoreReasons() {
+  const navEntry =
+    self.performance &&
+    performance.getEntriesByType &&
+    performance.getEntriesByType('navigation')[0];
+
+  if (navEntry) {
+    if (navEntry.notRestoredReasons) {
+      return navEntry.notRestoredReasons.reasons.toString();
+    }
+  }
+  return '(not set)';
+}
+
+/**
  * Returns a list of any `prerender` speculation rules defined by any
  * `script[type=speculationrules]` elements on the page.
  * @returns {Object}
@@ -330,7 +359,12 @@ function getMeta(name) {
 function setConfig() {
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({measurement_version: version});
-  window.dataLayer.push({navigation_type: getNavigationType()});
+  const navigationType = getNavigationType();
+  window.dataLayer.push({navigation_type: navigationType});
+  if (navigationType === 'back-forward') {
+    const reasons = getBackForwardNotRestoreReasons();
+    window.dataLayer.push({back_forward_not_restore_reasons: reasons});
+  }
   window.dataLayer.push({page_path: location.pathname});
   window.dataLayer.push({page_authors: getMeta('authors')});
   window.dataLayer.push({page_tags: getMeta('tags')});

--- a/types/utils/global.d.ts
+++ b/types/utils/global.d.ts
@@ -40,6 +40,22 @@ declare global {
     type: string;
   }
 
+  interface NotRestoredReasons {
+    url: string;
+    src: string;
+    id: string;
+    name: string;
+    blocked: boolean;
+    reasons: [string];
+    children: [NotRestoredReasons];
+  }
+
+  interface PerformanceNavigationTiming {
+    deliveryType: string;
+    activationStart: number;
+    notRestoredReasons: NotRestoredReasons
+  }
+
   var WebComponents: WebComponentsType;
   var firebase: firebase.app.App;
 }

--- a/types/utils/global.d.ts
+++ b/types/utils/global.d.ts
@@ -26,6 +26,18 @@ declare global {
     inert: boolean;
     recaptchaLoadCallback?: () => void;
     loadScript?: (url: string, type?: string) => void;
+    dataLayer?: Array;
+  }
+
+  interface Navigator {
+    connection: NetworkInformation;
+    deviceMemory: number;
+  }
+
+  interface PerformanceEntry {
+    deliveryType: string;
+    activationStart: number;
+    type: string;
   }
 
   var WebComponents: WebComponentsType;


### PR DESCRIPTION
Changes proposed in this pull request:

- Add no restored reasons API analytics as noticed we have a lot less bfcache usage on desktop than mobile and would like to understand why
- Also found a small bug when `attribution.eventEntry` is not set so included that fix too.

Equivalent change to d.c.c. is: https://github.com/GoogleChrome/developer.chrome.com/pull/7074