### PR TITLE
Fix typo in Learn PWA > Serving code snippet

### DIFF
--- a/src/site/content/en/learn/pwa/serving/index.md
+++ b/src/site/content/en/learn/pwa/serving/index.md
@@ -90,9 +90,9 @@ caches.match(urlOrRequest).then(response => {
 
 // Cache-specific search
 caches.open("pwa-assets").then(cache => {
-  cache.match(urlOrRequest).then(response) {
+  cache.match(urlOrRequest).then(response => {
     console.log(response ? response : "It's not in the cache");
-  }
+  })
 });
 ```
 


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/299176631

Changes proposed in this pull request:

- Fix arrow function syntax error in a code snippet in [Learn PWA > Serving > Responding from the cache](https://web.dev/learn/pwa/serving/#responding-from-the-cache)

