### PR TITLE
Speculation rules: match any hash fragment.

### DIFF
--- a/src/site/_includes/partials/head.njk
+++ b/src/site/_includes/partials/head.njk
@@ -52,11 +52,11 @@
       "where": {
         "and": [
           {
-            "href_matches": "/*\\?*", "relative_to": "document"
+            "href_matches": "/*\\?*#*", "relative_to": "document"
           },
           {
             "not": {
-              "href_matches": "/patterns/*\\?*",
+              "href_matches": "/patterns/*\\?*#*",
               "relative_to": "document"
             }
           }


### PR DESCRIPTION
This expands the scope slightly, but also we're contemplating a change which would make this unnecessary -- but while developer.chrome.com is using this syntax, it's more difficult to tell at a glance how common other uses are.