### PR TITLE
fix: Remove HTML tags from code example

### DIFF
--- a/src/site/content/en/blog/media-recording-video/index.md
+++ b/src/site/content/en/blog/media-recording-video/index.md
@@ -184,7 +184,7 @@ progressively save the data from the stream to you preferred destination.
   var handleSuccess = function(stream) {
     const options = {mimeType: 'video/webm'};
     const recordedChunks = [];
-    <strong>const mediaRecorder = new MediaRecorder(stream, options);
+    const mediaRecorder = new MediaRecorder(stream, options);
 
     mediaRecorder.addEventListener('dataavailable', function(e) {
       if (e.data.size > 0) {
@@ -202,7 +202,7 @@ progressively save the data from the stream to you preferred destination.
       downloadLink.download = 'acetest.webm';
     });
 
-    mediaRecorder.start();</strong>
+    mediaRecorder.start();
   };
 
   navigator.mediaDevices.getUserMedia({ audio: true, video: true })


### PR DESCRIPTION
This PR removes unintended use of a <strong> tag in the JS code example:

<img width="710" alt="Screenshot 2023-09-10 at 16 15 49" src="https://github.com/GoogleChrome/web.dev/assets/47426218/968bd87e-0b20-44a7-9cb7-ba0e486cc647">
