### PR TITLE
Update index.md

### DIFF
--- a/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
+++ b/src/site/content/en/fast/browser-level-image-lazy-loading/index.md
@@ -209,7 +209,7 @@ It is safer to avoid putting `loading=lazy` on above-the-fold images, as Chrome 
 
 ### How does the `loading` attribute work with images that are in the viewport but not immediately visible (for example: behind a carousel, or hidden by CSS for certain screen sizes)?
 
-Using `loading="lazy"` _may_ prevent them being loaded when they are not visible but within the [calculated-distance](#distance-from-viewport-thresholds). For example, Chrome, Safari and Firefox do not load images using `display: none;` styling—either on the image element or on a parent element. However, other techniques to hide images—such as using `opacity:0` styling—will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
+Using `loading="lazy"` _may_ prevent them being loaded when they are not visible but within the [calculated-distance](#distance-from-viewport-thresholds). For example, Chrome, Safari and Firefox do not load background-url images using `display: none;` styling—either on the image element or on a parent element. However, other techniques to hide images—such as using `opacity:0` styling—will still result in the images being loaded. Always test your implementation thoroughly to ensure it's acting as intended.
 
 ### What if I'm already using a third-party library or a script to lazy-load images?
 


### PR DESCRIPTION
Added background-url clarification on image loading behavior.

My understanding is that this current statement is false - `<img>` sources ARE loaded in Chrome, Safari and Firefox even when `display: none` styling is used on the image element or a parent element. Only `background-url` images would not be loaded, since their style attributes would never be evaluated.



