### PR TITLE
Fix broken RSS feeds

### DIFF
--- a/src/site/_includes/feed.njk
+++ b/src/site/_includes/feed.njk
@@ -20,7 +20,7 @@
       <link href="{{ absolutePostUrl }}"/>
       <updated>{{ post.date | rssDate }}</updated>
       <id>{{ absolutePostUrl }}</id>
-      <content type="text/html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+      <content type="html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
       {% for entry in post.data.authors %}
         {%- set author = collections.authors[entry] -%}
         <author>

--- a/src/site/content/en/authors/feed.njk
+++ b/src/site/content/en/authors/feed.njk
@@ -37,7 +37,7 @@ pagination:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="text/html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
     {% for entry in post.data.authors %}
     {%- set author = collections.authors[entry] -%}
     <author>

--- a/src/site/content/en/shows/feed.njk
+++ b/src/site/content/en/shows/feed.njk
@@ -39,7 +39,7 @@ pagination:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="text/html" mode="escaped">{{ post.data.description | md({linkify: true, breaks: true, xhtmlOut: true}) | safe }}</content>
+    <content type="html" mode="escaped">{{ post.data.description | md({linkify: true, breaks: true, xhtmlOut: true}) | safe }}</content>
     {% for entry in post.data.authors %}
     {%- set author = collections.authors[entry] -%}
     <author>

--- a/src/site/content/en/tags/feed.njk
+++ b/src/site/content/en/tags/feed.njk
@@ -39,7 +39,7 @@ pagination:
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | rssDate }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="text/html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content type="html" mode="escaped">{{ post.templateContent | replace("web-copy-code", "div") | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
     {% for entry in post.data.authors %}
     {%- set author = collections.authors[entry] -%}
     <author>


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes broken RSS feed for feedly. as reported by several users.
 
It looks like they don't accept `type="text/html"` anymore. The [spec](https://www.ietf.org/rfc/rfc4287.html#section-3.1.1) specifies we should be using `"html"` anyway. Doesn't look like we changed anything here, so maybe something changed at Feedly's end?

FYI, this was originally changed too `text/html` in #5873 but with no explanation why. D.C.C still uses `"html"`

[Prod](https://web.dev/feed.xml) (and recent other staging URLs) has this on Feedly:

<img width="715" alt="image" src="https://github.com/GoogleChrome/web.dev/assets/10931297/bc0c1752-cd9c-4d67-b74c-1c04faf843db">

This [branch's preview](https://deploy-preview-10424--web-dev-staging.netlify.app/feed.xml) has this on Feedly:

<img width="717" alt="image" src="https://github.com/GoogleChrome/web.dev/assets/10931297/591be0da-363b-46da-9414-cb07de4367da">



